### PR TITLE
fix(set_soc): place SOC value at data[6..7] instead of data[0..1]

### DIFF
--- a/crates/daly-bms-core/src/protocol.rs
+++ b/crates/daly-bms-core/src/protocol.rs
@@ -157,12 +157,15 @@ impl RequestFrame {
         Self::new(bms_address, cmd, data)
     }
 
-    /// Trame d'écriture SOC : valeur en % × 10, uint16 BE dans data[0..1].
+    /// Trame d'écriture SOC : valeur en % × 10, uint16 BE dans data[6..7].
+    ///
+    /// Protocole 0x21 : bytes [4-9] = date/time (zéros), bytes [10-11] = SOC
+    /// → data[6..7] dans le payload de 8 octets (conforme python-daly-bms).
     pub fn write_soc(bms_address: u8, soc_percent: f32) -> Self {
         let raw = (soc_percent * 10.0) as u16;
         let mut data = [0u8; 8];
-        data[0] = (raw >> 8) as u8;
-        data[1] = (raw & 0xFF) as u8;
+        data[6] = (raw >> 8) as u8;
+        data[7] = (raw & 0xFF) as u8;
         Self::new(bms_address, DataId::SetSoc, data)
     }
 

--- a/crates/daly-bms-core/src/write.rs
+++ b/crates/daly-bms-core/src/write.rs
@@ -93,8 +93,10 @@ pub async fn set_soc(
     info!(bms = format!("{:#04x}", addr), "set_soc → {:.1}%", soc_percent);
     let raw = (soc_percent * 10.0) as u16;
     let mut data = [0u8; 8];
-    data[0] = (raw >> 8) as u8;
-    data[1] = (raw & 0xFF) as u8;
+    // Protocole Daly 0x21 : bytes [4-9] = date/time (mis à 0), bytes [10-11] = SOC
+    // → data[6..7] dans le payload de 8 octets
+    data[6] = (raw >> 8) as u8;
+    data[7] = (raw & 0xFF) as u8;
     port.send_command(addr, DataId::SetSoc, data).await?;
     Ok(())
 }


### PR DESCRIPTION
Reverse-engineering of python-daly-bms and DIY Solar Forum protocol docs shows that command 0x21 uses bytes [4-9] for date/time (zeroed) and bytes [10-11] for the SOC value — i.e. data[6..7] in the 8-byte payload. Our previous encoding at data[0..1] was silently ignored by the BMS.

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G