### PR TITLE
fix(mqtt): topics Venus OS alignés sur dbus-mqttbattery (santuario/bm…

### DIFF
--- a/Config.docker.toml
+++ b/Config.docker.toml
@@ -100,6 +100,8 @@ name            = "BMS-360Ah"
 capacity_ah     = 360.0
 max_charge_a    = 200.0
 max_discharge_a = 120.0
+# Index topic MQTT Venus OS → santuario/bms/1/venus
+mqtt_index      = 1
 
 [[bms]]
 address         = "0x29"
@@ -107,3 +109,5 @@ name            = "BMS-320Ah"
 capacity_ah     = 320.0
 max_charge_a    = 200.0
 max_discharge_a = 120.0
+# Index topic MQTT Venus OS → santuario/bms/2/venus
+mqtt_index      = 2

--- a/Config.toml
+++ b/Config.toml
@@ -175,6 +175,9 @@ name            = "BMS-360Ah"
 capacity_ah     = 360.0
 max_charge_a    = 200.0
 max_discharge_a = 120.0
+# Index topic MQTT Venus OS → santuario/bms/1/venus
+# Doit correspondre à mqtt_index dans config.ini de dbus-mqttbattery sur le NanoPi
+mqtt_index      = 1
 
 [[bms]]
 address         = "0x29"       # RS485-41 (decimal 41)
@@ -182,6 +185,8 @@ name            = "BMS-320Ah"
 capacity_ah     = 320.0
 max_charge_a    = 200.0
 max_discharge_a = 120.0
+# Index topic MQTT Venus OS → santuario/bms/2/venus
+mqtt_index      = 2
 
 
 # =============================================================================

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -18,15 +18,18 @@ use crate::state::AppState;
 use daly_bms_core::types::BmsSnapshot;
 use rumqttc::{AsyncClient, MqttOptions, QoS};
 use serde_json::json;
+use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::interval;
 use tracing::{error, info, warn};
 
 /// Démarre la tâche de publication MQTT en arrière-plan.
 ///
-/// La tâche lit les derniers snapshots toutes les `publish_interval_sec`
-/// secondes et publie sur les topics configurés.
-pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig) {
+/// `addr_map` : table adresse RS485 → identifiant de topic (ex: 0x28 → "1").
+/// Permet d'aligner les topics sur la configuration `dbus-mqttbattery` du NanoPi
+/// (santuario/bms/1/venus, santuario/bms/2/venus, …).
+/// Si l'adresse n'est pas dans la map, on publie avec l'adresse décimale brute.
+pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap<u8, String>) {
     if !cfg.enabled {
         info!("MQTT bridge désactivé (enabled = false)");
         return;
@@ -67,7 +70,12 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig) {
 
         let snapshots = state.latest_snapshots().await;
         for snap in &snapshots {
-            if let Err(e) = publish_snapshot(&client, &cfg, snap).await {
+            // Résoudre l'identifiant de topic : "1", "2", … ou adresse décimale brute
+            let topic_id = addr_map
+                .get(&snap.address)
+                .cloned()
+                .unwrap_or_else(|| snap.address.to_string());
+            if let Err(e) = publish_snapshot(&client, &cfg, snap, &topic_id).await {
                 error!("MQTT publish erreur : {:?}", e);
             }
         }
@@ -75,12 +83,15 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig) {
 }
 
 /// Publie un snapshot complet sur tous les topics d'un BMS.
+///
+/// `topic_id` : identifiant résolu (ex: "1" pour 0x28, "2" pour 0x29).
 async fn publish_snapshot(
     client: &AsyncClient,
     cfg: &MqttConfig,
     snap: &BmsSnapshot,
+    topic_id: &str,
 ) -> anyhow::Result<()> {
-    let prefix = format!("{}/{}", cfg.topic_prefix, snap.address);
+    let prefix = format!("{}/{}", cfg.topic_prefix, topic_id);
 
     // Scalaires
     publish_str(client, &format!("{}/soc",     prefix), &format!("{:.1}", snap.soc)).await;

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -66,6 +66,9 @@ pub struct BmsDeviceConfig {
     pub max_charge_a: Option<f32>,
     /// Courant de décharge maximal autorisé (A)
     pub max_discharge_a: Option<f32>,
+    /// Index MQTT pour le topic Venus OS (ex: 1 → santuario/bms/1/venus).
+    /// Si absent, utilise la position dans le tableau [[bms]] (1-based).
+    pub mqtt_index: Option<u8>,
 }
 
 impl BmsDeviceConfig {

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -149,9 +149,22 @@ async fn main() -> anyhow::Result<()> {
     let state = AppState::new(config.clone());
 
     // ── Bridges en arrière-plan ─────────────────────────────────────────────────
+
+    // Map adresse RS485 → index topic MQTT (ex: 0x28 → "1", 0x29 → "2")
+    // Permet d'écrire santuario/bms/1/venus au lieu de santuario/bms/40/venus
+    let mqtt_addr_map: std::collections::HashMap<u8, String> = config.bms
+        .iter()
+        .enumerate()
+        .filter_map(|(i, bms_cfg)| {
+            let addr = bms_cfg.parsed_address()?;
+            let idx  = bms_cfg.mqtt_index.unwrap_or((i + 1) as u8);
+            Some((addr, idx.to_string()))
+        })
+        .collect();
+
     tokio::spawn({
-        let (s, c) = (state.clone(), config.mqtt.clone());
-        async move { mqtt::run_mqtt_bridge(s, c).await }
+        let (s, c, m) = (state.clone(), config.mqtt.clone(), mqtt_addr_map);
+        async move { mqtt::run_mqtt_bridge(s, c, m).await }
     });
     tokio::spawn({
         let (s, c) = (state.clone(), config.influxdb.clone());


### PR DESCRIPTION
…s/1/venus)

Problème : le bridge MQTT publiait sur santuario/bms/40/venus (adresse RS485 décimale) au lieu de santuario/bms/1/venus attendu par dbus-mqttbattery du NanoPi.

Solution :
- config.rs : ajout mqtt_index (Option<u8>) dans BmsDeviceConfig → détermine le segment de topic (ex : 1, 2)
- main.rs : construction d'une HashMap<u8, String> (adresse RS485 → topic_id) avant de lancer le bridge ; si mqtt_index absent, utilise la position dans le tableau [[bms]] (1-based) comme fallback
- mqtt.rs : run_mqtt_bridge accepte la map et appelle publish_snapshot avec le topic_id résolu → topic final = santuario/bms/{mqtt_index}/venus
- Config.toml + Config.docker.toml : mqtt_index = 1 (0x28) et 2 (0x29)

Topics produits :
  santuario/bms/1/venus  ← BMS-360Ah (0x28) santuario/bms/2/venus  ← BMS-320Ah (0x29)

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme