### PR TITLE
feat: page Paramètres BMS + firmware dans bandeau + commandes 0x50/0x…

### DIFF
--- a/crates/daly-bms-core/src/commands.rs
+++ b/crates/daly-bms-core/src/commands.rs
@@ -10,7 +10,7 @@ use crate::protocol::{
     decode_voltage, read_u16_be,
 };
 use crate::types::{
-    BalanceFlags, CellTemperatures, CellVoltages, MosStatus, SocData, StatusInfo,
+    BalanceFlags, BmsSettings, CellTemperatures, CellVoltages, MosStatus, SocData, StatusInfo,
 };
 use std::sync::Arc;
 use tracing::trace;
@@ -207,6 +207,143 @@ pub async fn get_alarm_flags(
     let mut alarm_bytes = [0u8; 7];
     alarm_bytes.copy_from_slice(&d[1..8]);
     Ok((charge_en, discharge_en, alarm_bytes))
+}
+
+// =============================================================================
+// Commandes de lecture — paramètres/configuration
+// =============================================================================
+
+/// Lit la capacité nominale et la tension nominale de cellule (0x50).
+///
+/// Layout data :
+/// - D0-D3 : Capacité nominale (mAh, uint32 BE)
+/// - D4-D5 : Réservé
+/// - D6-D7 : Tension nominale cellule (mV, uint16 BE)
+pub async fn get_rated_capacity(port: &Arc<DalyPort>, addr: u8) -> Result<(u32, u16)> {
+    let frame = port.send_command(addr, DataId::RatedCapacity, [0u8; 8]).await?;
+    let d = frame.data();
+    let capacity_mah = u32::from_be_bytes([d[0], d[1], d[2], d[3]]);
+    let nominal_mv   = read_u16_be(d, 6);
+    Ok((capacity_mah, nominal_mv))
+}
+
+/// Lit les seuils d'alarme tension cellule L1/L2 (0x59).
+///
+/// Retourne (high_l1_mv, high_l2_mv, low_l1_mv, low_l2_mv).
+pub async fn get_cell_volt_alarms(port: &Arc<DalyPort>, addr: u8) -> Result<(u16, u16, u16, u16)> {
+    let frame = port.send_command(addr, DataId::CellVoltAlarms, [0u8; 8]).await?;
+    let d = frame.data();
+    Ok((read_u16_be(d, 0), read_u16_be(d, 2), read_u16_be(d, 4), read_u16_be(d, 6)))
+}
+
+/// Lit les seuils d'alarme tension pack L1/L2 (0x5A).
+///
+/// Retourne (high_l1_dv, high_l2_dv, low_l1_dv, low_l2_dv) en 0.1 V.
+pub async fn get_pack_volt_alarms(port: &Arc<DalyPort>, addr: u8) -> Result<(u16, u16, u16, u16)> {
+    let frame = port.send_command(addr, DataId::PackVoltAlarms, [0u8; 8]).await?;
+    let d = frame.data();
+    Ok((read_u16_be(d, 0), read_u16_be(d, 2), read_u16_be(d, 4), read_u16_be(d, 6)))
+}
+
+/// Lit les seuils d'alarme courant charge/décharge L1/L2 (0x5B).
+///
+/// Encodage offset 30000 (même que courant 0x90).
+/// Charge : raw < 30000  → A = (30000 - raw) / 10
+/// Décharge : raw > 30000 → A = (raw - 30000) / 10
+pub async fn get_current_alarms(port: &Arc<DalyPort>, addr: u8) -> Result<(f32, f32, f32, f32)> {
+    let frame = port.send_command(addr, DataId::CurrentAlarms, [0u8; 8]).await?;
+    let d = frame.data();
+    let chg_l1 = (30000i32 - read_u16_be(d, 0) as i32).unsigned_abs() as f32 / 10.0;
+    let chg_l2 = (30000i32 - read_u16_be(d, 2) as i32).unsigned_abs() as f32 / 10.0;
+    let dch_l1 = (read_u16_be(d, 4) as i32 - 30000i32).unsigned_abs() as f32 / 10.0;
+    let dch_l2 = (read_u16_be(d, 6) as i32 - 30000i32).unsigned_abs() as f32 / 10.0;
+    Ok((chg_l1, chg_l2, dch_l1, dch_l2))
+}
+
+/// Lit les seuils d'alarme delta tension + delta température L1/L2 (0x5E).
+///
+/// Retourne (cell_delta_mv_l1, cell_delta_mv_l2, temp_delta_l1, temp_delta_l2).
+pub async fn get_delta_alarms(port: &Arc<DalyPort>, addr: u8) -> Result<(u16, u16, u8, u8)> {
+    let frame = port.send_command(addr, DataId::DeltaAlarms, [0u8; 8]).await?;
+    let d = frame.data();
+    Ok((read_u16_be(d, 0), read_u16_be(d, 2), d[4], d[5]))
+}
+
+/// Lit les seuils de balancing (0x5F).
+///
+/// Retourne (activation_mv, delta_mv).
+pub async fn get_balancing_thresh(port: &Arc<DalyPort>, addr: u8) -> Result<(u16, u16)> {
+    let frame = port.send_command(addr, DataId::BalancingThresh, [0u8; 8]).await?;
+    let d = frame.data();
+    Ok((read_u16_be(d, 0), read_u16_be(d, 2)))
+}
+
+/// Lit la version logicielle firmware (0x62, multi-trames, 7 chars/trame).
+///
+/// Exemple : "20210222-1.01T"
+pub async fn get_firmware_sw(port: &Arc<DalyPort>, addr: u8) -> Result<String> {
+    let frames = port.send_command_multi(addr, DataId::FirmwareSW, 2).await?;
+    let mut s = String::with_capacity(14);
+    for frame in &frames {
+        let d = frame.data();
+        // d[0] = numéro de trame, d[1..8] = 7 chars
+        for &b in &d[1..8] {
+            if b != 0x00 && b != 0x20 {
+                s.push(b as char);
+            }
+        }
+    }
+    Ok(s.trim().to_string())
+}
+
+/// Lit la version matérielle (0x63, multi-trames, 7 chars/trame).
+///
+/// Exemple : "DL-BMS-R32-01E"
+pub async fn get_firmware_hw(port: &Arc<DalyPort>, addr: u8) -> Result<String> {
+    let frames = port.send_command_multi(addr, DataId::FirmwareHW, 2).await?;
+    let mut s = String::with_capacity(14);
+    for frame in &frames {
+        let d = frame.data();
+        for &b in &d[1..8] {
+            if b != 0x00 && b != 0x20 {
+                s.push(b as char);
+            }
+        }
+    }
+    Ok(s.trim().to_string())
+}
+
+/// Lit tous les paramètres de configuration en une seule opération (0x50, 0x5F, 0x59, 0x5A, 0x5B, 0x5E).
+pub async fn get_bms_settings(port: &Arc<DalyPort>, addr: u8) -> Result<BmsSettings> {
+    let (rated_mah, nominal_mv)            = get_rated_capacity(port, addr).await?;
+    let (bal_act_mv, bal_delta_mv)         = get_balancing_thresh(port, addr).await?;
+    let (cv_hi1, cv_hi2, cv_lo1, cv_lo2)  = get_cell_volt_alarms(port, addr).await?;
+    let (pv_hi1, pv_hi2, pv_lo1, pv_lo2)  = get_pack_volt_alarms(port, addr).await?;
+    let (ci_c1, ci_c2, ci_d1, ci_d2)      = get_current_alarms(port, addr).await?;
+    let (dv_l1, dv_l2, dt_l1, dt_l2)      = get_delta_alarms(port, addr).await?;
+
+    Ok(BmsSettings {
+        rated_capacity_mah:    rated_mah,
+        nominal_cell_mv:       nominal_mv,
+        balancing_activation_mv: bal_act_mv,
+        balancing_delta_mv:    bal_delta_mv,
+        cell_high_v_l1_mv:     cv_hi1,
+        cell_high_v_l2_mv:     cv_hi2,
+        cell_low_v_l1_mv:      cv_lo1,
+        cell_low_v_l2_mv:      cv_lo2,
+        pack_high_v_l1_dv:     pv_hi1,
+        pack_high_v_l2_dv:     pv_hi2,
+        pack_low_v_l1_dv:      pv_lo1,
+        pack_low_v_l2_dv:      pv_lo2,
+        chg_high_a_l1:         ci_c1,
+        chg_high_a_l2:         ci_c2,
+        dch_high_a_l1:         ci_d1,
+        dch_high_a_l2:         ci_d2,
+        cell_delta_v_l1_mv:    dv_l1,
+        cell_delta_v_l2_mv:    dv_l2,
+        temp_delta_l1:         dt_l1,
+        temp_delta_l2:         dt_l2,
+    })
 }
 
 // =============================================================================

--- a/crates/daly-bms-core/src/lib.rs
+++ b/crates/daly-bms-core/src/lib.rs
@@ -23,7 +23,7 @@ pub mod poll;
 pub use error::DalyError;
 pub use types::{
     BmsSnapshot, DcData, Alarms, InfoData, HistoryData, SystemData,
-    IoData, CellVoltages, CellTemperatures, BmsAddress,
+    IoData, CellVoltages, CellTemperatures, BmsAddress, BmsSettings,
 };
 pub use protocol::{DataId, RequestFrame, ResponseFrame, FRAME_LEN};
 pub use bus::{DalyPort, DalyBusManager};

--- a/crates/daly-bms-core/src/poll.rs
+++ b/crates/daly-bms-core/src/poll.rs
@@ -10,7 +10,7 @@ use crate::types::{
     BmsSnapshot, DcData, HistoryData, InfoData, IoData, SystemData,
 };
 use chrono::Utc;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info, warn};
@@ -54,12 +54,36 @@ pub async fn poll_loop<F>(
 {
     let on_snapshot = Arc::new(on_snapshot);
     let mut backoff_ms = config.backoff_initial_ms;
+    // Cache des versions firmware (lues une seule fois par BMS)
+    let mut fw_cache: HashMap<u8, (String, String)> = HashMap::new();
 
     loop {
         let cycle_start = std::time::Instant::now();
 
+        // Lire les versions firmware pour les BMS non encore mis en cache
         for device in &manager.devices {
-            match poll_device(&manager.port, device, &config).await {
+            if !fw_cache.contains_key(&device.address) {
+                let sw = commands::get_firmware_sw(&manager.port, device.address)
+                    .await.unwrap_or_default();
+                let hw = commands::get_firmware_hw(&manager.port, device.address)
+                    .await.unwrap_or_default();
+                if !sw.is_empty() || !hw.is_empty() {
+                    info!(
+                        bms = format!("{:#04x}", device.address),
+                        fw_sw = %sw, fw_hw = %hw,
+                        "Firmware version lu"
+                    );
+                }
+                fw_cache.insert(device.address, (sw, hw));
+            }
+        }
+
+        for device in &manager.devices {
+            let (fw_sw, fw_hw) = fw_cache
+                .get(&device.address)
+                .cloned()
+                .unwrap_or_default();
+            match poll_device(&manager.port, device, &config, fw_sw, fw_hw).await {
                 Ok(snapshot) => {
                     backoff_ms = config.backoff_initial_ms; // reset backoff
                     on_snapshot(snapshot);
@@ -101,6 +125,8 @@ async fn poll_device(
     port: &Arc<DalyPort>,
     device: &BmsConfig,
     config: &PollConfig,
+    firmware_sw: String,
+    firmware_hw: String,
 ) -> crate::error::Result<BmsSnapshot> {
     let addr = device.address;
 
@@ -226,6 +252,8 @@ async fn poll_device(
         io,
         heating:            0,
         time_to_soc,
+        firmware_sw,
+        firmware_hw,
     };
 
     info!(

--- a/crates/daly-bms-core/src/protocol.rs
+++ b/crates/daly-bms-core/src/protocol.rs
@@ -79,10 +79,41 @@ pub enum DataId {
     AlarmFlags        = 0x98,
 
     // ── Commandes d'écriture ──────────────────────────────────────────────────
+    // ── Commandes de lecture — paramètres/configuration ──────────────────────
+    /// Capacité nominale du pack + tension nominale de cellule (mAh, mV)
+    RatedCapacity     = 0x50,
+    /// Seuils d'alarme tension cellule L1/L2 haut/bas (mV)
+    CellVoltAlarms    = 0x59,
+    /// Seuils d'alarme tension pack L1/L2 haut/bas (0.1 V)
+    PackVoltAlarms    = 0x5A,
+    /// Seuils d'alarme courant charge/décharge L1/L2 (offset 30000, 0.1 A)
+    CurrentAlarms     = 0x5B,
+    /// Seuils d'alarme delta tension cellule + delta température L1/L2
+    DeltaAlarms       = 0x5E,
+    /// Seuils de démarrage et delta acceptable pour le balancing (mV)
+    BalancingThresh   = 0x5F,
+    /// Version logicielle (multi-trames, 7 chars par trame)
+    FirmwareSW        = 0x62,
+    /// Version matérielle (multi-trames, 7 chars par trame)
+    FirmwareHW        = 0x63,
+
+    // ── Commandes d'écriture ──────────────────────────────────────────────────
     /// Reset BMS
     Reset             = 0x00,
     /// Calibration SOC (uint16 BE × 10 à l'offset 4)
     SetSoc            = 0x21,
+    /// Écriture capacité nominale + tension nominale de cellule
+    SetRatedCapacity  = 0x10,
+    /// Écriture seuils d'alarme tension cellule L1/L2
+    SetCellVoltAlarms = 0x19,
+    /// Écriture seuils d'alarme tension pack L1/L2
+    SetPackVoltAlarms = 0x1A,
+    /// Écriture seuils d'alarme courant L1/L2
+    SetCurrentAlarms  = 0x1B,
+    /// Écriture seuils delta tension/température L1/L2
+    SetDeltaAlarms    = 0x1E,
+    /// Écriture seuils balancing (activation + delta)
+    SetBalancingThresh = 0x1F,
     /// Commande MOS décharge (0x01 = on, 0x00 = off)
     SetDischargeMos   = 0xD9,
     /// Commande MOS charge (0x01 = on, 0x00 = off)
@@ -102,8 +133,22 @@ impl DataId {
             0x96 => Some(Self::Temperatures),
             0x97 => Some(Self::BalanceStatus),
             0x98 => Some(Self::AlarmFlags),
+            0x50 => Some(Self::RatedCapacity),
+            0x59 => Some(Self::CellVoltAlarms),
+            0x5A => Some(Self::PackVoltAlarms),
+            0x5B => Some(Self::CurrentAlarms),
+            0x5E => Some(Self::DeltaAlarms),
+            0x5F => Some(Self::BalancingThresh),
+            0x62 => Some(Self::FirmwareSW),
+            0x63 => Some(Self::FirmwareHW),
             0x00 => Some(Self::Reset),
             0x21 => Some(Self::SetSoc),
+            0x10 => Some(Self::SetRatedCapacity),
+            0x19 => Some(Self::SetCellVoltAlarms),
+            0x1A => Some(Self::SetPackVoltAlarms),
+            0x1B => Some(Self::SetCurrentAlarms),
+            0x1E => Some(Self::SetDeltaAlarms),
+            0x1F => Some(Self::SetBalancingThresh),
             0xD9 => Some(Self::SetDischargeMos),
             0xDA => Some(Self::SetChargeMos),
             _    => None,
@@ -112,7 +157,14 @@ impl DataId {
 
     /// `true` si c'est une commande d'écriture (dangereux sans confirmation).
     pub fn is_write(self) -> bool {
-        matches!(self, Self::Reset | Self::SetSoc | Self::SetDischargeMos | Self::SetChargeMos)
+        matches!(
+            self,
+            Self::Reset | Self::SetSoc
+            | Self::SetRatedCapacity | Self::SetCellVoltAlarms
+            | Self::SetPackVoltAlarms | Self::SetCurrentAlarms
+            | Self::SetDeltaAlarms | Self::SetBalancingThresh
+            | Self::SetDischargeMos | Self::SetChargeMos
+        )
     }
 }
 

--- a/crates/daly-bms-core/src/types.rs
+++ b/crates/daly-bms-core/src/types.rs
@@ -106,6 +106,14 @@ pub struct BmsSnapshot {
     /// Temps estimé pour atteindre chaque palier de SOC (% → secondes)
     #[serde(rename = "TimeToSoC")]
     pub time_to_soc: BTreeMap<u8, u32>,
+
+    /// Version logicielle firmware (ex: "20210222-1.01T") — lue une fois au démarrage
+    #[serde(rename = "FirmwareSW")]
+    pub firmware_sw: String,
+
+    /// Version matérielle (ex: "DL-BMS-R32-01E") — lue une fois au démarrage
+    #[serde(rename = "FirmwareHW")]
+    pub firmware_hw: String,
 }
 
 // =============================================================================
@@ -397,6 +405,68 @@ impl BalanceFlags {
             .map(|(i, &f)| (format!("Cell{}", i + 1), u8::from(f)))
             .collect()
     }
+}
+
+// =============================================================================
+// Paramètres de configuration du BMS (commandes 0x50, 0x59-0x5F)
+// =============================================================================
+
+/// Paramètres de configuration lus depuis le BMS (lecture à la demande).
+///
+/// Retourné par la commande GET /api/v1/bms/:id/settings.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BmsSettings {
+    // ── 0x50 : Capacité nominale + tension nominale ────────────────────────
+    /// Capacité nominale du pack (mAh)
+    pub rated_capacity_mah: u32,
+    /// Tension nominale des cellules (mV, ex: 3700 pour LFP)
+    pub nominal_cell_mv: u16,
+
+    // ── 0x5F : Seuils de balancing ─────────────────────────────────────────
+    /// Tension de cellule à partir de laquelle le balancing démarre (mV)
+    pub balancing_activation_mv: u16,
+    /// Delta de tension acceptable entre cellules (mV)
+    pub balancing_delta_mv: u16,
+
+    // ── 0x59 : Alarmes tension cellule ────────────────────────────────────
+    /// Alarme sur-tension cellule niveau 1 (mV)
+    pub cell_high_v_l1_mv: u16,
+    /// Alarme sur-tension cellule niveau 2 (mV)
+    pub cell_high_v_l2_mv: u16,
+    /// Alarme sous-tension cellule niveau 1 (mV)
+    pub cell_low_v_l1_mv: u16,
+    /// Alarme sous-tension cellule niveau 2 (mV)
+    pub cell_low_v_l2_mv: u16,
+
+    // ── 0x5A : Alarmes tension pack ───────────────────────────────────────
+    /// Alarme sur-tension pack niveau 1 (0.1 V)
+    pub pack_high_v_l1_dv: u16,
+    /// Alarme sur-tension pack niveau 2 (0.1 V)
+    pub pack_high_v_l2_dv: u16,
+    /// Alarme sous-tension pack niveau 1 (0.1 V)
+    pub pack_low_v_l1_dv: u16,
+    /// Alarme sous-tension pack niveau 2 (0.1 V)
+    pub pack_low_v_l2_dv: u16,
+
+    // ── 0x5B : Alarmes courant ────────────────────────────────────────────
+    /// Alarme sur-courant de charge niveau 1 (A, positif)
+    pub chg_high_a_l1: f32,
+    /// Alarme sur-courant de charge niveau 2 (A)
+    pub chg_high_a_l2: f32,
+    /// Alarme sur-courant de décharge niveau 1 (A, positif)
+    pub dch_high_a_l1: f32,
+    /// Alarme sur-courant de décharge niveau 2 (A)
+    pub dch_high_a_l2: f32,
+
+    // ── 0x5E : Alarmes delta tension / température ────────────────────────
+    /// Alarme déséquilibre tension cellule niveau 1 (mV)
+    pub cell_delta_v_l1_mv: u16,
+    /// Alarme déséquilibre tension cellule niveau 2 (mV)
+    pub cell_delta_v_l2_mv: u16,
+    /// Alarme delta température niveau 1 (°C)
+    pub temp_delta_l1: u8,
+    /// Alarme delta température niveau 2 (°C)
+    pub temp_delta_l2: u8,
 }
 
 /// Résultat de la commande 0x90 : SOC, tension, courant.

--- a/crates/daly-bms-core/src/write.rs
+++ b/crates/daly-bms-core/src/write.rs
@@ -101,6 +101,122 @@ pub async fn set_soc(
     Ok(())
 }
 
+// =============================================================================
+// Écriture des paramètres de configuration
+// =============================================================================
+
+/// Écrire les seuils d'alarme tension cellule (Data ID 0x19).
+///
+/// Paramètres en millivolts.
+pub async fn set_cell_volt_alarms(
+    port: &Arc<DalyPort>,
+    addr: u8,
+    high_l1_mv: u16,
+    high_l2_mv: u16,
+    low_l1_mv: u16,
+    low_l2_mv: u16,
+    read_only: bool,
+) -> Result<()> {
+    if read_only { return Err(DalyError::ReadOnly); }
+    let mut data = [0u8; 8];
+    data[0] = (high_l1_mv >> 8) as u8; data[1] = (high_l1_mv & 0xFF) as u8;
+    data[2] = (high_l2_mv >> 8) as u8; data[3] = (high_l2_mv & 0xFF) as u8;
+    data[4] = (low_l1_mv  >> 8) as u8; data[5] = (low_l1_mv  & 0xFF) as u8;
+    data[6] = (low_l2_mv  >> 8) as u8; data[7] = (low_l2_mv  & 0xFF) as u8;
+    info!(bms = format!("{:#04x}", addr), "set_cell_volt_alarms hi1={}mV hi2={}mV lo1={}mV lo2={}mV", high_l1_mv, high_l2_mv, low_l1_mv, low_l2_mv);
+    port.send_command(addr, DataId::SetCellVoltAlarms, data).await?;
+    Ok(())
+}
+
+/// Écrire les seuils d'alarme tension pack (Data ID 0x1A).
+///
+/// Paramètres en 0.1 V.
+pub async fn set_pack_volt_alarms(
+    port: &Arc<DalyPort>,
+    addr: u8,
+    high_l1_dv: u16,
+    high_l2_dv: u16,
+    low_l1_dv: u16,
+    low_l2_dv: u16,
+    read_only: bool,
+) -> Result<()> {
+    if read_only { return Err(DalyError::ReadOnly); }
+    let mut data = [0u8; 8];
+    data[0] = (high_l1_dv >> 8) as u8; data[1] = (high_l1_dv & 0xFF) as u8;
+    data[2] = (high_l2_dv >> 8) as u8; data[3] = (high_l2_dv & 0xFF) as u8;
+    data[4] = (low_l1_dv  >> 8) as u8; data[5] = (low_l1_dv  & 0xFF) as u8;
+    data[6] = (low_l2_dv  >> 8) as u8; data[7] = (low_l2_dv  & 0xFF) as u8;
+    info!(bms = format!("{:#04x}", addr), "set_pack_volt_alarms hi1={}dV hi2={}dV lo1={}dV lo2={}dV", high_l1_dv, high_l2_dv, low_l1_dv, low_l2_dv);
+    port.send_command(addr, DataId::SetPackVoltAlarms, data).await?;
+    Ok(())
+}
+
+/// Écrire les seuils d'alarme courant (Data ID 0x1B).
+///
+/// `chg_*` et `dch_*` en Ampères positifs.
+/// Encodage offset 30000 : charge = 30000 - (A × 10), décharge = 30000 + (A × 10).
+pub async fn set_current_alarms(
+    port: &Arc<DalyPort>,
+    addr: u8,
+    chg_l1_a: f32,
+    chg_l2_a: f32,
+    dch_l1_a: f32,
+    dch_l2_a: f32,
+    read_only: bool,
+) -> Result<()> {
+    if read_only { return Err(DalyError::ReadOnly); }
+    let enc_chg = |a: f32| -> u16 { (30000.0 - a * 10.0) as u16 };
+    let enc_dch = |a: f32| -> u16 { (30000.0 + a * 10.0) as u16 };
+    let c1 = enc_chg(chg_l1_a); let c2 = enc_chg(chg_l2_a);
+    let d1 = enc_dch(dch_l1_a); let d2 = enc_dch(dch_l2_a);
+    let mut data = [0u8; 8];
+    data[0] = (c1 >> 8) as u8; data[1] = (c1 & 0xFF) as u8;
+    data[2] = (c2 >> 8) as u8; data[3] = (c2 & 0xFF) as u8;
+    data[4] = (d1 >> 8) as u8; data[5] = (d1 & 0xFF) as u8;
+    data[6] = (d2 >> 8) as u8; data[7] = (d2 & 0xFF) as u8;
+    info!(bms = format!("{:#04x}", addr), "set_current_alarms chg={}/{}A dch={}/{}A", chg_l1_a, chg_l2_a, dch_l1_a, dch_l2_a);
+    port.send_command(addr, DataId::SetCurrentAlarms, data).await?;
+    Ok(())
+}
+
+/// Écrire les seuils d'alarme delta tension cellule + delta température (Data ID 0x1E).
+pub async fn set_delta_alarms(
+    port: &Arc<DalyPort>,
+    addr: u8,
+    cell_delta_l1_mv: u16,
+    cell_delta_l2_mv: u16,
+    temp_delta_l1: u8,
+    temp_delta_l2: u8,
+    read_only: bool,
+) -> Result<()> {
+    if read_only { return Err(DalyError::ReadOnly); }
+    let mut data = [0u8; 8];
+    data[0] = (cell_delta_l1_mv >> 8) as u8; data[1] = (cell_delta_l1_mv & 0xFF) as u8;
+    data[2] = (cell_delta_l2_mv >> 8) as u8; data[3] = (cell_delta_l2_mv & 0xFF) as u8;
+    data[4] = temp_delta_l1;
+    data[5] = temp_delta_l2;
+    info!(bms = format!("{:#04x}", addr), "set_delta_alarms dv={}/{}mV dt={}/{}°C", cell_delta_l1_mv, cell_delta_l2_mv, temp_delta_l1, temp_delta_l2);
+    port.send_command(addr, DataId::SetDeltaAlarms, data).await?;
+    Ok(())
+}
+
+/// Écrire les seuils de balancing (Data ID 0x1F).
+pub async fn set_balancing_thresh(
+    port: &Arc<DalyPort>,
+    addr: u8,
+    activation_mv: u16,
+    delta_mv: u16,
+    read_only: bool,
+) -> Result<()> {
+    if read_only { return Err(DalyError::ReadOnly); }
+    let mut data = [0u8; 8];
+    data[0] = (activation_mv >> 8) as u8; data[1] = (activation_mv & 0xFF) as u8;
+    data[2] = (delta_mv >> 8) as u8;      data[3] = (delta_mv & 0xFF) as u8;
+    info!(bms = format!("{:#04x}", addr), "set_balancing_thresh activation={}mV delta={}mV", activation_mv, delta_mv);
+    port.send_command(addr, DataId::SetBalancingThresh, data).await?;
+    Ok(())
+}
+
 /// Réinitialiser le BMS (Data ID 0x00). ⚠️ Utiliser avec précaution.
 pub async fn reset_bms(port: &Arc<DalyPort>, addr: u8, read_only: bool) -> Result<()> {
     if read_only {

--- a/crates/daly-bms-server/src/api/bms.rs
+++ b/crates/daly-bms-server/src/api/bms.rs
@@ -8,7 +8,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use axum::extract::ws::{Message, WebSocket};
-use daly_bms_core::types::BmsSnapshot;
+use daly_bms_core::types::{BmsSettings, BmsSnapshot};
 use futures::{SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -292,6 +292,217 @@ pub async fn set_soc(
                 "warning": "Pas d'ACK BMS (commande probablement reçue — vérifier le SOC dans 5s)",
             }))).into_response()
         }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
+    }
+}
+
+// =============================================================================
+// GET — Paramètres de configuration (lecture à la demande)
+// =============================================================================
+
+/// GET /api/v1/bms/:id/settings
+///
+/// Lit tous les paramètres de configuration du BMS (0x50, 0x5F, 0x59, 0x5A, 0x5B, 0x5E).
+/// Cette commande interroge directement le BMS sur le bus RS485.
+pub async fn get_settings(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    let addr = match parse_addr(&id) {
+        Some(a) => a,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "Adresse BMS invalide"}))).into_response(),
+    };
+    let port = match require_port(&state).await {
+        Ok(p)  => p,
+        Err(e) => return e,
+    };
+    match daly_bms_core::commands::get_bms_settings(&port, addr).await {
+        Ok(s) => (StatusCode::OK, Json(json!({
+            "bms": format!("{:#04x}", addr),
+            "settings": s,
+        }))).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
+    }
+}
+
+// =============================================================================
+// POST — Écriture des paramètres de configuration
+// =============================================================================
+
+#[derive(Deserialize)]
+pub struct CellVoltAlarmsCmd {
+    pub high_l1_mv: u16,
+    pub high_l2_mv: u16,
+    pub low_l1_mv:  u16,
+    pub low_l2_mv:  u16,
+    pub password:   String,
+}
+
+/// POST /api/v1/bms/:id/settings/cell-voltage-alarms
+pub async fn set_cell_volt_alarms(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<CellVoltAlarmsCmd>,
+) -> impl IntoResponse {
+    if body.password != DALY_WRITE_PASSWORD {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mot de passe incorrect"}))).into_response();
+    }
+    if state.config.read_only.enabled {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mode lecture seule actif"}))).into_response();
+    }
+    let addr = match parse_addr(&id) {
+        Some(a) => a,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "Adresse invalide"}))).into_response(),
+    };
+    let port = match require_port(&state).await { Ok(p) => p, Err(e) => return e };
+    match daly_bms_core::write::set_cell_volt_alarms(
+        &port, addr, body.high_l1_mv, body.high_l2_mv, body.low_l1_mv, body.low_l2_mv, false,
+    ).await {
+        Ok(()) => (StatusCode::OK, Json(json!({"ok": true, "bms": format!("{:#04x}", addr)}))).into_response(),
+        Err(daly_bms_core::error::DalyError::Timeout { .. }) =>
+            (StatusCode::OK, Json(json!({"ok": true, "warning": "Pas d'ACK BMS"}))).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct PackVoltAlarmsCmd {
+    pub high_l1_dv: u16,
+    pub high_l2_dv: u16,
+    pub low_l1_dv:  u16,
+    pub low_l2_dv:  u16,
+    pub password:   String,
+}
+
+/// POST /api/v1/bms/:id/settings/pack-voltage-alarms
+pub async fn set_pack_volt_alarms(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<PackVoltAlarmsCmd>,
+) -> impl IntoResponse {
+    if body.password != DALY_WRITE_PASSWORD {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mot de passe incorrect"}))).into_response();
+    }
+    if state.config.read_only.enabled {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mode lecture seule actif"}))).into_response();
+    }
+    let addr = match parse_addr(&id) {
+        Some(a) => a,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "Adresse invalide"}))).into_response(),
+    };
+    let port = match require_port(&state).await { Ok(p) => p, Err(e) => return e };
+    match daly_bms_core::write::set_pack_volt_alarms(
+        &port, addr, body.high_l1_dv, body.high_l2_dv, body.low_l1_dv, body.low_l2_dv, false,
+    ).await {
+        Ok(()) => (StatusCode::OK, Json(json!({"ok": true, "bms": format!("{:#04x}", addr)}))).into_response(),
+        Err(daly_bms_core::error::DalyError::Timeout { .. }) =>
+            (StatusCode::OK, Json(json!({"ok": true, "warning": "Pas d'ACK BMS"}))).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CurrentAlarmsCmd {
+    pub chg_l1_a: f32,
+    pub chg_l2_a: f32,
+    pub dch_l1_a: f32,
+    pub dch_l2_a: f32,
+    pub password: String,
+}
+
+/// POST /api/v1/bms/:id/settings/current-alarms
+pub async fn set_current_alarms(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<CurrentAlarmsCmd>,
+) -> impl IntoResponse {
+    if body.password != DALY_WRITE_PASSWORD {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mot de passe incorrect"}))).into_response();
+    }
+    if state.config.read_only.enabled {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mode lecture seule actif"}))).into_response();
+    }
+    let addr = match parse_addr(&id) {
+        Some(a) => a,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "Adresse invalide"}))).into_response(),
+    };
+    let port = match require_port(&state).await { Ok(p) => p, Err(e) => return e };
+    match daly_bms_core::write::set_current_alarms(
+        &port, addr, body.chg_l1_a, body.chg_l2_a, body.dch_l1_a, body.dch_l2_a, false,
+    ).await {
+        Ok(()) => (StatusCode::OK, Json(json!({"ok": true, "bms": format!("{:#04x}", addr)}))).into_response(),
+        Err(daly_bms_core::error::DalyError::Timeout { .. }) =>
+            (StatusCode::OK, Json(json!({"ok": true, "warning": "Pas d'ACK BMS"}))).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct DeltaAlarmsCmd {
+    pub cell_delta_l1_mv: u16,
+    pub cell_delta_l2_mv: u16,
+    pub temp_delta_l1:    u8,
+    pub temp_delta_l2:    u8,
+    pub password:         String,
+}
+
+/// POST /api/v1/bms/:id/settings/delta-alarms
+pub async fn set_delta_alarms(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<DeltaAlarmsCmd>,
+) -> impl IntoResponse {
+    if body.password != DALY_WRITE_PASSWORD {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mot de passe incorrect"}))).into_response();
+    }
+    if state.config.read_only.enabled {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mode lecture seule actif"}))).into_response();
+    }
+    let addr = match parse_addr(&id) {
+        Some(a) => a,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "Adresse invalide"}))).into_response(),
+    };
+    let port = match require_port(&state).await { Ok(p) => p, Err(e) => return e };
+    match daly_bms_core::write::set_delta_alarms(
+        &port, addr, body.cell_delta_l1_mv, body.cell_delta_l2_mv, body.temp_delta_l1, body.temp_delta_l2, false,
+    ).await {
+        Ok(()) => (StatusCode::OK, Json(json!({"ok": true, "bms": format!("{:#04x}", addr)}))).into_response(),
+        Err(daly_bms_core::error::DalyError::Timeout { .. }) =>
+            (StatusCode::OK, Json(json!({"ok": true, "warning": "Pas d'ACK BMS"}))).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct BalancingCmd {
+    pub activation_mv: u16,
+    pub delta_mv:      u16,
+    pub password:      String,
+}
+
+/// POST /api/v1/bms/:id/settings/balancing
+pub async fn set_balancing(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<BalancingCmd>,
+) -> impl IntoResponse {
+    if body.password != DALY_WRITE_PASSWORD {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mot de passe incorrect"}))).into_response();
+    }
+    if state.config.read_only.enabled {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Mode lecture seule actif"}))).into_response();
+    }
+    let addr = match parse_addr(&id) {
+        Some(a) => a,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "Adresse invalide"}))).into_response(),
+    };
+    let port = match require_port(&state).await { Ok(p) => p, Err(e) => return e };
+    match daly_bms_core::write::set_balancing_thresh(
+        &port, addr, body.activation_mv, body.delta_mv, false,
+    ).await {
+        Ok(()) => (StatusCode::OK, Json(json!({"ok": true, "bms": format!("{:#04x}", addr)}))).into_response(),
+        Err(daly_bms_core::error::DalyError::Timeout { .. }) =>
+            (StatusCode::OK, Json(json!({"ok": true, "warning": "Pas d'ACK BMS"}))).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
     }
 }

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -42,12 +42,20 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/bms/:id/export/csv",  get(bms::export_csv))
         .route("/api/v1/bms/compare",         get(bms::compare_all))
 
+        // ── BMS — Paramètres (lecture à la demande) ───────────────────────────
+        .route("/api/v1/bms/:id/settings",                         get(bms::get_settings))
+
         // ── BMS — Écriture ────────────────────────────────────────────────────
-        .route("/api/v1/bms/:id/mos",         post(bms::set_mos))
-        .route("/api/v1/bms/:id/soc",         post(bms::set_soc))
-        .route("/api/v1/bms/:id/soc/full",    post(bms::set_soc_full))
-        .route("/api/v1/bms/:id/soc/empty",   post(bms::set_soc_empty))
-        .route("/api/v1/bms/:id/reset",       post(bms::reset_bms))
+        .route("/api/v1/bms/:id/mos",                              post(bms::set_mos))
+        .route("/api/v1/bms/:id/soc",                              post(bms::set_soc))
+        .route("/api/v1/bms/:id/soc/full",                         post(bms::set_soc_full))
+        .route("/api/v1/bms/:id/soc/empty",                        post(bms::set_soc_empty))
+        .route("/api/v1/bms/:id/reset",                            post(bms::reset_bms))
+        .route("/api/v1/bms/:id/settings/cell-voltage-alarms",     post(bms::set_cell_volt_alarms))
+        .route("/api/v1/bms/:id/settings/pack-voltage-alarms",     post(bms::set_pack_volt_alarms))
+        .route("/api/v1/bms/:id/settings/current-alarms",          post(bms::set_current_alarms))
+        .route("/api/v1/bms/:id/settings/delta-alarms",            post(bms::set_delta_alarms))
+        .route("/api/v1/bms/:id/settings/balancing",               post(bms::set_balancing))
 
         // ── WebSocket ─────────────────────────────────────────────────────────
         .route("/ws/bms/stream",         get(bms::ws_all))

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -128,6 +128,8 @@ pub struct BmsSummary {
     pub cycles:                u32,
     pub max_charge_current:    f32,
     pub max_discharge_current: f32,
+    /// Version firmware (ex: "20210222-1.01T")
+    pub firmware_sw:           String,
     // Alarmes individuelles
     pub alarm_high_voltage:    bool,
     pub alarm_low_voltage:     bool,
@@ -192,6 +194,7 @@ impl BmsSummary {
             cycles:                snap.history.charge_cycles,
             max_charge_current:    snap.info.max_charge_current,
             max_discharge_current: snap.info.max_discharge_current,
+            firmware_sw:           snap.firmware_sw.clone(),
             alarm_high_voltage:    snap.alarms.high_voltage    != 0,
             alarm_low_voltage:     snap.alarms.low_voltage     != 0,
             alarm_high_temp:       snap.alarms.high_temperature != 0,
@@ -267,6 +270,22 @@ struct DetailTemplate {
 #[derive(Template)]
 #[template(path = "logs.html")]
 struct LogsTemplate {}
+
+/// Entrée BMS minimale pour la page Paramètres.
+#[derive(Debug, Clone)]
+pub struct SettingsBmsEntry {
+    pub address:     u8,
+    pub address_hex: String,
+    pub name:        String,
+    pub firmware_sw: String,
+    pub firmware_hw: String,
+}
+
+#[derive(Template)]
+#[template(path = "settings.html")]
+struct SettingsTemplate {
+    bms_list: Vec<SettingsBmsEntry>,
+}
 
 // =============================================================================
 // Handlers Axum
@@ -344,11 +363,25 @@ pub async fn dashboard_logs() -> Response {
     render(LogsTemplate {})
 }
 
+/// Page des paramètres BMS (globale, tous BMS).
+pub async fn dashboard_settings(State(state): State<AppState>) -> Response {
+    let snaps = state.latest_snapshots().await;
+    let bms_list = snaps.iter().map(|s| SettingsBmsEntry {
+        address:     s.address,
+        address_hex: format!("{:#04x}", s.address),
+        name:        s.name.clone(),
+        firmware_sw: s.firmware_sw.clone(),
+        firmware_hw: s.firmware_hw.clone(),
+    }).collect();
+    render(SettingsTemplate { bms_list })
+}
+
 /// Construit le routeur du dashboard (à fusionner dans le routeur principal).
 pub fn build_dashboard_router() -> Router<AppState> {
     Router::new()
-        .route("/",                  get(redirect_root))
-        .route("/dashboard",         get(dashboard_index))
-        .route("/dashboard/bms/:id", get(dashboard_bms))
-        .route("/dashboard/logs",    get(dashboard_logs))
+        .route("/",                      get(redirect_root))
+        .route("/dashboard",             get(dashboard_index))
+        .route("/dashboard/bms/:id",     get(dashboard_bms))
+        .route("/dashboard/logs",        get(dashboard_logs))
+        .route("/dashboard/settings",    get(dashboard_settings))
 }

--- a/crates/daly-bms-server/src/simulator.rs
+++ b/crates/daly-bms-server/src/simulator.rs
@@ -250,6 +250,8 @@ impl SimBmsState {
             },
             heating: 0,
             time_to_soc,
+            firmware_sw: "SIM-v1.0".into(),
+            firmware_hw: "SIM-HW-1".into(),
         }
     }
 }

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -548,6 +548,7 @@
   <div class="nav-brand">⚡ Daly<span>BMS</span></div>
   <div class="nav-links">
     <a href="/dashboard">Vue d'ensemble</a>
+    <a href="/dashboard/settings">Paramètres</a>
     <a href="/dashboard/logs">Logs</a>
     <a href="/api/v1/system/status" target="_blank">API</a>
   </div>

--- a/crates/daly-bms-server/templates/index.html
+++ b/crates/daly-bms-server/templates/index.html
@@ -43,6 +43,9 @@
       <div class="bms-hdr-right">
         <span class="bms-live-dot" id="live-dot-{{ bms.address }}"></span>
         <span>LIVE</span>
+        {% if !bms.firmware_sw.is_empty() %}
+          <span style="color:rgba(255,255,255,0.55);font-size:0.62rem;font-family:monospace">v{{ bms.firmware_sw }}</span>
+        {% endif %}
         <span class="bms-can-badge">{{ bms.can_id }}</span>
         <span class="bms-hdr-ts" id="ts-{{ bms.address }}">{{ bms.last_update }}</span>
       </div>

--- a/crates/daly-bms-server/templates/settings.html
+++ b/crates/daly-bms-server/templates/settings.html
@@ -1,0 +1,515 @@
+{% extends "base.html" %}
+
+{% block title %}Paramètres BMS — DalyBMS{% endblock %}
+
+{% block content %}
+<style>
+  .settings-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .settings-header h1 { font-size: 1.3rem; font-weight: 700; }
+
+  /* ── Panneau BMS ──────────────────────────────────────────────────── */
+  .bms-settings-panel {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+  }
+  .bms-settings-hdr {
+    background: #1a5f8a;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .bms-settings-hdr-title {
+    font-weight: 700;
+    color: #fff;
+    font-size: 0.95rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .bms-settings-hdr-right {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.72rem;
+    color: rgba(255,255,255,0.8);
+  }
+  .fw-badge {
+    background: rgba(255,255,255,0.15);
+    border: 1px solid rgba(255,255,255,0.25);
+    padding: 0.1rem 0.5rem;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 0.68rem;
+  }
+
+  /* ── Loading / Error ──────────────────────────────────────────────── */
+  .settings-loading {
+    padding: 1.5rem;
+    text-align: center;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+  .settings-error {
+    padding: 1rem 1.5rem;
+    color: var(--red);
+    font-size: 0.82rem;
+    background: rgba(207,34,46,0.05);
+    border-top: 1px solid rgba(207,34,46,0.2);
+  }
+
+  /* ── Sections de paramètres ───────────────────────────────────────── */
+  .settings-section {
+    padding: 1rem 1.25rem;
+    border-top: 1px solid var(--border);
+  }
+  .settings-section:first-of-type { border-top: none; }
+  .section-title {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.35rem;
+    border-bottom: 1px solid var(--surface2);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .edit-btn {
+    font-size: 0.68rem;
+    color: var(--accent);
+    background: none;
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    padding: 0.15rem 0.55rem;
+    cursor: pointer;
+    font-weight: 600;
+    transition: background 0.15s;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+  .edit-btn:hover { background: rgba(88,166,255,0.1); }
+
+  /* ── Grille de valeurs ──────────────────────────────────────────────── */
+  .params-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 0.5rem 1rem;
+  }
+  .param-item { display: flex; flex-direction: column; gap: 0.1rem; }
+  .param-label { font-size: 0.62rem; color: var(--muted); text-transform: uppercase; }
+  .param-value { font-size: 0.88rem; font-weight: 600; font-family: monospace; color: var(--text); }
+
+  /* ── Formulaire d'édition inline ────────────────────────────────────── */
+  .edit-form {
+    display: none;
+    margin-top: 0.75rem;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.85rem 1rem;
+  }
+  .edit-form.visible { display: block; }
+  .form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 0.5rem 1rem;
+    margin-bottom: 0.75rem;
+  }
+  .form-field { display: flex; flex-direction: column; gap: 0.2rem; }
+  .form-field label { font-size: 0.65rem; color: var(--muted); text-transform: uppercase; }
+  .form-field input {
+    font-size: 0.82rem;
+    font-family: monospace;
+    padding: 0.3rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--surface);
+    color: var(--text);
+    width: 100%;
+  }
+  .form-field input:focus { outline: none; border-color: var(--accent); }
+  .pwd-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .pwd-row input {
+    font-size: 0.82rem;
+    padding: 0.3rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--surface);
+    color: var(--text);
+    width: 140px;
+  }
+  .save-btn {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #fff;
+    background: var(--accent);
+    border: none;
+    border-radius: 4px;
+    padding: 0.35rem 0.9rem;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .save-btn:hover { background: #0757ba; }
+  .cancel-btn {
+    font-size: 0.78rem;
+    color: var(--muted);
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.35rem 0.75rem;
+    cursor: pointer;
+  }
+  .form-result {
+    margin-top: 0.5rem;
+    font-size: 0.78rem;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    display: none;
+  }
+  .form-result.ok   { background: rgba(26,127,55,0.1); color: var(--green); display: block; }
+  .form-result.err  { background: rgba(207,34,46,0.1); color: var(--red);   display: block; }
+
+  .info-note {
+    margin: 0.5rem 0 0;
+    font-size: 0.72rem;
+    color: var(--muted);
+    font-style: italic;
+  }
+</style>
+
+<div class="settings-header">
+  <h1>⚙️ Paramètres BMS</h1>
+  <span style="font-size:0.8rem;color:var(--muted)">Lecture et modification des seuils de protection</span>
+</div>
+
+{% if bms_list.is_empty() %}
+<div class="card" style="text-align:center;padding:3rem;color:var(--muted)">
+  <div style="font-size:2rem;margin-bottom:0.75rem">🔌</div>
+  <div>Aucun BMS détecté — démarrez le polling ou le simulateur.</div>
+</div>
+{% else %}
+
+{% for bms in bms_list %}
+<div class="bms-settings-panel">
+  {# ── En-tête ─────────────────────────────────────────────── #}
+  <div class="bms-settings-hdr">
+    <div class="bms-settings-hdr-title">🔋 {{ bms.name }}</div>
+    <div class="bms-settings-hdr-right">
+      {% if !bms.firmware_sw.is_empty() %}
+        <span class="fw-badge">SW: {{ bms.firmware_sw }}</span>
+      {% endif %}
+      {% if !bms.firmware_hw.is_empty() %}
+        <span class="fw-badge">HW: {{ bms.firmware_hw }}</span>
+      {% endif %}
+      <span style="color:rgba(255,255,255,0.5)">{{ bms.address_hex }}</span>
+    </div>
+  </div>
+
+  {# ── Corps : chargement JS ──────────────────────────────── #}
+  <div id="settings-body-{{ bms.address }}" class="settings-loading">
+    Chargement des paramètres…
+  </div>
+</div>
+{% endfor %}
+
+<p class="info-note">
+  💡 Mot de passe requis pour les modifications : <code>12345678</code> (mot de passe Daly par défaut).
+  Certains BMS n'envoient pas de confirmation — vérifiez la valeur après modification.
+</p>
+{% endif %}
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+// ─── Chargement et affichage des paramètres ──────────────────────────────────
+const BMS_LIST = [
+{% for bms in bms_list %}
+  { addr: {{ bms.address }}, hex: "{{ bms.address_hex }}", name: "{{ bms.name }}" },
+{% endfor %}
+];
+
+function fmt(v, unit, decimals) {
+  if (v === undefined || v === null) return '—';
+  const n = typeof v === 'number' ? v : parseFloat(v);
+  return isNaN(n) ? '—' : n.toFixed(decimals || 0) + ' ' + (unit || '');
+}
+
+function renderSettings(addr, s) {
+  const body = document.getElementById('settings-body-' + addr);
+  if (!body) return;
+
+  const cap_ah = s.rated_capacity_mah ? (s.rated_capacity_mah / 1000).toFixed(1) + ' Ah' : '—';
+  const nom_mv = s.nominal_cell_mv ? s.nominal_cell_mv + ' mV' : '—';
+
+  body.innerHTML = `
+    <!-- ── Capacité nominale ── -->
+    <div class="settings-section">
+      <div class="section-title">
+        <span>Capacité nominale (0x50 — lecture seule)</span>
+      </div>
+      <div class="params-grid">
+        <div class="param-item"><span class="param-label">Capacité pack</span><span class="param-value">${cap_ah}</span></div>
+        <div class="param-item"><span class="param-label">Tension nominale cellule</span><span class="param-value">${nom_mv}</span></div>
+      </div>
+    </div>
+
+    <!-- ── Balancing ── -->
+    <div class="settings-section">
+      <div class="section-title">
+        <span>Seuils de balancing (0x5F)</span>
+        <button class="edit-btn" onclick="toggleForm('bal', ${addr})">Modifier</button>
+      </div>
+      <div class="params-grid">
+        <div class="param-item"><span class="param-label">Tension d'activation</span><span class="param-value" id="bal-act-${addr}">${fmt(s.balancing_activation_mv, 'mV')}</span></div>
+        <div class="param-item"><span class="param-label">Delta acceptable</span><span class="param-value" id="bal-dlt-${addr}">${fmt(s.balancing_delta_mv, 'mV')}</span></div>
+      </div>
+      <div class="edit-form" id="form-bal-${addr}">
+        <div class="form-grid">
+          <div class="form-field"><label>Activation (mV)</label><input type="number" id="inp-bal-act-${addr}" value="${s.balancing_activation_mv || 0}"></div>
+          <div class="form-field"><label>Delta (mV)</label><input type="number" id="inp-bal-dlt-${addr}" value="${s.balancing_delta_mv || 0}"></div>
+        </div>
+        <div class="pwd-row">
+          <input type="password" placeholder="Mot de passe" id="pwd-bal-${addr}">
+          <button class="save-btn" onclick="saveBalancing(${addr})">Enregistrer</button>
+          <button class="cancel-btn" onclick="toggleForm('bal', ${addr})">Annuler</button>
+        </div>
+        <div class="form-result" id="res-bal-${addr}"></div>
+      </div>
+    </div>
+
+    <!-- ── Alarmes tension cellule ── -->
+    <div class="settings-section">
+      <div class="section-title">
+        <span>Seuils alarme tension cellule (0x59)</span>
+        <button class="edit-btn" onclick="toggleForm('cv', ${addr})">Modifier</button>
+      </div>
+      <div class="params-grid">
+        <div class="param-item"><span class="param-label">Sur-tension L1</span><span class="param-value" id="cv-h1-${addr}">${fmt(s.cell_high_v_l1_mv, 'mV')}</span></div>
+        <div class="param-item"><span class="param-label">Sur-tension L2</span><span class="param-value" id="cv-h2-${addr}">${fmt(s.cell_high_v_l2_mv, 'mV')}</span></div>
+        <div class="param-item"><span class="param-label">Sous-tension L1</span><span class="param-value" id="cv-l1-${addr}">${fmt(s.cell_low_v_l1_mv, 'mV')}</span></div>
+        <div class="param-item"><span class="param-label">Sous-tension L2</span><span class="param-value" id="cv-l2-${addr}">${fmt(s.cell_low_v_l2_mv, 'mV')}</span></div>
+      </div>
+      <div class="edit-form" id="form-cv-${addr}">
+        <div class="form-grid">
+          <div class="form-field"><label>Sur-tension L1 (mV)</label><input type="number" id="inp-cv-h1-${addr}" value="${s.cell_high_v_l1_mv || 0}"></div>
+          <div class="form-field"><label>Sur-tension L2 (mV)</label><input type="number" id="inp-cv-h2-${addr}" value="${s.cell_high_v_l2_mv || 0}"></div>
+          <div class="form-field"><label>Sous-tension L1 (mV)</label><input type="number" id="inp-cv-l1-${addr}" value="${s.cell_low_v_l1_mv || 0}"></div>
+          <div class="form-field"><label>Sous-tension L2 (mV)</label><input type="number" id="inp-cv-l2-${addr}" value="${s.cell_low_v_l2_mv || 0}"></div>
+        </div>
+        <div class="pwd-row">
+          <input type="password" placeholder="Mot de passe" id="pwd-cv-${addr}">
+          <button class="save-btn" onclick="saveCellVoltAlarms(${addr})">Enregistrer</button>
+          <button class="cancel-btn" onclick="toggleForm('cv', ${addr})">Annuler</button>
+        </div>
+        <div class="form-result" id="res-cv-${addr}"></div>
+      </div>
+    </div>
+
+    <!-- ── Alarmes tension pack ── -->
+    <div class="settings-section">
+      <div class="section-title">
+        <span>Seuils alarme tension pack (0x5A)</span>
+        <button class="edit-btn" onclick="toggleForm('pv', ${addr})">Modifier</button>
+      </div>
+      <div class="params-grid">
+        <div class="param-item"><span class="param-label">Sur-tension L1</span><span class="param-value" id="pv-h1-${addr}">${fmt(s.pack_high_v_l1_dv, '', 0)} × 0.1V = ${s.pack_high_v_l1_dv ? (s.pack_high_v_l1_dv/10).toFixed(1)+'V' : '—'}</span></div>
+        <div class="param-item"><span class="param-label">Sur-tension L2</span><span class="param-value" id="pv-h2-${addr}">${s.pack_high_v_l2_dv ? (s.pack_high_v_l2_dv/10).toFixed(1)+'V' : '—'}</span></div>
+        <div class="param-item"><span class="param-label">Sous-tension L1</span><span class="param-value" id="pv-l1-${addr}">${s.pack_low_v_l1_dv ? (s.pack_low_v_l1_dv/10).toFixed(1)+'V' : '—'}</span></div>
+        <div class="param-item"><span class="param-label">Sous-tension L2</span><span class="param-value" id="pv-l2-${addr}">${s.pack_low_v_l2_dv ? (s.pack_low_v_l2_dv/10).toFixed(1)+'V' : '—'}</span></div>
+      </div>
+      <div class="edit-form" id="form-pv-${addr}">
+        <div class="form-grid">
+          <div class="form-field"><label>Sur-tension L1 (0.1V)</label><input type="number" id="inp-pv-h1-${addr}" value="${s.pack_high_v_l1_dv || 0}"></div>
+          <div class="form-field"><label>Sur-tension L2 (0.1V)</label><input type="number" id="inp-pv-h2-${addr}" value="${s.pack_high_v_l2_dv || 0}"></div>
+          <div class="form-field"><label>Sous-tension L1 (0.1V)</label><input type="number" id="inp-pv-l1-${addr}" value="${s.pack_low_v_l1_dv || 0}"></div>
+          <div class="form-field"><label>Sous-tension L2 (0.1V)</label><input type="number" id="inp-pv-l2-${addr}" value="${s.pack_low_v_l2_dv || 0}"></div>
+        </div>
+        <div class="pwd-row">
+          <input type="password" placeholder="Mot de passe" id="pwd-pv-${addr}">
+          <button class="save-btn" onclick="savePackVoltAlarms(${addr})">Enregistrer</button>
+          <button class="cancel-btn" onclick="toggleForm('pv', ${addr})">Annuler</button>
+        </div>
+        <div class="form-result" id="res-pv-${addr}"></div>
+      </div>
+    </div>
+
+    <!-- ── Alarmes courant ── -->
+    <div class="settings-section">
+      <div class="section-title">
+        <span>Seuils alarme courant (0x5B)</span>
+        <button class="edit-btn" onclick="toggleForm('ci', ${addr})">Modifier</button>
+      </div>
+      <div class="params-grid">
+        <div class="param-item"><span class="param-label">Sur-courant CHG L1</span><span class="param-value" id="ci-c1-${addr}">${fmt(s.chg_high_a_l1, 'A', 1)}</span></div>
+        <div class="param-item"><span class="param-label">Sur-courant CHG L2</span><span class="param-value" id="ci-c2-${addr}">${fmt(s.chg_high_a_l2, 'A', 1)}</span></div>
+        <div class="param-item"><span class="param-label">Sur-courant DCH L1</span><span class="param-value" id="ci-d1-${addr}">${fmt(s.dch_high_a_l1, 'A', 1)}</span></div>
+        <div class="param-item"><span class="param-label">Sur-courant DCH L2</span><span class="param-value" id="ci-d2-${addr}">${fmt(s.dch_high_a_l2, 'A', 1)}</span></div>
+      </div>
+      <div class="edit-form" id="form-ci-${addr}">
+        <div class="form-grid">
+          <div class="form-field"><label>CHG max L1 (A)</label><input type="number" step="0.1" id="inp-ci-c1-${addr}" value="${s.chg_high_a_l1 || 0}"></div>
+          <div class="form-field"><label>CHG max L2 (A)</label><input type="number" step="0.1" id="inp-ci-c2-${addr}" value="${s.chg_high_a_l2 || 0}"></div>
+          <div class="form-field"><label>DCH max L1 (A)</label><input type="number" step="0.1" id="inp-ci-d1-${addr}" value="${s.dch_high_a_l1 || 0}"></div>
+          <div class="form-field"><label>DCH max L2 (A)</label><input type="number" step="0.1" id="inp-ci-d2-${addr}" value="${s.dch_high_a_l2 || 0}"></div>
+        </div>
+        <div class="pwd-row">
+          <input type="password" placeholder="Mot de passe" id="pwd-ci-${addr}">
+          <button class="save-btn" onclick="saveCurrentAlarms(${addr})">Enregistrer</button>
+          <button class="cancel-btn" onclick="toggleForm('ci', ${addr})">Annuler</button>
+        </div>
+        <div class="form-result" id="res-ci-${addr}"></div>
+      </div>
+    </div>
+
+    <!-- ── Alarmes delta ── -->
+    <div class="settings-section">
+      <div class="section-title">
+        <span>Seuils alarme déséquilibre (0x5E)</span>
+        <button class="edit-btn" onclick="toggleForm('da', ${addr})">Modifier</button>
+      </div>
+      <div class="params-grid">
+        <div class="param-item"><span class="param-label">Delta tension L1</span><span class="param-value" id="da-v1-${addr}">${fmt(s.cell_delta_v_l1_mv, 'mV')}</span></div>
+        <div class="param-item"><span class="param-label">Delta tension L2</span><span class="param-value" id="da-v2-${addr}">${fmt(s.cell_delta_v_l2_mv, 'mV')}</span></div>
+        <div class="param-item"><span class="param-label">Delta temp L1</span><span class="param-value" id="da-t1-${addr}">${fmt(s.temp_delta_l1, '°C')}</span></div>
+        <div class="param-item"><span class="param-label">Delta temp L2</span><span class="param-value" id="da-t2-${addr}">${fmt(s.temp_delta_l2, '°C')}</span></div>
+      </div>
+      <div class="edit-form" id="form-da-${addr}">
+        <div class="form-grid">
+          <div class="form-field"><label>Delta tension L1 (mV)</label><input type="number" id="inp-da-v1-${addr}" value="${s.cell_delta_v_l1_mv || 0}"></div>
+          <div class="form-field"><label>Delta tension L2 (mV)</label><input type="number" id="inp-da-v2-${addr}" value="${s.cell_delta_v_l2_mv || 0}"></div>
+          <div class="form-field"><label>Delta temp L1 (°C)</label><input type="number" id="inp-da-t1-${addr}" value="${s.temp_delta_l1 || 0}"></div>
+          <div class="form-field"><label>Delta temp L2 (°C)</label><input type="number" id="inp-da-t2-${addr}" value="${s.temp_delta_l2 || 0}"></div>
+        </div>
+        <div class="pwd-row">
+          <input type="password" placeholder="Mot de passe" id="pwd-da-${addr}">
+          <button class="save-btn" onclick="saveDeltaAlarms(${addr})">Enregistrer</button>
+          <button class="cancel-btn" onclick="toggleForm('da', ${addr})">Annuler</button>
+        </div>
+        <div class="form-result" id="res-da-${addr}"></div>
+      </div>
+    </div>
+  `;
+}
+
+function showError(addr, msg) {
+  const body = document.getElementById('settings-body-' + addr);
+  if (body) body.innerHTML = `<div class="settings-error">⚠️ ${msg}</div>`;
+}
+
+// Charger les paramètres de chaque BMS au chargement
+BMS_LIST.forEach(function(bms) {
+  fetch('/api/v1/bms/' + bms.addr + '/settings')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data.error) { showError(bms.addr, data.error); return; }
+      renderSettings(bms.addr, data.settings);
+    })
+    .catch(function(e) { showError(bms.addr, 'Erreur réseau : ' + e.message); });
+});
+
+// ─── Toggle formulaire d'édition ─────────────────────────────────────────────
+function toggleForm(type, addr) {
+  const form = document.getElementById('form-' + type + '-' + addr);
+  if (!form) return;
+  form.classList.toggle('visible');
+}
+
+// ─── Afficher résultat ────────────────────────────────────────────────────────
+function showResult(id, ok, msg) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.textContent = ok ? '✓ ' + msg : '✗ ' + msg;
+  el.className = 'form-result ' + (ok ? 'ok' : 'err');
+  if (ok) setTimeout(function() { el.className = 'form-result'; }, 4000);
+}
+
+// ─── Fonctions de sauvegarde ─────────────────────────────────────────────────
+function postSettings(addr, endpoint, body, resId) {
+  fetch('/api/v1/bms/' + addr + '/settings/' + endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(data) {
+    if (data.ok) {
+      showResult(resId, true, data.warning || 'Paramètre enregistré');
+    } else {
+      showResult(resId, false, data.error || 'Erreur inconnue');
+    }
+  })
+  .catch(function(e) { showResult(resId, false, 'Erreur réseau : ' + e.message); });
+}
+
+function saveBalancing(addr) {
+  const pwd = document.getElementById('pwd-bal-' + addr).value;
+  postSettings(addr, 'balancing', {
+    activation_mv: parseInt(document.getElementById('inp-bal-act-' + addr).value),
+    delta_mv:      parseInt(document.getElementById('inp-bal-dlt-' + addr).value),
+    password: pwd,
+  }, 'res-bal-' + addr);
+}
+
+function saveCellVoltAlarms(addr) {
+  const pwd = document.getElementById('pwd-cv-' + addr).value;
+  postSettings(addr, 'cell-voltage-alarms', {
+    high_l1_mv: parseInt(document.getElementById('inp-cv-h1-' + addr).value),
+    high_l2_mv: parseInt(document.getElementById('inp-cv-h2-' + addr).value),
+    low_l1_mv:  parseInt(document.getElementById('inp-cv-l1-' + addr).value),
+    low_l2_mv:  parseInt(document.getElementById('inp-cv-l2-' + addr).value),
+    password: pwd,
+  }, 'res-cv-' + addr);
+}
+
+function savePackVoltAlarms(addr) {
+  const pwd = document.getElementById('pwd-pv-' + addr).value;
+  postSettings(addr, 'pack-voltage-alarms', {
+    high_l1_dv: parseInt(document.getElementById('inp-pv-h1-' + addr).value),
+    high_l2_dv: parseInt(document.getElementById('inp-pv-h2-' + addr).value),
+    low_l1_dv:  parseInt(document.getElementById('inp-pv-l1-' + addr).value),
+    low_l2_dv:  parseInt(document.getElementById('inp-pv-l2-' + addr).value),
+    password: pwd,
+  }, 'res-pv-' + addr);
+}
+
+function saveCurrentAlarms(addr) {
+  const pwd = document.getElementById('pwd-ci-' + addr).value;
+  postSettings(addr, 'current-alarms', {
+    chg_l1_a: parseFloat(document.getElementById('inp-ci-c1-' + addr).value),
+    chg_l2_a: parseFloat(document.getElementById('inp-ci-c2-' + addr).value),
+    dch_l1_a: parseFloat(document.getElementById('inp-ci-d1-' + addr).value),
+    dch_l2_a: parseFloat(document.getElementById('inp-ci-d2-' + addr).value),
+    password: pwd,
+  }, 'res-ci-' + addr);
+}
+
+function saveDeltaAlarms(addr) {
+  const pwd = document.getElementById('pwd-da-' + addr).value;
+  postSettings(addr, 'delta-alarms', {
+    cell_delta_l1_mv: parseInt(document.getElementById('inp-da-v1-' + addr).value),
+    cell_delta_l2_mv: parseInt(document.getElementById('inp-da-v2-' + addr).value),
+    temp_delta_l1:    parseInt(document.getElementById('inp-da-t1-' + addr).value),
+    temp_delta_l2:    parseInt(document.getElementById('inp-da-t2-' + addr).value),
+    password: pwd,
+  }, 'res-da-' + addr);
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
…59-0x5F/0x62-0x63

Nouveautés :
- Page dédiée /dashboard/settings : lecture et modification des seuils d'alarme (tension cellule, tension pack, courant, delta), balancing, capacité nominale (lecture seule), avec formulaire protégé par mot de passe
- Firmware SW (0x62) et HW (0x63) lus une fois au démarrage et affichés dans le bandeau de chaque carte BMS (ex: vSIM-v1.0)
- Lien "Paramètres" ajouté dans la navigation principale
- Nouveaux DataIds protocole : 0x50, 0x59, 0x5A, 0x5B, 0x5E, 0x5F, 0x62, 0x63
  + commandes écriture 0x10, 0x19, 0x1A, 0x1B, 0x1E, 0x1F
- Nouveaux endpoints API REST : GET  /api/v1/bms/:id/settings POST /api/v1/bms/:id/settings/cell-voltage-alarms POST /api/v1/bms/:id/settings/pack-voltage-alarms POST /api/v1/bms/:id/settings/current-alarms POST /api/v1/bms/:id/settings/delta-alarms POST /api/v1/bms/:id/settings/balancing
- BmsSettings type + firmware_sw/hw dans BmsSnapshot

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G