### PR TITLE
fix(config): port vide = auto-détection, db_path vide = alertes désac…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -8,7 +8,9 @@
 
 [serial]
 # Port série RS485 (USB → /dev/ttyUSB* ou /dev/ttyACM*)
-port = "/dev/ttyUSB1"
+# Sur Linux : /dev/ttyUSB0 ou /dev/ttyUSB1
+# Sur Windows : laisser vide pour auto-détection, ou spécifier COM6, COM4...
+port = ""
 
 # Vitesse de communication (Daly standard = 9600)
 baud = 9600
@@ -109,7 +111,8 @@ batch_flush_interval_sec = 5.0
 
 [alerts]
 # Chemin de la base SQLite pour journal des alertes
-db_path = "/var/lib/daly-bms/alerts.db"
+# Laisser vide pour désactiver les alertes (pas de base SQLite requise)
+db_path = ""
 
 # Intervalle d'évaluation des règles (secondes)
 check_interval_sec = 1.0

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -125,7 +125,7 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Flags d'auto-détection ────────────────────────────────────────────────
     // Actifs uniquement si aucun fichier config ET aucun argument CLI fourni.
-    let auto_detect_port    = !args.simulate && args.port.is_none()      && !config_from_file;
+    let auto_detect_port    = !args.simulate && args.port.is_none()      && (!config_from_file || config.serial.port.is_empty());
     let auto_discover_addrs = !args.simulate && args.bms_addrs.is_empty() && !config_from_file;
 
     // ── Logging ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
…tivées

- Config.toml: port = "" pour que Windows auto-détecte (COM6 etc.)
- Config.toml: db_path = "" pour désactiver SQLite (chemin Linux invalide)
- main.rs: auto_detect_port actif si port vide même avec config fichier

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme