### PR TITLE
feat(config): Config.docker.toml + corrections pour test Windows complet

### DIFF
--- a/Config.docker.toml
+++ b/Config.docker.toml
@@ -1,0 +1,109 @@
+# =============================================================================
+# DalyBMS — Configuration pour Docker Compose (stack complète)
+# =============================================================================
+# Ce fichier est monté dans le conteneur dalybms-server via docker-compose.yml.
+# NE PAS utiliser pour le déploiement natif (utiliser Config.toml à la place).
+#
+# Différences vs Config.toml :
+#   - mqtt.host    = "mosquitto"             (nom réseau Docker interne)
+#   - influxdb.url = "http://dalybms-influxdb:8086"  (nom réseau Docker interne)
+#   - influxdb.enabled = true
+#   - influxdb.token   = même valeur que INFLUX_TOKEN dans .env
+# =============================================================================
+
+[serial]
+# Ignoré en mode --simulate
+port             = ""
+baud             = 9600
+poll_interval_ms = 1000
+default_cell_count   = 16
+default_temp_sensors = 4
+ring_buffer_size     = 3600
+auto_discover        = false
+auto_discover_start  = 1
+auto_discover_end    = 16
+# Adresses des BMS simulés (doit correspondre à --sim-bms dans docker-compose.yml)
+addresses = ["0x28", "0x29"]
+
+
+[api]
+bind          = "0.0.0.0:8000"
+api_key       = ""
+cors_allow_all = true
+
+
+[logging]
+level  = "info"
+format = "pretty"
+
+
+[mqtt]
+enabled              = true
+# "mosquitto" = nom du service dans le réseau Docker interne
+host                 = "mosquitto"
+port                 = 1883
+topic_prefix         = "santuario/bms"
+publish_interval_sec = 1
+format               = "json"
+
+
+[influxdb]
+enabled = true
+# "dalybms-influxdb" = nom du service dans le réseau Docker interne
+url     = "http://dalybms-influxdb:8086"
+
+# !! IMPORTANT : mettre ici le même token que INFLUX_TOKEN dans votre .env !!
+# Exemple : si .env contient  INFLUX_TOKEN=montoken123
+# alors mettre ici :           token = "montoken123"
+token   = "REMPLACEZ_PAR_VOTRE_INFLUX_TOKEN"
+
+org                      = "santuario"
+bucket                   = "daly_bms"
+bucket_downsampled       = "daly_bms_1m"
+batch_size               = 50
+batch_flush_interval_sec = 5.0
+
+
+[alerts]
+# Laisser vide pour désactiver les alertes SQLite
+db_path            = "/var/lib/daly-bms/alerts.db"
+check_interval_sec = 1.0
+telegram_token     = ""
+telegram_chat_id   = ""
+smtp_host          = ""
+smtp_port          = 587
+smtp_username      = ""
+smtp_password      = ""
+smtp_from          = "dalybms@santuario.local"
+smtp_to            = "admin@santuario.local"
+
+[alerts.thresholds]
+cell_ovp_v            = 3.60
+cell_uvp_v            = 2.90
+cell_delta_mv         = 100.0
+soc_low_percent       = 20.0
+soc_critical_percent  = 10.0
+temp_high_c           = 45.0
+current_high_a        = 80.0
+
+
+[read_only]
+enabled = false
+
+
+# =============================================================================
+# BMS simulés (correspond à --sim-bms 0x28,0x29)
+# =============================================================================
+[[bms]]
+address         = "0x28"
+name            = "BMS-360Ah"
+capacity_ah     = 360.0
+max_charge_a    = 200.0
+max_discharge_a = 120.0
+
+[[bms]]
+address         = "0x29"
+name            = "BMS-320Ah"
+capacity_ah     = 320.0
+max_charge_a    = 200.0
+max_discharge_a = 120.0

--- a/Config.toml
+++ b/Config.toml
@@ -1,9 +1,16 @@
 # =============================================================================
-# DalyBMS — Rust Edition — Fichier de configuration exemple
+# DalyBMS — Rust Edition — Configuration principale
 # =============================================================================
-# Copiez ce fichier en config.toml et adaptez les valeurs.
-# Les sections commentées ou vides désactivent la fonctionnalité correspondante.
-# Tous les chemins sont absolus en production (recommandé).
+# Ce fichier est utilisé pour :
+#   - Développement Windows (cargo run, BMS réel ou simulateur)
+#   - Déploiement natif Linux / Raspberry Pi 5
+#
+# Pour la stack Docker complète (docker compose up), utiliser Config.docker.toml.
+#
+# Ordre de chargement :
+#   1. Variable d'environnement DALY_CONFIG
+#   2. ./Config.toml  (répertoire courant — Windows / dev)
+#   3. /etc/daly-bms/config.toml  (Linux production)
 # Date de référence : mars 2026
 
 [serial]
@@ -67,7 +74,10 @@ format = "pretty"
 [mqtt]
 enabled = true
 
-host = "192.168.1.120"
+# Windows avec Docker Desktop local → "localhost"
+# Windows avec NanoPi comme broker → "192.168.1.120"
+# Raspberry Pi 5 production        → "localhost" (Mosquitto local) ou IP NanoPi
+host = "localhost"
 port = 1883
 
 # Préfixe des topics (ex: santuario/bms/1/venus)
@@ -87,12 +97,18 @@ format = "json"
 
 
 [influxdb]
-enabled = false
+# true  = activer l'écriture InfluxDB (Docker infra doit être démarré)
+# false = désactiver (pas de Docker, ou test sans InfluxDB)
+enabled = true
 
+# Windows Docker Desktop ou Linux local → http://localhost:8086
+# Docker Compose interne             → http://dalybms-influxdb:8086 (Config.docker.toml)
 url = "http://localhost:8086"
 
-# Token avec droits write sur les buckets
-token = ""
+# Token généré par InfluxDB (identique à INFLUX_TOKEN dans .env)
+# Générer : docker exec dalybms-influxdb influx auth create --org santuario --all-access
+# Ou via UI : http://localhost:8086 → Load Data → API Tokens
+token = "REMPLACEZ_PAR_VOTRE_INFLUX_TOKEN"
 
 org = "santuario"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,14 +144,16 @@ services:
       DALY_CONFIG:    /etc/daly-bms/config.toml
       DALY_API_KEY:   ${DALY_API_KEY:-}
     volumes:
-      # Config personnalisée (optionnel — le binaire utilise ses défauts sinon)
-      - ./Config.toml:/etc/daly-bms/config.toml:ro
+      # Config Docker (MQTT=mosquitto, InfluxDB=dalybms-influxdb)
+      # Pour hardware réel, monter Config.toml à la place
+      - ./Config.docker.toml:/etc/daly-bms/config.toml:ro
       # Journal des alertes SQLite
       - dalybms-alerts:/var/lib/daly-bms
-    # Mode simulation par défaut (2 BMS fictifs)
-    # Pour hardware réel, remplacer par : command: []
-    # et ajouter : devices: [/dev/ttyUSB0:/dev/ttyUSB0]
-    command: ["--simulate", "--sim-bms", "0x01,0x02"]
+    # Mode simulation : 2 BMS fictifs (adresses 0x28 et 0x29 comme en production)
+    # Pour hardware réel Linux : remplacer par command: [] et décommenter devices
+    command: ["--simulate", "--sim-bms", "0x28,0x29"]
+    # devices:
+    #   - /dev/ttyUSB0:/dev/ttyUSB0
     depends_on:
       mosquitto:
         condition: service_healthy


### PR DESCRIPTION
Config.docker.toml (nouveau) :
- mqtt.host = "mosquitto" (réseau Docker interne)
- influxdb.url = "http://dalybms-influxdb:8086" (réseau Docker interne)
- influxdb.enabled = true
- sim-bms 0x28,0x29 (adresses production)

docker-compose.yml :
- Monte Config.docker.toml au lieu de Config.toml
- sim-bms corrigé en 0x28,0x29 (cohérent avec Config.docker.toml)
- Commentaire devices: pour future migration hardware

Config.toml (Windows dev + BMS réel) :
- mqtt.host = "localhost" (Docker Desktop local)
- influxdb.enabled = true
- Commentaires clairs pour les deux scénarios (localhost vs NanoPi)

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme