### PR TITLE
fix(write): correct SOC frame encoding — data[0..1] not data[4..5]

### DIFF
--- a/crates/daly-bms-core/src/protocol.rs
+++ b/crates/daly-bms-core/src/protocol.rs
@@ -157,12 +157,12 @@ impl RequestFrame {
         Self::new(bms_address, cmd, data)
     }
 
-    /// Trame d'écriture SOC : valeur en % × 10, uint16 BE dans data[4..5].
+    /// Trame d'écriture SOC : valeur en % × 10, uint16 BE dans data[0..1].
     pub fn write_soc(bms_address: u8, soc_percent: f32) -> Self {
         let raw = (soc_percent * 10.0) as u16;
         let mut data = [0u8; 8];
-        data[4] = (raw >> 8) as u8;
-        data[5] = (raw & 0xFF) as u8;
+        data[0] = (raw >> 8) as u8;
+        data[1] = (raw & 0xFF) as u8;
         Self::new(bms_address, DataId::SetSoc, data)
     }
 

--- a/crates/daly-bms-core/src/write.rs
+++ b/crates/daly-bms-core/src/write.rs
@@ -91,15 +91,11 @@ pub async fn set_soc(
         return Err(anyhow::anyhow!("SOC hors plage [0, 100] : {}", soc_percent).into());
     }
     info!(bms = format!("{:#04x}", addr), "set_soc → {:.1}%", soc_percent);
-    use crate::protocol::RequestFrame;
-    let frame = RequestFrame::write_soc(addr, soc_percent);
-    // Envoi direct (send_command reconstruit la trame)
-    port.send_command(addr, DataId::SetSoc, {
-        let mut d = [0u8; 8];
-        d.copy_from_slice(&frame.bytes[4..12]);
-        d
-    })
-    .await?;
+    let raw = (soc_percent * 10.0) as u16;
+    let mut data = [0u8; 8];
+    data[0] = (raw >> 8) as u8;
+    data[1] = (raw & 0xFF) as u8;
+    port.send_command(addr, DataId::SetSoc, data).await?;
     Ok(())
 }
 


### PR DESCRIPTION
The Daly BMS SetSoc command (0x21) expects the SOC value (uint16 BE, ×10) at data[0..1] of the 8-byte payload. It was incorrectly placed at data[4..5], causing the BMS to receive 0x0000 (0%) regardless of the requested value.

Also simplify set_soc() to build the data array directly instead of constructing a full RequestFrame and re-extracting its bytes.

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G