### PR TITLE
Fix charge_cycles: use 0x94 bytes[5-6] (u16) instead of 0x93 byte[3] …

### DIFF
--- a/crates/daly-bms-core/src/poll.rs
+++ b/crates/daly-bms-core/src/poll.rs
@@ -190,7 +190,7 @@ async fn poll_device(
     };
 
     let history = HistoryData {
-        charge_cycles:   mos.charge_cycles,
+        charge_cycles:   status.cycle_count as u32, // 0x94 bytes[5-6] : u16, correct
         minimum_voltage: 0.0, // non disponible en temps réel
         maximum_voltage: 0.0,
         total_ah_drawn:  0.0,


### PR DESCRIPTION
…(u8 BMS life)

0x93 byte[3] is the "BMS life" counter — a rolling u8 (0-255) unrelated to charge cycles. The actual cycle count is in command 0x94 bytes[5-6] as u16 (up to 65535), which matches what Node-RED displays.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme