### PR TITLE
fix(protocol): adressage multi-BMS Daly — byte[1] = 0x3F + board_number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ name = "daly-bms-probe"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "daly-bms-core",
  "tokio",
  "tokio-serial",
  "tokio-util",

--- a/crates/daly-bms-core/src/protocol.rs
+++ b/crates/daly-bms-core/src/protocol.rs
@@ -1,21 +1,49 @@
 //! Format des trames UART Daly BMS et calcul du checksum.
 //!
-//! ## Format d'une trame (12 octets)
+//! ## Format d'une trame (13 octets)
 //!
 //! ```text
 //! [0]  0xA5        Start flag
-//! [1]  Adresse     0x40 (PC→BMS) ou 0x01–0xFF (BMS→PC)
+//! [1]  Adresse     PC→BMS : 0x3F + board_number  |  BMS→PC : board_number
 //! [2]  Data ID     Commande (0x90, 0x91, …)
 //! [3]  0x08        Longueur du champ Data (toujours 8)
-//! [4-11] Data      8 octets de données (requête : 0x00, réponse : valeurs)
-//! [11] Checksum    Somme des octets [0–10] & 0xFF
+//! [4-11] Data      8 octets (requête : réservés 0x00 ; réponse : valeurs)
+//! [12] Checksum    Somme des octets [0–11] & 0xFF
 //! ```
+//!
+//! ## Adressage multi-BMS (protocole Daly V1.21 §2.1)
+//!
+//! Le BMS filtre les requêtes sur `byte[1]` (son adresse PC écoutée).
+//! Le board number N correspond à `byte[1] = 0x3F + N` dans la requête PC.
+//!
+//! ```text
+//! Board 1  →  requête byte[1] = 0x40,  réponse byte[1] = 0x01
+//! Board 2  →  requête byte[1] = 0x41,  réponse byte[1] = 0x02
+//! Board N  →  requête byte[1] = 0x3F+N, réponse byte[1] = N
+//! ```
+//!
+//! Les 8 octets de données sont réservés (0x00) dans la direction PC→BMS.
 
 /// Longueur totale d'une trame Daly (requête ou réponse simple).
 pub const FRAME_LEN: usize = 13;
 
-/// Adresse PC (Host → BMS).
+/// Base de l'adresse PC : `PC_BASE + board_number` = adresse écoutée par ce BMS.
+pub const PC_BASE: u8 = 0x3F;
+
+/// Adresse PC pour le board 1 (valeur historique, conservée pour compatibilité).
 pub const PC_ADDRESS: u8 = 0x40;
+
+/// Calcule l'adresse PC à mettre dans `byte[1]` pour le board/BMS `addr`.
+///
+/// ```
+/// use daly_bms_core::protocol::pc_address_for;
+/// assert_eq!(pc_address_for(1), 0x40);
+/// assert_eq!(pc_address_for(2), 0x41);
+/// ```
+#[inline]
+pub fn pc_address_for(bms_addr: u8) -> u8 {
+    PC_BASE.wrapping_add(bms_addr)
+}
 
 /// Octet de démarrage de trame.
 pub const START_FLAG: u8 = 0xA5;
@@ -101,52 +129,38 @@ pub struct RequestFrame {
 impl RequestFrame {
     /// Construit une trame de requête avec les 8 octets de données spécifiés.
     ///
-    /// Protocole Daly RS485 parallèle (Parallel Manage) :
-    /// - Byte[1]  = PC_ADDRESS (0x40) — toujours fixe
-    /// - Data[0]  = adresse BMS cible (Board number : 0x01, 0x02…)
-    ///              0x00 = broadcast (tous les BMS répondent)
-    ///
-    /// C'est data[0] qui sélectionne le BMS, PAS byte[1].
-    /// Les BMS configurés en mode parallèle (Board number ≥ 1) répondent
-    /// uniquement à leur adresse dans data[0] ou au broadcast (0x00).
+    /// Protocole Daly V1.21 §2.3.1 :
+    /// - `byte[1]` = `0x3F + bms_address` (adresse PC écoutée par ce BMS)
+    /// - `data[0..7]` = réservés (0x00) sauf pour certaines commandes d'écriture
     pub fn new(bms_address: u8, cmd: DataId, data: [u8; 8]) -> Self {
         let mut bytes = [0u8; FRAME_LEN];
         bytes[0] = START_FLAG;
-        bytes[1] = PC_ADDRESS;   // 0x40 — toujours
+        bytes[1] = pc_address_for(bms_address);  // 0x3F + bms_address
         bytes[2] = cmd as u8;
         bytes[3] = DATA_LEN;
         bytes[4..12].copy_from_slice(&data);
         bytes[12] = checksum(&bytes[..12]);
-        let _ = bms_address;
         Self { bytes }
     }
 
-    /// Trame de lecture standard : data[0] = bms_address (adressage parallèle Daly).
+    /// Trame de lecture standard : data[0..7] = 0x00 (réservé).
     ///
-    /// `A5 40 <CMD> 08 <bms_addr> 00 00 00 00 00 00 00 <CS>`
+    /// `A5 [0x3F+addr] <CMD> 08 00 00 00 00 00 00 00 00 <CS>`
     pub fn read(bms_address: u8, cmd: DataId) -> Self {
-        let mut data = [0u8; 8];
-        data[0] = bms_address;  // Adresse BMS cible dans data[0]
-        Self::new(bms_address, cmd, data)
+        Self::new(bms_address, cmd, [0u8; 8])
     }
 
-    /// Trame d'écriture avec 1 octet de payload.
-    ///
-    /// Pour les commandes d'écriture, l'adresse BMS est dans data[0] et la
-    /// valeur dans data[1] (protocole parallèle Daly).
+    /// Trame d'écriture avec 1 octet de payload dans data[0].
     pub fn write_byte(bms_address: u8, cmd: DataId, value: u8) -> Self {
         let mut data = [0u8; 8];
-        data[0] = bms_address;
-        data[1] = value;
+        data[0] = value;
         Self::new(bms_address, cmd, data)
     }
 
-    /// Trame d'écriture SOC : valeur en % × 10, uint16 BE.
-    /// data[0] = adresse BMS, data[4..5] = valeur SOC
+    /// Trame d'écriture SOC : valeur en % × 10, uint16 BE dans data[4..5].
     pub fn write_soc(bms_address: u8, soc_percent: f32) -> Self {
         let raw = (soc_percent * 10.0) as u16;
         let mut data = [0u8; 8];
-        data[0] = bms_address;
         data[4] = (raw >> 8) as u8;
         data[5] = (raw & 0xFF) as u8;
         Self::new(bms_address, DataId::SetSoc, data)
@@ -340,19 +354,28 @@ mod tests {
 
     #[test]
     fn test_request_frame_checksum() {
-        // Protocole parallèle Daly : byte[1]=0x40, data[0]=adresse BMS
-        // BMS 0x01 : checksum = 0xA5 + 0x40 + 0x90 + 0x08 + 0x01 = 0x17E → 0x7E
+        // BMS board 1 : byte[1] = 0x3F+1 = 0x40, data = 0x00
+        // checksum = 0xA5 + 0x40 + 0x90 + 0x08 = 0x17D → 0x7D
         let frame = RequestFrame::read(0x01, DataId::PackStatus);
         assert_eq!(frame.bytes[0], START_FLAG);
-        assert_eq!(frame.bytes[1], PC_ADDRESS); // 0x40
+        assert_eq!(frame.bytes[1], 0x40);   // pc_address_for(1) = 0x40
         assert_eq!(frame.bytes[2], 0x90);
         assert_eq!(frame.bytes[3], DATA_LEN);
-        assert_eq!(frame.bytes[4], 0x01);       // data[0] = adresse BMS
-        assert_eq!(frame.bytes[12], 0x7E);
+        assert_eq!(frame.bytes[4], 0x00);   // data[0] réservé = 0x00
+        assert_eq!(frame.bytes[12], 0x7D);
 
-        // BMS 0x02 : checksum = 0xA5 + 0x40 + 0x90 + 0x08 + 0x02 = 0x17F → 0x7F
+        // BMS board 2 : byte[1] = 0x3F+2 = 0x41, data = 0x00
+        // checksum = 0xA5 + 0x41 + 0x90 + 0x08 = 0x17E → 0x7E
         let frame2 = RequestFrame::read(0x02, DataId::PackStatus);
-        assert_eq!(frame2.bytes[4], 0x02);      // data[0] = adresse BMS
-        assert_eq!(frame2.bytes[12], 0x7F);
+        assert_eq!(frame2.bytes[1], 0x41);  // pc_address_for(2) = 0x41
+        assert_eq!(frame2.bytes[4], 0x00);  // data[0] réservé = 0x00
+        assert_eq!(frame2.bytes[12], 0x7E);
+    }
+
+    #[test]
+    fn test_pc_address_for() {
+        assert_eq!(pc_address_for(1), 0x40);
+        assert_eq!(pc_address_for(2), 0x41);
+        assert_eq!(pc_address_for(3), 0x42);
     }
 }

--- a/crates/daly-bms-probe/Cargo.toml
+++ b/crates/daly-bms-probe/Cargo.toml
@@ -8,6 +8,7 @@ name = "daly-bms-probe"
 path = "src/main.rs"
 
 [dependencies]
+daly-bms-core = { path = "../daly-bms-core" }
 tokio        = { workspace = true }
 tokio-serial = { workspace = true }
 clap         = { workspace = true }

--- a/crates/daly-bms-probe/src/main.rs
+++ b/crates/daly-bms-probe/src/main.rs
@@ -1,83 +1,31 @@
 //! daly-bms-probe — outil de diagnostic RS485 brut
 //!
-//! Teste 3 variantes d'adressage pour chaque BMS afin de déterminer
-//! quelle trame provoque une réponse.
-//!
-//! Variante A : byte[1]=0x40 (PC), data[0]=bms_addr  ← actuel
-//! Variante B : byte[1]=bms_addr, data[0]=0x00       ← mode parallèle Daly
-//! Variante C : byte[1]=0x40 (PC), data[0]=0x00      ← broadcast standard
+//! Protocole Daly V1.21 §2.1 multi-BMS confirmé :
+//!   byte[1] requête = 0x3F + board_number
+//!   Board 1 → byte[1]=0x40 → réponse byte[1]=0x01
+//!   Board 2 → byte[1]=0x41 → réponse byte[1]=0x02
 
 use clap::Parser;
+use daly_bms_core::protocol::{checksum, pc_address_for, DataId, RequestFrame, FRAME_LEN, START_FLAG};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_serial::SerialPortBuilderExt;
 
-/// Durée d'écoute après chaque envoi (secondes)
 const LISTEN_SECS: u64 = 5;
-
-/// Pause entre deux envois (ms)
-const PAUSE_MS: u64 = 1000;
-
-/// Commande PackStatus (SOC)
-const CMD_PACK_STATUS: u8 = 0x90;
-
-/// Adresse source PC
-const PC_ADDR: u8 = 0x40;
+const PAUSE_MS:    u64 = 800;
 
 #[derive(Parser)]
-#[command(name = "daly-bms-probe", about = "Diagnostic RS485 brut pour BMS Daly")]
+#[command(name = "daly-bms-probe", about = "Diagnostic RS485 Daly multi-BMS")]
 struct Cli {
-    /// Port série (ex: COM6 ou /dev/ttyUSB0)
     #[arg(long, default_value = "COM6")]
     port: String,
 
-    /// Baud rate
     #[arg(long, default_value_t = 9600)]
     baud: u32,
 
-    /// Adresses BMS à sonder (séparées par virgule, ex: 0x01,0x02)
-    #[arg(long, default_value = "0x01,0x02")]
-    bms: String,
-}
-
-fn checksum(data: &[u8]) -> u8 {
-    data.iter().fold(0u8, |acc, &b| acc.wrapping_add(b))
-}
-
-/// Variante A : byte[1]=0x40 (PC), data[0]=bms_addr
-fn frame_a(bms_addr: u8) -> [u8; 13] {
-    let mut f = [0u8; 13];
-    f[0] = 0xA5;
-    f[1] = PC_ADDR;
-    f[2] = CMD_PACK_STATUS;
-    f[3] = 0x08;
-    f[4] = bms_addr;   // data[0] = adresse BMS
-    f[12] = checksum(&f[..12]);
-    f
-}
-
-/// Variante B : byte[1]=bms_addr, data[0]=0x00  (mode parallèle Daly)
-fn frame_b(bms_addr: u8) -> [u8; 13] {
-    let mut f = [0u8; 13];
-    f[0] = 0xA5;
-    f[1] = bms_addr;   // adresse BMS dans byte[1]
-    f[2] = CMD_PACK_STATUS;
-    f[3] = 0x08;
-    // data[0..7] = 0x00
-    f[12] = checksum(&f[..12]);
-    f
-}
-
-/// Variante C : byte[1]=0x40 (PC), data[0]=0x00  (broadcast standard)
-fn frame_c() -> [u8; 13] {
-    let mut f = [0u8; 13];
-    f[0] = 0xA5;
-    f[1] = PC_ADDR;
-    f[2] = CMD_PACK_STATUS;
-    f[3] = 0x08;
-    // data[0..7] = 0x00 (pas d'adresse spécifique)
-    f[12] = checksum(&f[..12]);
-    f
+    /// Board numbers à interroger (ex: 1,2)
+    #[arg(long, default_value = "1,2")]
+    boards: String,
 }
 
 fn fmt_frame(f: &[u8]) -> String {
@@ -85,28 +33,44 @@ fn fmt_frame(f: &[u8]) -> String {
     format!("[{}]", parts.join(", "))
 }
 
-async fn probe_variant(
-    port: &mut tokio_serial::SerialStream,
-    label: &str,
-    frame: &[u8],
-) {
-    println!("  Variante {} — TX : {}", label, fmt_frame(frame));
+fn decode_response(f: &[u8]) {
+    if f.len() != FRAME_LEN || f[0] != START_FLAG { return; }
+    let bms_addr = f[1];
+    let cmd      = f[2];
+    let chk_ok   = if checksum(&f[..12]) == f[12] { "chk=OK" } else { "chk=ERREUR" };
+
+    if cmd == DataId::PackStatus as u8 {
+        let voltage     = u16::from_be_bytes([f[4], f[5]]);
+        let current_raw = u16::from_be_bytes([f[6], f[7]]) as i32;
+        let soc         = u16::from_be_bytes([f[10], f[11]]);
+        println!("      → BMS={:#04x}  V={:.1}V  I={:+.1}A  SOC={:.1}%  {}",
+            bms_addr,
+            voltage as f32 / 10.0,
+            (current_raw - 30_000) as f32 / 10.0,
+            soc as f32 / 10.0,
+            chk_ok,
+        );
+    } else {
+        println!("      → BMS={:#04x}  cmd={:#04x}  {}", bms_addr, cmd, chk_ok);
+    }
+}
+
+async fn probe_once(port: &mut tokio_serial::SerialStream, label: &str, frame: &[u8]) {
+    println!("  {}  TX : {}", label, fmt_frame(frame));
 
     // Vider buffer entrant
-    {
-        let mut drain = [0u8; 256];
-        let _ = tokio::time::timeout(Duration::from_millis(200), port.read(&mut drain)).await;
-    }
+    let mut drain = [0u8; 256];
+    let _ = tokio::time::timeout(Duration::from_millis(100), port.read(&mut drain)).await;
 
     if let Err(e) = port.write_all(frame).await {
-        println!("    ERREUR envoi : {}", e);
+        println!("      ERREUR envoi : {}", e);
         return;
     }
 
     let t0 = Instant::now();
     let deadline = Duration::from_secs(LISTEN_SECS);
-    let mut frame_buf: Vec<u8> = Vec::new();
-    let mut got_response = false;
+    let mut buf: Vec<u8> = Vec::new();
+    let mut got = false;
 
     loop {
         let elapsed = t0.elapsed();
@@ -116,63 +80,39 @@ async fn probe_variant(
         let mut byte = [0u8; 1];
         match tokio::time::timeout(remaining.min(Duration::from_millis(100)), port.read_exact(&mut byte)).await {
             Ok(Ok(_)) => {
-                frame_buf.push(byte[0]);
-                if frame_buf.len() == 13 {
-                    let ms = t0.elapsed().as_millis();
-                    println!("    +{:>5}ms  RX : {}", ms, fmt_frame(&frame_buf));
-                    got_response = true;
-                    frame_buf.clear();
+                buf.push(byte[0]);
+                if buf.len() == FRAME_LEN {
+                    println!("      +{:>5}ms  RX : {}", t0.elapsed().as_millis(), fmt_frame(&buf));
+                    decode_response(&buf);
+                    got = true;
+                    buf.clear();
                 }
-                if frame_buf.len() >= 64 {
-                    println!("    GARBAGE ({} octets) : {}", frame_buf.len(), fmt_frame(&frame_buf));
-                    frame_buf.clear();
-                }
+                if buf.len() >= 64 { buf.clear(); }
             }
-            Ok(Err(e)) => { println!("    erreur lecture : {}", e); break; }
-            Err(_) => {
-                // timeout 100ms — afficher partiel si fin de deadline
-                if !frame_buf.is_empty() && t0.elapsed() >= deadline {
-                    println!("    PARTIEL ({} octets) : {}", frame_buf.len(), fmt_frame(&frame_buf));
-                }
-            }
+            _ => {}
         }
     }
-
-    if !got_response {
-        println!("    (aucune réponse en {}s)", LISTEN_SECS);
-    }
+    if !got { println!("      (aucune réponse en {}s)", LISTEN_SECS); }
 }
 
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
 
-    let addresses: Vec<u8> = cli.bms.split(',')
-        .filter_map(|s| {
-            let s = s.trim();
-            if s.starts_with("0x") || s.starts_with("0X") {
-                u8::from_str_radix(&s[2..], 16).ok()
-            } else {
-                s.parse().ok()
-            }
-        })
+    let board_numbers: Vec<u8> = cli.boards.split(',')
+        .filter_map(|s| s.trim().parse::<u8>().ok())
         .collect();
 
-    if addresses.is_empty() {
-        eprintln!("ERREUR : aucune adresse BMS valide");
+    if board_numbers.is_empty() {
+        eprintln!("ERREUR : aucun board number valide (ex: --boards 1,2)");
         std::process::exit(1);
     }
 
     println!("=============================================================");
-    println!("  daly-bms-probe  —  Diagnostic adressage RS485");
+    println!("  daly-bms-probe  —  Daly multi-BMS RS485");
     println!("  Port : {}  Baud : {}", cli.port, cli.baud);
-    println!("  Ecoute : {}s par variante", LISTEN_SECS);
+    println!("  Board N → requête byte[1] = 0x{:02X}+N", 0x3Fu8);
     println!("=============================================================");
-    println!();
-    println!("  Variante A : byte[1]=0x40(PC), data[0]=bms_addr  (actuel)");
-    println!("  Variante B : byte[1]=bms_addr, data[0]=0x00      (mode parallèle)");
-    println!("  Variante C : byte[1]=0x40(PC), data[0]=0x00      (broadcast)");
-    println!();
 
     let mut port = tokio_serial::new(&cli.port, cli.baud)
         .timeout(Duration::from_millis(100))
@@ -182,23 +122,28 @@ async fn main() {
             std::process::exit(1);
         });
 
-    for &addr in &addresses {
-        println!("-------------------------------------------------------------");
-        println!("  BMS {:#04x}", addr);
-        println!("-------------------------------------------------------------");
-
-        probe_variant(&mut port, "A", &frame_a(addr)).await;
-        tokio::time::sleep(Duration::from_millis(PAUSE_MS)).await;
-
-        probe_variant(&mut port, "B", &frame_b(addr)).await;
-        tokio::time::sleep(Duration::from_millis(PAUSE_MS)).await;
-
-        probe_variant(&mut port, "C", &frame_c()).await;
-        tokio::time::sleep(Duration::from_millis(PAUSE_MS)).await;
+    for &board in &board_numbers {
+        let pc_addr = pc_address_for(board);
         println!();
+        println!("-------------------------------------------------------------");
+        println!("  Board {}  (byte[1] requête = {:#04x})", board, pc_addr);
+        println!("-------------------------------------------------------------");
+
+        let frame = RequestFrame::read(board, DataId::PackStatus);
+        probe_once(&mut port, "PackStatus (0x90)", frame.as_bytes()).await;
+        tokio::time::sleep(Duration::from_millis(PAUSE_MS)).await;
+
+        let frame = RequestFrame::read(board, DataId::MosStatus);
+        probe_once(&mut port, "MosStatus  (0x93)", frame.as_bytes()).await;
+        tokio::time::sleep(Duration::from_millis(PAUSE_MS)).await;
+
+        let frame = RequestFrame::read(board, DataId::StatusInfo1);
+        probe_once(&mut port, "StatusInfo (0x94)", frame.as_bytes()).await;
+        tokio::time::sleep(Duration::from_millis(PAUSE_MS)).await;
     }
 
+    println!();
     println!("=============================================================");
-    println!("  Probe terminé. Copiez tout le contenu ci-dessus.");
+    println!("  Probe terminé.");
     println!("=============================================================");
 }


### PR DESCRIPTION
Le protocole Daly V1.21 §2.1 filtre les requêtes sur byte[1] (adresse source PC). En mode multi-BMS, chaque board N écoute uniquement byte[1] = 0x3F + N :
  Board 1 → requête byte[1]=0x40, réponse byte[1]=0x01
  Board 2 → requête byte[1]=0x41, réponse byte[1]=0x02

Confirmé par probe hardware : BMS 0x02 répond uniquement à TX [A5,41,...].

- protocol.rs : ajout pc_address_for(), RequestFrame corrigé (data=0x00 réservé)
- probe/main.rs : utilise daly-bms-core, teste PackStatus/MOS/StatusInfo par board
- probe/Cargo.toml : ajout dépendance daly-bms-core

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme