### PR TITLE
fix(infra): remove :? syntax incompatible with Docker Compose v5

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -40,7 +40,7 @@ services:
       - DOCKER_INFLUXDB_INIT_PASSWORD=${INFLUXDB_ADMIN_PASSWORD:-supersecret}
       - DOCKER_INFLUXDB_INIT_ORG=${INFLUX_ORG:-santuario}
       - DOCKER_INFLUXDB_INIT_BUCKET=${INFLUX_BUCKET:-daly_bms}
-      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUX_TOKEN:?Erreur : INFLUX_TOKEN obligatoire}
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUX_TOKEN}
     volumes:
       - influxdb-data:/var/lib/influxdb2
       - influxdb-config:/etc/influxdb2
@@ -62,7 +62,7 @@ services:
       - "3001:3000"   # 3000 réservé pour dev, on mappe sur 3001
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?Erreur : GRAFANA_ADMIN_PASSWORD obligatoire}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_AUTH_ANONYMOUS_ENABLED=false
     volumes:


### PR DESCRIPTION
Docker Compose v5 interprets ${VAR:?message} as a YAML map instead of a string, causing startup failure. Replaced with simple ${VAR} for INFLUX_TOKEN and GRAFANA_ADMIN_PASSWORD.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme