### PR TITLE
fix(docker): rust:latest pour compatibilite ar_archive_writer 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version     = "0.1.0"
 edition     = "2021"
 authors     = ["DalyBMS Rust Team"]
 license     = "MIT"
-rust-version = "1.80"
+rust-version = "1.88"
 repository  = "https://github.com/thieryus007-cloud/Daly-BMS-Rust"
 
 # =============================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # =============================================================================
 # Stage 1 — Builder
 # =============================================================================
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:latest-slim-bookworm AS builder
 
 # Dépendances système nécessaires pour les crates natives (rusqlite bundled, openssl)
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
ar_archive_writer 0.5.1 (dep de rusqlite bundled) requiert let-chains stabilise dans Rust 1.88+. Passage a rust:latest pour eviter les problemes de version.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme