### PR TITLE
chore: supprimer tous les warnings de compilation

### DIFF
--- a/crates/daly-bms-cli/src/main.rs
+++ b/crates/daly-bms-cli/src/main.rs
@@ -26,7 +26,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use daly_bms_core::{
-    bus::{BmsConfig, DalyBusManager, DalyPort},
+    bus::{DalyBusManager, DalyPort},
     commands,
     write,
 };
@@ -274,7 +274,7 @@ async fn cmd_discover(port: &Arc<DalyPort>, start: u8, end: u8) {
     }
 }
 
-async fn cmd_poll(port: &Arc<DalyPort>, addr: u8, cells: u8, interval_sec: u64) -> Result<()> {
+async fn cmd_poll(port: &Arc<DalyPort>, addr: u8, _cells: u8, interval_sec: u64) -> Result<()> {
     use tokio::time::{sleep, Duration};
     println!("Polling BMS {:#04x} (Ctrl+C pour arrêter)…", addr);
     loop {

--- a/crates/daly-bms-core/src/commands.rs
+++ b/crates/daly-bms-core/src/commands.rs
@@ -10,7 +10,7 @@ use crate::protocol::{
     decode_voltage, read_u16_be,
 };
 use crate::types::{
-    BalanceFlags, CellTemperatures, CellVoltages, MosStatus, SocData, StatusInfo, SystemData,
+    BalanceFlags, CellTemperatures, CellVoltages, MosStatus, SocData, StatusInfo,
 };
 use std::sync::Arc;
 use tracing::trace;

--- a/crates/daly-bms-core/src/poll.rs
+++ b/crates/daly-bms-core/src/poll.rs
@@ -7,7 +7,7 @@ use crate::bus::{BmsConfig, DalyBusManager, DalyPort};
 use crate::commands;
 use crate::error::DalyError;
 use crate::types::{
-    Alarms, BmsSnapshot, DcData, HistoryData, InfoData, IoData, SystemData,
+    BmsSnapshot, DcData, HistoryData, InfoData, IoData, SystemData,
 };
 use chrono::Utc;
 use std::collections::BTreeMap;
@@ -137,7 +137,7 @@ async fn poll_device(
 
     // ── 0x96 : Températures individuelles — sensor_count issu du 0x94 ────────
     let sensor_count = if status.temp_sensor_count > 0 { status.temp_sensor_count } else { device.temp_sensor_count };
-    let temperatures = retry(config.retries, || {
+    let _temperatures = retry(config.retries, || {
         commands::get_temperatures(port, addr, sensor_count)
     }).await.unwrap_or_default();
 

--- a/crates/daly-bms-server/src/api/bms.rs
+++ b/crates/daly-bms-server/src/api/bms.rs
@@ -10,9 +10,8 @@ use axum::{
 use axum::extract::ws::{Message, WebSocket};
 use daly_bms_core::types::BmsSnapshot;
 use futures::{SinkExt, StreamExt};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::{json, Value};
-use std::sync::Arc;
 
 // =============================================================================
 // Helpers
@@ -214,7 +213,9 @@ pub async fn compare_all(State(state): State<AppState>) -> Json<Value> {
 
 #[derive(Deserialize)]
 pub struct MosCommand {
+    #[allow(dead_code)]
     pub charge: Option<bool>,
+    #[allow(dead_code)]
     pub discharge: Option<bool>,
 }
 
@@ -230,6 +231,7 @@ pub async fn set_mos(
 
 #[derive(Deserialize)]
 pub struct SocCommand {
+    #[allow(dead_code)]
     pub soc: f32,
 }
 

--- a/crates/daly-bms-server/src/bridges/alerts.rs
+++ b/crates/daly-bms-server/src/bridges/alerts.rs
@@ -28,6 +28,7 @@ pub enum Severity {
 }
 
 impl Severity {
+    #[allow(dead_code)]
     fn icon(&self) -> &'static str {
         match self {
             Self::Warning  => "⚠️",
@@ -57,6 +58,7 @@ pub struct AlertContext<'a> {
 pub struct AlertRule {
     pub id:          &'static str,
     pub description: &'static str,
+    #[allow(dead_code)]
     pub severity:    Severity,
     pub cooldown:    Duration,
     pub trigger:     Box<dyn Fn(&AlertContext) -> Option<f32> + Send + Sync>,

--- a/crates/daly-bms-server/src/bridges/influx.rs
+++ b/crates/daly-bms-server/src/bridges/influx.rs
@@ -11,7 +11,6 @@ use influxdb2::Client;
 use influxdb2::models::DataPoint;
 use tracing::{error, info, warn};
 use std::time::Duration;
-use tokio::sync::mpsc;
 
 /// Démarre la tâche d'écriture InfluxDB en arrière-plan.
 pub async fn run_influx_bridge(state: AppState, cfg: InfluxConfig) {

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -162,6 +162,7 @@ pub struct MqttConfig {
 }
 
 impl MqttConfig {
+    #[allow(dead_code)]
     pub fn default_enabled() -> Self {
         Self {
             enabled:              false,
@@ -189,6 +190,7 @@ pub struct InfluxConfig {
 }
 
 impl InfluxConfig {
+    #[allow(dead_code)]
     pub fn default_enabled() -> Self {
         Self {
             enabled:                  false,

--- a/crates/daly-bms-server/src/simulator.rs
+++ b/crates/daly-bms-server/src/simulator.rs
@@ -125,7 +125,7 @@ impl SimBmsState {
     /// Températures simulées (légèrement corrélées au courant absolu).
     fn temperature(&self) -> f32 {
         let heat = self.current.abs() * 0.08; // ~0.8°C par 10A
-        let ambient_variation = ((self.tick as f32 / 900.0).sin() * 1.5); // ±1.5°C sur 15 min
+        let ambient_variation = (self.tick as f32 / 900.0).sin() * 1.5; // ±1.5°C sur 15 min
         (self.temp_base + heat + ambient_variation).clamp(15.0, 50.0)
     }
 


### PR DESCRIPTION
- commands.rs : supprimer import SystemData non utilisé
- poll.rs : supprimer import Alarms, préfixer _temperatures
- cli/main.rs : supprimer import BmsConfig, renommer cells → _cells
- server/api/bms.rs : supprimer imports Serialize et Arc
- server/bridges/influx.rs : supprimer import tokio::sync::mpsc
- server/simulator.rs : supprimer parenthèses superflues
- server/config.rs : #[allow(dead_code)] sur default_enabled()
- server/api/bms.rs : #[allow(dead_code)] sur champs TODO Phase 2
- server/bridges/alerts.rs : #[allow(dead_code)] sur severity et icon()

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme