### PR TITLE
fix(influxdb): add reset-influx target to purge stale BMS data (0x28/…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ARM_RELEASE_DIR := target/$(TARGET_ARM)/release
 # Infrastructure Docker
 # =============================================================================
 
-.PHONY: up down restart logs reset ps
+.PHONY: up down restart logs reset reset-influx ps
 
 up:
 	docker compose -f docker-compose.infra.yml up -d
@@ -38,7 +38,15 @@ logs:
 
 reset:
 	docker compose -f docker-compose.infra.yml down -v
-	@echo "⚠ Volumes supprimés — données InfluxDB/Grafana effacées"
+	@echo "⚠ Volumes supprimés — données InfluxDB/Grafana/Node-RED effacées"
+
+# Reset uniquement InfluxDB (conserve Grafana config + Node-RED)
+# Utile pour repartir avec une base vierge sans perdre les dashboards Grafana
+reset-influx:
+	docker compose -f docker-compose.infra.yml stop influxdb
+	docker volume rm $$(docker volume ls -q | grep influxdb) 2>/dev/null || true
+	docker compose -f docker-compose.infra.yml up -d influxdb
+	@echo "✓ InfluxDB réinitialisé — token conservé depuis .env"
 
 ps:
 	docker compose -f docker-compose.infra.yml ps

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -452,6 +452,55 @@ Serveur Rust (natif, hors Docker) :
 
 ---
 
+### Phase 1.8 — Reset base InfluxDB (données parasites 0x28/0x29) ✅ COMPLÉTÉ (17 mars 2026)
+
+#### Problème observé
+
+Grafana affichait 4 BMS (0x01, 0x02, 0x28, 0x29) alors que seuls 0x01 et 0x02 sont connectés.
+Les adresses 0x28/0x29 correspondent aux anciennes adresses RS485 utilisées pendant la phase NanoPi.
+Ces données résiduelles polluaient tous les panels Grafana.
+
+#### Solution : repartir avec une base InfluxDB vierge
+
+Le token est **conservé** car `DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUX_TOKEN}` est dans
+`docker-compose.infra.yml` — InfluxDB se réinitialise avec le même token au redémarrage.
+
+**Commandes sur le RPi5 :**
+```bash
+cd ~/Daly-BMS-Rust
+
+# Option 1 — Reset InfluxDB uniquement (Grafana et Node-RED conservés)
+make reset-influx
+
+# Option 2 — Reset complet (tout efface, tout recrée proprement)
+make reset
+make up
+```
+
+**Vérification après reset :**
+```bash
+# Attendre ~15 secondes que InfluxDB démarre
+docker logs dalybms-influxdb --tail 20
+
+# Relancer le serveur Rust pour qu'il recommence à écrire
+sudo systemctl restart daly-bms    # si installé en service systemd
+```
+
+Grafana affichera uniquement 0x01 et 0x02 dès les premières données reçues (< 5 secondes).
+
+#### Makefile — cibles disponibles
+
+| Commande | Effet |
+|---|---|
+| `make up` | Démarre toute l'infra Docker |
+| `make down` | Arrête les containers (volumes conservés) |
+| `make reset-influx` | Supprime uniquement le volume InfluxDB, redémarre |
+| `make reset` | Supprime TOUS les volumes (InfluxDB + Grafana + Node-RED) |
+| `make logs` | Suit les logs de tous les containers |
+| `make ps` | État des containers |
+
+---
+
 ### Phase 2 — Validation hardware réel (PROCHAINE ÉTAPE — RPi5 + BMS physiques)
 
 **Durée estimée** : 3–5 jours | **Prérequis** : Matériel BMS physique


### PR DESCRIPTION
…0x29)

- Add `make reset-influx` to Makefile: stops influxdb, removes volume, restarts with same token from .env (non-destructive to Grafana/Node-RED)
- Update docs/Plan.md Phase 1.8: document stale address problem (0x28/0x29 from old NanoPi config), reset procedure, Makefile targets table

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G