### PR TITLE
feat(dashboard): boxplot ECharts par cellule + tri numérique des cell…

### DIFF
--- a/crates/daly-bms-server/src/dashboard/charts.rs
+++ b/crates/daly-bms-server/src/dashboard/charts.rs
@@ -135,14 +135,18 @@ pub fn cell_voltages_bar(
                       else if delta_mv > 50.0 { C_YELLOW }
                       else { C_GREEN };
 
-    let labels: Vec<String> = voltages.keys()
-        .map(|k| format!("\"C{}\"", k.trim_start_matches("Cell")))
+    // Tri numérique (Cell1 < Cell2 < … < Cell16), pas alphabétique
+    let mut sorted: Vec<(&String, &f32)> = voltages.iter().collect();
+    sorted.sort_by_key(|(k, _)| k.trim_start_matches("Cell").parse::<u16>().unwrap_or(0));
+
+    let labels: Vec<String> = sorted.iter()
+        .map(|(k, _)| format!("\"C{}\"", k.trim_start_matches("Cell")))
         .collect();
 
-    let values: Vec<String> = voltages.iter()
+    let values: Vec<String> = sorted.iter()
         .map(|(k, &v)| {
-            let is_min    = k == min_cell_id;
-            let is_max    = k == max_cell_id;
+            let is_min    = *k == min_cell_id;
+            let is_max    = *k == max_cell_id;
             let color     = if is_min { C_RED } else if is_max { C_GREEN } else { C_BLUE };
             let label     = if is_min { "MIN" } else if is_max { "MAX" } else { "" };
             let show_lbl  = !label.is_empty();
@@ -308,6 +312,110 @@ pub fn cell_spread_history(data: &HistoryData) -> String {
         grid  = C_GRID,
         green = C_GREEN,
         red   = C_RED,
+    )
+}
+
+// =============================================================================
+// Boxplot — distribution historique par cellule
+// =============================================================================
+
+/// Génère l'option ECharts boxplot montrant la distribution [min, Q1, médiane, Q3, max]
+/// de la tension de chaque cellule sur l'ensemble des snapshots historiques.
+///
+/// Nécessite au moins 4 snapshots. Les cellules sont triées numériquement.
+pub fn cell_boxplot(history: &[BmsSnapshot]) -> String {
+    if history.len() < 4 {
+        return "{}".to_string();
+    }
+
+    // Regrouper les tensions par cellule à travers tous les snapshots
+    let mut per_cell: BTreeMap<String, Vec<f32>> = BTreeMap::new();
+    for snap in history {
+        for (k, &v) in &snap.voltages {
+            per_cell.entry(k.clone()).or_default().push(v);
+        }
+    }
+    if per_cell.is_empty() {
+        return "{}".to_string();
+    }
+
+    // Tri numérique
+    let mut cells: Vec<(String, Vec<f32>)> = per_cell.into_iter().collect();
+    cells.sort_by_key(|(k, _)| k.trim_start_matches("Cell").parse::<u16>().unwrap_or(0));
+
+    let mut labels   = Vec::new();
+    let mut box_data = Vec::new();
+
+    for (k, mut vals) in cells {
+        if vals.is_empty() { continue; }
+        vals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let n  = vals.len();
+        let mn = vals[0];
+        let mx = vals[n - 1];
+        let q1 = vals[n / 4];
+        let md = vals[n / 2];
+        let q3 = vals[(3 * n) / 4];
+
+        labels.push(format!("\"C{}\"", k.trim_start_matches("Cell")));
+        box_data.push(format!("[{mn:.4},{q1:.4},{md:.4},{q3:.4},{mx:.4}]",
+            mn = mn, q1 = q1, md = md, q3 = q3, mx = mx));
+    }
+
+    format!(r#"{{
+  "backgroundColor": "{bg}",
+  "animation": false,
+  "title": {{
+    "text": "Distribution par cellule ({n} snapshots)",
+    "textStyle": {{ "color": "{muted}", "fontSize": 11, "fontWeight": "normal" }},
+    "top": "2%"
+  }},
+  "tooltip": {{
+    "trigger": "item",
+    "backgroundColor": "{surface}",
+    "borderColor": "{axis}",
+    "textStyle": {{ "color": "{text}", "fontSize": 11 }}
+  }},
+  "grid": {{ "left": "1%", "right": "2%", "top": "14%", "bottom": "12%", "containLabel": true }},
+  "xAxis": {{
+    "type":      "category",
+    "data":      [{labels}],
+    "axisLabel": {{ "color": "{muted}", "fontSize": 9 }},
+    "axisLine":  {{ "lineStyle": {{ "color": "{axis}" }} }}
+  }},
+  "yAxis": {{
+    "type":      "value",
+    "scale":     true,
+    "axisLabel": {{ "color": "{muted}", "formatter": "{{value}} V", "fontSize": 9 }},
+    "splitLine": {{ "lineStyle": {{ "color": "{grid}", "type": "dashed" }} }}
+  }},
+  "series": [{{
+    "type":     "boxplot",
+    "data":     [{data}],
+    "boxWidth": ["20%", "45%"],
+    "itemStyle": {{
+      "color":       "rgba(88,166,255,0.15)",
+      "borderColor": "{blue}",
+      "borderWidth": 1.5
+    }},
+    "emphasis": {{
+      "itemStyle": {{
+        "color":       "rgba(88,166,255,0.30)",
+        "borderColor": "{blue}",
+        "borderWidth": 2
+      }}
+    }}
+  }}]
+}}"#,
+        bg      = C_BG,
+        surface = "#161b22",
+        text    = "#e6edf3",
+        n       = history.len(),
+        labels  = labels.join(", "),
+        data    = box_data.join(", "),
+        muted   = C_MUTED,
+        axis    = C_AXIS,
+        grid    = C_GRID,
+        blue    = C_BLUE,
     )
 }
 

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -171,6 +171,7 @@ pub struct BmsDetail {
     // Options ECharts (JSON brut, injectés dans <script>)
     pub soc_gauge_json:       String,
     pub cells_bar_json:       String,
+    pub cells_boxplot_json:   String,
     pub cells_spread_json:    String,
     pub soc_history_json:     String,
     pub current_history_json: String,
@@ -253,6 +254,7 @@ pub async fn dashboard_bms(
                                   &snap.system.min_voltage_cell_id,
                                   &snap.system.max_voltage_cell_id,
                               ),
+        cells_boxplot_json:   charts::cell_boxplot(&history),
         cells_spread_json:    charts::cell_spread_history(&hist_data),
         soc_history_json:     charts::soc_history_line(&hist_data),
         current_history_json: charts::current_history_line(&hist_data),

--- a/crates/daly-bms-server/templates/bms_detail.html
+++ b/crates/daly-bms-server/templates/bms_detail.html
@@ -124,6 +124,18 @@
   </div>
 </div>
 
+{# ─── Boxplot distribution historique par cellule ────────────────────────── #}
+<div class="chart-section">
+  <h3>Boxplot cellules — distribution historique
+    <span style="font-size:0.7rem;color:var(--muted);font-weight:400;margin-left:0.5rem">
+      ┤min · Q1 · médiane · Q3 · max├ sur la session
+    </span>
+  </h3>
+  <div class="chart-box">
+    <div id="chart-boxplot" style="height:240px"></div>
+  </div>
+</div>
+
 {# ─── Historique SOC + Courant (2 colonnes) ──────────────────────────────── #}
 <div class="chart-row">
   <div class="chart-section" style="margin-bottom:0">
@@ -178,6 +190,7 @@
 {# JSON ECharts (cachés) #}
 <script type="application/json" id="opt-gauge">{{ detail.soc_gauge_json|safe }}</script>
 <script type="application/json" id="opt-cells">{{ detail.cells_bar_json|safe }}</script>
+<script type="application/json" id="opt-boxplot">{{ detail.cells_boxplot_json|safe }}</script>
 <script type="application/json" id="opt-spread">{{ detail.cells_spread_json|safe }}</script>
 <script type="application/json" id="opt-soc">{{ detail.soc_history_json|safe }}</script>
 <script type="application/json" id="opt-cur">{{ detail.current_history_json|safe }}</script>
@@ -201,15 +214,16 @@
   }
 
   const cGauge  = initChart('soc-gauge',   'opt-gauge');
-  const cCells  = initChart('chart-cells', 'opt-cells');
-  const cSpread = initChart('chart-spread','opt-spread');
+  const cCells   = initChart('chart-cells',   'opt-cells');
+  const cBoxplot = initChart('chart-boxplot', 'opt-boxplot');
+  const cSpread  = initChart('chart-spread',  'opt-spread');
   const cSoc    = initChart('chart-soc',   'opt-soc');
   const cCur    = initChart('chart-cur',   'opt-cur');
   const cVT     = initChart('chart-vt',    'opt-vt');
 
   // ─── Resize automatique ────────────────────────────────────────────────────
   window.addEventListener('resize', function() {
-    [cGauge, cCells, cSpread, cSoc, cCur, cVT].forEach(function(c) { if (c) c.resize(); });
+    [cGauge, cCells, cBoxplot, cSpread, cSoc, cCur, cVT].forEach(function(c) { if (c) c.resize(); });
   });
 
   // ─── Helpers ───────────────────────────────────────────────────────────────
@@ -302,10 +316,38 @@
 
         if (cSoc) cSoc.setOption({ xAxis: { data: ts }, series: [{ data: soc }] });
         if (cCur) cCur.setOption({ xAxis: { data: ts }, series: [{ data: cur }] });
-        if (cVT)  cVT.setOption({
-          xAxis: { data: ts },
-          series: [{ data: volt }, { data: temp }]
-        });
+        if (cVT)  cVT.setOption({ xAxis: { data: ts }, series: [{ data: volt }, { data: temp }] });
+
+        // Spread min/max par snapshot
+        const minCv = data.map(function(s) { return s.System.MinCellVoltage; });
+        const maxCv = data.map(function(s) { return s.System.MaxCellVoltage; });
+        if (cSpread) cSpread.setOption({ xAxis: { data: ts }, series: [{ data: maxCv }, { data: minCv }] });
+
+        // Boxplot : regrouper les tensions par cellule et recalculer les statistiques
+        if (cBoxplot && data.length >= 4) {
+          var cellMap = {};
+          data.forEach(function(s) {
+            if (!s.Voltages) return;
+            Object.entries(s.Voltages).forEach(function(e) {
+              if (!cellMap[e[0]]) cellMap[e[0]] = [];
+              cellMap[e[0]].push(+e[1]);
+            });
+          });
+          var cellKeys = Object.keys(cellMap).sort(function(a, b) {
+            return parseInt(a.replace(/\D/g,'')) - parseInt(b.replace(/\D/g,''));
+          });
+          var bpLabels = cellKeys.map(function(k) { return 'C' + k.replace(/\D/g,''); });
+          var bpData   = cellKeys.map(function(k) {
+            var v = cellMap[k].slice().sort(function(a,b){return a-b;});
+            var n = v.length;
+            return [v[0], v[Math.floor(n/4)], v[Math.floor(n/2)], v[Math.floor(3*n/4)], v[n-1]];
+          });
+          cBoxplot.setOption({
+            title: { text: 'Distribution par cellule (' + data.length + ' snapshots)' },
+            xAxis: { data: bpLabels },
+            series: [{ data: bpData }]
+          });
+        }
       })
       .catch(function() {});
   }


### PR DESCRIPTION
…ules

charts.rs :
  - cell_voltages_bar() : tri numérique Cell1<Cell2<…<Cell16 (fix tri alphabétique qui donnait C1,C10,C11,…C2)
  - cell_boxplot() : nouveau chart boxplot ECharts calculant [min, Q1, médiane, Q3, max] par cellule depuis l'historique — cellules triées numériquement, axe Y auto-scale

mod.rs :
  - BmsDetail : nouveau champ cells_boxplot_json
  - Génération via charts::cell_boxplot(&history)

bms_detail.html :
  - Section boxplot pleine largeur entre spread et historique SOC
  - opt-boxplot JSON caché, initialisation cBoxplot
  - refreshHistory() : recalcule le boxplot depuis l'API history (tri numérique, calcul percentiles en JS)
  - refreshHistory() met à jour le spread chart également
  - Resize handler inclut le nouveau chart

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme