### PR TITLE
fix(bus,commands,poll): fix intermittent cell voltage readings

### DIFF
--- a/crates/daly-bms-core/src/bus.rs
+++ b/crates/daly-bms-core/src/bus.rs
@@ -143,6 +143,80 @@ impl DalyPort {
         }
     }
 
+    /// Envoie une commande et lit N trames de réponse successives sans flush entre elles.
+    ///
+    /// Utilisé pour les commandes multi-trames (0x95, 0x96) où le BMS envoie toutes
+    /// les trames d'un coup après une seule requête.
+    pub async fn send_command_multi(
+        &self,
+        bms_address: u8,
+        cmd: DataId,
+        n_frames: usize,
+    ) -> Result<Vec<ResponseFrame>> {
+        if n_frames == 0 {
+            return Ok(Vec::new());
+        }
+
+        let request = RequestFrame::new(bms_address, cmd, [0u8; 8]);
+        let mut port = self.inner.lock().await;
+
+        // Vider le buffer avant l'envoi
+        let _ = Self::flush_input(&mut *port).await;
+
+        let req_bytes = request.as_bytes();
+        trace!(
+            bms = format!("{:#04x}", bms_address),
+            cmd = format!("{:#04x}", cmd as u8),
+            n_frames,
+            raw = format!("{:02X?}", req_bytes),
+            "→ envoi trame multi"
+        );
+        port.write_all(req_bytes).await?;
+        port.flush().await?;
+
+        // Délai TX→RX une seule fois
+        tokio::time::sleep(Duration::from_millis(INTER_FRAME_DELAY_MS)).await;
+
+        // Lire N trames consécutives sans flush entre elles
+        let mut frames = Vec::with_capacity(n_frames);
+        for frame_idx in 0..n_frames {
+            let mut buf = [0u8; FRAME_LEN];
+            let read_result = timeout(
+                Duration::from_millis(self.timeout_ms),
+                port.read_exact(&mut buf),
+            )
+            .await;
+
+            match read_result {
+                Err(_elapsed) => {
+                    warn!(
+                        bms   = format!("{:#04x}", bms_address),
+                        cmd   = format!("{:#04x}", cmd as u8),
+                        frame = frame_idx,
+                        "Timeout trame multi"
+                    );
+                    return Err(DalyError::Timeout { bms_id: bms_address, cmd: cmd as u8 });
+                }
+                Ok(Err(e)) => return Err(e.into()),
+                Ok(Ok(_)) => {
+                    trace!(
+                        bms   = format!("{:#04x}", bms_address),
+                        cmd   = format!("{:#04x}", cmd as u8),
+                        frame = frame_idx,
+                        raw   = format!("{:02X?}", &buf),
+                        "← trame multi reçue"
+                    );
+                    let frame = ResponseFrame::parse(&buf)?;
+                    // Valider adresse et commande (le numéro de trame est dans data[0])
+                    frame.validate_for(bms_address, cmd)?;
+                    frames.push(frame);
+                }
+            }
+        }
+
+        Ok(frames)
+    }
+
     /// Vide le buffer de réception (lecture non-bloquante avec timeout court).
     async fn flush_input(port: &mut tokio_serial::SerialStream) -> std::io::Result<()> {
         let mut tmp = [0u8; 256];

--- a/crates/daly-bms-core/src/commands.rs
+++ b/crates/daly-bms-core/src/commands.rs
@@ -97,32 +97,30 @@ pub async fn get_status_info(port: &Arc<DalyPort>, addr: u8) -> Result<StatusInf
 
 /// Lit les tensions individuelles de toutes les cellules (0x95, multi-trames).
 ///
-/// Le protocole Daly envoie 3 tensions par trame (uint16 BE, en millivolts).
-/// Le nombre de trames = ceil(cell_count / 3).
-/// Chaque trame successive incrémente automatiquement l'index de bloc.
+/// Le BMS répond avec toutes les trames d'un coup après une seule requête.
+/// Chaque trame contient 3 tensions (uint16 BE, millivolts) :
+///   data[0]   = numéro de trame (1-based)
+///   data[1-2] = cellule N
+///   data[3-4] = cellule N+1
+///   data[5-6] = cellule N+2
 pub async fn get_cell_voltages(
     port: &Arc<DalyPort>,
     addr: u8,
     cell_count: u8,
 ) -> Result<CellVoltages> {
     let frame_count = (cell_count as usize + 2) / 3;
+    let frames = port.send_command_multi(addr, DataId::CellVoltages1, frame_count).await?;
+
     let mut voltages = Vec::with_capacity(cell_count as usize);
-
-    for i in 0..frame_count {
-        // La trame de requête précise le numéro de bloc dans data[0]
-        let mut data = [0u8; 8];
-        data[0] = (i + 1) as u8;
-        let frame = port.send_command(addr, DataId::CellVoltages1, data).await?;
+    for (i, frame) in frames.iter().enumerate() {
         let d = frame.data();
-
-        // 3 cellules par trame, octets 1-2, 3-4, 5-6 (octet 0 = frame index)
+        // 3 cellules par trame, aux offsets 1-2, 3-4, 5-6 (offset 0 = frame index)
         for j in 0..3 {
             let cell_idx = i * 3 + j;
             if cell_idx >= cell_count as usize {
                 break;
             }
-            let offset = 1 + j * 2;
-            voltages.push(decode_cell_voltage(d, offset));
+            voltages.push(decode_cell_voltage(d, 1 + j * 2));
         }
         trace!(addr = format!("{:#04x}", addr), frame = i + 1, "tensions cellules lues");
     }
@@ -132,21 +130,21 @@ pub async fn get_cell_voltages(
 
 /// Lit les températures individuelles de tous les capteurs (0x96, multi-trames).
 ///
-/// 7 températures par trame (7 octets, encodage = valeur + 40).
+/// Le BMS répond avec toutes les trames d'un coup après une seule requête.
+/// Chaque trame contient 7 températures (encodage = valeur + 40) :
+///   data[0]   = numéro de trame (1-based)
+///   data[1-7] = températures capteurs
 pub async fn get_temperatures(
     port: &Arc<DalyPort>,
     addr: u8,
     sensor_count: u8,
 ) -> Result<CellTemperatures> {
     let frame_count = (sensor_count as usize + 6) / 7;
+    let frames = port.send_command_multi(addr, DataId::Temperatures, frame_count).await?;
+
     let mut temperatures = Vec::with_capacity(sensor_count as usize);
-
-    for i in 0..frame_count {
-        let mut data = [0u8; 8];
-        data[0] = (i + 1) as u8;
-        let frame = port.send_command(addr, DataId::Temperatures, data).await?;
+    for (i, frame) in frames.iter().enumerate() {
         let d = frame.data();
-
         for j in 0..7 {
             let sensor_idx = i * 7 + j;
             if sensor_idx >= sensor_count as usize {

--- a/crates/daly-bms-core/src/poll.rs
+++ b/crates/daly-bms-core/src/poll.rs
@@ -129,14 +129,16 @@ async fn poll_device(
         commands::get_status_info(port, addr)
     }).await?;
 
-    // ── 0x95 : Tensions individuelles ─────────────────────────────────────────
+    // ── 0x95 : Tensions individuelles — cell_count issu du 0x94 ──────────────
+    let cell_count = if status.cell_count > 0 { status.cell_count } else { device.cell_count };
     let cell_voltages = retry(config.retries, || {
-        commands::get_cell_voltages(port, addr, device.cell_count)
+        commands::get_cell_voltages(port, addr, cell_count)
     }).await.unwrap_or_default();
 
-    // ── 0x96 : Températures individuelles ─────────────────────────────────────
+    // ── 0x96 : Températures individuelles — sensor_count issu du 0x94 ────────
+    let sensor_count = if status.temp_sensor_count > 0 { status.temp_sensor_count } else { device.temp_sensor_count };
     let temperatures = retry(config.retries, || {
-        commands::get_temperatures(port, addr, device.temp_sensor_count)
+        commands::get_temperatures(port, addr, sensor_count)
     }).await.unwrap_or_default();
 
     // ── 0x97 : Flags d'équilibrage ────────────────────────────────────────────


### PR DESCRIPTION
Root cause: for multi-frame responses (0x95 cell voltages, 0x96 temps), the BMS sends ALL frames at once after a single request. The previous code sent N separate requests and called flush_input before each one, discarding already-buffered frames from the BMS burst.

Changes:
- bus.rs: add send_command_multi() — one request, N responses read consecutively without flushing between frames
- commands.rs: get_cell_voltages() and get_temperatures() now use send_command_multi() instead of N individual send_command() calls
- poll.rs: use status.cell_count and status.temp_sensor_count from command 0x94 instead of the hardcoded BmsConfig defaults

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme