### PR TITLE
feat(dashboard): add SSR dashboard — Askama + ECharts (Option A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +297,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -525,6 +578,7 @@ name = "daly-bms-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "askama",
  "axum",
  "bytes",
  "chrono",
@@ -1036,6 +1090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,7 +1515,7 @@ dependencies = [
  "idna",
  "mime",
  "native-tls",
- "nom",
+ "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
  "socket2 0.6.3",
@@ -1466,6 +1529,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1542,6 +1611,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1699,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2950,6 +3045,12 @@ checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -35,3 +35,4 @@ chrono         = { workspace = true }
 uuid           = { workspace = true }
 futures        = { workspace = true }
 bytes          = { workspace = true }
+askama         = "0.12"

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -5,6 +5,7 @@
 pub mod system;
 pub mod bms;
 
+use crate::dashboard;
 use crate::state::AppState;
 use axum::{
     Router,
@@ -21,6 +22,9 @@ pub fn build_router(state: AppState) -> Router {
         .allow_headers(Any);
 
     Router::new()
+        // ── Dashboard HTML ────────────────────────────────────────────────────
+        .merge(dashboard::build_dashboard_router())
+
         // ── Système ─────────────────────────────────────────────────────────
         .route("/api/v1/system/status",  get(system::get_status))
         .route("/api/v1/config",         get(system::get_config))

--- a/crates/daly-bms-server/src/dashboard/charts.rs
+++ b/crates/daly-bms-server/src/dashboard/charts.rs
@@ -1,0 +1,389 @@
+//! Générateurs d'options ECharts côté serveur (Rust → JSON → template HTML).
+//!
+//! Chaque fonction retourne une `String` JSON représentant un objet `option`
+//! ECharts complet, prêt à être injecté dans `echarts.setOption(...)`.
+//!
+//! Le rendu graphique est assuré par la bibliothèque ECharts (JS) côté navigateur ;
+//! Rust ne fait que construire la configuration, sans aucune dépendance JS.
+
+use daly_bms_core::types::BmsSnapshot;
+use std::collections::BTreeMap;
+
+// ─── Palette couleurs (dark theme GitHub-like) ───────────────────────────────
+const C_BG:      &str = "transparent";
+const C_MUTED:   &str = "#8b949e";
+const C_GRID:    &str = "#21262d";
+const C_AXIS:    &str = "#30363d";
+const C_BLUE:    &str = "#58a6ff";
+const C_GREEN:   &str = "#3fb950";
+const C_YELLOW:  &str = "#d29922";
+const C_RED:     &str = "#f85149";
+const C_ORANGE:  &str = "#fb8500";
+
+// =============================================================================
+// Jauge SOC (page d'accueil — mini, et détail — grande)
+// =============================================================================
+
+/// Génère l'option ECharts pour une jauge SOC.
+/// `size` indique le style : "mini" pour les cartes, "full" pour le détail.
+pub fn soc_gauge(soc: f32, size: &str) -> String {
+    let font_size  = if size == "full" { 36 } else { 22 };
+    let title_size = if size == "full" { 13  } else { 10 };
+    let radius     = if size == "full" { "88%" } else { "85%" };
+    let line_width = if size == "full" { 16 } else { 10 };
+
+    // Couleur de la valeur selon seuils SOC
+    let color = match soc as u32 {
+        0..=14  => C_RED,
+        15..=24 => C_ORANGE,
+        25..=39 => C_YELLOW,
+        _       => C_GREEN,
+    };
+
+    format!(r#"{{
+  "backgroundColor": "{bg}",
+  "series": [{{
+    "type": "gauge",
+    "startAngle": 205,
+    "endAngle": -25,
+    "min": 0,
+    "max": 100,
+    "splitNumber": 5,
+    "radius": "{radius}",
+    "center": ["50%", "55%"],
+    "axisLine": {{
+      "lineStyle": {{
+        "width": {lw},
+        "color": [
+          [0.15, "{c_red}"],
+          [0.25, "{c_orange}"],
+          [0.40, "{c_yellow}"],
+          [1.00, "{c_green}"]
+        ]
+      }}
+    }},
+    "pointer": {{
+      "show": true,
+      "length": "58%",
+      "width": 4,
+      "itemStyle": {{ "color": "auto" }}
+    }},
+    "axisTick":  {{ "show": false }},
+    "splitLine": {{ "show": false }},
+    "axisLabel": {{ "show": false }},
+    "detail": {{
+      "valueAnimation": true,
+      "formatter": "{{value}}%",
+      "color":     "{c_val}",
+      "fontSize":  {fs},
+      "fontWeight": "bold",
+      "offsetCenter": [0, "20%"]
+    }},
+    "title": {{
+      "color":        "{c_title}",
+      "fontSize":     {ts},
+      "offsetCenter": [0, "50%"]
+    }},
+    "data": [{{"value": {soc:.1}, "name": "SOC"}}]
+  }}]
+}}"#,
+        bg      = C_BG,
+        radius  = radius,
+        lw      = line_width,
+        c_red   = C_RED,
+        c_orange= C_ORANGE,
+        c_yellow= C_YELLOW,
+        c_green = C_GREEN,
+        c_val   = color,
+        c_title = C_MUTED,
+        fs      = font_size,
+        ts      = title_size,
+        soc     = soc,
+    )
+}
+
+// =============================================================================
+// Barres — tensions des cellules
+// =============================================================================
+
+/// Génère l'option ECharts pour le graphe de tensions des cellules (bar chart).
+pub fn cell_voltages_bar(voltages: &BTreeMap<String, f32>) -> String {
+    let labels: Vec<String> = voltages.keys()
+        .map(|k| {
+            // "Cell1" → "C1"
+            let n = k.trim_start_matches("Cell");
+            format!("\"C{}\"", n)
+        })
+        .collect();
+
+    let values: Vec<String> = voltages.values()
+        .map(|&v| {
+            // Colorier en rouge si hors plage normale (< 2.95V ou > 3.62V)
+            let color = if v < 2.95 || v > 3.62 { C_RED }
+                        else if (v - voltages.values().cloned()
+                            .fold(f32::INFINITY, f32::min)).abs() < 0.001 { C_YELLOW }
+                        else { C_BLUE };
+            format!(r#"{{"value": {:.3}, "itemStyle": {{"color": "{}"}}}}"#, v, color)
+        })
+        .collect();
+
+    format!(r#"{{
+  "backgroundColor": "{bg}",
+  "animation": false,
+  "grid": {{ "left": "2%", "right": "2%", "top": "8%", "bottom": "12%", "containLabel": true }},
+  "xAxis": {{
+    "type":      "category",
+    "data":      [{labels}],
+    "axisLabel": {{ "color": "{muted}", "fontSize": 9 }},
+    "axisLine":  {{ "lineStyle": {{ "color": "{axis}" }} }}
+  }},
+  "yAxis": {{
+    "type":      "value",
+    "min":       2.9,
+    "max":       3.7,
+    "splitNumber": 4,
+    "axisLabel": {{ "color": "{muted}", "formatter": "{{value}}V", "fontSize": 9 }},
+    "splitLine": {{ "lineStyle": {{ "color": "{grid}", "type": "dashed" }} }}
+  }},
+  "series": [{{
+    "type": "bar",
+    "data": [{values}],
+    "barMaxWidth": 20,
+    "itemStyle": {{ "borderRadius": [3, 3, 0, 0] }},
+    "markLine": {{
+      "silent": true,
+      "symbol": "none",
+      "data": [
+        {{ "yAxis": 2.95, "lineStyle": {{ "color": "{red}",    "type": "dashed" }}, "label": {{ "show": false }} }},
+        {{ "yAxis": 3.62, "lineStyle": {{ "color": "{red}",    "type": "dashed" }}, "label": {{ "show": false }} }},
+        {{ "yAxis": 3.40, "lineStyle": {{ "color": "{yellow}", "type": "dotted" }}, "label": {{ "show": false }} }}
+      ]
+    }}
+  }}]
+}}"#,
+        bg     = C_BG,
+        labels = labels.join(", "),
+        values = values.join(", "),
+        muted  = C_MUTED,
+        axis   = C_AXIS,
+        grid   = C_GRID,
+        red    = C_RED,
+        yellow = C_YELLOW,
+    )
+}
+
+// =============================================================================
+// Lignes — historique SOC + courant
+// =============================================================================
+
+/// Données d'historique extraites de la série de snapshots.
+pub struct HistoryData {
+    pub timestamps: Vec<String>,
+    pub soc:        Vec<f32>,
+    pub current:    Vec<f32>,
+    pub voltage:    Vec<f32>,
+    pub temp_max:   Vec<f32>,
+}
+
+impl HistoryData {
+    /// Construit depuis une liste de snapshots (ordre chronologique, du plus ancien au plus récent).
+    pub fn from_snapshots(snaps: &[BmsSnapshot]) -> Self {
+        let mut timestamps = Vec::with_capacity(snaps.len());
+        let mut soc        = Vec::with_capacity(snaps.len());
+        let mut current    = Vec::with_capacity(snaps.len());
+        let mut voltage    = Vec::with_capacity(snaps.len());
+        let mut temp_max   = Vec::with_capacity(snaps.len());
+
+        for s in snaps {
+            timestamps.push(s.timestamp.format("%H:%M:%S").to_string());
+            soc.push(s.soc);
+            current.push(s.dc.current);
+            voltage.push(s.dc.voltage);
+            temp_max.push(s.system.max_cell_temperature);
+        }
+        Self { timestamps, soc, current, voltage, temp_max }
+    }
+}
+
+/// Génère l'option ECharts pour l'historique SOC (line chart avec aire).
+pub fn soc_history_line(data: &HistoryData) -> String {
+    let ts_json  = json_str_array(&data.timestamps);
+    let soc_json = json_f32_array(&data.soc);
+
+    format!(r#"{{
+  "backgroundColor": "{bg}",
+  "animation": false,
+  "grid": {{ "left": "3%", "right": "2%", "top": "8%", "bottom": "18%", "containLabel": true }},
+  "xAxis": {{
+    "type":      "category",
+    "data":      {ts},
+    "axisLabel": {{ "color": "{muted}", "fontSize": 8, "rotate": 30, "interval": "auto" }},
+    "axisLine":  {{ "lineStyle": {{ "color": "{axis}" }} }}
+  }},
+  "yAxis": {{
+    "type":      "value",
+    "min":       0,
+    "max":       100,
+    "axisLabel": {{ "color": "{muted}", "formatter": "{{value}}%", "fontSize": 9 }},
+    "splitLine": {{ "lineStyle": {{ "color": "{grid}", "type": "dashed" }} }}
+  }},
+  "series": [{{
+    "type":   "line",
+    "data":   {soc},
+    "smooth": true,
+    "symbol": "none",
+    "lineStyle": {{ "color": "{green}", "width": 2 }},
+    "areaStyle": {{
+      "color": {{
+        "type": "linear", "x": 0, "y": 0, "x2": 0, "y2": 1,
+        "colorStops": [
+          {{ "offset": 0, "color": "rgba(63,185,80,0.35)" }},
+          {{ "offset": 1, "color": "rgba(63,185,80,0.02)" }}
+        ]
+      }}
+    }}
+  }}],
+  "dataZoom": [{{ "type": "inside" }}, {{ "type": "slider", "height": 16, "bottom": 0 }}]
+}}"#,
+        bg    = C_BG,
+        ts    = ts_json,
+        soc   = soc_json,
+        muted = C_MUTED,
+        axis  = C_AXIS,
+        grid  = C_GRID,
+        green = C_GREEN,
+    )
+}
+
+/// Génère l'option ECharts pour l'historique courant (+ charge, - décharge).
+pub fn current_history_line(data: &HistoryData) -> String {
+    let ts_json      = json_str_array(&data.timestamps);
+    let current_json = json_f32_array(&data.current);
+
+    format!(r#"{{
+  "backgroundColor": "{bg}",
+  "animation": false,
+  "grid": {{ "left": "3%", "right": "2%", "top": "8%", "bottom": "18%", "containLabel": true }},
+  "xAxis": {{
+    "type":      "category",
+    "data":      {ts},
+    "axisLabel": {{ "color": "{muted}", "fontSize": 8, "rotate": 30, "interval": "auto" }},
+    "axisLine":  {{ "lineStyle": {{ "color": "{axis}" }} }}
+  }},
+  "yAxis": {{
+    "type":      "value",
+    "axisLabel": {{ "color": "{muted}", "formatter": "{{value}}A", "fontSize": 9 }},
+    "splitLine": {{ "lineStyle": {{ "color": "{grid}", "type": "dashed" }} }}
+  }},
+  "series": [{{
+    "type":   "line",
+    "data":   {cur},
+    "smooth": true,
+    "symbol": "none",
+    "lineStyle": {{ "color": "{blue}", "width": 2 }},
+    "markLine": {{
+      "silent": true,
+      "symbol": "none",
+      "data": [{{ "yAxis": 0, "lineStyle": {{ "color": "{muted}", "type": "dashed" }} }}]
+    }}
+  }}],
+  "dataZoom": [{{ "type": "inside" }}, {{ "type": "slider", "height": 16, "bottom": 0 }}]
+}}"#,
+        bg    = C_BG,
+        ts    = ts_json,
+        cur   = current_json,
+        muted = C_MUTED,
+        axis  = C_AXIS,
+        grid  = C_GRID,
+        blue  = C_BLUE,
+    )
+}
+
+/// Génère l'option ECharts pour l'historique tension + température (double axe Y).
+pub fn voltage_temp_line(data: &HistoryData) -> String {
+    let ts_json   = json_str_array(&data.timestamps);
+    let volt_json = json_f32_array(&data.voltage);
+    let temp_json = json_f32_array(&data.temp_max);
+
+    format!(r#"{{
+  "backgroundColor": "{bg}",
+  "animation": false,
+  "legend": {{
+    "data": ["Tension (V)", "Temp max (°C)"],
+    "textStyle": {{ "color": "{muted}", "fontSize": 10 }},
+    "top": 0
+  }},
+  "grid": {{ "left": "3%", "right": "5%", "top": "18%", "bottom": "18%", "containLabel": true }},
+  "xAxis": {{
+    "type":      "category",
+    "data":      {ts},
+    "axisLabel": {{ "color": "{muted}", "fontSize": 8, "rotate": 30, "interval": "auto" }},
+    "axisLine":  {{ "lineStyle": {{ "color": "{axis}" }} }}
+  }},
+  "yAxis": [
+    {{
+      "type":      "value",
+      "name":      "V",
+      "nameTextStyle": {{ "color": "{muted}", "fontSize": 9 }},
+      "axisLabel": {{ "color": "{muted}", "formatter": "{{value}}V", "fontSize": 9 }},
+      "splitLine": {{ "lineStyle": {{ "color": "{grid}", "type": "dashed" }} }}
+    }},
+    {{
+      "type":      "value",
+      "name":      "°C",
+      "nameTextStyle": {{ "color": "{muted}", "fontSize": 9 }},
+      "axisLabel": {{ "color": "{muted}", "formatter": "{{value}}°C", "fontSize": 9 }},
+      "splitLine": {{ "show": false }}
+    }}
+  ],
+  "series": [
+    {{
+      "name":   "Tension (V)",
+      "type":   "line",
+      "yAxisIndex": 0,
+      "data":   {volt},
+      "smooth": true,
+      "symbol": "none",
+      "lineStyle": {{ "color": "{blue}", "width": 2 }}
+    }},
+    {{
+      "name":   "Temp max (°C)",
+      "type":   "line",
+      "yAxisIndex": 1,
+      "data":   {temp},
+      "smooth": true,
+      "symbol": "none",
+      "lineStyle": {{ "color": "{orange}", "width": 2 }}
+    }}
+  ],
+  "dataZoom": [{{ "type": "inside" }}, {{ "type": "slider", "height": 16, "bottom": 0 }}]
+}}"#,
+        bg     = C_BG,
+        ts     = ts_json,
+        volt   = volt_json,
+        temp   = temp_json,
+        muted  = C_MUTED,
+        axis   = C_AXIS,
+        grid   = C_GRID,
+        blue   = C_BLUE,
+        orange = C_ORANGE,
+    )
+}
+
+// =============================================================================
+// Utilitaires de sérialisation JSON
+// =============================================================================
+
+fn json_str_array(v: &[String]) -> String {
+    let inner: Vec<String> = v.iter()
+        .map(|s| format!("\"{}\"", s.replace('"', "\\\"")))
+        .collect();
+    format!("[{}]", inner.join(","))
+}
+
+fn json_f32_array(v: &[f32]) -> String {
+    let inner: Vec<String> = v.iter()
+        .map(|f| format!("{:.3}", f))
+        .collect();
+    format!("[{}]", inner.join(","))
+}

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -1,0 +1,269 @@
+//! Dashboard web — serveur de pages HTML + assets.
+//!
+//! Stack : Axum (SSR) + Askama (templates compilés) + Apache ECharts (JS côté navigateur).
+//! Aucune dépendance npm / React / Node.js — binaire unique auto-suffisant.
+//!
+//! Routes exposées :
+//! - `GET /`                   → redirect vers /dashboard
+//! - `GET /dashboard`          → vue d'ensemble de tous les BMS
+//! - `GET /dashboard/bms/:id`  → détail complet d'un BMS
+
+pub mod charts;
+
+use crate::state::AppState;
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{Html, IntoResponse, Redirect, Response},
+    routing::get,
+    Router,
+};
+use daly_bms_core::types::BmsSnapshot;
+use std::sync::atomic::Ordering;
+use tracing::error;
+
+// =============================================================================
+// Filtres Askama pour le formatage des nombres
+// =============================================================================
+
+mod filters {
+    /// Formate un f32 avec 1 décimale : 52.1
+    pub fn f1(v: &f32) -> ::askama::Result<String> {
+        Ok(format!("{:.1}", v))
+    }
+    /// Formate un f32 sans décimale : 1234
+    pub fn f0(v: &f32) -> ::askama::Result<String> {
+        Ok(format!("{:.0}", v))
+    }
+    /// Formate un f32 avec 3 décimales : 3.405
+    pub fn f3(v: &f32) -> ::askama::Result<String> {
+        Ok(format!("{:.3}", v))
+    }
+    /// Formate un courant avec signe : +12.3 ou -8.5
+    pub fn sign(v: &f32) -> ::askama::Result<String> {
+        if *v >= 0.0 {
+            Ok(format!("+{:.1}", v))
+        } else {
+            Ok(format!("{:.1}", v))
+        }
+    }
+    /// Formate un f32 en millivolts (×1000, 0 décimales) : "23 mV"
+    pub fn mv(v: &f32) -> ::askama::Result<String> {
+        Ok(format!("{:.0}", v))
+    }
+    /// "s" si n ≠ 1, "" sinon
+    pub fn pluralize(v: &usize) -> ::askama::Result<String> {
+        Ok(if *v == 1 { String::new() } else { "s".to_string() })
+    }
+}
+
+// =============================================================================
+// Helpers de rendu
+// =============================================================================
+
+/// Rend un template Askama en réponse HTTP, ou 500 en cas d'erreur.
+fn render<T: Template>(t: T) -> Response {
+    match t.render() {
+        Ok(html) => Html(html).into_response(),
+        Err(e) => {
+            error!("Template render error: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+/// Parse une adresse BMS depuis un segment de chemin ("1", "0x01", "01").
+fn parse_addr(s: &str) -> Option<u8> {
+    let s = s.trim();
+    if s.starts_with("0x") || s.starts_with("0X") {
+        u8::from_str_radix(&s[2..], 16).ok()
+    } else {
+        s.parse::<u8>().ok()
+    }
+}
+
+// =============================================================================
+// Structures de données pour les templates
+// =============================================================================
+
+/// Résumé d'un BMS pour la carte de la page d'accueil.
+#[derive(Debug, Clone)]
+pub struct BmsSummary {
+    pub address:        u8,
+    pub address_hex:    String,   // "0x01"
+    pub soc:            f32,
+    pub voltage:        f32,
+    pub current:        f32,
+    pub power:          f32,
+    pub temp_max:       f32,
+    pub cell_delta_mv:  f32,
+    pub capacity_ah:    f32,
+    pub any_alarm:      bool,
+    pub charge_ok:      bool,
+    pub discharge_ok:   bool,
+    pub last_update:    String,   // "HH:MM:SS"
+    pub soc_gauge_json: String,   // option ECharts (JSON brut)
+}
+
+impl BmsSummary {
+    fn from_snapshot(snap: &BmsSnapshot) -> Self {
+        let delta = (snap.system.max_cell_voltage - snap.system.min_cell_voltage) * 1000.0;
+        Self {
+            address:        snap.address,
+            address_hex:    format!("{:#04x}", snap.address),
+            soc:            snap.soc,
+            voltage:        snap.dc.voltage,
+            current:        snap.dc.current,
+            power:          snap.dc.power,
+            temp_max:       snap.system.max_cell_temperature,
+            cell_delta_mv:  delta,
+            capacity_ah:    snap.capacity,
+            any_alarm:      snap.alarms.any_active(),
+            charge_ok:      snap.io.allow_to_charge  != 0,
+            discharge_ok:   snap.io.allow_to_discharge != 0,
+            last_update:    snap.timestamp.format("%H:%M:%S").to_string(),
+            soc_gauge_json: charts::soc_gauge(snap.soc, "mini"),
+        }
+    }
+}
+
+/// Ligne d'alarme pour le tableau de la page détail.
+#[derive(Debug, Clone)]
+pub struct AlarmRow {
+    pub name:   &'static str,
+    pub active: bool,
+}
+
+fn build_alarms(snap: &BmsSnapshot) -> Vec<AlarmRow> {
+    let a = &snap.alarms;
+    vec![
+        AlarmRow { name: "Sur-tension pack",          active: a.high_voltage != 0 },
+        AlarmRow { name: "Sous-tension pack",          active: a.low_voltage  != 0 },
+        AlarmRow { name: "Cellule sous-tension",       active: a.low_cell_voltage != 0 },
+        AlarmRow { name: "SOC bas",                    active: a.low_soc != 0 },
+        AlarmRow { name: "Sur-temp. charge",           active: a.high_charge_temperature != 0 },
+        AlarmRow { name: "Sous-temp. charge",          active: a.low_charge_temperature  != 0 },
+        AlarmRow { name: "Sur-température",            active: a.high_temperature != 0 },
+        AlarmRow { name: "Sous-température",           active: a.low_temperature  != 0 },
+        AlarmRow { name: "Sur-courant charge",         active: a.high_charge_current    != 0 },
+        AlarmRow { name: "Sur-courant décharge",       active: a.high_discharge_current != 0 },
+        AlarmRow { name: "Déséquilibre cellules",      active: a.cell_imbalance != 0 },
+        AlarmRow { name: "Fusible grillé",             active: a.fuse_blown != 0 },
+    ]
+}
+
+/// Détails complets pour la page d'un BMS.
+pub struct BmsDetail {
+    pub summary:              BmsSummary,
+    // Infos cellules
+    pub cell_count:           u8,
+    pub min_cell_v:           f32,
+    pub max_cell_v:           f32,
+    pub min_cell_id:          String,
+    pub max_cell_id:          String,
+    // Infos état batterie
+    pub soh:                  f32,
+    pub cycles:               u32,
+    pub time_to_go_h:         f32,
+    // Alarmes
+    pub alarms:               Vec<AlarmRow>,
+    // Options ECharts (JSON brut, injectés dans <script>)
+    pub soc_gauge_json:       String,
+    pub cells_bar_json:       String,
+    pub soc_history_json:     String,
+    pub current_history_json: String,
+    pub volt_temp_json:       String,
+}
+
+// =============================================================================
+// Templates Askama
+// =============================================================================
+
+#[derive(Template)]
+#[template(path = "index.html")]
+struct IndexTemplate {
+    polling:   bool,
+    bms_count: usize,
+    bms_list:  Vec<BmsSummary>,
+}
+
+#[derive(Template)]
+#[template(path = "bms_detail.html")]
+struct DetailTemplate {
+    detail: BmsDetail,
+}
+
+// =============================================================================
+// Handlers Axum
+// =============================================================================
+
+/// Redirige `/` → `/dashboard`.
+pub async fn redirect_root() -> Redirect {
+    Redirect::temporary("/dashboard")
+}
+
+/// Page d'accueil — vue d'ensemble de tous les BMS.
+pub async fn dashboard_index(State(state): State<AppState>) -> Response {
+    let polling  = state.polling_active.load(Ordering::Relaxed);
+    let snaps    = state.latest_snapshots().await;
+    let bms_list = snaps.iter().map(BmsSummary::from_snapshot).collect();
+
+    render(IndexTemplate { polling, bms_count: snaps.len(), bms_list })
+}
+
+/// Page de détail d'un BMS.
+pub async fn dashboard_bms(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Response {
+    let addr = match parse_addr(&id) {
+        Some(a) => a,
+        None    => return StatusCode::BAD_REQUEST.into_response(),
+    };
+    let snap = match state.latest_for(addr).await {
+        Some(s) => s,
+        None    => return (StatusCode::NOT_FOUND, "BMS non trouvé").into_response(),
+    };
+
+    // Historique : 300 derniers snapshots (≈ 5 min à 1 Hz), remis en ordre chronologique
+    let mut history = state.history_for(addr, 300).await;
+    history.reverse();
+
+    let hist_data    = charts::HistoryData::from_snapshots(&history);
+    let time_to_go_h = if snap.dc.current < -0.5 {
+        snap.time_to_go as f32 / 3600.0
+    } else { 0.0 };
+
+    let detail = BmsDetail {
+        summary:              BmsSummary::from_snapshot(&snap),
+        cell_count:           snap.system.nr_of_cells_per_battery,
+        min_cell_v:           snap.system.min_cell_voltage,
+        max_cell_v:           snap.system.max_cell_voltage,
+        min_cell_id:          snap.system.min_voltage_cell_id.clone(),
+        max_cell_id:          snap.system.max_voltage_cell_id.clone(),
+        soh:                  snap.soh,
+        cycles:               snap.history.charge_cycles,
+        time_to_go_h,
+        alarms:               build_alarms(&snap),
+        soc_gauge_json:       charts::soc_gauge(snap.soc, "full"),
+        cells_bar_json:       charts::cell_voltages_bar(&snap.voltages),
+        soc_history_json:     charts::soc_history_line(&hist_data),
+        current_history_json: charts::current_history_line(&hist_data),
+        volt_temp_json:       charts::voltage_temp_line(&hist_data),
+    };
+
+    render(DetailTemplate { detail })
+}
+
+// =============================================================================
+// Routeur du dashboard
+// =============================================================================
+
+/// Construit le routeur du dashboard (à fusionner dans le routeur principal).
+pub fn build_dashboard_router() -> Router<AppState> {
+    Router::new()
+        .route("/",                  get(redirect_root))
+        .route("/dashboard",         get(dashboard_index))
+        .route("/dashboard/bms/:id", get(dashboard_bms))
+}

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -18,6 +18,7 @@ mod state;
 mod api;
 mod bridges;
 mod simulator;
+mod dashboard;
 
 use crate::bridges::{alerts, influx, mqtt};
 use crate::config::AppConfig;

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -1,0 +1,408 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}DalyBMS{% endblock %}</title>
+  <style>
+    /* ─── Variables ───────────────────────────────────────────────────── */
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --surface2: #21262d;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #58a6ff;
+      --green:    #3fb950;
+      --yellow:   #d29922;
+      --orange:   #fb8500;
+      --red:      #f85149;
+      --radius:   8px;
+      --shadow:   0 4px 16px rgba(0,0,0,0.4);
+    }
+
+    /* ─── Reset & Base ────────────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { font-size: 14px; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* ─── Nav ─────────────────────────────────────────────────────────── */
+    .nav {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      padding: 0.75rem 1.5rem;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+    .nav-brand {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      letter-spacing: -0.3px;
+    }
+    .nav-brand span { color: var(--accent); }
+    .nav-links { display: flex; gap: 1rem; flex: 1; }
+    .nav-links a {
+      color: var(--muted);
+      font-size: 0.875rem;
+      padding: 0.25rem 0.5rem;
+      border-radius: 4px;
+      transition: background 0.15s, color 0.15s;
+    }
+    .nav-links a:hover, .nav-links a.active {
+      color: var(--text);
+      background: var(--surface2);
+      text-decoration: none;
+    }
+    .nav-status {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+    .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--muted);
+    }
+    .dot.active { background: var(--green); animation: pulse 2s infinite; }
+    .dot.alarm  { background: var(--red);   animation: pulse 1s infinite; }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: 0.3; }
+    }
+
+    /* ─── Main ────────────────────────────────────────────────────────── */
+    main {
+      flex: 1;
+      padding: 1.5rem;
+      max-width: 1600px;
+      width: 100%;
+      margin: 0 auto;
+    }
+
+    /* ─── Cards ───────────────────────────────────────────────────────── */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+      box-shadow: var(--shadow);
+    }
+    .card-title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+    }
+
+    /* ─── Grille BMS (overview) ───────────────────────────────────────── */
+    .bms-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+      gap: 1rem;
+    }
+
+    /* ─── Carte BMS ───────────────────────────────────────────────────── */
+    .bms-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+      box-shadow: var(--shadow);
+      transition: border-color 0.2s;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+    .bms-card:hover { border-color: var(--accent); }
+    .bms-card.alarm { border-color: var(--red); }
+
+    .bms-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .bms-addr {
+      font-size: 1rem;
+      font-weight: 700;
+      font-family: monospace;
+      color: var(--accent);
+    }
+    .bms-time {
+      font-size: 0.7rem;
+      color: var(--muted);
+    }
+
+    /* ─── Layout gauge + stats ────────────────────────────────────────── */
+    .bms-body {
+      display: grid;
+      grid-template-columns: 140px 1fr;
+      gap: 0.75rem;
+      align-items: center;
+    }
+    .gauge-wrap { height: 130px; }
+
+    /* ─── Stats horizontaux ───────────────────────────────────────────── */
+    .stats-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.4rem 0.75rem;
+    }
+    .stat { display: flex; flex-direction: column; }
+    .stat-label { font-size: 0.65rem; color: var(--muted); text-transform: uppercase; }
+    .stat-value { font-size: 0.95rem; font-weight: 600; font-family: monospace; }
+    .stat-value.pos { color: var(--green); }
+    .stat-value.neg { color: var(--accent); }
+    .stat-value.warn{ color: var(--yellow); }
+    .stat-value.err { color: var(--red); }
+
+    /* ─── Badges ──────────────────────────────────────────────────────── */
+    .badge {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 20px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+    }
+    .badge.ok     { background: rgba(63,185,80,0.15);  color: var(--green); }
+    .badge.warn   { background: rgba(210,153,34,0.15); color: var(--yellow); }
+    .badge.alarm  { background: rgba(248,81,73,0.2);   color: var(--red); }
+    .badge.off    { background: rgba(139,148,158,0.15); color: var(--muted); }
+
+    .bms-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+    .mos-badges { display: flex; gap: 0.35rem; }
+    .link-detail {
+      font-size: 0.75rem;
+      color: var(--accent);
+      padding: 0.25rem 0.75rem;
+      border: 1px solid var(--accent);
+      border-radius: 4px;
+      transition: background 0.15s;
+    }
+    .link-detail:hover { background: rgba(88,166,255,0.1); text-decoration: none; }
+
+    /* ─── Page Détail ─────────────────────────────────────────────────── */
+    .detail-header {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1.25rem;
+    }
+    .detail-header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      font-family: monospace;
+    }
+    .back-link {
+      font-size: 0.8rem;
+      color: var(--muted);
+      padding: 0.3rem 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+    }
+    .back-link:hover { color: var(--text); text-decoration: none; background: var(--surface2); }
+
+    .detail-grid {
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+    .detail-gauge { height: 200px; }
+
+    .kpi-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 0.75rem;
+    }
+    .kpi {
+      background: var(--surface2);
+      border-radius: var(--radius);
+      padding: 0.75rem 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+    }
+    .kpi-label { font-size: 0.65rem; text-transform: uppercase; color: var(--muted); }
+    .kpi-value {
+      font-size: 1.25rem;
+      font-weight: 700;
+      font-family: monospace;
+    }
+    .kpi-value.green  { color: var(--green); }
+    .kpi-value.blue   { color: var(--accent); }
+    .kpi-value.yellow { color: var(--yellow); }
+    .kpi-value.red    { color: var(--red); }
+    .kpi-value.orange { color: var(--orange); }
+
+    /* ─── Charts ──────────────────────────────────────────────────────── */
+    .chart-section { margin-bottom: 1rem; }
+    .chart-section h3 {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+      margin-bottom: 0.5rem;
+      padding-left: 0.25rem;
+    }
+    .chart-box {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .chart-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    /* ─── Tableau alarmes ─────────────────────────────────────────────── */
+    table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+    thead th {
+      text-align: left;
+      padding: 0.5rem 0.75rem;
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+      font-weight: 600;
+      font-size: 0.7rem;
+      text-transform: uppercase;
+    }
+    tbody td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--surface2); }
+    tbody tr:last-child td { border-bottom: none; }
+    tbody tr:hover { background: var(--surface2); }
+
+    /* ─── Info-bar accueil ────────────────────────────────────────────── */
+    .info-bar {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      margin-bottom: 1.25rem;
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+    .info-bar strong { color: var(--text); }
+
+    /* ─── Footer ──────────────────────────────────────────────────────── */
+    footer {
+      padding: 0.75rem 1.5rem;
+      text-align: center;
+      font-size: 0.7rem;
+      color: var(--muted);
+      border-top: 1px solid var(--border);
+    }
+
+    /* ─── Responsive ──────────────────────────────────────────────────── */
+    @media (max-width: 680px) {
+      main { padding: 0.75rem; }
+      .bms-grid { grid-template-columns: 1fr; }
+      .detail-grid { grid-template-columns: 1fr; }
+      .chart-row { grid-template-columns: 1fr; }
+      .kpi-row { grid-template-columns: repeat(2, 1fr); }
+      .bms-body { grid-template-columns: 120px 1fr; }
+      .gauge-wrap { height: 110px; }
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-brand">⚡ Daly<span>BMS</span></div>
+  <div class="nav-links">
+    <a href="/dashboard">Vue d'ensemble</a>
+    <a href="/api/v1/system/status" target="_blank">API</a>
+  </div>
+  <div class="nav-status" id="ws-status">
+    <div class="dot" id="ws-dot"></div>
+    <span id="ws-label">Connexion…</span>
+  </div>
+</nav>
+
+<main>
+  {% block content %}{% endblock %}
+</main>
+
+<footer>
+  DalyBMS Rust Edition &nbsp;·&nbsp;
+  <a href="/api/v1/system/status">API status</a> &nbsp;·&nbsp;
+  <a href="/ws/bms/stream">WebSocket</a>
+</footer>
+
+<!-- Apache ECharts 5.5 (CDN — remplacer par /static/echarts.min.js pour usage hors-ligne) -->
+<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+
+<script>
+// ─── Client WebSocket temps réel ───────────────────────────────────────────
+(function() {
+  const dot   = document.getElementById('ws-dot');
+  const label = document.getElementById('ws-label');
+
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  const url   = `${proto}://${location.host}/ws/bms/stream`;
+
+  let ws, retryDelay = 2000;
+
+  function connect() {
+    ws = new WebSocket(url);
+
+    ws.onopen = () => {
+      dot.className   = 'dot active';
+      label.textContent = 'Connecté';
+      retryDelay = 2000;
+    };
+
+    ws.onmessage = (ev) => {
+      let snaps;
+      try { snaps = JSON.parse(ev.data); } catch { return; }
+      if (!Array.isArray(snaps)) return;
+      // Dispatcher aux handlers de la page courante
+      if (typeof window.onBmsUpdate === 'function') window.onBmsUpdate(snaps);
+    };
+
+    ws.onclose = () => {
+      dot.className   = 'dot';
+      label.textContent = `Reconnexion dans ${retryDelay/1000}s…`;
+      setTimeout(connect, retryDelay);
+      retryDelay = Math.min(retryDelay * 2, 30000);
+    };
+
+    ws.onerror = () => ws.close();
+  }
+
+  connect();
+})();
+</script>
+
+{% block scripts %}{% endblock %}
+
+</body>
+</html>

--- a/crates/daly-bms-server/templates/bms_detail.html
+++ b/crates/daly-bms-server/templates/bms_detail.html
@@ -1,0 +1,277 @@
+{% extends "base.html" %}
+
+{% block title %}BMS {{ detail.summary.address_hex }} — DalyBMS{% endblock %}
+
+{% block content %}
+
+{# ─── En-tête ─────────────────────────────────────────────────────────────── #}
+<div class="detail-header">
+  <a href="/dashboard" class="back-link">← Retour</a>
+  <h1>BMS {{ detail.summary.address_hex }}</h1>
+  <span class="badge {% if detail.summary.any_alarm %}alarm{% else %}ok{% endif %}" style="font-size:0.85rem">
+    {% if detail.summary.any_alarm %}⚠ ALARME{% else %}✓ Normal{% endif %}
+  </span>
+  <span style="margin-left:auto;font-size:0.75rem;color:var(--muted)">
+    Dernier snapshot : <span id="last-ts">{{ detail.summary.last_update }}</span>
+  </span>
+</div>
+
+{# ─── Ligne 1 : jauge SOC + KPIs ─────────────────────────────────────────── #}
+<div class="detail-grid" style="margin-bottom:1rem">
+
+  {# Jauge #}
+  <div class="card" style="display:flex;align-items:center;justify-content:center;">
+    <div class="detail-gauge" id="soc-gauge" style="width:200px;height:200px"></div>
+  </div>
+
+  {# KPIs #}
+  <div style="display:flex;flex-direction:column;gap:0.75rem">
+    <div class="kpi-row">
+      <div class="kpi">
+        <span class="kpi-label">Tension pack</span>
+        <span class="kpi-value blue" id="kpi-v">{{ detail.summary.voltage|f1 }} V</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">Courant</span>
+        <span class="kpi-value {% if detail.summary.current > 0.0 %}green{% else if detail.summary.current < -0.1 %}blue{% endif %}"
+              id="kpi-i">{{ detail.summary.current|sign }} A</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">Puissance</span>
+        <span class="kpi-value" id="kpi-p">{{ detail.summary.power|f0 }} W</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">Temp. max</span>
+        <span class="kpi-value {% if detail.summary.temp_max > 45.0 %}red{% else if detail.summary.temp_max > 35.0 %}yellow{% endif %}"
+              id="kpi-t">{{ detail.summary.temp_max|f1 }} °C</span>
+      </div>
+    </div>
+
+    <div class="kpi-row">
+      <div class="kpi">
+        <span class="kpi-label">SOC</span>
+        <span class="kpi-value {% if detail.summary.soc < 15.0 %}red{% else if detail.summary.soc < 25.0 %}orange{% else if detail.summary.soc < 40.0 %}yellow{% else %}green{% endif %}"
+              id="kpi-soc">{{ detail.summary.soc|f1 }} %</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">SOH</span>
+        <span class="kpi-value {% if detail.soh < 70.0 %}red{% else if detail.soh < 85.0 %}yellow{% else %}green{% endif %}">
+          {{ detail.soh|f1 }} %</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">Δ cellules</span>
+        <span class="kpi-value {% if detail.summary.cell_delta_mv > 100.0 %}red{% else if detail.summary.cell_delta_mv > 50.0 %}yellow{% endif %}"
+              id="kpi-d">{{ detail.summary.cell_delta_mv|mv }} mV</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">Restant</span>
+        <span class="kpi-value" id="kpi-c">{{ detail.summary.capacity_ah|f1 }} Ah</span>
+      </div>
+    </div>
+
+    <div class="kpi-row">
+      <div class="kpi">
+        <span class="kpi-label">Cycles</span>
+        <span class="kpi-value">{{ detail.cycles }}</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">Autonomie</span>
+        <span class="kpi-value" id="kpi-ttg">
+          {% if detail.time_to_go_h > 0.0 %}{{ detail.time_to_go_h|f1 }} h{% else %}—{% endif %}
+        </span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">Cellules</span>
+        <span class="kpi-value">{{ detail.cell_count }}</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">MOS CHG/DCH</span>
+        <span class="kpi-value" style="font-size:0.9rem">
+          {% if detail.summary.charge_ok %}<span style="color:var(--green)">C✓</span>{% else %}<span style="color:var(--red)">C✗</span>{% endif %}
+          &nbsp;
+          {% if detail.summary.discharge_ok %}<span style="color:var(--green)">D✓</span>{% else %}<span style="color:var(--red)">D✗</span>{% endif %}
+        </span>
+      </div>
+    </div>
+
+    {# Min/Max cellules #}
+    <div style="display:flex;gap:0.75rem;font-size:0.8rem;color:var(--muted);padding:0 0.25rem">
+      <span>Min : <strong style="color:var(--text)">{{ detail.min_cell_id }}</strong> = <span id="kpi-vmin">{{ detail.min_cell_v|f3 }}</span> V</span>
+      <span>Max : <strong style="color:var(--text)">{{ detail.max_cell_id }}</strong> = <span id="kpi-vmax">{{ detail.max_cell_v|f3 }}</span> V</span>
+    </div>
+  </div>
+</div>
+
+{# ─── Tensions des cellules ───────────────────────────────────────────────── #}
+<div class="chart-section">
+  <h3>Tensions cellules</h3>
+  <div class="chart-box">
+    <div id="chart-cells" style="height:220px"></div>
+  </div>
+</div>
+
+{# ─── Historique SOC + Courant (2 colonnes) ──────────────────────────────── #}
+<div class="chart-row">
+  <div class="chart-section" style="margin-bottom:0">
+    <h3>Historique SOC</h3>
+    <div class="chart-box">
+      <div id="chart-soc" style="height:200px"></div>
+    </div>
+  </div>
+  <div class="chart-section" style="margin-bottom:0">
+    <h3>Historique Courant</h3>
+    <div class="chart-box">
+      <div id="chart-cur" style="height:200px"></div>
+    </div>
+  </div>
+</div>
+
+{# ─── Tension + Température ───────────────────────────────────────────────── #}
+<div class="chart-section">
+  <h3>Tension &amp; Température (historique)</h3>
+  <div class="chart-box">
+    <div id="chart-vt" style="height:220px"></div>
+  </div>
+</div>
+
+{# ─── Tableau des alarmes ─────────────────────────────────────────────────── #}
+<div class="card chart-section">
+  <div class="card-title">État des alarmes</div>
+  <table>
+    <thead>
+      <tr>
+        <th>Alarme</th>
+        <th style="text-align:center">État</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for alarm in detail.alarms %}
+      <tr>
+        <td>{{ alarm.name }}</td>
+        <td style="text-align:center">
+          {% if alarm.active %}
+            <span class="badge alarm">⚠ ACTIF</span>
+          {% else %}
+            <span class="badge ok">OK</span>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+{# JSON ECharts (cachés) #}
+<script type="application/json" id="opt-gauge">{{ detail.soc_gauge_json|safe }}</script>
+<script type="application/json" id="opt-cells">{{ detail.cells_bar_json|safe }}</script>
+<script type="application/json" id="opt-soc">{{ detail.soc_history_json|safe }}</script>
+<script type="application/json" id="opt-cur">{{ detail.current_history_json|safe }}</script>
+<script type="application/json" id="opt-vt">{{ detail.volt_temp_json|safe }}</script>
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function() {
+  const BMS_ADDR = {{ detail.summary.address }};
+
+  // ─── Initialisation des 5 graphiques ──────────────────────────────────────
+  function initChart(domId, optId) {
+    const dom = document.getElementById(domId);
+    const opt = document.getElementById(optId);
+    if (!dom || !opt) return null;
+    const c = echarts.init(dom, null, { renderer: 'svg' });
+    c.setOption(JSON.parse(opt.textContent));
+    return c;
+  }
+
+  const cGauge = initChart('soc-gauge', 'opt-gauge');
+  const cCells = initChart('chart-cells','opt-cells');
+  const cSoc   = initChart('chart-soc',  'opt-soc');
+  const cCur   = initChart('chart-cur',  'opt-cur');
+  const cVT    = initChart('chart-vt',   'opt-vt');
+
+  // ─── Resize automatique ────────────────────────────────────────────────────
+  window.addEventListener('resize', function() {
+    [cGauge, cCells, cSoc, cCur, cVT].forEach(function(c) { if (c) c.resize(); });
+  });
+
+  // ─── Helpers ───────────────────────────────────────────────────────────────
+  function set(id, val) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = val;
+  }
+  function fmt1(n) { return (+n).toFixed(1); }
+  function fmt0(n) { return (+n).toFixed(0); }
+  function fmt3(n) { return (+n).toFixed(3); }
+
+  // ─── Mise à jour en temps-réel (WebSocket) ─────────────────────────────────
+  window.onBmsUpdate = function(snaps) {
+    const s = snaps.find(function(x) { return x.address === BMS_ADDR; });
+    if (!s) return;
+
+    // Jauge SOC
+    if (cGauge) cGauge.setOption({ series: [{ data: [{ value: s.Soc, name: 'SOC' }] }] });
+
+    // KPIs texte
+    set('kpi-v',   fmt1(s.Dc.Voltage)  + ' V');
+    set('kpi-i',   (s.Dc.Current >= 0 ? '+' : '') + fmt1(s.Dc.Current) + ' A');
+    set('kpi-p',   fmt0(s.Dc.Power)    + ' W');
+    set('kpi-t',   fmt1(s.System.MaxCellTemperature) + ' °C');
+    set('kpi-soc', fmt1(s.Soc) + ' %');
+    set('kpi-c',   fmt1(s.Capacity) + ' Ah');
+
+    const delta = (s.System.MaxCellVoltage - s.System.MinCellVoltage) * 1000;
+    set('kpi-d', fmt0(delta) + ' mV');
+    set('kpi-vmin', fmt3(s.System.MinCellVoltage));
+    set('kpi-vmax', fmt3(s.System.MaxCellVoltage));
+
+    // Horodatage
+    const d = new Date(s.timestamp);
+    set('last-ts', isNaN(d) ? '—' : d.toLocaleTimeString());
+
+    // Bar chart cellules (mise à jour directe des valeurs)
+    if (cCells && s.Voltages) {
+      const entries = Object.entries(s.Voltages).sort(function(a, b) {
+        return parseInt(a[0].replace(/\D/g,'')) - parseInt(b[0].replace(/\D/g,''));
+      });
+      const labels = entries.map(function(e) { return '"C' + e[0].replace(/\D/g,'') + '"'; });
+      const values = entries.map(function(e) { return +e[1]; });
+      cCells.setOption({
+        xAxis: { data: labels.map(function(l) { return l.replace(/"/g,''); }) },
+        series: [{ data: values }]
+      });
+    }
+  };
+
+  // ─── Rafraîchissement de l'historique (toutes les 30 s) ───────────────────
+  function refreshHistory() {
+    fetch('/api/v1/bms/' + BMS_ADDR + '/history')
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (!Array.isArray(data) || data.length === 0) return;
+
+        // data est un tableau de BmsSnapshot en ordre (plus récent en premier si history_for reverse)
+        // On suppose ici ordre chronologique (ancien → récent) après reverse côté serveur
+        const ts   = data.map(function(s) { return new Date(s.timestamp).toLocaleTimeString(); });
+        const soc  = data.map(function(s) { return s.Soc; });
+        const cur  = data.map(function(s) { return s.Dc.Current; });
+        const volt = data.map(function(s) { return s.Dc.Voltage; });
+        const temp = data.map(function(s) { return s.System.MaxCellTemperature; });
+
+        if (cSoc) cSoc.setOption({ xAxis: { data: ts }, series: [{ data: soc }] });
+        if (cCur) cCur.setOption({ xAxis: { data: ts }, series: [{ data: cur }] });
+        if (cVT)  cVT.setOption({
+          xAxis: { data: ts },
+          series: [{ data: volt }, { data: temp }]
+        });
+      })
+      .catch(function() {});
+  }
+
+  // Premier rafraîchissement après 5 s, puis toutes les 30 s
+  setTimeout(refreshHistory, 5000);
+  setInterval(refreshHistory, 30000);
+})();
+</script>
+{% endblock %}

--- a/crates/daly-bms-server/templates/index.html
+++ b/crates/daly-bms-server/templates/index.html
@@ -1,0 +1,175 @@
+{% extends "base.html" %}
+
+{% block title %}Vue d'ensemble — DalyBMS{% endblock %}
+
+{% block content %}
+
+{# ─── Barre d'info ───────────────────────────────────────────────────────── #}
+<div class="info-bar">
+  <div style="display:flex;align-items:center;gap:0.5rem;">
+    <div class="dot {% if polling %}active{% else %}{% endif %}"></div>
+    {% if polling %}
+      <strong>Polling actif</strong>
+    {% else %}
+      <span style="color:var(--muted)">Polling arrêté</span>
+    {% endif %}
+  </div>
+  <div><strong>{{ bms_count }}</strong> BMS détecté{{ bms_count|pluralize }}</div>
+  <div style="margin-left:auto;font-size:0.7rem;color:var(--muted)" id="last-refresh">
+    Dernière maj : <span id="refresh-ts">—</span>
+  </div>
+</div>
+
+{# ─── Grille de cartes BMS ──────────────────────────────────────────────── #}
+{% if bms_count == 0 %}
+<div class="card" style="text-align:center;padding:3rem;color:var(--muted)">
+  <div style="font-size:2.5rem;margin-bottom:1rem">🔌</div>
+  <div style="font-size:1rem;margin-bottom:0.5rem">Aucun BMS détecté</div>
+  <div style="font-size:0.8rem">Démarrez le serveur avec <code>--simulate</code> pour tester,<br>
+  ou vérifiez le câblage RS485.</div>
+</div>
+{% else %}
+<div class="bms-grid" id="bms-grid">
+{% for bms in bms_list %}
+  <div class="bms-card {% if bms.any_alarm %}alarm{% endif %}" data-addr="{{ bms.address }}">
+
+    {# En-tête : adresse + horodatage #}
+    <div class="bms-card-header">
+      <span class="bms-addr">BMS {{ bms.address_hex }}</span>
+      <span class="bms-time" id="ts-{{ bms.address }}">{{ bms.last_update }}</span>
+    </div>
+
+    {# Corps : jauge SOC + stats #}
+    <div class="bms-body">
+      <div class="gauge-wrap" id="gauge-{{ bms.address }}"></div>
+
+      <div class="stats-grid">
+        <div class="stat">
+          <span class="stat-label">Tension</span>
+          <span class="stat-value" id="v-{{ bms.address }}">{{ bms.voltage|f1 }} V</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">Courant</span>
+          <span class="stat-value {% if bms.current > 0.0 %}pos{% else if bms.current < -0.1 %}neg{% endif %}"
+                id="i-{{ bms.address }}">{{ bms.current|sign }} A</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">Puissance</span>
+          <span class="stat-value" id="p-{{ bms.address }}">{{ bms.power|f0 }} W</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">Temp. max</span>
+          <span class="stat-value {% if bms.temp_max > 45.0 %}err{% else if bms.temp_max > 35.0 %}warn{% endif %}"
+                id="t-{{ bms.address }}">{{ bms.temp_max|f1 }} °C</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">Δ cellules</span>
+          <span class="stat-value {% if bms.cell_delta_mv > 100.0 %}err{% else if bms.cell_delta_mv > 50.0 %}warn{% endif %}"
+                id="d-{{ bms.address }}">{{ bms.cell_delta_mv|mv }} mV</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">Restant</span>
+          <span class="stat-value" id="c-{{ bms.address }}">{{ bms.capacity_ah|f1 }} Ah</span>
+        </div>
+      </div>
+    </div>
+
+    {# Pied : badges MOS + lien détail #}
+    <div class="bms-footer">
+      <div class="mos-badges">
+        {% if bms.charge_ok %}
+          <span class="badge ok">CHG ✓</span>
+        {% else %}
+          <span class="badge off">CHG ✗</span>
+        {% endif %}
+        {% if bms.discharge_ok %}
+          <span class="badge ok">DCH ✓</span>
+        {% else %}
+          <span class="badge off">DCH ✗</span>
+        {% endif %}
+        {% if bms.any_alarm %}
+          <span class="badge alarm">⚠ ALARME</span>
+        {% endif %}
+      </div>
+      <a href="/dashboard/bms/{{ bms.address }}" class="link-detail">Détail →</a>
+    </div>
+
+    {# JSON option ECharts (caché, lu par JS) #}
+    <script type="application/json" id="opt-{{ bms.address }}">{{ bms.soc_gauge_json|safe }}</script>
+
+  </div>
+{% endfor %}
+</div>
+{% endif %}
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+// ─── Initialisation des jauges ECharts ───────────────────────────────────────
+const _gauges = {};   // addr → echarts instance
+
+document.querySelectorAll('.bms-card[data-addr]').forEach(function(card) {
+  const addr = parseInt(card.dataset.addr, 10);
+  const dom  = document.getElementById('gauge-' + addr);
+  const opt  = document.getElementById('opt-'   + addr);
+  if (!dom || !opt) return;
+
+  const chart = echarts.init(dom, null, { renderer: 'svg' });
+  chart.setOption(JSON.parse(opt.textContent));
+  _gauges[addr] = chart;
+});
+
+// ─── Mise à jour temps-réel via WebSocket ────────────────────────────────────
+window.onBmsUpdate = function(snaps) {
+  const now = new Date().toLocaleTimeString();
+  const tsEl = document.getElementById('refresh-ts');
+  if (tsEl) tsEl.textContent = now;
+
+  snaps.forEach(function(s) {
+    const a = s.address;
+
+    // Jauge SOC
+    const g = _gauges[a];
+    if (g) g.setOption({ series: [{ data: [{ value: s.Soc, name: 'SOC' }] }] });
+
+    // Helpers de mise à jour DOM
+    function set(id, txt) {
+      const el = document.getElementById(id + '-' + a);
+      if (el) el.textContent = txt;
+    }
+    function fmt1(n) { return n.toFixed(1); }
+    function fmt0(n) { return n.toFixed(0); }
+
+    set('v',  fmt1(s.Dc.Voltage) + ' V');
+    set('i',  (s.Dc.Current >= 0 ? '+' : '') + fmt1(s.Dc.Current) + ' A');
+    set('p',  fmt0(s.Dc.Power)   + ' W');
+    set('t',  fmt1(s.System.MaxCellTemperature) + ' °C');
+
+    const delta = (s.System.MaxCellVoltage - s.System.MinCellVoltage) * 1000;
+    set('d',  fmt0(delta) + ' mV');
+    set('c',  fmt1(s.Capacity) + ' Ah');
+
+    // Horodatage
+    const tsEl2 = document.getElementById('ts-' + a);
+    if (tsEl2) {
+      const d = new Date(s.timestamp);
+      tsEl2.textContent = isNaN(d) ? '—' : d.toLocaleTimeString();
+    }
+
+    // Couleur courant
+    const iEl = document.getElementById('i-' + a);
+    if (iEl) {
+      iEl.className = 'stat-value ' + (s.Dc.Current > 0.1 ? 'pos' : s.Dc.Current < -0.1 ? 'neg' : '');
+    }
+
+    // Alarme : bordure rouge sur la carte
+    const card = document.querySelector('.bms-card[data-addr="' + a + '"]');
+    if (card) {
+      const hasAlarm = s.Alarms && Object.values(s.Alarms).some(v => v !== 0);
+      card.classList.toggle('alarm', hasAlarm);
+    }
+  });
+};
+</script>
+{% endblock %}


### PR DESCRIPTION
- Axum server-side rendering with Askama compiled templates (zero JS build)
- Vue d'ensemble (`/dashboard`): cartes BMS avec jauge SOC ECharts mini, stats tensions/courant/puissance/température/delta-cellules, badges MOS
- Page détail (`/dashboard/bms/:id`): jauge SOC plein format, KPI row, bar chart cellules, historique SOC / courant / tension+temp (5 charts)
- Tableau des 12 alarmes Daly avec badge couleur
- Client WebSocket vanilla JS: mise à jour temps-réel (jauges + KPIs + cellules)
- Rafraîchissement historique toutes les 30 s via fetch /api/v1/bms/:id/history
- Dark theme GitHub-like (CSS Grid responsive, aucune dépendance CSS externe)
- Filtres Askama custom: f0/f1/f3/sign/mv/pluralize pour formatage nombres
- ECharts 5.5 chargé depuis CDN jsDelivr (remplacer par fichier local si offline)
- Route `/` redirige vers `/dashboard`

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme