### PR TITLE
fix(bus): correct Daly protocol — data bytes must be 0x00 for read co…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -17,7 +17,7 @@
 # Port série RS485 (USB → /dev/ttyUSB* ou /dev/ttyACM*)
 # Sur Linux : /dev/ttyUSB0 ou /dev/ttyUSB1
 # Sur Windows : laisser vide pour auto-détection, ou spécifier COM5, COM6...
-port = ""
+port = "/dev/ttyUSB0"
 
 # Vitesse de communication (Daly standard = 9600)
 baud = 9600
@@ -65,7 +65,7 @@ cors_allow_all = true
 
 [logging]
 # Niveau de logs (trace, debug, info, warn, error)
-level = "info"
+level = "trace"
 
 # Format des logs (pretty = coloré et lisible, json = pour parsing)
 format = "pretty"

--- a/crates/daly-bms-core/src/bus.rs
+++ b/crates/daly-bms-core/src/bus.rs
@@ -60,13 +60,15 @@ impl DalyPort {
         cmd: DataId,
         data: [u8; 8],
     ) -> Result<ResponseFrame> {
-        // Adressage Daly parallèle : data[0] = board number pour les lectures.
-        // Les commandes d'écriture gardent leur payload dans data[0].
-        let mut frame_data = data;
-        if !cmd.is_write() {
-            frame_data[0] = bms_address;
-        }
-        let request = RequestFrame::new(bms_address, cmd, frame_data);
+        // Protocole Daly V1.21 §2.3.1 : les 8 octets data sont réservés (0x00)
+        // pour les commandes de lecture. L'adressage multi-BMS est assuré
+        // uniquement par byte[1] = 0x3F + bms_address (géré dans RequestFrame::new).
+        // Les commandes d'écriture utilisent data tel quel (payload fourni par l'appelant).
+        let request = if cmd.is_write() {
+            RequestFrame::new(bms_address, cmd, data)
+        } else {
+            RequestFrame::read(bms_address, cmd)
+        };
         trace!(
             bms = format!("{:#04x}", bms_address),
             cmd = format!("{:#04x}", cmd as u8),
@@ -202,9 +204,8 @@ impl DalyPort {
             return Ok(Vec::new());
         }
 
-        let mut multi_data = [0u8; 8];
-        multi_data[0] = bms_address;  // Adressage Daly parallèle
-        let request = RequestFrame::new(bms_address, cmd, multi_data);
+        // Protocole Daly V1.21 : data bytes = 0x00 pour les lectures multi-trames.
+        let request = RequestFrame::read(bms_address, cmd);
         let mut port = self.inner.lock().await;
 
         // Vider le buffer avant l'envoi


### PR DESCRIPTION
…mmands

The send_command() and send_command_multi() functions were incorrectly setting data[0] = bms_address for read frames, producing a different checksum than what the BMS expects. The Daly V1.21 protocol §2.3.1 requires all 8 data bytes to be 0x00 for reads; addressing is done solely via byte[1] = 0x3F + board_number.

Also set Config.toml port to /dev/ttyUSB0 (FTDI FT232R confirmed on Pi 5) and logging level to trace to aid hardware diagnostics.

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G