### PR TITLE
fix(protocol): use BMS address in request byte[1] for RS485 selective…

### DIFF
--- a/crates/daly-bms-core/src/protocol.rs
+++ b/crates/daly-bms-core/src/protocol.rs
@@ -101,19 +101,18 @@ pub struct RequestFrame {
 impl RequestFrame {
     /// Construit une trame de requête avec les 8 octets de données spécifiés.
     ///
-    /// Protocole Daly UART V1.21 :
-    /// - Byte[1] = 0x40 (adresse PC/hôte fixe, identique pour toutes les requêtes)
-    /// - La trame de réponse contient l'adresse BMS en byte[1] (ex: 0x01)
-    /// - `bms_address` est conservé uniquement pour valider la réponse
+    /// Protocole Daly RS485 multi-BMS :
+    /// - Byte[1] = adresse BMS cible (0x01, 0x02, …) — seul ce BMS répond
+    /// - Pour un seul BMS l'adresse est 0x01 par défaut
+    /// - La trame de réponse contient la même adresse en byte[1]
     pub fn new(bms_address: u8, cmd: DataId, data: [u8; 8]) -> Self {
         let mut bytes = [0u8; FRAME_LEN];
         bytes[0] = START_FLAG;
-        bytes[1] = PC_ADDRESS;   // 0x40 — adresse hôte fixe (PC → BMS)
+        bytes[1] = bms_address;   // Adresse BMS cible (adressage sélectif RS485)
         bytes[2] = cmd as u8;
         bytes[3] = DATA_LEN;
         bytes[4..12].copy_from_slice(&data);
         bytes[12] = checksum(&bytes[..12]);
-        let _ = bms_address; // utilisé uniquement pour valider la réponse
         Self { bytes }
     }
 
@@ -326,13 +325,17 @@ mod tests {
 
     #[test]
     fn test_request_frame_checksum() {
+        // BMS 0x01 : checksum = 0xA5 + 0x01 + 0x90 + 0x08 = 0x13E → 0x3E
         let frame = RequestFrame::read(0x01, DataId::PackStatus);
         assert_eq!(frame.bytes[0], START_FLAG);
-        // Byte[1] = PC_ADDRESS (0x40), pas l'adresse BMS
-        assert_eq!(frame.bytes[1], PC_ADDRESS);
+        assert_eq!(frame.bytes[1], 0x01); // adresse BMS cible
         assert_eq!(frame.bytes[2], 0x90);
         assert_eq!(frame.bytes[3], DATA_LEN);
-        // checksum = 0xA5 + 0x40 + 0x90 + 0x08 = 0x17D → 0x7D
-        assert_eq!(frame.bytes[12], 0x7D);
+        assert_eq!(frame.bytes[12], 0x3E);
+
+        // BMS 0x02 : checksum = 0xA5 + 0x02 + 0x90 + 0x08 = 0x13F → 0x3F
+        let frame2 = RequestFrame::read(0x02, DataId::PackStatus);
+        assert_eq!(frame2.bytes[1], 0x02);
+        assert_eq!(frame2.bytes[12], 0x3F);
     }
 }


### PR DESCRIPTION
… addressing

With 0x40 (broadcast), ALL BMS on the bus respond to every request — making multi-BMS polling impossible. Each BMS only responds when its own address appears in byte[1] of the request frame.

The original timeout on COM5 was caused by CAN wiring, not by this field. With RS485 correctly wired on COM6, selective addressing works.

Request frames are now:
  BMS 0x01: A5 01 <CMD> 08 ... checksum=0x3E
  BMS 0x02: A5 02 <CMD> 08 ... checksum=0x3F

Note: the second BMS must be configured with address 0x02 via its DIP switches or Daly configuration tool before it will respond to 0x02 requests.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme