### PR TITLE
fix(mqtt): retirer AllowToHeat du payload Venus OS

### DIFF
--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -200,7 +200,6 @@ fn build_venus_payload(snap: &BmsSnapshot) -> serde_json::Value {
             "AllowToCharge":    1,
             "AllowToDischarge": 1,
             "AllowToBalance":   snap.io.allow_to_balance,
-            "AllowToHeat":      snap.io.allow_to_heat,
             "ExternalRelay":    snap.io.external_relay,
         },
     })


### PR DESCRIPTION
AllowToHeat n'est pas un champ reconnu par dbus-mqtt-battery, ce qui génère des WARNING en boucle. Champs Io valides : AllowToCharge, AllowToDischarge, AllowToBalance, ExternalRelay.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme