### PR TITLE
fix(commands): correct byte offsets for 0x90 PackStatus decoding

### DIFF
--- a/crates/daly-bms-core/src/commands.rs
+++ b/crates/daly-bms-core/src/commands.rs
@@ -16,13 +16,19 @@ use std::sync::Arc;
 use tracing::trace;
 
 /// Lit le statut pack : tension totale, courant, SOC (Data ID 0x90).
+///
+/// Layout du champ Data (8 octets, protocole Daly UART V1.21) :
+/// - D0-D1 : Tension totale pack      (uint16 BE, 0.1 V)
+/// - D2-D3 : Tension acquisition      (uint16 BE, 0.1 V) — ignoré ici
+/// - D4-D5 : Courant                  (uint16 BE, offset 30000, 0.1 A)
+/// - D6-D7 : SOC                      (uint16 BE, 0.1 %)
 pub async fn get_pack_status(port: &Arc<DalyPort>, addr: u8) -> Result<SocData> {
     let frame = port.send_command(addr, DataId::PackStatus, [0u8; 8]).await?;
     let d = frame.data();
     Ok(SocData {
         voltage: decode_voltage(d, 0),
-        current: decode_current(d, 2),
-        soc:     decode_soc(d, 4),
+        current: decode_current(d, 4),
+        soc:     decode_soc(d, 6),
     })
 }
 


### PR DESCRIPTION
The Daly UART 0x90 response data field has 4 fields, not 3:
  D0-D1 : Pack voltage        (0.1V)
  D2-D3 : Acquisition voltage (0.1V)  ← was incorrectly decoded as current
  D4-D5 : Current             (offset 30000, 0.1A)
  D6-D7 : SOC                 (0.1%)

Previous offsets (0, 2, 4) caused:
  current = -3000 A  (D2-D3 = 0x0000 → (0-30000)/10)
  soc     = 3005 %   (D4-D5 = 0x7564 = 30052 → /10)

Fixed offsets (0, 4, 6) now decode correctly.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme