### PR TITLE
fix(grafana): utiliser syntaxe ${INFLUX_TOKEN} pour substitution env var

### DIFF
--- a/grafana/provisioning/datasources/influxdb.yaml
+++ b/grafana/provisioning/datasources/influxdb.yaml
@@ -21,4 +21,4 @@ datasources:
       timeInterval: "10s"
 
     secureJsonData:
-      token: $INFLUX_TOKEN
+      token: ${INFLUX_TOKEN}


### PR DESCRIPTION
Grafana 11 requiert ${VAR} plutôt que $VAR dans les fichiers de provisioning.

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme