### PR TITLE
fix(bus): forcer data[0]=bms_address pour les lectures (adressage par…

### DIFF
--- a/crates/daly-bms-core/src/bus.rs
+++ b/crates/daly-bms-core/src/bus.rs
@@ -60,7 +60,13 @@ impl DalyPort {
         cmd: DataId,
         data: [u8; 8],
     ) -> Result<ResponseFrame> {
-        let request = RequestFrame::new(bms_address, cmd, data);
+        // Adressage Daly parallèle : data[0] = board number pour les lectures.
+        // Les commandes d'écriture gardent leur payload dans data[0].
+        let mut frame_data = data;
+        if !cmd.is_write() {
+            frame_data[0] = bms_address;
+        }
+        let request = RequestFrame::new(bms_address, cmd, frame_data);
         trace!(
             bms = format!("{:#04x}", bms_address),
             cmd = format!("{:#04x}", cmd as u8),


### PR DESCRIPTION
…allèle Daly)

Bug : commands.rs passait [0u8;8] et RequestFrame::new ignorait bms_address, donc toutes les requêtes étaient des broadcasts (data[0]=0x00). BMS 0x01 répond aux broadcasts, BMS 0x02 peut-être seulement à son adresse propre.

Fix : dans send_command, pour les commandes de lecture (!cmd.is_write()), on force frame_data[0] = bms_address avant de construire la trame.

Requête pour BMS 0x01 : A5 40 90 08 01 00...00 7E (avant : 7D)
Requête pour BMS 0x02 : A5 40 90 08 02 00...00 7F (avant : 7D)

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme