### PR TITLE
docs: mise à jour documentation session 15 mars 2026

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Daly-BMS — Rust Edition
 
-**Version Rust complète** — mise à jour 14 mars 2026
+**Version Rust complète** — mise à jour 15 mars 2026
 Remplacement total de la stack Python/FastAPI par **Rust** (workspace multi-crates : `daly-bms-core` + `daly-bms-server` + `daly-bms-cli`).
 
 > Infrastructure Docker **inchangée** (Mosquitto, InfluxDB, Grafana, Node-RED).
@@ -15,17 +15,27 @@ Raspberry pi os lite (64-bit)
 ## Architecture globale
 
 ```
-Pack A (0x01) ─┐
-Pack B (0x02) ─┤── RS485/USB ── RPi CM5 ──[ daly-bms-server ]── Dashboard React
-Pack C (0x03) ─┤                              (Axum natif)         WebSocket /ws/bms/stream
-Pack D (0x04) ─┘                                    │
-(jusqu'à 32)                          ┌─────────────┼─────────────┐
-                                      ▼             ▼             ▼
-                                 Mosquitto      InfluxDB      AlertEngine
-                                 (MQTT)         (séries)      (SQLite)
-                                      │
-                                 dbus-mqtt-battery (Venus OS / NanoPi)
+Pack A (0x28) ─┐
+Pack B (0x29) ─┤── RS485/USB ── RPi CM5 ──[ daly-bms-server ]── Dashboard React
+               │                              (Axum natif)         WebSocket /ws/bms/stream
+               │                                    │
+               │                    ┌───────────────┼───────────────┐
+               │                    ▼               ▼               ▼
+               │               Mosquitto        InfluxDB        AlertEngine
+               │               (MQTT)           (séries)        (SQLite)
+               │                    │
+               │      dbus-mqtt-battery-41/42 (Venus OS / NanoPi)
+               │                    │
+               │                    ▼
+               │              D-Bus Venus OS
+               │         (GUI / VRM / systemcalc)
+               │
+               └── [TRANSITION] dbus-canbattery.can0 (stoppé — remplacé par flux MQTT)
 ```
+
+> **Architecture confirmée** : `dbus-mqtt-battery` fonctionne en mode **MQTT → D-Bus**
+> (abonnement MQTT → service virtuel Venus OS). La connexion CAN directe est donc
+> redondante une fois le RPi CM5 opérationnel.
 
 ### Workspace Rust
 
@@ -152,6 +162,22 @@ Marge tampon / cache	    ~200 MB	          ~400 MB
 **Matériel** : Raspberry Pi CM5 (ou Pi 4/5) + adaptateur USB/RS485
 **OS** : Debian Bookworm / Ubuntu 24.04 (aarch64 ou x86_64)
 **Permissions** : `sudo usermod -aG dialout $USER`
+
+### Compatibilité Raspberry Pi 5 Compute Module
+
+Le binary Rust compilé pour `aarch64` est **directement compatible** RPi5 CM sans recompilation.
+Seul le `Config.toml` doit être adapté (port série, IP MQTT).
+
+| Paramètre | Cerbo GX / NanoPi | Raspberry Pi 5 CM |
+|---|---|---|
+| `serial.port` | `/dev/ttyUSB0` | `/dev/ttyUSB0` ou `/dev/ttyAMA0` |
+| `mqtt.host` | IP locale | IP locale |
+| Service manager | `runit/s6` (`svc`) | `systemd` (`systemctl`) |
+
+Compilation native sur le RPi5 :
+```bash
+cargo build --release
+```
 
 ---
 
@@ -357,12 +383,15 @@ RUST_LOG=debug daly-bms-server
 - [x] Phase 0 : Bridges (MQTT, InfluxDB, AlertEngine)
 - [x] Phase 0 : CLI (clap, toutes les commandes)
 - [x] Phase 1 : Infrastructure Docker
-- [ ] Phase 2 : Port série réel + tests sur matériel BMS
+- [x] Phase 1 : MQTT publish_interval_sec réduit à 1s (temps réel)
+- [x] Phase 1 : Architecture Venus OS confirmée (MQTT → D-Bus via dbus-mqtt-battery)
+- [x] Phase 1 : Service dbus-canbattery.can0 stoppé sur NanoPi (CAN remplacé par MQTT)
+- [ ] Phase 2 : Déploiement RPi5 CM — port série réel + tests sur matériel BMS
 - [ ] Phase 2 : Commandes d'écriture activées (MOS, SOC, reset)
 - [ ] Phase 2 : Découverte auto + tests d'intégration
 - [ ] Phase 3 : Docker complet (binaire Rust + nginx + dashboard)
 - [ ] Phase 4 : Dashboard Rust natif (Leptos/Dioxus)
-- [ ] Phase 4 : Support Venus OS natif via dbus
+- [ ] Phase 4 : Support Venus OS natif via D-Bus (fork dbus-serialbattery)
 
 ---
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -1,7 +1,7 @@
 # Plan d'Implémentation — DalyBMS Rust Edition
 
-**Version** : 2.0
-**Date** : 14 Mars 2026
+**Version** : 2.1
+**Date** : 15 Mars 2026
 **Référence Python** : [thieryus007-cloud/Daly-BMS](https://github.com/thieryus007-cloud/Daly-BMS)
 **Dépôt Rust** : [thieryus007-cloud/Daly-BMS-Rust](https://github.com/thieryus007-cloud/Daly-BMS-Rust)
 
@@ -287,7 +287,36 @@ make ps     # vérifier
 
 ---
 
-### Phase 2 — Validation port série (PROCHAINE ÉTAPE)
+### Phase 1.5 — Intégration Venus OS / NanoPi ✅ COMPLÉTÉ (15 mars 2026)
+
+#### Architecture validée en production
+
+- **Flux confirmé** : MQTT → `dbus-mqtt-battery` → D-Bus Venus OS
+- **Service CAN stoppé** : `svc -d /service/dbus-canbattery.can0` (récupère ~60 MB RAM + 6% CPU)
+- **publish_interval_sec** réduit de 5s → **1s** pour rafraîchissement temps réel
+
+#### État ressources NanoPi Cerbo GX (512 MB RAM)
+
+| Process | RAM | CPU |
+|---|---|---|
+| node-red | ~229 MB | ~4% |
+| gui (VNC) | ~164 MB | ~6% |
+| dbus-modbus-client | ~91 MB | 0% |
+| dbus-canbattery.can0 | stoppé | — |
+| dbus-mqtt-battery x2 | ~84 MB | ~2% |
+
+RAM disponible : ~77 MB. Le binary Rust (~10 MB) remplacera plusieurs scripts Python.
+
+#### Compatibilité Raspberry Pi 5 Compute Module
+
+- Architecture ARM64 (aarch64) identique → **binaire directement compatible**
+- Seul `Config.toml` à adapter (port série, IP MQTT)
+- Service manager différent : `systemd` sur RPi5 vs `runit/s6` sur Cerbo GX
+- Compilation native : `cargo build --release` sur le RPi5
+
+---
+
+### Phase 2 — Validation port série (PROCHAINE ÉTAPE — RPi5)
 
 **Durée estimée** : 3–5 jours | **Prérequis** : Matériel BMS physique
 
@@ -589,4 +618,4 @@ curl http://localhost:8000/api/v1/system/status | jq
 
 ---
 
-*Document mis à jour le 14 mars 2026 — Version 2.0*
+*Document mis à jour le 15 mars 2026 — Version 2.1*

--- a/nanoPi/README.md
+++ b/nanoPi/README.md
@@ -1,7 +1,52 @@
-# NanoPi — Configuration dbus-mqtt-battery
+# NanoPi — Configuration Venus OS (Cerbo GX)
 
 Fichiers à copier sur le NanoPi Venus OS pour les deux instances du driver
 [dbus-mqtt-battery](https://github.com/mr-manuel/venus-os_dbus-mqtt-battery).
+
+---
+
+## Architecture confirmée (15 mars 2026)
+
+Le flux de données a été vérifié en production :
+
+```
+RPi CM5 (Rust RS485)
+       │
+       ▼ MQTT publish (toutes les 1s)
+Mosquitto / FlashMQ
+  santuario/bms/1/venus
+  santuario/bms/2/venus
+       │
+       ▼ subscribe (dbus-mqtt-battery)
+dbus-mqtt-battery-41  →  com.victronenergy.battery.mqtt_battery_141
+dbus-mqtt-battery-42  →  com.victronenergy.battery.mqtt_battery_142
+       │
+       ▼ D-Bus Venus OS
+  GUI / VRM Portal / systemcalc / hub4control
+```
+
+> `dbus-mqtt-battery` fonctionne en mode **MQTT → D-Bus** (abonnement MQTT,
+> création d'un service batterie virtuel sur le bus système Venus OS).
+
+---
+
+## Migration depuis CAN
+
+Lors du passage de `dbus-serialbattery.py can0` vers le flux MQTT du RPi CM5,
+arrêter le service CAN sur le NanoPi :
+
+```bash
+# Arrêter sans désinstaller (récupère ~60 MB RAM + 6% CPU)
+svc -d /service/dbus-canbattery.can0
+
+# Vérifier l'état
+svstat /service/dbus-canbattery.can0
+
+# Relancer si besoin
+svc -u /service/dbus-canbattery.can0
+```
+
+---
 
 ## Structure sur le NanoPi
 
@@ -24,24 +69,61 @@ scp nanopi/config-bms2.ini root@192.168.1.120:/data/etc/dbus-mqtt-battery-42/con
 ssh root@192.168.1.120 "svc -t /service/dbus-mqtt-battery-41 /service/dbus-mqtt-battery-42"
 ```
 
-## Topic MQTT publié par le RPi CM5
+## Topics MQTT publiés par le RPi CM5
 
 ```
-santuario/bms/1/venus   → dbus-mqtt-battery-41  (Pack 320Ah)
-santuario/bms/2/venus   → dbus-mqtt-battery-42  (Pack 360Ah)
+santuario/bms/1/venus   → dbus-mqtt-battery-41  (BMS-360Ah, adresse 0x28)
+santuario/bms/2/venus   → dbus-mqtt-battery-42  (BMS-320Ah, adresse 0x29)
 ```
 
-Activé par `MQTT_VENUS_ENABLED=1` dans le `.env` Python du RPi CM5.
+Intervalle de publication : **1 seconde** (`publish_interval_sec = 1` dans Config.toml).
+
+---
+
+## Surveillance ressources NanoPi (BusyBox compatible)
+
+Venus OS utilise BusyBox — utiliser ces commandes adaptées :
+
+```bash
+# Vue CPU + RAM temps réel (meilleure option)
+top -b -n 1 | head -n 20
+
+# Surveillance continue refresh 2s
+watch -n 2 'top -b -n 1 | head -n 20'
+
+# RAM disponible
+cat /proc/meminfo | grep -E "MemTotal|MemFree|MemAvailable"
+```
+
+### État du système (15 mars 2026)
+
+| Process | RAM | CPU | Notes |
+|---|---|---|---|
+| `node-red` | ~229 MB | ~4% | Flow Grid déconnexion actif |
+| `gui` (VNC) | ~164 MB | ~6% | Interface locale |
+| `dbus-modbus-client` | ~91 MB | 0% | Modbus TCP |
+| `dbus-canbattery.can0` | ~60 MB | 0% | **STOPPÉ** — remplacé par MQTT |
+| `flashmq` | ~49 MB | 0% | Broker MQTT local |
+| `dbus-mqtt-battery-41/42` | ~42 MB x2 | 1% | Bridge MQTT → D-Bus |
+
+RAM disponible après arrêt du service CAN : **~77 MB** (free + cache).
+
+---
 
 ## Vérification sur le NanoPi
 
 ```bash
-# Vérifier que le driver est actif
+# Vérifier que les drivers sont actifs
 svstat /service/dbus-mqtt-battery-41
+svstat /service/dbus-mqtt-battery-42
 
 # Voir les données reçues sur D-Bus
 dbus -y com.victronenergy.battery.mqtt_battery_141 / GetValue
 
-# Logs du driver
+# Logs des drivers
 tail -f /var/log/dbus-mqtt-battery-41/current
+tail -f /var/log/dbus-mqtt-battery-42/current
+
+# Vérifier le service CAN (doit être stoppé)
+svstat /service/dbus-canbattery.can0
 ```


### PR DESCRIPTION
- Architecture Venus OS confirmée (MQTT → D-Bus via dbus-mqtt-battery)
- publish_interval_sec 5 → 1s pour rafraîchissement temps réel
- Service dbus-canbattery.can0 stoppé sur NanoPi (libère ~60 MB + 6% CPU)
- Compatibilité RPi5 CM documentée (ARM64, Config.toml à adapter)
- Commandes monitoring BusyBox compatibles pour Cerbo GX
- Roadmap et Plan.md mis à jour (Phase 1.5 complétée)

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme