### PR TITLE
diag(bus): log voltage+SOC quand adresse inattendue (test proxy maste…

### DIFF
--- a/crates/daly-bms-core/src/bus.rs
+++ b/crates/daly-bms-core/src/bus.rs
@@ -132,6 +132,22 @@ impl DalyPort {
                     "← réponse reçue"
                 );
                 let frame = ResponseFrame::parse(&buf)?;
+                // Diagnostic proxy : si l'adresse ne correspond pas et que c'est
+                // une réponse PackStatus (0x90), loguer voltage+SOC pour savoir
+                // si BMS 0x01 proxy les données du slave ou répond avec les siennes.
+                if frame.address() != bms_address && cmd == DataId::PackStatus {
+                    let d = frame.data();
+                    let voltage_raw = u16::from_be_bytes([d[0], d[1]]);
+                    let soc_raw     = u16::from_be_bytes([d[6], d[7]]);
+                    warn!(
+                        bms     = format!("{:#04x}", bms_address),
+                        actual  = format!("{:#04x}", frame.address()),
+                        raw     = format!("{:02X?}", &buf),
+                        voltage = format!("{:.1}V", voltage_raw as f32 * 0.1),
+                        soc     = format!("{:.1}%", soc_raw as f32 * 0.1),
+                        "Adresse inattendue — données décodées (proxy ?)"
+                    );
+                }
                 frame.validate_for(bms_address, cmd)?;
                 debug!(
                     bms = format!("{:#04x}", bms_address),


### PR DESCRIPTION
…r→slave)

Quand BMS 0x01 répond à une requête destinée à BMS 0x02, on décode et logge maintenant voltage+SOC de la réponse reçue. Cela permet de vérifier si BMS 0x01 proxy les données de BMS 0x02 (valeurs différentes) ou répond avec ses propres données (valeurs identiques).

WARN log : bms="0x02" actual="0x01" voltage=".." soc=".." raw=[...]

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme