### PR TITLE
feat(web): add logs viewer + fix deploy Text file busy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ PI_BIN_PATH ?= /usr/local/bin/daly-bms-server
 
 deploy: build-arm
 	scp $(ARM_RELEASE_DIR)/$(BINARY) $(PI_HOST):/tmp/$(BINARY)
-	ssh $(PI_HOST) "sudo mv /tmp/$(BINARY) $(PI_BIN_PATH) && sudo chmod +x $(PI_BIN_PATH) && sudo systemctl restart daly-bms"
+	ssh $(PI_HOST) "sudo install -m 755 /tmp/$(BINARY) $(PI_BIN_PATH) && sudo systemctl restart daly-bms && sudo systemctl status daly-bms --no-pager -l"
 	@echo "✓ Déployé sur $(PI_HOST)"
 
 # =============================================================================

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -27,6 +27,7 @@ pub fn build_router(state: AppState) -> Router {
 
         // ── Système ─────────────────────────────────────────────────────────
         .route("/api/v1/system/status",  get(system::get_status))
+        .route("/api/v1/system/logs",    get(system::get_logs))
         .route("/api/v1/config",         get(system::get_config))
         .route("/api/v1/discover",       get(system::discover))
 

--- a/crates/daly-bms-server/src/api/system.rs
+++ b/crates/daly-bms-server/src/api/system.rs
@@ -3,10 +3,11 @@
 use crate::state::AppState;
 use axum::{
     Json,
-    extract::State,
+    extract::{Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
+use serde::Deserialize;
 use serde_json::{json, Value};
 use std::sync::atomic::Ordering;
 
@@ -62,6 +63,24 @@ pub async fn get_config(State(state): State<AppState>) -> Json<Value> {
         "influxdb_enabled": cfg.influxdb.enabled,
         "read_only": cfg.read_only.enabled,
     }))
+}
+
+/// GET /api/v1/system/logs?limit=N
+///
+/// Retourne les dernières entrées de logs capturées en mémoire (max 200).
+#[derive(Deserialize)]
+pub struct LogsQuery {
+    pub limit: Option<usize>,
+}
+
+pub async fn get_logs(
+    State(state): State<AppState>,
+    Query(params): Query<LogsQuery>,
+) -> Json<Value> {
+    let limit = params.limit.unwrap_or(100).min(200);
+    let buf = state.log_buffer.lock().unwrap();
+    let logs: Vec<_> = buf.iter().rev().take(limit).collect();
+    Json(json!({ "logs": logs, "total": buf.len() }))
 }
 
 /// GET /api/v1/discover

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -264,6 +264,10 @@ struct DetailTemplate {
     detail: BmsDetail,
 }
 
+#[derive(Template)]
+#[template(path = "logs.html")]
+struct LogsTemplate {}
+
 // =============================================================================
 // Handlers Axum
 // =============================================================================
@@ -335,10 +339,16 @@ pub async fn dashboard_bms(
 // Routeur du dashboard
 // =============================================================================
 
+/// Page des logs serveur.
+pub async fn dashboard_logs() -> Response {
+    render(LogsTemplate {})
+}
+
 /// Construit le routeur du dashboard (à fusionner dans le routeur principal).
 pub fn build_dashboard_router() -> Router<AppState> {
     Router::new()
         .route("/",                  get(redirect_root))
         .route("/dashboard",         get(dashboard_index))
         .route("/dashboard/bms/:id", get(dashboard_bms))
+        .route("/dashboard/logs",    get(dashboard_logs))
 }

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -23,13 +23,56 @@ mod dashboard;
 
 use crate::bridges::{alerts, influx, mqtt};
 use crate::config::AppConfig;
-use crate::state::AppState;
+use crate::state::{AppState, LogBuffer, LogEntry};
 use daly_bms_core::bus::{BmsConfig, DalyBusManager, DalyPort};
 use daly_bms_core::poll::{poll_loop, PollConfig};
+use std::collections::VecDeque;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::Ordering;
 use tracing::{error, info, warn};
+use tracing::Subscriber;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+
+// =============================================================================
+// Couche tracing → buffer web
+// =============================================================================
+
+struct WebLogLayer {
+    buffer: LogBuffer,
+}
+
+struct MsgVisitor(String);
+
+impl tracing::field::Visit for MsgVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" { self.0 = value.to_string(); }
+        else if !self.0.is_empty()   { self.0.push_str(&format!(" {}={}", field.name(), value)); }
+    }
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" { self.0 = format!("{:?}", value).trim_matches('"').to_string(); }
+        else if !self.0.is_empty()   { self.0.push_str(&format!(" {}={:?}", field.name(), value)); }
+    }
+}
+
+impl<S: Subscriber> Layer<S> for WebLogLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let level = event.metadata().level().to_string().to_uppercase();
+        let mut v = MsgVisitor(String::new());
+        event.record(&mut v);
+        let entry = LogEntry {
+            timestamp: chrono::Local::now().format("%H:%M:%S").to_string(),
+            level,
+            message: v.0,
+        };
+        if let Ok(mut buf) = self.buffer.lock() {
+            if buf.len() >= 200 { buf.pop_front(); }
+            buf.push_back(entry);
+        }
+    }
+}
 
 // =============================================================================
 // Arguments CLI du serveur
@@ -130,11 +173,15 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Logging ────────────────────────────────────────────────────────────────
     let log_level = config.logging.level.clone();
-    tracing_subscriber::fmt()
-        .with_env_filter(
+    let log_buffer: LogBuffer = Arc::new(Mutex::new(VecDeque::new()));
+
+    tracing_subscriber::registry()
+        .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&log_level)),
         )
+        .with(tracing_subscriber::fmt::layer())
+        .with(WebLogLayer { buffer: log_buffer.clone() })
         .init();
 
     let mode = if args.simulate { "SIMULATION" } else { "HARDWARE" };
@@ -146,7 +193,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // ── État partagé ───────────────────────────────────────────────────────────
-    let state = AppState::new(config.clone());
+    let state = AppState::new(config.clone(), log_buffer);
 
     // ── Bridges en arrière-plan ─────────────────────────────────────────────────
 

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -6,9 +6,25 @@
 use crate::config::AppConfig;
 use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
+use serde::Serialize;
 use std::collections::{BTreeMap, VecDeque};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::sync::{broadcast, RwLock};
+
+// =============================================================================
+// Buffer de logs en mémoire (pour l'interface web)
+// =============================================================================
+
+/// Une entrée de log capturée depuis tracing.
+#[derive(Clone, Serialize)]
+pub struct LogEntry {
+    pub timestamp: String,
+    pub level: String,
+    pub message: String,
+}
+
+/// Ring buffer de logs partagé (200 entrées max).
+pub type LogBuffer = Arc<Mutex<VecDeque<LogEntry>>>;
 
 /// Capacité du canal broadcast WebSocket.
 const WS_BROADCAST_CAPACITY: usize = 128;
@@ -64,10 +80,13 @@ pub struct AppState {
     /// Port série partagé — None en mode simulateur.
     /// Partagé avec le poll_loop via le Mutex interne de DalyPort.
     pub port: Arc<RwLock<Option<Arc<DalyPort>>>>,
+
+    /// Buffer de logs pour l'interface web.
+    pub log_buffer: LogBuffer,
 }
 
 impl AppState {
-    pub fn new(config: AppConfig) -> Self {
+    pub fn new(config: AppConfig, log_buffer: LogBuffer) -> Self {
         let (ws_tx, _) = broadcast::channel(WS_BROADCAST_CAPACITY);
         let addresses = config.bms_addresses();
         let ring_size = config.serial.ring_buffer_size;
@@ -83,6 +102,7 @@ impl AppState {
             ws_tx,
             polling_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             port: Arc::new(RwLock::new(None)),
+            log_buffer,
         }
     }
 

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -548,6 +548,7 @@
   <div class="nav-brand">⚡ Daly<span>BMS</span></div>
   <div class="nav-links">
     <a href="/dashboard">Vue d'ensemble</a>
+    <a href="/dashboard/logs">Logs</a>
     <a href="/api/v1/system/status" target="_blank">API</a>
   </div>
   <div class="nav-status" id="ws-status">

--- a/crates/daly-bms-server/templates/logs.html
+++ b/crates/daly-bms-server/templates/logs.html
@@ -1,0 +1,92 @@
+{% extends "base.html" %}
+
+{% block title %}Logs — DalyBMS{% endblock %}
+
+{% block content %}
+<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
+  <h2 style="font-size:1rem;font-weight:700;">Logs serveur</h2>
+  <div style="display:flex;align-items:center;gap:0.75rem;">
+    <span style="font-size:0.75rem;color:var(--muted);" id="log-count">—</span>
+    <label style="font-size:0.75rem;color:var(--muted);display:flex;align-items:center;gap:0.35rem;">
+      <input type="checkbox" id="auto-scroll" checked> Auto-scroll
+    </label>
+    <button onclick="clearLogs()" style="font-size:0.72rem;padding:0.2rem 0.6rem;border:1px solid var(--border);border-radius:4px;background:var(--surface);cursor:pointer;color:var(--muted);">
+      Vider
+    </button>
+  </div>
+</div>
+
+<div class="card" style="padding:0;overflow:hidden;">
+  <div id="log-container"
+       style="font-family:monospace;font-size:0.72rem;line-height:1.6;
+              max-height:70vh;overflow-y:auto;background:#0d1117;border-radius:var(--radius);">
+    <div id="log-lines" style="padding:0.5rem 0.75rem;"></div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+const COLORS = {
+  'ERROR': '#f85149',
+  'WARN':  '#e3b341',
+  'INFO':  '#58a6ff',
+  'DEBUG': '#8b949e',
+  'TRACE': '#6e7681',
+};
+
+let localLogs = [];
+let lastCount = 0;
+
+function clearLogs() {
+  localLogs = [];
+  lastCount = 0;
+  render();
+}
+
+function render() {
+  const container = document.getElementById('log-lines');
+  const autoScroll = document.getElementById('auto-scroll').checked;
+  const wrap = document.getElementById('log-container');
+
+  const html = localLogs.map(function(e) {
+    const col = COLORS[e.level] || '#8b949e';
+    const lvl = e.level.padEnd(5, ' ');
+    const msg = escapeHtml(e.message);
+    return '<div style="white-space:pre-wrap;word-break:break-all;">'
+         + '<span style="color:#6e7681;">' + e.timestamp + '</span> '
+         + '<span style="color:' + col + ';font-weight:600;">' + lvl + '</span> '
+         + '<span style="color:#e6edf3;">' + msg + '</span>'
+         + '</div>';
+  }).join('');
+  container.innerHTML = html;
+
+  document.getElementById('log-count').textContent = localLogs.length + ' entrées';
+  if (autoScroll) wrap.scrollTop = wrap.scrollHeight;
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+async function fetchLogs() {
+  try {
+    const r = await fetch('/api/v1/system/logs?limit=200');
+    if (!r.ok) return;
+    const data = await r.json();
+    const incoming = (data.logs || []).reverse(); // API retourne newest-first, on remet oldest-first
+    if (incoming.length !== lastCount) {
+      localLogs = incoming;
+      lastCount = incoming.length;
+      render();
+    }
+  } catch (_) {}
+}
+
+fetchLogs();
+setInterval(fetchLogs, 3000);
+</script>
+{% endblock %}


### PR DESCRIPTION
- Makefile: use `install` instead of `mv` to atomically replace running binary (avoids ETXTBSY with no need to stop the service first)
- state.rs: add LogEntry/LogBuffer ring buffer (200 entries)
- main.rs: add WebLogLayer tracing subscriber that feeds the ring buffer, switch from fmt().init() to registry() to compose layers
- api/system.rs: add GET /api/v1/system/logs?limit=N endpoint
- dashboard: add /dashboard/logs page with dark terminal, color-coded levels, auto-refresh every 3s, auto-scroll
- base.html: add "Logs" link in navbar

Deploy workflow (from local machine, one command):
  make deploy

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G