### PR TITLE
feat: add Docker + Grafana infrastructure (Phase 3)

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,53 @@
+# =============================================================================
+# DalyBMS — Variables d'environnement Docker
+# =============================================================================
+# Copiez ce fichier en .env et adaptez les valeurs AVANT de lancer docker compose.
+# NE commitez jamais .env dans git (déjà dans .gitignore).
+#
+# Usage :
+#   cp .env.docker .env
+#   nano .env
+#   docker compose up -d
+
+# =============================================================================
+# InfluxDB
+# =============================================================================
+INFLUXDB_ADMIN_USER=admin
+INFLUXDB_ADMIN_PASSWORD=changeme_influx_pass
+
+# Organisation et bucket (doit correspondre à Config.toml)
+INFLUX_ORG=santuario
+INFLUX_BUCKET=daly_bms
+
+# Token d'accès InfluxDB (générez-le avec :
+#   docker exec dalybms-influxdb influx auth create \
+#     --org santuario --all-access
+# Ou via l'UI : http://localhost:8086 )
+INFLUX_TOKEN=REMPLACEZ_PAR_VOTRE_TOKEN_INFLUXDB
+
+# =============================================================================
+# Grafana
+# =============================================================================
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=changeme_grafana_pass
+
+# =============================================================================
+# MQTT (Mosquitto)
+# =============================================================================
+# Pas de mot de passe en mode anonymous (réseau local)
+# Pour activer l'auth, décommenter et configurer password_file dans mosquitto.conf
+# MQTT_USER=dalybms
+# MQTT_PASS=changeme_mqtt_pass
+
+# =============================================================================
+# Serveur BMS (daly-bms-server)
+# =============================================================================
+# Port série (mode hardware) — ignoré en mode --simulate
+DALY_SERIAL_PORT=/dev/ttyUSB0
+DALY_SERIAL_BAUD=9600
+
+# Niveau de logs
+RUST_LOG=info
+
+# Clé API pour les endpoints de contrôle (vide = pas d'auth)
+DALY_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,10 @@
 # Configuration & Secrets
 # =============================================================================
 .env
-.env.docker
 .env.local
 config.toml
 !Config.toml          # Config.toml est le fichier exemple versionné
+# .env.docker est versionnée (c'est le template, pas les vrais secrets)
 
 # =============================================================================
 # Build artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,93 @@
+# =============================================================================
+# DalyBMS Server — Dockerfile multi-stage
+# =============================================================================
+# Build stage : Rust officiel (cache des dépendances optimisé)
+# Runtime stage : Debian slim (minimal, ~50 MB final)
+#
+# Build local :
+#   docker build -t dalybms-server:latest .
+#
+# Build cross (Pi5 arm64) depuis x86_64 :
+#   docker buildx build --platform linux/arm64 -t dalybms-server:arm64 .
+
+# =============================================================================
+# Stage 1 — Builder
+# =============================================================================
+FROM rust:1.80-slim-bookworm AS builder
+
+# Dépendances système nécessaires pour les crates natives (rusqlite bundled, openssl)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libssl-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# ── Astuce : copier d'abord les Cargo.toml pour cacher les deps ──────────────
+# Cela évite de recompiler toutes les dépendances à chaque changement de code.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/daly-bms-core/Cargo.toml    crates/daly-bms-core/
+COPY crates/daly-bms-server/Cargo.toml  crates/daly-bms-server/
+COPY crates/daly-bms-cli/Cargo.toml     crates/daly-bms-cli/
+
+# Créer des fichiers src stub pour que cargo fetch/check fonctionne
+RUN mkdir -p crates/daly-bms-core/src \
+             crates/daly-bms-server/src \
+             crates/daly-bms-cli/src && \
+    echo "fn main() {}" > crates/daly-bms-server/src/main.rs && \
+    echo "fn main() {}" > crates/daly-bms-cli/src/main.rs && \
+    touch crates/daly-bms-core/src/lib.rs
+
+# Pré-compiler les dépendances (layer cacheable)
+RUN cargo build --release --bin daly-bms-server 2>/dev/null || true
+
+# ── Copier les vraies sources et compiler ────────────────────────────────────
+COPY crates/ crates/
+
+# Forcer la recompilation des crates locaux
+RUN touch crates/daly-bms-core/src/lib.rs \
+          crates/daly-bms-server/src/main.rs
+
+RUN cargo build --release --bin daly-bms-server
+
+# =============================================================================
+# Stage 2 — Runtime
+# =============================================================================
+FROM debian:bookworm-slim AS runtime
+
+# Dépendances runtime minimales
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Utilisateur non-root pour la sécurité
+RUN useradd -m -u 1000 -s /bin/sh dalybms
+
+# Répertoires de données
+RUN mkdir -p /etc/daly-bms /var/lib/daly-bms && \
+    chown -R dalybms:dalybms /var/lib/daly-bms
+
+# Binaire compilé
+COPY --from=builder /build/target/release/daly-bms-server /usr/local/bin/daly-bms-server
+
+# Config exemple (peut être surchargée via volume)
+COPY Config.toml /etc/daly-bms/config.toml.example
+
+USER dalybms
+
+# Port API HTTP
+EXPOSE 8000
+
+# Healthcheck (vérifie que l'API répond)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD curl -f http://localhost:8000/api/v1/system/status || exit 1
+
+# Variables d'environnement par défaut
+ENV DALY_CONFIG=/etc/daly-bms/config.toml
+ENV RUST_LOG=info
+
+# Par défaut : mode simulation (surcharger avec "" pour hardware)
+ENTRYPOINT ["/usr/local/bin/daly-bms-server"]
+CMD ["--simulate"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,227 @@
+# =============================================================================
+# DalyBMS — Stack complète Docker Compose
+# =============================================================================
+# Inclut : Mosquitto · InfluxDB · Grafana · daly-bms-server (simulé)
+#
+# Prérequis :
+#   cp .env.docker .env && nano .env   # adapter les secrets
+#
+# Démarrage :
+#   docker compose up -d
+#   docker compose logs -f dalybms-server
+#
+# URLs après démarrage :
+#   API REST   → http://localhost:8000/api/v1/bms
+#   WebSocket  → ws://localhost:8000/ws/bms/stream
+#   Grafana    → http://localhost:3001  (admin / GRAFANA_ADMIN_PASSWORD)
+#   InfluxDB   → http://localhost:8086
+#   Node-RED   → http://localhost:1880
+#
+# Mode hardware réel (Pi) :
+#   Remplacer CMD dans le service dalybms-server par [] et ajouter :
+#     devices:
+#       - /dev/ttyUSB0:/dev/ttyUSB0
+#   Puis : docker compose up -d dalybms-server
+
+version: "3.9"
+
+# =============================================================================
+# Services
+# =============================================================================
+services:
+
+  # ── Broker MQTT ─────────────────────────────────────────────────────────────
+  mosquitto:
+    image: eclipse-mosquitto:2.0.18
+    container_name: dalybms-mosquitto
+    restart: unless-stopped
+    ports:
+      - "1883:1883"
+      - "9001:9001"
+    volumes:
+      - ./docker/mosquitto/config:/mosquitto/config:ro
+      - mosquitto-data:/mosquitto/data
+      - mosquitto-log:/mosquitto/log
+    healthcheck:
+      test: ["CMD-SHELL", "mosquitto_pub -h localhost -t '$$health' -m ok -q 0 && echo ok"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - dalybms-net
+
+  # ── Base de données temporelle ───────────────────────────────────────────────
+  influxdb:
+    image: influxdb:2.7.10
+    container_name: dalybms-influxdb
+    restart: unless-stopped
+    ports:
+      - "8086:8086"
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE:     setup
+      DOCKER_INFLUXDB_INIT_USERNAME: ${INFLUXDB_ADMIN_USER:-admin}
+      DOCKER_INFLUXDB_INIT_PASSWORD: ${INFLUXDB_ADMIN_PASSWORD:-supersecret123}
+      DOCKER_INFLUXDB_INIT_ORG:      ${INFLUX_ORG:-santuario}
+      DOCKER_INFLUXDB_INIT_BUCKET:   ${INFLUX_BUCKET:-daly_bms}
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${INFLUX_TOKEN:?Erreur: INFLUX_TOKEN manquant dans .env}
+      # Rétention par défaut du bucket : 30 jours
+      DOCKER_INFLUXDB_INIT_RETENTION: 720h
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+      - influxdb-config:/etc/influxdb2
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8086/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - dalybms-net
+
+  # ── Visualisation Grafana ────────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:11.6.0
+    container_name: dalybms-grafana
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER:     ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?Erreur: GRAFANA_ADMIN_PASSWORD manquant dans .env}
+      GF_USERS_ALLOW_SIGN_UP:     "false"
+      GF_AUTH_ANONYMOUS_ENABLED:  "false"
+      # Passer le token InfluxDB pour le provisioning datasource
+      INFLUX_TOKEN:               ${INFLUX_TOKEN}
+      INFLUX_ORG:                 ${INFLUX_ORG:-santuario}
+      INFLUX_BUCKET:              ${INFLUX_BUCKET:-daly_bms}
+      # Plugins supplémentaires (séparés par des virgules)
+      GF_INSTALL_PLUGINS:         ""
+      # Timezone
+      GF_DEFAULT_TIMEZONE:        "browser"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/api/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - dalybms-net
+
+  # ── Serveur BMS Rust (mode simulation) ──────────────────────────────────────
+  dalybms-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: dalybms-server:latest
+    container_name: dalybms-server
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      RUST_LOG:       ${RUST_LOG:-info}
+      DALY_CONFIG:    /etc/daly-bms/config.toml
+      DALY_API_KEY:   ${DALY_API_KEY:-}
+    volumes:
+      # Config personnalisée (optionnel — le binaire utilise ses défauts sinon)
+      - ./Config.toml:/etc/daly-bms/config.toml:ro
+      # Journal des alertes SQLite
+      - dalybms-alerts:/var/lib/daly-bms
+    # Mode simulation par défaut (2 BMS fictifs)
+    # Pour hardware réel, remplacer par : command: []
+    # et ajouter : devices: [/dev/ttyUSB0:/dev/ttyUSB0]
+    command: ["--simulate", "--sim-bms", "0x01,0x02"]
+    depends_on:
+      mosquitto:
+        condition: service_healthy
+      influxdb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/api/v1/system/status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "5"
+    networks:
+      - dalybms-net
+
+  # ── Node-RED (automatisation / logique métier) ───────────────────────────────
+  nodered:
+    image: nodered/node-red:4.0.2
+    container_name: dalybms-nodered
+    restart: unless-stopped
+    ports:
+      - "1880:1880"
+    environment:
+      TZ: Europe/Paris
+    volumes:
+      - nodered-data:/data
+    depends_on:
+      mosquitto:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:1880"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - dalybms-net
+
+# =============================================================================
+# Réseau interne
+# =============================================================================
+networks:
+  dalybms-net:
+    driver: bridge
+    name: dalybms-net
+
+# =============================================================================
+# Volumes persistants
+# =============================================================================
+volumes:
+  mosquitto-data:
+    name: dalybms-mosquitto-data
+  mosquitto-log:
+    name: dalybms-mosquitto-log
+  influxdb-data:
+    name: dalybms-influxdb-data
+  influxdb-config:
+    name: dalybms-influxdb-config
+  grafana-data:
+    name: dalybms-grafana-data
+  nodered-data:
+    name: dalybms-nodered-data
+  dalybms-alerts:
+    name: dalybms-alerts

--- a/docker/mosquitto/config/mosquitto.conf
+++ b/docker/mosquitto/config/mosquitto.conf
@@ -1,0 +1,36 @@
+# =============================================================================
+# Mosquitto — Configuration pour DalyBMS
+# =============================================================================
+
+# Listener MQTT standard
+listener 1883 0.0.0.0
+
+# Listener MQTT over WebSocket (utile pour dashboard JS / Node-RED)
+listener 9001
+protocol websockets
+
+# Permettre les connexions anonymes (réseau local uniquement)
+# En production : configurer allow_anonymous false + password_file
+allow_anonymous true
+
+# Persistance des messages (reconnexion propre des clients)
+persistence true
+persistence_location /mosquitto/data/
+
+# Logs
+log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
+log_type error
+log_type warning
+log_type notice
+log_type information
+log_timestamp true
+
+# QoS max supporté
+max_qos 2
+
+# Rétention des messages (utile pour "last will" du serveur BMS)
+retained_messages true
+
+# Taille max d'un message (1 MB suffisant pour les snapshots JSON BMS)
+message_size_limit 1048576

--- a/grafana/provisioning/dashboards/bms-overview.json
+++ b/grafana/provisioning/dashboards/bms-overview.json
@@ -1,0 +1,891 @@
+{
+  "__inputs": [],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "influxdb", "name": "InfluxDB", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "gauge", "name": "Gauge", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "table", "name": "Table", "version": "" }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Surveillance temps réel des batteries Daly BMS (LiFePO4) via InfluxDB 2.x",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Vue d'ensemble",
+      "type": "row"
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "min": 0, "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "orange", "value": 15 },
+              { "color": "yellow", "value": 25 },
+              { "color": "green",  "value": 40 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": { "titleSize": 14, "valueSize": 32 }
+      },
+      "pluginVersion": "10.4.0",
+      "title": "SOC par BMS (%)",
+      "type": "gauge",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: -2m)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"soc\")\n  |> last()\n  |> rename(columns: {address: \"BMS\"})",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "yellow", "value": 46 },
+              { "color": "green",  "value": 50 },
+              { "color": "orange", "value": 57 }
+            ]
+          },
+          "unit": "volt",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "title": "Tension Pack",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: -2m)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"voltage\")\n  |> last()",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue",   "value": null },
+              { "color": "green",  "value": -0.5 },
+              { "color": "orange", "value": 50 },
+              { "color": "red",    "value": 80 }
+            ]
+          },
+          "unit": "amp",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "title": "Courant (+ charge / - décharge)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: -2m)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current\")\n  |> last()",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 2000 },
+              { "color": "red",    "value": 4000 }
+            ]
+          },
+          "unit": "watt",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "title": "Puissance",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: -2m)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"power\")\n  |> last()",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "orange", "value": 35 },
+              { "color": "red",    "value": 45 }
+            ]
+          },
+          "unit": "celsius",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 5 },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "title": "Température max cellules",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: -2m)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp_max\")\n  |> last()",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "orange", "value": 30 },
+              { "color": "red",    "value": 80 }
+            ]
+          },
+          "unit": "mvolt",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 5 },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "title": "Delta cellules (déséquilibre)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: -2m)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"cell_delta_mv\")\n  |> last()",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red",   "index": 0, "text": "BLOQUÉ" },
+                           "1": { "color": "green", "index": 1, "text": "OK"     } },
+              "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",   "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 5 },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "title": "MOS Charge / Décharge",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: -2m)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"charge_mos\" or r[\"_field\"] == \"discharge_mos\")\n  |> last()\n  |> pivot(rowKey: [\"address\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 101,
+      "title": "Séries temporelles",
+      "type": "row"
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "min": 0, "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red",   "value": 80 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "min"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "SOC (%) — historique",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"soc\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "line", "steps": [{"color": "orange", "value": 57}, {"color": "red", "value": 58}] }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 57 },
+              { "color": "red", "value": 58 }
+            ]
+          },
+          "unit": "volt",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "min", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Tension Pack (V)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"voltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red",   "value": 80 }
+            ]
+          },
+          "unit": "amp",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "min", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Courant (A) — positif=charge, négatif=décharge",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red",   "value": 80 }
+            ]
+          },
+          "unit": "watt",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "id": 13,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "min", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Puissance (W)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"power\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 },
+      "id": 102,
+      "title": "Cellules & Températures",
+      "type": "row"
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "line+area" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "red", "value": 3.62 },
+              { "color": "transparent", "value": 2.95 }
+            ]
+          },
+          "unit": "volt",
+          "decimals": 3,
+          "min": 2.8,
+          "max": 3.7
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 27 },
+      "id": 20,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Tensions individuelles des cellules (V)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_cell_voltage\")\n  |> filter(fn: (r) => r[\"_field\"] == \"voltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({ r with _field: r.address + \"/\" + r.cell }))\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "line+area" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "orange", "value": 30 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "mvolt",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
+      "id": 21,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Delta cellules — déséquilibre (mV)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"cell_delta_mv\")\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> yield(name: \"max\")",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "line+area" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "orange", "value": 35 },
+              { "color": "red", "value": 45 }
+            ]
+          },
+          "unit": "celsius",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
+      "id": 22,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Températures (°C)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp_max\" or r[\"_field\"] == \"temp_min\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({ r with _field: r.address + \"/\" + r._field }))\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
+      "id": 103,
+      "title": "Capacité & Santé",
+      "type": "row"
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }]
+          },
+          "unit": "watth",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
+      "id": 30,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Capacité restante (Ah)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"capacity\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 46 },
+      "id": 31,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Alarmes actives (0=OK, 1=Alerte)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> filter(fn: (r) => r[\"_field\"] == \"any_alarm\")\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> yield(name: \"max\")",
+          "refId": "A"
+        }
+      ]
+    }
+
+  ],
+
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "tags": ["dalybms", "lifepo4", "battery", "iot"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "influxdb", "uid": "influxdb-dalybms" },
+        "definition": "from(bucket: v.defaultBucket)\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> keep(columns: [\"address\"])\n  |> distinct(column: \"address\")",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "bms_address",
+        "options": [],
+        "query": "from(bucket: v.defaultBucket)\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"bms_status\")\n  |> keep(columns: [\"address\"])\n  |> distinct(column: \"address\")",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query",
+        "label": "BMS Address"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "DalyBMS — Vue d'ensemble",
+  "uid": "dalybms-overview-v1",
+  "version": 1
+}

--- a/grafana/provisioning/dashboards/provider.yaml
+++ b/grafana/provisioning/dashboards/provider.yaml
@@ -1,0 +1,19 @@
+# =============================================================================
+# Grafana — Provisioning dashboards provider
+# =============================================================================
+# Grafana charge automatiquement tous les .json du dossier /dashboards/
+
+apiVersion: 1
+
+providers:
+  - name: DalyBMS
+    orgId: 1
+    folder: DalyBMS
+    folderUid: dalybms-folder
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/grafana/provisioning/datasources/influxdb.yaml
+++ b/grafana/provisioning/datasources/influxdb.yaml
@@ -1,0 +1,26 @@
+# =============================================================================
+# Grafana — Provisioning datasource InfluxDB 2.x (Flux)
+# =============================================================================
+# Ce fichier est monté en lecture seule dans /etc/grafana/provisioning/datasources/
+# Les variables ${...} sont résolues depuis les variables d'environnement Grafana.
+
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB-DalyBMS
+    type: influxdb
+    uid: influxdb-dalybms
+    access: proxy
+    url: http://dalybms-influxdb:8086
+    isDefault: true
+    editable: false
+
+    jsonData:
+      version: Flux
+      organization: ${INFLUX_ORG:-santuario}
+      defaultBucket: ${INFLUX_BUCKET:-daly_bms}
+      # Timeout des requêtes Flux (secondes)
+      timeInterval: "10s"
+
+    secureJsonData:
+      token: ${INFLUX_TOKEN}


### PR DESCRIPTION
Services :
- Mosquitto 2.0.18 (MQTT broker avec config custom)
- InfluxDB 2.7.10 (base temporelle, init auto via env)
- Grafana 11.6.0 (provisioning automatique datasource + dashboard)
- daly-bms-server (image Rust, mode --simulate par défaut)
- Node-RED 4.0.2 (automatisation MQTT)

Fichiers ajoutés :
- Dockerfile : build multi-stage Rust (cache deps + runtime slim)
- docker-compose.yml : stack complète avec réseau interne + volumes nommés
- docker/mosquitto/config/mosquitto.conf : MQTT + WebSocket sur 9001
- grafana/provisioning/datasources/influxdb.yaml : Flux / InfluxDB 2.x
- grafana/provisioning/dashboards/provider.yaml : chargement auto des JSON
- grafana/provisioning/dashboards/bms-overview.json : dashboard complet (SOC gauge, tensions, courant, puissance, cellules, températures, alarmes)
- .env.docker : template des variables d'environnement

Dashboard Grafana : 6 panneaux stat + 7 séries temporelles + 1 gauge
Queries Flux couvrant : bms_status + bms_cell_voltage measurements

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme