### PR TITLE
fix(config): change API port 8000→8080 to avoid Docker port conflict

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -51,7 +51,7 @@ addresses = ["0x01", "0x02"]
 
 [api]
 # Interface et port d'écoute (0.0.0.0 = accessible depuis le réseau local)
-bind = "0.0.0.0:8000"
+bind = "0.0.0.0:8080"
 
 # Clé API pour protéger les endpoints d'écriture (MOS, SOC, config, reset)
 # Vide ou absent = pas d'authentification (développement uniquement !)


### PR DESCRIPTION
Docker-proxy was occupying port 8000 on the Pi 5.
The daly-bms-server now listens on 8080.

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G