### PR TITLE
docs: correction syntaxe dbus -y et validation post-reboot

### DIFF
--- a/docs/DEPLOY-VENUS-ARMV7.md
+++ b/docs/DEPLOY-VENUS-ARMV7.md
@@ -245,8 +245,8 @@ svstat /service/daly-bms-venus
 # Processus actifs (BusyBox)
 ps | grep daly
 
-# D-Bus — liste services battery
-dbus -y --system list | grep battery
+# D-Bus — liste services battery (syntaxe correcte Venus OS)
+dbus -y | grep battery
 
 # D-Bus — lire valeurs
 dbus -y com.victronenergy.battery.mqtt_1 /Soc GetValue


### PR DESCRIPTION
- Corriger dbus -y list → dbus -y (syntaxe correcte Venus OS)
- Valider déploiement complet après reboot : mqtt_1 99.0%, mqtt_2 99.4%
- dbus-mqtt-battery désinstallé, daly-bms-venus Rust opérationnel

https://claude.ai/code/session_01DFh3VFa2yF118BGm8pXd9n