### PR TITLE
fix(grafana): use env vars in datasource provisioning to fix org/toke…

### DIFF
--- a/grafana/provisioning/datasources/influxdb.yaml
+++ b/grafana/provisioning/datasources/influxdb.yaml
@@ -20,9 +20,9 @@ datasources:
 
     jsonData:
       version: Flux
-      organization: santuario
-      defaultBucket: daly_bms
+      organization: "${INFLUX_ORG}"
+      defaultBucket: "${INFLUX_BUCKET}"
       timeInterval: "10s"
 
     secureJsonData:
-      token: "TGEh4wl5TE7SEeJd7GDdyjDebo48xEJaD63MKbgdNhLz54-AWLxWtEBxoAqIEPd9KOucM_kpJGtvFu3oZ98KeQ=="
+      token: "${INFLUX_TOKEN}"


### PR DESCRIPTION
…n bug

Replace hardcoded organization and token values with environment variable substitution (${INFLUX_ORG}, ${INFLUX_BUCKET}, ${INFLUX_TOKEN}) to work around Grafana's known bug where secureJsonData is not applied when an existing datasource entry is present in the grafana-data SQLite volume.

See: https://github.com/grafana/grafana/issues/27389
     https://github.com/grafana/grafana/issues/27011

https://claude.ai/code/session_01N66mj7iBiQX9pUkTfLBqme