### PR TITLE
fix(commands,probe): corriger décodage MosStatus et courant PackStatus

### DIFF
--- a/crates/daly-bms-core/src/commands.rs
+++ b/crates/daly-bms-core/src/commands.rs
@@ -69,15 +69,22 @@ pub async fn get_temperature_minmax(
 }
 
 /// Lit l'état des MOSFET, les cycles et la capacité résiduelle (0x93).
+///
+/// Layout selon Daly UART V1.21 :
+/// - D0 : State (0=repos, 1=charge, 2=décharge)
+/// - D1 : Charge MOS state  (0=off, 1=on)
+/// - D2 : Discharge MOS status (0=off, 1=on)
+/// - D3 : BMS life (0–255 cycles)
+/// - D4-D7 : Remain capacity (mAh, uint32 BE)
 pub async fn get_mos_status(port: &Arc<DalyPort>, addr: u8) -> Result<MosStatus> {
     let frame = port.send_command(addr, DataId::MosStatus, [0u8; 8]).await?;
     let d = frame.data();
     Ok(MosStatus {
-        charge_mos:           d[0] & 0x02 != 0,
-        discharge_mos:        d[0] & 0x01 != 0,
-        bms_life:             d[1],
+        charge_mos:            d[1] != 0,
+        discharge_mos:         d[2] != 0,
+        bms_life:              d[3],
         residual_capacity_mah: u32::from_be_bytes([d[4], d[5], d[6], d[7]]),
-        charge_cycles:        read_u16_be(d, 2) as u32,
+        charge_cycles:         d[3] as u32,
     })
 }
 

--- a/crates/daly-bms-probe/src/main.rs
+++ b/crates/daly-bms-probe/src/main.rs
@@ -40,8 +40,13 @@ fn decode_response(f: &[u8]) {
     let chk_ok   = if checksum(&f[..12]) == f[12] { "chk=OK" } else { "chk=ERREUR" };
 
     if cmd == DataId::PackStatus as u8 {
+        // frame[4..11] = data[0..7]
+        // D0-D1 : tension totale (0.1 V)
+        // D2-D3 : tension acquisition (ignoré)
+        // D4-D5 : courant (offset 30000, 0.1 A)  → f[8], f[9]
+        // D6-D7 : SOC (0.1 %)                    → f[10], f[11]
         let voltage     = u16::from_be_bytes([f[4], f[5]]);
-        let current_raw = u16::from_be_bytes([f[6], f[7]]) as i32;
+        let current_raw = u16::from_be_bytes([f[8], f[9]]) as i32;
         let soc         = u16::from_be_bytes([f[10], f[11]]);
         println!("      → BMS={:#04x}  V={:.1}V  I={:+.1}A  SOC={:.1}%  {}",
             bms_addr,
@@ -50,6 +55,25 @@ fn decode_response(f: &[u8]) {
             soc as f32 / 10.0,
             chk_ok,
         );
+    } else if cmd == DataId::MosStatus as u8 {
+        // D0=state(0=repos,1=chg,2=dch), D1=CHG_MOS, D2=DCH_MOS, D3=cycles, D4..7=mAh
+        let state    = f[4];
+        let chg_mos  = f[5];
+        let dch_mos  = f[6];
+        let cycles   = f[7];
+        let capacity = u32::from_be_bytes([f[8], f[9], f[10], f[11]]);
+        let state_str = match state { 0 => "repos", 1 => "charge", 2 => "décharge", _ => "?" };
+        println!("      → BMS={:#04x}  state={}  CHG_MOS={}  DCH_MOS={}  cycles={}  cap={}mAh  {}",
+            bms_addr, state_str, chg_mos, dch_mos, cycles, capacity, chk_ok);
+    } else if cmd == DataId::StatusInfo1 as u8 {
+        // D0=nb_cells, D1=nb_temp, D2=charger, D3=load, D4=DIO, D5-D6=cycle_count
+        let cells    = f[4];
+        let temps    = f[5];
+        let charger  = f[6];
+        let load     = f[7];
+        let cycles   = u16::from_be_bytes([f[9], f[10]]);
+        println!("      → BMS={:#04x}  cells={}  temp_sensors={}  charger={}  load={}  cycles={}  {}",
+            bms_addr, cells, temps, charger, load, cycles, chk_ok);
     } else {
         println!("      → BMS={:#04x}  cmd={:#04x}  {}", bms_addr, cmd, chk_ok);
     }


### PR DESCRIPTION
commands.rs get_mos_status :
  - d[0]=state (repos/charge/décharge), pas flags MOS
  - d[1]=charge_MOS, d[2]=discharge_MOS, d[3]=bms_life/cycles
  - d[4..7]=capacité résiduelle mAh (inchangé) Confirmé sur données brutes : [01,01,01,7C,00,00,68,10]

probe decode_response :
  - PackStatus courant : f[8,9] (D4-D5) au lieu de f[6,7] (D2-D3 gather voltage)
  - Ajout décodage MosStatus et StatusInfo1 lisibles

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme