### PR TITLE
fix(infra): mosquitto bind mount + healthcheck non-bloquant

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -14,14 +14,15 @@ services:
       - "1883:1883"       # MQTT standard
       - "9001:9001"       # MQTT over WebSocket (pour Node-RED si besoin)
     volumes:
-      - mosquitto-conf:/mosquitto/config
+      - ./docker/mosquitto/config:/mosquitto/config:ro
       - mosquitto-data:/mosquitto/data
       - mosquitto-log:/mosquitto/log
     healthcheck:
-      test: ["CMD", "mosquitto_sub", "-t", "test", "-C", "1"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "mosquitto_pub", "-t", "healthcheck", "-m", "ping", "-q"]
+      interval: 15s
+      timeout: 5s
       retries: 3
+      start_period: 5s
     logging:
       driver: "json-file"
       options:
@@ -97,7 +98,6 @@ services:
       retries: 3
 
 volumes:
-  mosquitto-conf:
   mosquitto-data:
   mosquitto-log:
   influxdb-data:


### PR DESCRIPTION
- Remplace le volume nommé mosquitto-conf par un bind mount vers ./docker/mosquitto/config pour que mosquitto.conf soit effectivement chargé
- Remplace healthcheck mosquitto_sub (bloquant, attend un message) par mosquitto_pub (non-bloquant, teste simplement la connectivité du broker)
- Ajoute start_period: 5s pour laisser le broker démarrer avant le 1er check

Fixes: container dalybms-mosquitto is unhealthy

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme