### PR TITLE
feat(write): implement SOC calibration and BMS reset from web interface

### DIFF
--- a/crates/daly-bms-server/src/api/bms.rs
+++ b/crates/daly-bms-server/src/api/bms.rs
@@ -211,70 +211,160 @@ pub async fn compare_all(State(state): State<AppState>) -> Json<Value> {
 // POST — Écriture
 // =============================================================================
 
+/// Mot de passe Daly requis pour les commandes d'écriture (identique à l'app Daly).
+const DALY_WRITE_PASSWORD: &str = "12345678";
+
+/// Extrait le port série depuis l'état. Retourne une erreur HTTP si indisponible.
+async fn require_port(state: &AppState) -> Result<std::sync::Arc<daly_bms_core::bus::DalyPort>, Response> {
+    let guard = state.port.read().await;
+    match guard.as_ref() {
+        Some(p) => Ok(p.clone()),
+        None => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "Port série non disponible (mode simulateur ou port non ouvert)"})),
+        ).into_response()),
+    }
+}
+
 #[derive(Deserialize)]
 pub struct MosCommand {
     #[allow(dead_code)]
     pub charge: Option<bool>,
     #[allow(dead_code)]
     pub discharge: Option<bool>,
+    #[allow(dead_code)]
+    pub password: Option<String>,
 }
 
-/// POST /api/v1/bms/:id/mos
+/// POST /api/v1/bms/:id/mos — Non implémenté (hors scope interface web)
 pub async fn set_mos(
     Path(_id): Path<String>,
     State(_state): State<AppState>,
     Json(_body): Json<MosCommand>,
 ) -> impl IntoResponse {
-    // TODO: Phase 2 — appeler daly_bms_core::write::set_charge_mos / set_discharge_mos
-    (StatusCode::NOT_IMPLEMENTED, Json(json!({"error": "Phase 2"})))
+    (StatusCode::NOT_IMPLEMENTED, Json(json!({"error": "Commande MOS non exposée via l'interface web"})))
 }
 
 #[derive(Deserialize)]
 pub struct SocCommand {
-    #[allow(dead_code)]
     pub soc: f32,
+    pub password: String,
 }
 
 /// POST /api/v1/bms/:id/soc
+///
+/// Calibre le SOC du BMS à la valeur indiquée.
+/// Body JSON : `{ "soc": 80.0, "password": "12345678" }`
 pub async fn set_soc(
-    Path(_id): Path<String>,
-    State(_state): State<AppState>,
-    Json(_body): Json<SocCommand>,
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<SocCommand>,
 ) -> impl IntoResponse {
-    (StatusCode::NOT_IMPLEMENTED, Json(json!({"error": "Phase 2"})))
+    if body.password != DALY_WRITE_PASSWORD {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mot de passe incorrect"}))).into_response();
+    }
+    if !(0.0..=100.0).contains(&body.soc) {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "SOC hors plage [0, 100]"}))).into_response();
+    }
+    if state.config.read_only.enabled {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mode lecture seule actif"}))).into_response();
+    }
+    let addr = match parse_addr(&id) {
+        Some(a) => a,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "Adresse BMS invalide"}))).into_response(),
+    };
+    let port = match require_port(&state).await {
+        Ok(p)  => p,
+        Err(e) => return e,
+    };
+    match daly_bms_core::write::set_soc(&port, addr, body.soc, false).await {
+        Ok(()) => (StatusCode::OK, Json(json!({
+            "ok": true,
+            "bms": format!("{:#04x}", addr),
+            "soc": body.soc,
+        }))).into_response(),
+        Err(daly_bms_core::error::DalyError::Timeout { .. }) => {
+            // Certains BMS n'envoient pas d'ACK après écriture SOC — comportement normal.
+            (StatusCode::OK, Json(json!({
+                "ok": true,
+                "bms": format!("{:#04x}", addr),
+                "soc": body.soc,
+                "warning": "Pas d'ACK BMS (commande probablement reçue — vérifier le SOC dans 5s)",
+            }))).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
+    }
 }
 
-/// POST /api/v1/bms/:id/soc/full
+/// POST /api/v1/bms/:id/soc/full — SOC → 100%
 pub async fn set_soc_full(
-    Path(_id): Path<String>,
+    Path(id): Path<String>,
     State(_state): State<AppState>,
 ) -> impl IntoResponse {
-    (StatusCode::NOT_IMPLEMENTED, Json(json!({"error": "Phase 2"})))
+    (StatusCode::NOT_IMPLEMENTED, Json(json!({"error": "Utiliser POST /soc avec { soc: 100, password: ... }",
+        "hint": format!("POST /api/v1/bms/{}/soc", id)
+    })))
 }
 
-/// POST /api/v1/bms/:id/soc/empty
+/// POST /api/v1/bms/:id/soc/empty — SOC → 0%
 pub async fn set_soc_empty(
-    Path(_id): Path<String>,
+    Path(id): Path<String>,
     State(_state): State<AppState>,
 ) -> impl IntoResponse {
-    (StatusCode::NOT_IMPLEMENTED, Json(json!({"error": "Phase 2"})))
+    (StatusCode::NOT_IMPLEMENTED, Json(json!({"error": "Utiliser POST /soc avec { soc: 0, password: ... }",
+        "hint": format!("POST /api/v1/bms/{}/soc", id)
+    })))
 }
 
 #[derive(Deserialize)]
 pub struct ResetCommand {
     pub confirm: bool,
+    pub password: String,
 }
 
 /// POST /api/v1/bms/:id/reset
+///
+/// Réinitialise le BMS. Nécessite `confirm: true` ET le mot de passe Daly.
+/// Body JSON : `{ "confirm": true, "password": "12345678" }`
 pub async fn reset_bms(
-    Path(_id): Path<String>,
-    State(_state): State<AppState>,
+    Path(id): Path<String>,
+    State(state): State<AppState>,
     Json(body): Json<ResetCommand>,
 ) -> impl IntoResponse {
     if !body.confirm {
         return (StatusCode::BAD_REQUEST, Json(json!({"error": "confirm: true requis"}))).into_response();
     }
-    (StatusCode::NOT_IMPLEMENTED, Json(json!({"error": "Phase 2"}))).into_response()
+    if body.password != DALY_WRITE_PASSWORD {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mot de passe incorrect"}))).into_response();
+    }
+    if state.config.read_only.enabled {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mode lecture seule actif"}))).into_response();
+    }
+    let addr = match parse_addr(&id) {
+        Some(a) => a,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "Adresse BMS invalide"}))).into_response(),
+    };
+    let port = match require_port(&state).await {
+        Ok(p)  => p,
+        Err(e) => return e,
+    };
+    match daly_bms_core::write::reset_bms(&port, addr, false).await {
+        Ok(()) => (StatusCode::OK, Json(json!({
+            "ok": true,
+            "bms": format!("{:#04x}", addr),
+            "action": "reset",
+        }))).into_response(),
+        Err(daly_bms_core::error::DalyError::Timeout { .. }) => {
+            // Le reset ne renvoie généralement pas d'ACK.
+            (StatusCode::OK, Json(json!({
+                "ok": true,
+                "bms": format!("{:#04x}", addr),
+                "action": "reset",
+                "warning": "Pas d'ACK BMS (normal après un reset)",
+            }))).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
+    }
 }
 
 // =============================================================================

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -229,6 +229,9 @@ async fn main() -> anyhow::Result<()> {
                     info!("Port série {} ouvert à {} baud", resolved_port, config.serial.baud);
                     state.polling_active.store(true, Ordering::Relaxed);
 
+                    // Rendre le port disponible pour les commandes d'écriture
+                    state.set_port(port.clone()).await;
+
                     // ── 2. Résoudre les adresses BMS (auto-découverte ou config) ──
                     let addresses = if auto_discover_addrs {
                         info!("Découverte automatique des BMS sur le bus RS485 (0x01..0x04)...");

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -4,6 +4,7 @@
 //! et les handlers Axum.
 
 use crate::config::AppConfig;
+use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
@@ -59,6 +60,10 @@ pub struct AppState {
 
     /// Indicateur polling actif.
     pub polling_active: Arc<std::sync::atomic::AtomicBool>,
+
+    /// Port série partagé — None en mode simulateur.
+    /// Partagé avec le poll_loop via le Mutex interne de DalyPort.
+    pub port: Arc<RwLock<Option<Arc<DalyPort>>>>,
 }
 
 impl AppState {
@@ -77,7 +82,13 @@ impl AppState {
             buffers: Arc::new(RwLock::new(buffers)),
             ws_tx,
             polling_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            port: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Enregistre le port série ouvert (mode hardware uniquement).
+    pub async fn set_port(&self, port: Arc<DalyPort>) {
+        *self.port.write().await = Some(port);
     }
 
     /// Enregistre un nouveau snapshot dans le ring buffer et broadcast WebSocket.

--- a/crates/daly-bms-server/templates/bms_detail.html
+++ b/crates/daly-bms-server/templates/bms_detail.html
@@ -156,9 +156,148 @@
   </table>
 </div>
 
+{# ─── Actions BMS ─────────────────────────────────────────────────────────── #}
+<div class="card chart-section" style="margin-bottom:1rem">
+  <div class="card-title">Actions BMS</div>
+  <div style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center">
+    <button onclick="openSocModal()" class="btn-action">⚡ Calibrer SOC</button>
+    <button onclick="openResetModal()" class="btn-action btn-danger">⚠ Reset BMS</button>
+    <span style="font-size:0.7rem;color:var(--muted)">
+      Mot de passe Daly requis &nbsp;·&nbsp; Inopérant en mode simulateur
+    </span>
+  </div>
+</div>
+
+{# ─── Modal Calibration SOC ───────────────────────────────────────────────── #}
+<div id="modal-soc" class="modal-overlay" style="display:none" onclick="if(event.target===this)closeSocModal()">
+  <div class="modal-box">
+    <div class="modal-title">⚡ Calibration SOC</div>
+    <div class="modal-body">
+      <label class="modal-label">Nouvelle valeur SOC (%)</label>
+      <input type="number" id="soc-value" min="0" max="100" step="0.1" value="100" class="modal-input">
+      <label class="modal-label" style="margin-top:0.75rem">Mot de passe Daly</label>
+      <input type="password" id="soc-password" value="12345678" class="modal-input" autocomplete="off">
+      <div id="soc-result" style="margin-top:0.6rem;min-height:1.2em;font-size:0.75rem"></div>
+    </div>
+    <div class="modal-footer">
+      <button onclick="closeSocModal()" class="btn-modal-cancel">Annuler</button>
+      <button onclick="submitSoc()" class="btn-modal-confirm">Envoyer</button>
+    </div>
+  </div>
+</div>
+
+{# ─── Modal Reset BMS ─────────────────────────────────────────────────────── #}
+<div id="modal-reset" class="modal-overlay" style="display:none" onclick="if(event.target===this)closeResetModal()">
+  <div class="modal-box">
+    <div class="modal-title" style="color:var(--red)">⚠ Reset BMS {{ detail.summary.address_hex }}</div>
+    <div class="modal-body">
+      <p style="color:var(--red);font-size:0.8rem;background:rgba(207,34,46,0.07);border:1px solid rgba(207,34,46,0.25);border-radius:4px;padding:0.6rem 0.75rem;margin-bottom:0.75rem">
+        Cette opération réinitialise le BMS. Les paramètres de fonctionnement sont conservés par le BMS mais la communication sera interrompue quelques secondes.
+      </p>
+      <label class="modal-label">Mot de passe Daly</label>
+      <input type="password" id="reset-password" value="12345678" class="modal-input" autocomplete="off">
+      <label class="modal-label" style="margin-top:0.75rem;display:flex;align-items:center;gap:0.5rem;cursor:pointer">
+        <input type="checkbox" id="reset-confirm" style="width:auto">
+        Je confirme le reset du BMS {{ detail.summary.address_hex }}
+      </label>
+      <div id="reset-result" style="margin-top:0.6rem;min-height:1.2em;font-size:0.75rem"></div>
+    </div>
+    <div class="modal-footer">
+      <button onclick="closeResetModal()" class="btn-modal-cancel">Annuler</button>
+      <button onclick="submitReset()" class="btn-modal-confirm" style="background:var(--red)">Reset</button>
+    </div>
+  </div>
+</div>
+
 {# JSON ECharts (cachés) #}
 <script type="application/json" id="opt-cells">{{ detail.cells_bar_json|safe }}</script>
 <script type="application/json" id="opt-boxplot">{{ detail.cells_boxplot_json|safe }}</script>
+
+<style>
+  .btn-action {
+    padding: 0.45rem 1rem;
+    border: 1px solid var(--accent);
+    background: var(--surface);
+    color: var(--accent);
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-weight: 600;
+    transition: background 0.15s;
+  }
+  .btn-action:hover { background: rgba(9,105,218,0.08); }
+  .btn-danger { border-color: var(--red); color: var(--red); }
+  .btn-danger:hover { background: rgba(207,34,46,0.08); }
+
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+  .modal-box {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    width: min(440px, 92vw);
+    padding: 1.5rem;
+  }
+  .modal-title {
+    font-size: 1rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+  }
+  .modal-body { display: flex; flex-direction: column; }
+  .modal-label {
+    display: block;
+    font-size: 0.72rem;
+    color: var(--muted);
+    margin-bottom: 0.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .modal-input {
+    width: 100%;
+    padding: 0.45rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 0.875rem;
+    background: var(--surface2);
+    color: var(--text);
+  }
+  .modal-input:focus { outline: 2px solid var(--accent); border-color: transparent; }
+  .modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1.25rem;
+  }
+  .btn-modal-cancel {
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--border);
+    background: var(--surface2);
+    color: var(--text);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+  }
+  .btn-modal-confirm {
+    padding: 0.4rem 1rem;
+    border: none;
+    background: var(--accent);
+    color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+  .btn-modal-confirm:hover { opacity: 0.88; }
+  .btn-modal-cancel:hover  { background: var(--border); }
+</style>
 
 {% endblock %}
 
@@ -166,6 +305,7 @@
 <script>
 (function() {
   const BMS_ADDR = {{ detail.summary.address }};
+  window._bmsAddr = BMS_ADDR;  // exposé pour les fonctions globales (modals)
 
   // ─── Initialisation des graphiques ────────────────────────────────────────
   function initChart(domId, optId) {
@@ -324,5 +464,73 @@
   setTimeout(refreshHistory, 5000);
   setInterval(refreshHistory, 30000);
 })();
+
+// ─── Actions BMS — fonctions globales (appelées depuis onclick="") ───────────
+function openSocModal()   { document.getElementById('modal-soc').style.display   = 'flex'; }
+function closeSocModal()  { document.getElementById('modal-soc').style.display   = 'none'; document.getElementById('soc-result').textContent = ''; }
+function openResetModal() { document.getElementById('modal-reset').style.display = 'flex'; }
+function closeResetModal(){ document.getElementById('modal-reset').style.display = 'none'; document.getElementById('reset-result').textContent = ''; document.getElementById('reset-confirm').checked = false; }
+
+function _bmsActionResult(id, ok, msg) {
+  var el = document.getElementById(id);
+  el.style.color = ok ? 'var(--green)' : 'var(--red)';
+  el.textContent = msg;
+}
+
+function submitSoc() {
+  var soc = parseFloat(document.getElementById('soc-value').value);
+  var pwd = document.getElementById('soc-password').value;
+  if (isNaN(soc) || soc < 0 || soc > 100) {
+    _bmsActionResult('soc-result', false, 'SOC invalide — valeur entre 0 et 100 %');
+    return;
+  }
+  document.getElementById('soc-result').style.color = 'var(--muted)';
+  document.getElementById('soc-result').textContent = 'Envoi en cours…';
+  fetch('/api/v1/bms/' + window._bmsAddr + '/soc', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ soc: soc, password: pwd })
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(data) {
+    if (data.ok) {
+      var msg = '✓ SOC calibré à ' + soc.toFixed(1) + ' %';
+      if (data.warning) msg += '  (' + data.warning + ')';
+      _bmsActionResult('soc-result', true, msg);
+      setTimeout(closeSocModal, 2500);
+    } else {
+      _bmsActionResult('soc-result', false, '✗ ' + (data.error || 'Erreur inconnue'));
+    }
+  })
+  .catch(function(e) { _bmsActionResult('soc-result', false, '✗ Erreur réseau : ' + e); });
+}
+
+function submitReset() {
+  var pwd     = document.getElementById('reset-password').value;
+  var confirm = document.getElementById('reset-confirm').checked;
+  if (!confirm) {
+    _bmsActionResult('reset-result', false, 'Cocher la case de confirmation');
+    return;
+  }
+  document.getElementById('reset-result').style.color = 'var(--muted)';
+  document.getElementById('reset-result').textContent = 'Envoi du reset…';
+  fetch('/api/v1/bms/' + window._bmsAddr + '/reset', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ confirm: true, password: pwd })
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(data) {
+    if (data.ok) {
+      var msg = '✓ Reset envoyé — BMS redémarre (quelques secondes d\'interruption)';
+      if (data.warning) msg += '  (' + data.warning + ')';
+      _bmsActionResult('reset-result', true, msg);
+      setTimeout(closeResetModal, 3000);
+    } else {
+      _bmsActionResult('reset-result', false, '✗ ' + (data.error || 'Erreur inconnue'));
+    }
+  })
+  .catch(function(e) { _bmsActionResult('reset-result', false, '✗ Erreur réseau : ' + e); });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
- state.rs: add port: Arc<RwLock<Option<Arc<DalyPort>>>> to AppState so write commands can access the shared RS485 port (DalyPort Mutex ensures exclusive access even while poll_loop is running)

- main.rs: store port in AppState (state.set_port(port.clone()).await) before handing it to DalyBusManager — both share the same Arc

- api/bms.rs: implement POST /api/v1/bms/:id/soc and /reset
  - password "12345678" required (matches Daly app behaviour)
  - read_only mode check before touching the bus
  - graceful handling of no-ACK timeout (normal on some BMS firmwares)
  - simulator mode returns 503 SERVICE_UNAVAILABLE (port = None)
  - MOS commands remain NOT_IMPLEMENTED (out of scope)

- bms_detail.html: add "Actions BMS" section with two modals
  - SOC calibration modal: numeric input (0-100%) + password field
  - Reset BMS modal: warning banner + password + confirmation checkbox
  - Feedback inline (green success / red error + warning if no ACK)
  - Click outside modal to dismiss
  - window._bmsAddr exposes BMS address to global modal functions

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G