### PR TITLE
fix(nodered): réparer capteur température virtuel Venus OS instance 100

### DIFF
--- a/docker/mosquitto/config/mosquitto.conf
+++ b/docker/mosquitto/config/mosquitto.conf
@@ -49,10 +49,11 @@ restart_timeout 30
 topic N/c0619ab9929a/# in 0
 
 # Venus OS commandes — écriture vers NanoPi (W/ = commandes pour Venus)
-topic W/c0619ab9929a/# out 0
+# QoS 1 : garantit la livraison même si le NanoPi redémarre (message mis en file)
+topic W/c0619ab9929a/# out 1
 
 # Venus OS keepalive — requêtes de lecture (R/ = demande de valeur fraîche)
-topic R/c0619ab9929a/# out 0
+topic R/c0619ab9929a/# out 1
 
 # Shelly topics — bidirectionnel (pendant transition avant reconfiguration Shelly)
 topic shellypro2pm-ec62608840a4/# both 0

--- a/flux-nodered/meteo.json
+++ b/flux-nodered/meteo.json
@@ -55,19 +55,58 @@
         "type": "function",
         "z": "e6e3a16384301f83",
         "name": "Extraire température",
-        "func": "const temp = msg.payload.current.temperature_2m;\nconst humidity = msg.payload.current.relative_humidity_2m;\n\n// Stocker dans contexte global\ncontext.global.set('outdoor_temp', temp);\n\n// Payload Venus MQTT format\nmsg.payload = {\"value\": temp};\nmsg.topic = \"W/c0619ab9929a/temperature/100/Temperature\";\n\nnode.status({fill: 'green', shape: 'dot', text: `${temp}°C — Humidité: ${humidity}%`});\n\nreturn msg;",
+        "func": "const temp = msg.payload.current.temperature_2m;\nconst humidity = msg.payload.current.relative_humidity_2m;\n\n// Stocker dans contexte global pour le keepalive\ncontext.global.set('outdoor_temp', temp);\ncontext.global.set('outdoor_humidity', humidity);\n\nconst base = 'W/c0619ab9929a/temperature/100';\n\nnode.status({fill: 'green', shape: 'dot', text: `${temp}°C — ${humidity}%`});\n\n// Envoyer les 4 topics nécessaires à Venus OS pour (re)créer le capteur virtuel\nreturn [[\n    {payload: {\"value\": temp},          topic: `${base}/Temperature`},\n    {payload: {\"value\": humidity},       topic: `${base}/Humidity`},\n    {payload: {\"value\": \"Outdoor temp\"}, topic: `${base}/CustomName`},\n    {payload: {\"value\": 2},             topic: `${base}/TemperatureType`}\n]];",
         "outputs": 1,
         "timeout": "",
         "noerr": 0,
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 440,
-        "y": 120,
+        "x": 260,
+        "y": 140,
         "wires": [
             [
                 "meteo_mqtt_out",
                 "d65816bfa4e7b8c4"
+            ]
+        ]
+    },
+    {
+        "id": "temp_keepalive_inject",
+        "type": "inject",
+        "z": "e6e3a16384301f83",
+        "name": "Keepalive Venus (toutes les 60s)",
+        "props": [],
+        "repeat": "60",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0,
+        "topic": "",
+        "x": 220,
+        "y": 260,
+        "wires": [
+            [
+                "temp_keepalive_fn"
+            ]
+        ]
+    },
+    {
+        "id": "temp_keepalive_fn",
+        "type": "function",
+        "z": "e6e3a16384301f83",
+        "name": "Republier depuis contexte",
+        "func": "const temp = context.global.get('outdoor_temp');\nconst humidity = context.global.get('outdoor_humidity');\n\n// Attendre la première récupération Open-Meteo\nif (temp === undefined || temp === null) {\n    return null;\n}\n\nconst base = 'W/c0619ab9929a/temperature/100';\n\nreturn [[\n    {payload: {\"value\": temp},    topic: `${base}/Temperature`},\n    {payload: {\"value\": humidity}, topic: `${base}/Humidity`}\n]];",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 560,
+        "y": 260,
+        "wires": [
+            [
+                "meteo_mqtt_out"
             ]
         ]
     },
@@ -77,7 +116,7 @@
         "z": "e6e3a16384301f83",
         "name": "Venus Température",
         "topic": "",
-        "qos": "0",
+        "qos": "1",
         "retain": "",
         "respTopic": "",
         "contentType": "",
@@ -85,8 +124,8 @@
         "correl": "",
         "expiry": "",
         "broker": "pi5_mqtt_broker",
-        "x": 680,
-        "y": 120,
+        "x": 840,
+        "y": 160,
         "wires": []
     },
     {
@@ -101,8 +140,8 @@
         "complete": "false",
         "statusVal": "",
         "statusType": "auto",
-        "x": 680,
-        "y": 180,
+        "x": 840,
+        "y": 220,
         "wires": []
     },
     {


### PR DESCRIPTION
Problème: après reboot du NanoPi, le capteur virtuel (instance 100) ne se reconnectait pas malgré les envois MQTT toutes les 15 min.

Causes identifiées:
1. Seul /Temperature était envoyé — Venus OS dbus-mqtt a besoin de 4 topics pour (re)créer le service virtuel: Temperature, Humidity, CustomName, TemperatureType
2. QoS 0 = messages perdus si bridge en cours de reconnexion au reboot
3. Intervalle 15 min = capteur marqué déconnecté entre les updates

Corrections:
- flux-nodered/meteo.json:
  * Envoi des 4 topics Venus OS (Temperature, Humidity, CustomName, TemperatureType=2) à chaque mise à jour Open-Meteo
  * Ajout keepalive toutes les 60s (republication Temperature + Humidity depuis contexte global) pour maintenir le statut "Connecté"
  * Humidity stockée dans contexte global pour le keepalive
  * QoS 0 → QoS 1 sur le noeud MQTT out

- docker/mosquitto/config/mosquitto.conf:
  * Bridge W/ et R/ topics: QoS 0 → QoS 1
  * Garantit la livraison des commandes même si NanoPi redémarre

https://claude.ai/code/session_01XsDVWy6q2pD8GUg3GZueYa