### PR TITLE
fix(autodetect): éviter double ouverture du port sur Windows

### DIFF
--- a/crates/daly-bms-server/src/autodetect.rs
+++ b/crates/daly-bms-server/src/autodetect.rs
@@ -5,13 +5,17 @@
 
 use daly_bms_core::bus::DalyPort;
 use daly_bms_core::protocol::DataId;
+use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 /// Scanne tous les ports série disponibles et retourne le premier sur lequel
 /// un Daly BMS répond à PackStatus (0x90, adresse 0x01).
 ///
+/// Retourne le nom du port ET le port déjà ouvert pour éviter une double
+/// ouverture (problème "Accès refusé" sur Windows).
+///
 /// Timeout par port : 800 ms (un Daly répond normalement en < 200 ms).
-pub async fn find_daly_port(baud: u32) -> Option<String> {
+pub async fn find_daly_port(baud: u32) -> Option<(String, Arc<DalyPort>)> {
     let ports = match tokio_serial::available_ports() {
         Ok(p) => p,
         Err(e) => {
@@ -46,7 +50,8 @@ pub async fn find_daly_port(baud: u32) -> Option<String> {
         match port.send_command(0x01, DataId::PackStatus, [0u8; 8]).await {
             Ok(_) => {
                 info!("Daly BMS détecté sur {}", name);
-                return Some(name);
+                // Retourner le port déjà ouvert — évite une 2ème ouverture sur Windows
+                return Some((name, port));
             }
             Err(e) => {
                 debug!("{} : pas de réponse Daly ({})", name, e);

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -187,23 +187,29 @@ async fn main() -> anyhow::Result<()> {
         // Mode hardware réel
 
         // ── 1. Résoudre le port (auto-détection ou config) ───────────────────
-        let resolved_port = if auto_detect_port {
+        // find_daly_port() retourne le port déjà ouvert pour éviter la double
+        // ouverture Windows ("Accès refusé" si on ouvre, ferme, puis rouvre).
+        let (resolved_port, pre_opened_port) = if auto_detect_port {
             info!("Port non spécifié — détection automatique en cours...");
             match autodetect::find_daly_port(config.serial.baud).await {
-                Some(p) => p,
+                Some((name, port)) => (name, Some(port)),
                 None => {
                     error!("Aucun Daly BMS détecté sur les ports série disponibles.");
                     warn!("Relancez avec --port COMx pour forcer un port.");
                     warn!("Démarrage en mode API-seule (pas de données BMS).");
-                    String::new()
+                    (String::new(), None)
                 }
             }
         } else {
-            config.serial.port.clone()
+            (config.serial.port.clone(), None)
         };
 
         if !resolved_port.is_empty() {
-            let dal_port = DalyPort::open(&resolved_port, config.serial.baud, 500);
+            // Réutiliser le port pré-ouvert (auto-détect) ou en ouvrir un nouveau
+            let dal_port = match pre_opened_port {
+                Some(p) => Ok(p),
+                None    => DalyPort::open(&resolved_port, config.serial.baud, 500),
+            };
             match dal_port {
                 Ok(port) => {
                     info!("Port série {} ouvert à {} baud", resolved_port, config.serial.baud);


### PR DESCRIPTION
find_daly_port() retourne maintenant (String, Arc<DalyPort>) au lieu de String seule. Le port ouvert lors du test est réutilisé directement dans main.rs, ce qui évite l'erreur "Accès refusé" Windows qui survenait lors de la tentative de ré-ouverture immédiate du même port COM.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme