### PR TITLE
fix(infra): supprime retained_messages invalide + retire :ro sur bind…

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -14,7 +14,7 @@ services:
       - "1883:1883"       # MQTT standard
       - "9001:9001"       # MQTT over WebSocket (pour Node-RED si besoin)
     volumes:
-      - ./docker/mosquitto/config:/mosquitto/config:ro
+      - ./docker/mosquitto/config:/mosquitto/config
       - mosquitto-data:/mosquitto/data
       - mosquitto-log:/mosquitto/log
     healthcheck:

--- a/docker/mosquitto/config/mosquitto.conf
+++ b/docker/mosquitto/config/mosquitto.conf
@@ -29,8 +29,5 @@ log_timestamp true
 # QoS max supporté
 max_qos 2
 
-# Rétention des messages (utile pour "last will" du serveur BMS)
-retained_messages true
-
 # Taille max d'un message (1 MB suffisant pour les snapshots JSON BMS)
 message_size_limit 1048576


### PR DESCRIPTION
… mount

- retained_messages n'est pas une directive Mosquitto 2.x valide → erreur fatale
- Le bind mount :ro empêche le chown de l'entrypoint mosquitto → retire :ro

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme