### PR TITLE
feat(deploy): service systemd complet pour Raspberry Pi 5

### DIFF
--- a/contrib/daly-bms.service
+++ b/contrib/daly-bms.service
@@ -1,1 +1,37 @@
+[Unit]
+Description=DalyBMS Server — Rust RS485 BMS monitor
+Documentation=https://github.com/thieryus007-cloud/Daly-BMS-Rust
+After=network.target
+Wants=network.target
 
+[Service]
+Type=simple
+User=dalybms
+Group=dalybms
+
+# Fichier de configuration TOML
+Environment=DALY_CONFIG=/etc/daly-bms/config.toml
+
+# Niveau de log (trace, debug, info, warn, error)
+Environment=RUST_LOG=info
+
+ExecStart=/usr/local/bin/daly-bms-server
+
+# Redémarrage automatique en cas de crash
+Restart=on-failure
+RestartSec=5s
+
+# Accès au port série RS485 (/dev/ttyUSB* ou /dev/ttyACM*)
+SupplementaryGroups=dialout
+
+# Sécurité minimale
+NoNewPrivileges=true
+PrivateTmp=true
+
+# Logs via journald
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=daly-bms
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/install-systemd.sh
+++ b/contrib/install-systemd.sh
@@ -17,7 +17,7 @@ BINARY_DEST="/usr/local/bin/daly-bms-server"
 SERVICE_SRC="contrib/daly-bms.service"
 SERVICE_DEST="/etc/systemd/system/daly-bms.service"
 
-CONFIG_EXAMPLE="config.example.toml"
+CONFIG_EXAMPLE="Config.toml"
 CONFIG_DEST="/etc/daly-bms/config.toml"
 
 CONFIG_DIR="/etc/daly-bms"


### PR DESCRIPTION
contrib/daly-bms.service :
  - Fichier était vide — rempli avec configuration complète
  - User/Group dalybms avec accès dialout (/dev/ttyUSB*)
  - DALY_CONFIG=/etc/daly-bms/config.toml via Environment=
  - Restart=on-failure avec délai 5s (redémarrage auto après crash)
  - NoNewPrivileges + PrivateTmp (sécurité minimale)
  - Logs via journald (journalctl -u daly-bms -f)

contrib/install-systemd.sh :
  - Correction référence config : config.example.toml → Config.toml

Notes Pi 5 :
  - Auto-détection port fonctionne sur Linux (/dev/ttyUSB0, /dev/ttyACM0)
  - Cross-compilation : make build-arm (target aarch64-unknown-linux-gnu)
  - Déploiement SSH  : make deploy PI_HOST=pi@192.168.1.x
  - Installation     : sudo bash contrib/install-systemd.sh

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme