### PR TITLE
feat(server): add --port and --bms CLI args, fix Windows serial default

### DIFF
--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -97,7 +97,7 @@ pub struct SerialConfig {
 impl Default for SerialConfig {
     fn default() -> Self {
         Self {
-            port:               "/dev/ttyUSB0".into(),
+            port:               if cfg!(windows) { "COM1".into() } else { "/dev/ttyUSB0".into() },
             baud:               9600,
             poll_interval_ms:   1000,
             default_cell_count: 16,

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -38,6 +38,10 @@ use tracing::{error, info, warn};
 struct ServerArgs {
     simulate:  bool,
     sim_addrs: Vec<u8>,
+    /// Port série explicite (ex: COM3, /dev/ttyUSB0)
+    port:      Option<String>,
+    /// Adresses BMS pour le mode hardware (ex: 0x01,0x02)
+    bms_addrs: Vec<u8>,
 }
 
 impl ServerArgs {
@@ -47,21 +51,32 @@ impl ServerArgs {
 
         let sim_addrs = args.windows(2)
             .find(|w| w[0] == "--sim-bms")
-            .map(|w| {
-                w[1].split(',')
-                    .filter_map(|s| {
-                        let s = s.trim();
-                        if s.starts_with("0x") || s.starts_with("0X") {
-                            u8::from_str_radix(&s[2..], 16).ok()
-                        } else {
-                            s.parse::<u8>().ok()
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            })
+            .map(|w| Self::parse_addresses(&w[1]))
             .unwrap_or_default();
 
-        Self { simulate, sim_addrs }
+        let port = args.windows(2)
+            .find(|w| w[0] == "--port" || w[0] == "-p")
+            .map(|w| w[1].clone());
+
+        let bms_addrs = args.windows(2)
+            .find(|w| w[0] == "--bms")
+            .map(|w| Self::parse_addresses(&w[1]))
+            .unwrap_or_default();
+
+        Self { simulate, sim_addrs, port, bms_addrs }
+    }
+
+    fn parse_addresses(s: &str) -> Vec<u8> {
+        s.split(',')
+            .filter_map(|s| {
+                let s = s.trim();
+                if s.starts_with("0x") || s.starts_with("0X") {
+                    u8::from_str_radix(&s[2..], 16).ok()
+                } else {
+                    s.parse::<u8>().ok()
+                }
+            })
+            .collect()
     }
 }
 
@@ -74,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
     let args = ServerArgs::parse();
 
     // ── Configuration ──────────────────────────────────────────────────────────
-    let config = AppConfig::load_default()
+    let mut config = AppConfig::load_default()
         .unwrap_or_else(|e| {
             // Fallback : configuration par défaut (dev / simulation)
             eprintln!("Config non trouvée ({}) — utilisation des valeurs par défaut", e);
@@ -88,6 +103,17 @@ async fn main() -> anyhow::Result<()> {
                 read_only: config::ReadOnlyConfig::default(),
             }
         });
+
+    // ── Override port série depuis CLI ─────────────────────────────────────────
+    if let Some(ref port) = args.port {
+        config.serial.port = port.clone();
+    }
+    // Override adresses BMS hardware depuis CLI
+    if !args.bms_addrs.is_empty() {
+        config.serial.addresses = args.bms_addrs.iter()
+            .map(|a| format!("{:#04x}", a))
+            .collect();
+    }
 
     // ── Logging ────────────────────────────────────────────────────────────────
     let log_level = config.logging.level.clone();


### PR DESCRIPTION
- Add --port/-p argument to daly-bms-server to specify serial port from command line (e.g. --port COM3 on Windows, --port /dev/ttyUSB1 on Linux)
- Add --bms argument for hardware mode to specify BMS addresses explicitly (e.g. --bms 0x01,0x02), overriding config file values
- Fix default serial port: use COM1 on Windows, /dev/ttyUSB0 on Linux
- CLI args override config file values, allowing easy hardware testing without creating a config.toml

Usage: cargo run --bin daly-bms-server -- --port COM3 --bms 0x01

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme