### PR TITLE
fix(probe): tester 3 variantes d'adressage pour identifier le protoco…

### DIFF
--- a/crates/daly-bms-probe/src/main.rs
+++ b/crates/daly-bms-probe/src/main.rs
@@ -1,24 +1,27 @@
 //! daly-bms-probe — outil de diagnostic RS485 brut
 //!
-//! Envoie une requête SOC (0x90) à chaque adresse BMS spécifiée,
-//! puis lit TOUT ce qui arrive pendant LISTEN_SECS secondes.
-//! Aucun décodage : hex brut uniquement.
+//! Teste 3 variantes d'adressage pour chaque BMS afin de déterminer
+//! quelle trame provoque une réponse.
+//!
+//! Variante A : byte[1]=0x40 (PC), data[0]=bms_addr  ← actuel
+//! Variante B : byte[1]=bms_addr, data[0]=0x00       ← mode parallèle Daly
+//! Variante C : byte[1]=0x40 (PC), data[0]=0x00      ← broadcast standard
 
 use clap::Parser;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_serial::SerialPortBuilderExt;
 
-/// Durée d'écoute après chaque envoi de trame
-const LISTEN_SECS: u64 = 30;
+/// Durée d'écoute après chaque envoi (secondes)
+const LISTEN_SECS: u64 = 5;
 
-/// Pause entre les deux sessions (BMS 0x01 → BMS 0x02)
-const PAUSE_BETWEEN_SECS: u64 = 3;
+/// Pause entre deux envois (ms)
+const PAUSE_MS: u64 = 1000;
 
 /// Commande PackStatus (SOC)
 const CMD_PACK_STATUS: u8 = 0x90;
 
-/// Adresse source PC dans le protocole Daly
+/// Adresse source PC
 const PC_ADDR: u8 = 0x40;
 
 #[derive(Parser)]
@@ -37,37 +40,114 @@ struct Cli {
     bms: String,
 }
 
-/// Calcule le checksum Daly : somme de tous les octets, tronquée à u8
 fn checksum(data: &[u8]) -> u8 {
     data.iter().fold(0u8, |acc, &b| acc.wrapping_add(b))
 }
 
-/// Construit la trame de requête pour une adresse BMS donnée (commande SOC / 0x90)
-///
-/// Format standard Daly (13 octets) :
-///   [A5] [40] [cmd] [08] [data0..7] [checksum]
-///
-/// data[0] = adresse BMS cible (pour adressage parallèle Daly)
-fn build_request(bms_addr: u8, cmd: u8) -> [u8; 13] {
-    let mut frame = [0u8; 13];
-    frame[0] = 0xA5;        // start
-    frame[1] = PC_ADDR;     // source : PC (0x40)
-    frame[2] = cmd;         // commande
-    frame[3] = 0x08;        // longueur data
-    frame[4] = bms_addr;    // data[0] = adresse BMS cible
-    // frame[5..11] = 0x00
-    frame[12] = checksum(&frame[..12]);
-    frame
+/// Variante A : byte[1]=0x40 (PC), data[0]=bms_addr
+fn frame_a(bms_addr: u8) -> [u8; 13] {
+    let mut f = [0u8; 13];
+    f[0] = 0xA5;
+    f[1] = PC_ADDR;
+    f[2] = CMD_PACK_STATUS;
+    f[3] = 0x08;
+    f[4] = bms_addr;   // data[0] = adresse BMS
+    f[12] = checksum(&f[..12]);
+    f
+}
+
+/// Variante B : byte[1]=bms_addr, data[0]=0x00  (mode parallèle Daly)
+fn frame_b(bms_addr: u8) -> [u8; 13] {
+    let mut f = [0u8; 13];
+    f[0] = 0xA5;
+    f[1] = bms_addr;   // adresse BMS dans byte[1]
+    f[2] = CMD_PACK_STATUS;
+    f[3] = 0x08;
+    // data[0..7] = 0x00
+    f[12] = checksum(&f[..12]);
+    f
+}
+
+/// Variante C : byte[1]=0x40 (PC), data[0]=0x00  (broadcast standard)
+fn frame_c() -> [u8; 13] {
+    let mut f = [0u8; 13];
+    f[0] = 0xA5;
+    f[1] = PC_ADDR;
+    f[2] = CMD_PACK_STATUS;
+    f[3] = 0x08;
+    // data[0..7] = 0x00 (pas d'adresse spécifique)
+    f[12] = checksum(&f[..12]);
+    f
+}
+
+fn fmt_frame(f: &[u8]) -> String {
+    let parts: Vec<String> = f.iter().map(|b| format!("{:02X}", b)).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+async fn probe_variant(
+    port: &mut tokio_serial::SerialStream,
+    label: &str,
+    frame: &[u8],
+) {
+    println!("  Variante {} — TX : {}", label, fmt_frame(frame));
+
+    // Vider buffer entrant
+    {
+        let mut drain = [0u8; 256];
+        let _ = tokio::time::timeout(Duration::from_millis(200), port.read(&mut drain)).await;
+    }
+
+    if let Err(e) = port.write_all(frame).await {
+        println!("    ERREUR envoi : {}", e);
+        return;
+    }
+
+    let t0 = Instant::now();
+    let deadline = Duration::from_secs(LISTEN_SECS);
+    let mut frame_buf: Vec<u8> = Vec::new();
+    let mut got_response = false;
+
+    loop {
+        let elapsed = t0.elapsed();
+        if elapsed >= deadline { break; }
+        let remaining = deadline - elapsed;
+
+        let mut byte = [0u8; 1];
+        match tokio::time::timeout(remaining.min(Duration::from_millis(100)), port.read_exact(&mut byte)).await {
+            Ok(Ok(_)) => {
+                frame_buf.push(byte[0]);
+                if frame_buf.len() == 13 {
+                    let ms = t0.elapsed().as_millis();
+                    println!("    +{:>5}ms  RX : {}", ms, fmt_frame(&frame_buf));
+                    got_response = true;
+                    frame_buf.clear();
+                }
+                if frame_buf.len() >= 64 {
+                    println!("    GARBAGE ({} octets) : {}", frame_buf.len(), fmt_frame(&frame_buf));
+                    frame_buf.clear();
+                }
+            }
+            Ok(Err(e)) => { println!("    erreur lecture : {}", e); break; }
+            Err(_) => {
+                // timeout 100ms — afficher partiel si fin de deadline
+                if !frame_buf.is_empty() && t0.elapsed() >= deadline {
+                    println!("    PARTIEL ({} octets) : {}", frame_buf.len(), fmt_frame(&frame_buf));
+                }
+            }
+        }
+    }
+
+    if !got_response {
+        println!("    (aucune réponse en {}s)", LISTEN_SECS);
+    }
 }
 
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
 
-    // Parse les adresses BMS
-    let addresses: Vec<u8> = cli
-        .bms
-        .split(',')
+    let addresses: Vec<u8> = cli.bms.split(',')
         .filter_map(|s| {
             let s = s.trim();
             if s.starts_with("0x") || s.starts_with("0X") {
@@ -84,13 +164,16 @@ async fn main() {
     }
 
     println!("=============================================================");
-    println!("  daly-bms-probe  —  Diagnostic RS485 brut");
+    println!("  daly-bms-probe  —  Diagnostic adressage RS485");
     println!("  Port : {}  Baud : {}", cli.port, cli.baud);
-    println!("  Ecoute : {}s par BMS", LISTEN_SECS);
+    println!("  Ecoute : {}s par variante", LISTEN_SECS);
     println!("=============================================================");
     println!();
+    println!("  Variante A : byte[1]=0x40(PC), data[0]=bms_addr  (actuel)");
+    println!("  Variante B : byte[1]=bms_addr, data[0]=0x00      (mode parallèle)");
+    println!("  Variante C : byte[1]=0x40(PC), data[0]=0x00      (broadcast)");
+    println!();
 
-    // Ouvre le port série
     let mut port = tokio_serial::new(&cli.port, cli.baud)
         .timeout(Duration::from_millis(100))
         .open_native_async()
@@ -99,124 +182,22 @@ async fn main() {
             std::process::exit(1);
         });
 
-    for (i, &addr) in addresses.iter().enumerate() {
-        // Pause entre sessions (sauf la première)
-        if i > 0 {
-            println!();
-            println!("--- Pause {}s avant session suivante ---", PAUSE_BETWEEN_SECS);
-            tokio::time::sleep(Duration::from_secs(PAUSE_BETWEEN_SECS)).await;
-        }
+    for &addr in &addresses {
+        println!("-------------------------------------------------------------");
+        println!("  BMS {:#04x}", addr);
+        println!("-------------------------------------------------------------");
 
-        let request = build_request(addr, CMD_PACK_STATUS);
+        probe_variant(&mut port, "A", &frame_a(addr)).await;
+        tokio::time::sleep(Duration::from_millis(PAUSE_MS)).await;
 
-        println!("=============================================================");
-        println!("  SESSION BMS {:#04x}  (commande {:#04x} = PackStatus/SOC)", addr, CMD_PACK_STATUS);
-        println!("=============================================================");
+        probe_variant(&mut port, "B", &frame_b(addr)).await;
+        tokio::time::sleep(Duration::from_millis(PAUSE_MS)).await;
+
+        probe_variant(&mut port, "C", &frame_c()).await;
+        tokio::time::sleep(Duration::from_millis(PAUSE_MS)).await;
         println!();
-        println!(">>> TX trame ({} octets) :", request.len());
-        print!("    [");
-        for (j, b) in request.iter().enumerate() {
-            if j > 0 { print!(", "); }
-            print!("{:02X}", b);
-        }
-        println!("]");
-        println!();
-
-        // Vider le buffer en entrée (lecture rapide jusqu'à timeout)
-        {
-            let mut drain = [0u8; 256];
-            let _ = tokio::time::timeout(
-                Duration::from_millis(200),
-                port.read(&mut drain),
-            ).await;
-        }
-
-        // Envoyer la requête
-        if let Err(e) = port.write_all(&request).await {
-            eprintln!("ERREUR envoi : {}", e);
-            continue;
-        }
-        let t0 = Instant::now();
-
-        println!("<<< RX brut pendant {}s :", LISTEN_SECS);
-        println!();
-
-        let mut total_bytes = 0usize;
-        let mut frame_buf: Vec<u8> = Vec::new();
-        let deadline = Duration::from_secs(LISTEN_SECS);
-
-        loop {
-            let elapsed = t0.elapsed();
-            if elapsed >= deadline {
-                break;
-            }
-            let remaining = deadline - elapsed;
-
-            let mut byte = [0u8; 1];
-            match tokio::time::timeout(remaining.min(Duration::from_millis(100)), port.read_exact(&mut byte)).await {
-                Ok(Ok(_)) => {
-                    frame_buf.push(byte[0]);
-                    total_bytes += 1;
-
-                    // Afficher la trame dès qu'on a 13 octets (taille standard Daly)
-                    if frame_buf.len() == 13 {
-                        let ms = t0.elapsed().as_millis();
-                        print!("  +{:>6}ms  [", ms);
-                        for (j, b) in frame_buf.iter().enumerate() {
-                            if j > 0 { print!(", "); }
-                            print!("{:02X}", b);
-                        }
-                        println!("]");
-                        frame_buf.clear();
-                    }
-                    // Sécurité : si on accumule sans voir de trame valide, vider
-                    if frame_buf.len() >= 64 {
-                        let ms = t0.elapsed().as_millis();
-                        print!("  +{:>6}ms  GARBAGE ({} octets) [", ms, frame_buf.len());
-                        for (j, b) in frame_buf.iter().enumerate() {
-                            if j > 0 { print!(", "); }
-                            print!("{:02X}", b);
-                        }
-                        println!("]");
-                        frame_buf.clear();
-                    }
-                }
-                Ok(Err(e)) => {
-                    eprintln!("  erreur lecture : {}", e);
-                    break;
-                }
-                Err(_timeout) => {
-                    // Rien reçu dans les 100ms — afficher le reste s'il y en a
-                    if !frame_buf.is_empty() {
-                        let ms = t0.elapsed().as_millis();
-                        print!("  +{:>6}ms  PARTIEL ({} octets) [", ms, frame_buf.len());
-                        for (j, b) in frame_buf.iter().enumerate() {
-                            if j > 0 { print!(", "); }
-                            print!("{:02X}", b);
-                        }
-                        println!("]");
-                        frame_buf.clear();
-                    }
-                }
-            }
-        }
-
-        // Résidu final
-        if !frame_buf.is_empty() {
-            let ms = t0.elapsed().as_millis();
-            print!("  +{:>6}ms  RÉSIDU ({} octets) [", ms, frame_buf.len());
-            for (j, b) in frame_buf.iter().enumerate() {
-                if j > 0 { print!(", "); }
-                print!("{:02X}", b);
-            }
-            println!("]");
-        }
-
-        println!();
-        println!("  Total reçu : {} octets ({} trames de 13 octets)", total_bytes, total_bytes / 13);
     }
 
-    println!();
     println!("=============================================================");
     println!("  Probe terminé. Copiez tout le contenu ci-dessus.");
     println!("=============================================================");


### PR DESCRIPTION
…le BMS 0x02

Variante A : byte[1]=0x40, data[0]=bms_addr (mode actuel)
Variante B : byte[1]=bms_addr, data[0]=0x00 (mode parallèle Daly)
Variante C : byte[1]=0x40, data[0]=0x00     (broadcast)

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme