### PR TITLE
fix: figer AllowToCharge/AllowToDischarge à 1 dans le payload Venus

### DIFF
--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -214,9 +214,11 @@ fn build_venus_payload(snap: &BmsSnapshot) -> serde_json::Value {
         },
         "Voltages": voltages_map,
         "Balances": balances_map,
+        // AllowToCharge / AllowToDischarge volontairement figés à 1 :
+        // on ne veut pas que Venus OS (systemcalc) transmette ces signaux aux MPPT.
         "Io": {
-            "AllowToCharge":    snap.io.allow_to_charge,
-            "AllowToDischarge": snap.io.allow_to_discharge,
+            "AllowToCharge":    1,
+            "AllowToDischarge": 1,
             "AllowToBalance":   snap.io.allow_to_balance,
             "AllowToHeat":      snap.io.allow_to_heat,
             "ExternalRelay":    snap.io.external_relay,


### PR DESCRIPTION
Venus OS systemcalc transmet ces flags aux MPPT même sans DVCC. On ne veut pas que le BMS contrôle les MPPT via ces signaux.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme