### PR TITLE
feat: ajouter bouton Reset BMS dans la page Paramètres

### DIFF
--- a/crates/daly-bms-server/templates/settings.html
+++ b/crates/daly-bms-server/templates/settings.html
@@ -192,6 +192,54 @@
     color: var(--muted);
     font-style: italic;
   }
+
+  /* ── Bouton Reset ─────────────────────────────────────────────────── */
+  .btn-reset {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--red);
+    background: none;
+    border: 1px solid var(--red);
+    border-radius: 4px;
+    padding: 0.35rem 0.9rem;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .btn-reset:hover { background: rgba(207,34,46,0.08); }
+
+  /* ── Modal Reset ──────────────────────────────────────────────────── */
+  .modal-overlay {
+    position: fixed; inset: 0;
+    background: rgba(0,0,0,0.55);
+    display: flex; align-items: center; justify-content: center;
+    z-index: 1000;
+  }
+  .modal-box {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 8px 32px rgba(0,0,0,0.35);
+    width: 100%; max-width: 420px;
+    padding: 1.25rem 1.5rem 1rem;
+  }
+  .modal-title { font-size: 1rem; font-weight: 700; margin-bottom: 1rem; }
+  .modal-label { font-size: 0.72rem; color: var(--muted); display: block; margin-bottom: 0.25rem; }
+  .modal-input {
+    width: 100%; font-size: 0.85rem; font-family: monospace;
+    padding: 0.35rem 0.6rem;
+    border: 1px solid var(--border); border-radius: 4px;
+    background: var(--surface2); color: var(--text);
+  }
+  .modal-input:focus { outline: none; border-color: var(--accent); }
+  .modal-footer { display: flex; gap: 0.75rem; justify-content: flex-end; margin-top: 1rem; }
+  .btn-modal-cancel {
+    font-size: 0.78rem; color: var(--muted); background: none;
+    border: 1px solid var(--border); border-radius: 4px; padding: 0.35rem 0.75rem; cursor: pointer;
+  }
+  .btn-modal-confirm {
+    font-size: 0.78rem; font-weight: 600; color: #fff;
+    border: none; border-radius: 4px; padding: 0.35rem 0.9rem; cursor: pointer;
+  }
 </style>
 
 <div class="settings-header">
@@ -234,6 +282,29 @@
   Certains BMS n'envoient pas de confirmation — vérifiez la valeur après modification.
 </p>
 {% endif %}
+
+{# ─── Modal Reset BMS (partagé entre tous les BMS) ─────────────────────────── #}
+<div id="modal-reset-settings" class="modal-overlay" style="display:none" onclick="if(event.target===this)closeResetModal()">
+  <div class="modal-box">
+    <div class="modal-title" style="color:var(--red)">⚠ Reset BMS</div>
+    <div>
+      <p style="color:var(--red);font-size:0.8rem;background:rgba(207,34,46,0.07);border:1px solid rgba(207,34,46,0.25);border-radius:4px;padding:0.6rem 0.75rem;margin-bottom:0.75rem">
+        Cette opération réinitialise le BMS. Les paramètres sont conservés mais la communication sera interrompue quelques secondes.
+      </p>
+      <label class="modal-label">Mot de passe Daly</label>
+      <input type="password" id="rst-password" value="12345678" class="modal-input" autocomplete="off">
+      <label class="modal-label" style="margin-top:0.75rem;display:flex;align-items:center;gap:0.5rem;cursor:pointer">
+        <input type="checkbox" id="rst-confirm" style="width:auto">
+        Je confirme le reset de ce BMS
+      </label>
+      <div id="rst-result" style="margin-top:0.6rem;min-height:1.2em;font-size:0.75rem"></div>
+    </div>
+    <div class="modal-footer">
+      <button onclick="closeResetModal()" class="btn-modal-cancel">Annuler</button>
+      <button onclick="submitReset()" class="btn-modal-confirm" style="background:var(--red)">Reset</button>
+    </div>
+  </div>
+</div>
 
 {% endblock %}
 
@@ -406,6 +477,15 @@ function renderSettings(addr, s) {
         <div class="form-result" id="res-da-${addr}"></div>
       </div>
     </div>
+
+    <!-- ── Actions BMS ── -->
+    <div class="settings-section">
+      <div class="section-title"><span>Actions BMS</span></div>
+      <div style="display:flex;gap:0.75rem;align-items:center;flex-wrap:wrap">
+        <button class="btn-reset" onclick="openResetModalFor(${addr})">⚠ Reset BMS</button>
+        <span style="font-size:0.7rem;color:var(--muted)">Inopérant en mode simulateur</span>
+      </div>
+    </div>
   `;
 }
 
@@ -518,6 +598,54 @@ function saveDeltaAlarms(addr) {
     temp_delta_l2:    parseInt(document.getElementById('inp-da-t2-' + addr).value),
     password: pwd,
   }, 'res-da-' + addr);
+}
+
+// ─── Reset BMS ───────────────────────────────────────────────────────────────
+var _resetAddr = null;
+
+function openResetModalFor(addr) {
+  _resetAddr = addr;
+  document.getElementById('rst-confirm').checked = false;
+  document.getElementById('rst-result').textContent = '';
+  document.getElementById('modal-reset-settings').style.display = 'flex';
+}
+function closeResetModal() {
+  document.getElementById('modal-reset-settings').style.display = 'none';
+}
+function submitReset() {
+  if (!_resetAddr) return;
+  var pwd     = document.getElementById('rst-password').value;
+  var confirm = document.getElementById('rst-confirm').checked;
+  var resEl   = document.getElementById('rst-result');
+  if (!confirm) {
+    resEl.style.color = 'var(--red)';
+    resEl.textContent = 'Cocher la case de confirmation';
+    return;
+  }
+  resEl.style.color = 'var(--muted)';
+  resEl.textContent = 'Envoi du reset…';
+  fetch('/api/v1/bms/' + _resetAddr + '/reset', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ confirm: true, password: pwd })
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(data) {
+    if (data.ok) {
+      var msg = '✓ Reset envoyé — BMS redémarre (quelques secondes d\'interruption)';
+      if (data.warning) msg += '  (' + data.warning + ')';
+      resEl.style.color = 'var(--green)';
+      resEl.textContent = msg;
+      setTimeout(closeResetModal, 3000);
+    } else {
+      resEl.style.color = 'var(--red)';
+      resEl.textContent = '✗ ' + (data.error || 'Erreur inconnue');
+    }
+  })
+  .catch(function(e) {
+    resEl.style.color = 'var(--red)';
+    resEl.textContent = '✗ Erreur réseau : ' + e;
+  });
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
Chaque panneau BMS de la page Paramètres dispose maintenant d'une section "Actions BMS" avec un bouton Reset. Un modal partagé (variable _resetAddr) gère la confirmation et le mot de passe avant d'appeler POST /api/v1/bms/:id/reset.

https://claude.ai/code/session_01Vuud8UGnnKGgPGzovVmn8G