### PR TITLE
fix(grafana): hardcoder token et supprimer ancien datasource cassé

### DIFF
--- a/grafana/provisioning/datasources/influxdb.yaml
+++ b/grafana/provisioning/datasources/influxdb.yaml
@@ -1,18 +1,22 @@
 # =============================================================================
 # Grafana — Provisioning datasource InfluxDB 2.x (Flux)
 # =============================================================================
-# Ce fichier est monté en lecture seule dans /etc/grafana/provisioning/datasources/
 
 apiVersion: 1
+
+deleteDatasources:
+  - name: InfluxDB-DalyBMS
+    orgId: 1
 
 datasources:
   - name: InfluxDB-DalyBMS
     type: influxdb
-    uid: influxdb-dalybms
+    uid: influxdb-dalybms-flux
     access: proxy
-    url: http://influxdb:8086
+    url: http://dalybms-influxdb:8086
     isDefault: true
     editable: true
+    orgId: 1
 
     jsonData:
       version: Flux
@@ -21,4 +25,4 @@ datasources:
       timeInterval: "10s"
 
     secureJsonData:
-      token: ${INFLUX_TOKEN}
+      token: "TGEh4wl5TE7SEeJd7GDdyjDebo48xEJaD63MKbgdNhLz54-AWLxWtEBxoAqIEPd9KOucM_kpJGtvFu3oZ98KeQ=="


### PR DESCRIPTION
- deleteDatasources pour supprimer l'ancien UID conflictuel
- Nouveau UID influxdb-dalybms-flux pour éviter le cache Grafana
- Token hardcodé pour contourner l'échec de substitution ${INFLUX_TOKEN}
- URL dalybms-influxdb (nom container Docker)

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme