### PR TITLE
fix: retry settings fetch × 3 + sequential BMS loading

### DIFF
--- a/crates/daly-bms-server/src/api/bms.rs
+++ b/crates/daly-bms-server/src/api/bms.rs
@@ -316,13 +316,26 @@ pub async fn get_settings(
         Ok(p)  => p,
         Err(e) => return e,
     };
-    match daly_bms_core::commands::get_bms_settings(&port, addr).await {
-        Ok(s) => (StatusCode::OK, Json(json!({
-            "bms": format!("{:#04x}", addr),
-            "settings": s,
-        }))).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response(),
+    // Retry jusqu'à 3 fois avec 300 ms de délai entre tentatives.
+    // Nécessaire sur bus RS485 partagé : la première tentative peut tomber sur
+    // un moment de contention avec le polling ou un autre BMS.
+    let mut last_err = None;
+    for attempt in 0u8..3 {
+        match daly_bms_core::commands::get_bms_settings(&port, addr).await {
+            Ok(s) => return (StatusCode::OK, Json(json!({
+                "bms": format!("{:#04x}", addr),
+                "settings": s,
+            }))).into_response(),
+            Err(e) => {
+                if attempt < 2 {
+                    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+                }
+                last_err = Some(e);
+            }
+        }
     }
+    let e = last_err.unwrap();
+    (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("{:?}", e)}))).into_response()
 }
 
 // =============================================================================

--- a/crates/daly-bms-server/templates/settings.html
+++ b/crates/daly-bms-server/templates/settings.html
@@ -414,16 +414,24 @@ function showError(addr, msg) {
   if (body) body.innerHTML = `<div class="settings-error">⚠️ ${msg}</div>`;
 }
 
-// Charger les paramètres de chaque BMS au chargement
-BMS_LIST.forEach(function(bms) {
+// Charger les paramètres de chaque BMS séquentiellement.
+// Sur bus RS485 partagé, les requêtes parallèles provoquent de la contention
+// entre BMS et des timeouts sur le second BMS.
+(function loadNext(idx) {
+  if (idx >= BMS_LIST.length) return;
+  var bms = BMS_LIST[idx];
   fetch('/api/v1/bms/' + bms.addr + '/settings')
     .then(function(r) { return r.json(); })
     .then(function(data) {
-      if (data.error) { showError(bms.addr, data.error); return; }
-      renderSettings(bms.addr, data.settings);
+      if (data.error) { showError(bms.addr, data.error); }
+      else { renderSettings(bms.addr, data.settings); }
+      loadNext(idx + 1);
     })
-    .catch(function(e) { showError(bms.addr, 'Erreur réseau : ' + e.message); });
-});
+    .catch(function(e) {
+      showError(bms.addr, 'Erreur réseau : ' + e.message);
+      loadNext(idx + 1);
+    });
+}(0));
 
 // ─── Toggle formulaire d'édition ─────────────────────────────────────────────
 function toggleForm(type, addr) {


### PR DESCRIPTION
Sur bus RS485 partagé, les requêtes paramètres simultanées (BMS1 + BMS2) créent de la contention : BMS2 timeout sur cmd 0x50 car le bus n'est pas encore stable après les réponses de BMS1.

- api/bms.rs get_settings : 3 tentatives avec 300 ms de délai entre elles
- settings.html : chargement séquentiel (BMS2 attend la fin de BMS1) pour éviter l'entrelacement des commandes RS485

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G