### PR TITLE
fix(docker): mettre a jour Rust 1.80 -> 1.85 pour edition2024

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # =============================================================================
 # Stage 1 — Builder
 # =============================================================================
-FROM rust:1.80-slim-bookworm AS builder
+FROM rust:1.85-slim-bookworm AS builder
 
 # Dépendances système nécessaires pour les crates natives (rusqlite bundled, openssl)
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
clap_lex v1.1.0 requiert edition2024 qui necessite Rust >= 1.85.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme