### PR TITLE
feat(venus): add com.victronenergy.temperature D-Bus bridge

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -129,6 +129,33 @@ watchdog_sec = 30
 republish_sec = 25
 
 
+# =============================================================================
+# Capteurs de température (daly-bms-venus → com.victronenergy.temperature.{n})
+# =============================================================================
+# Topic MQTT source : santuario/heat/{n}/venus
+# Payload attendu (publié par Node-RED) :
+#   { "Temperature": 15.3, "TemperatureType": 4, "Humidity": 65.0, "Pressure": 101.3 }
+#
+# TemperatureType : 0=battery 1=fridge 2=generic 3=Room 4=Outdoor 5=WaterHeater 6=Freezer
+# La valeur config a PRIORITÉ sur celle du payload.
+
+[heat]
+# Préfixe des topics température (séparé du BMS prefix)
+topic_prefix = "santuario/heat"
+
+[[sensors]]
+mqtt_index       = 1       # Topic : santuario/heat/1/venus
+name             = "Temperature Exterieure"
+temperature_type = 4       # 4 = Outdoor
+device_instance  = 20      # DeviceInstance Venus OS / VRM
+
+[[sensors]]
+mqtt_index       = 2       # Topic : santuario/heat/2/venus
+name             = "Chauffe-eau"
+temperature_type = 5       # 5 = WaterHeater
+device_instance  = 21      # DeviceInstance Venus OS / VRM
+
+
 [influxdb]
 # true  = activer l'écriture InfluxDB (Docker infra doit être démarré)
 # false = désactiver (pas de Docker, ou test sans InfluxDB)

--- a/crates/daly-bms-venus/src/config.rs
+++ b/crates/daly-bms-venus/src/config.rs
@@ -24,6 +24,14 @@ pub struct VenusServiceConfig {
     /// Configurations par BMS (pour mqtt_index et DeviceInstance)
     #[serde(default)]
     pub bms: Vec<BmsRef>,
+
+    /// Configuration du préfixe MQTT heat (capteurs température)
+    #[serde(default)]
+    pub heat: HeatConfig,
+
+    /// Configurations par capteur de température
+    #[serde(default)]
+    pub sensors: Vec<SensorRef>,
 }
 
 /// Référence à la config MQTT du serveur principal.
@@ -85,6 +93,51 @@ fn default_dbus_bus()       -> String { "system".to_string() }
 fn default_service_prefix() -> String { "mqtt".to_string() }
 fn default_watchdog_sec()   -> u64    { 30 }
 fn default_republish_sec()  -> u64    { 25 }
+
+// =============================================================================
+// Configuration capteurs de température (heat)
+// =============================================================================
+
+/// Préfixe MQTT pour les capteurs de température.
+///
+/// Topic abonné : `{topic_prefix}/+/venus`
+/// Exemple : `santuario/heat/1/venus`
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HeatConfig {
+    /// Préfixe des topics heat (ex: "santuario/heat")
+    pub topic_prefix: String,
+}
+
+impl Default for HeatConfig {
+    fn default() -> Self {
+        Self { topic_prefix: "santuario/heat".to_string() }
+    }
+}
+
+/// Configuration d'un capteur de température individuel.
+///
+/// Une section `[[sensors]]` par capteur dans le TOML.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SensorRef {
+    /// Index dans le topic MQTT (ex: 1 → `santuario/heat/1/venus`).
+    pub mqtt_index: Option<u8>,
+
+    /// Nom affiché dans Venus OS (`/ProductName` et `/CustomName` par défaut).
+    pub name: Option<String>,
+
+    /// Type de température par défaut si absent du payload :
+    /// 0=battery, 1=fridge, 2=generic, 3=Room, 4=Outdoor, 5=WaterHeater, 6=Freezer.
+    /// Prioritaire sur la valeur du payload.
+    pub temperature_type: Option<i32>,
+
+    /// DeviceInstance Venus OS D-Bus (affiché dans VRM).
+    /// Si absent, utilise `mqtt_index` comme fallback.
+    pub device_instance: Option<u32>,
+}
+
+// =============================================================================
+// Configuration BMS (existante)
+// =============================================================================
 
 /// Référence légère à une configuration BMS individuelle.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]

--- a/crates/daly-bms-venus/src/main.rs
+++ b/crates/daly-bms-venus/src/main.rs
@@ -1,16 +1,17 @@
-//! `daly-bms-venus` — Service D-Bus Venus OS pour Daly BMS
+//! `daly-bms-venus` — Bridge MQTT → D-Bus Venus OS (batteries + capteurs)
 //!
-//! Ce binaire crée des services `com.victronenergy.battery.{n}` sur le D-Bus
-//! du Victron GX (Venus OS) en lisant les données depuis le broker MQTT local.
+//! Ce binaire enregistre sur le D-Bus du Victron GX (Venus OS) :
+//! - `com.victronenergy.battery.{n}` pour chaque BMS Daly (topic `bms/{n}/venus`)
+//! - `com.victronenergy.temperature.{n}` pour chaque capteur température
+//!   (topic `heat/{n}/venus` — outdoor temp, water heater…)
 //!
 //! ## Flux
 //!
 //! ```text
-//! [MQTT broker] → [mqtt_source] → [BatteryManager] → [D-Bus: com.victronenergy.battery.*]
-//!                                                           ↓
-//!                                                    [Venus systemcalc]
-//!                                                           ↓
-//!                                                    [VRM Portal]
+//! [MQTT: bms/{n}/venus]  → [BatteryManager] → [D-Bus: com.victronenergy.battery.{n}]
+//! [MQTT: heat/{n}/venus] → [SensorManager]  → [D-Bus: com.victronenergy.temperature.{n}]
+//!                                                    ↓
+//!                                             [Venus systemcalc → VRM Portal]
 //! ```
 //!
 //! ## Utilisation
@@ -27,13 +28,16 @@ mod battery_service;
 mod config;
 mod manager;
 mod mqtt_source;
+mod sensor_manager;
+mod temperature_service;
 mod types;
 
 use anyhow::Result;
 use clap::Parser;
 use config::VenusServiceConfig;
 use manager::BatteryManager;
-use mqtt_source::start_mqtt_source;
+use mqtt_source::{start_mqtt_source, start_sensor_mqtt_source};
+use sensor_manager::SensorManager;
 use std::path::PathBuf;
 use tokio::sync::mpsc;
 use tracing::{error, info};
@@ -88,11 +92,13 @@ async fn main() -> Result<()> {
     }
 
     info!(
-        version = env!("CARGO_PKG_VERSION"),
-        dbus_bus = %cfg.venus.dbus_bus,
-        mqtt_host = %cfg.mqtt.host,
-        mqtt_prefix = %cfg.mqtt.topic_prefix,
-        bms_count = cfg.bms.len(),
+        version     = env!("CARGO_PKG_VERSION"),
+        dbus_bus    = %cfg.venus.dbus_bus,
+        mqtt_host   = %cfg.mqtt.host,
+        bms_prefix  = %cfg.mqtt.topic_prefix,
+        heat_prefix = %cfg.heat.topic_prefix,
+        bms_count   = cfg.bms.len(),
+        sensor_count = cfg.sensors.len(),
         "daly-bms-venus démarrage"
     );
 
@@ -101,20 +107,35 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Canal MQTT → Manager (buffer 64 messages)
-    let (tx, rx) = mpsc::channel(64);
-
-    // Démarrer la source MQTT en arrière-plan
+    // -------------------------------------------------------------------------
+    // Bridge BMS batteries : MQTT bms/{n}/venus → D-Bus battery.{n}
+    // -------------------------------------------------------------------------
+    let (bms_tx, bms_rx) = mpsc::channel(64);
     let mqtt_cfg = cfg.mqtt.clone();
     tokio::spawn(async move {
-        start_mqtt_source(mqtt_cfg, tx).await;
+        start_mqtt_source(mqtt_cfg, bms_tx).await;
     });
 
-    // Démarrer le manager D-Bus (bloquant)
-    let manager = BatteryManager::new(cfg.venus, cfg.bms, rx);
+    let battery_manager = BatteryManager::new(cfg.venus.clone(), cfg.bms, bms_rx);
+    tokio::spawn(async move {
+        if let Err(e) = battery_manager.run().await {
+            error!("BatteryManager terminé avec erreur : {:#}", e);
+        }
+    });
 
-    if let Err(e) = manager.run().await {
-        error!("BatteryManager terminé avec erreur : {:#}", e);
+    // -------------------------------------------------------------------------
+    // Bridge capteurs température : MQTT heat/{n}/venus → D-Bus temperature.{n}
+    // -------------------------------------------------------------------------
+    let (sensor_tx, sensor_rx) = mpsc::channel(64);
+    let mqtt_cfg2    = cfg.mqtt.clone();
+    let heat_prefix  = cfg.heat.topic_prefix.clone();
+    tokio::spawn(async move {
+        start_sensor_mqtt_source(mqtt_cfg2, heat_prefix, sensor_tx).await;
+    });
+
+    let sensor_manager = SensorManager::new(cfg.venus, cfg.sensors, sensor_rx);
+    if let Err(e) = sensor_manager.run().await {
+        error!("SensorManager terminé avec erreur : {:#}", e);
         std::process::exit(1);
     }
 

--- a/crates/daly-bms-venus/src/mqtt_source.rs
+++ b/crates/daly-bms-venus/src/mqtt_source.rs
@@ -1,26 +1,37 @@
 //! Source MQTT : abonnement au broker et parsing des payloads Venus OS.
 //!
-//! S'abonne sur `{prefix}/+/venus` et émet des événements `MqttEvent`
-//! portant l'`mqtt_index` (déduit du topic) et le `VenusPayload` parsé.
+//! ## Topics surveillés
+//!
+//! - `{bms_prefix}/+/venus`  → batteries BMS Daly → `MqttEvent`
+//! - `{heat_prefix}/+/venus` → capteurs température → `SensorMqttEvent`
 
 use crate::config::MqttRef;
-use crate::types::VenusPayload;
+use crate::types::{HeatPayload, VenusPayload};
 use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 // =============================================================================
-// Événement émis vers le manager
+// Événements émis vers les managers
 // =============================================================================
 
-/// Événement reçu depuis MQTT.
+/// Événement batterie reçu depuis MQTT (topic BMS).
 #[derive(Debug)]
 pub struct MqttEvent {
     /// Index du BMS (déduit du topic : `prefix/1/venus` → `1`)
     pub mqtt_index: u8,
     /// Payload Venus OS parsé
     pub payload: VenusPayload,
+}
+
+/// Événement capteur température reçu depuis MQTT (topic heat).
+#[derive(Debug)]
+pub struct SensorMqttEvent {
+    /// Index du capteur (déduit du topic : `prefix/1/venus` → `1`)
+    pub mqtt_index: u8,
+    /// Payload température parsé
+    pub payload: HeatPayload,
 }
 
 // =============================================================================
@@ -134,6 +145,94 @@ fn uuid_short() -> String {
     format!("{:08x}", t)
 }
 
+// =============================================================================
+// Source MQTT pour capteurs de température (santuario/heat/{n}/venus)
+// =============================================================================
+
+/// Démarre la source MQTT pour les capteurs de température.
+///
+/// S'abonne sur `{heat_prefix}/+/venus`, parse le `HeatPayload` et émet
+/// des `SensorMqttEvent` vers le `SensorManager`.
+pub async fn start_sensor_mqtt_source(
+    cfg:        MqttRef,
+    heat_prefix: String,
+    tx:         mpsc::Sender<SensorMqttEvent>,
+) {
+    let subscribe_topic = format!("{}/+/venus", heat_prefix);
+
+    info!(
+        broker = %format!("{}:{}", cfg.host, cfg.port),
+        topic  = %subscribe_topic,
+        "Démarrage source MQTT capteurs température"
+    );
+
+    loop {
+        match sensor_connect_and_run(&cfg, &subscribe_topic, &heat_prefix, &tx).await {
+            Ok(()) => {
+                warn!("MQTT source capteurs terminée de façon inattendue, reconnexion dans 5s");
+            }
+            Err(e) => {
+                error!("MQTT source capteurs erreur : {:#}, reconnexion dans 5s", e);
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn sensor_connect_and_run(
+    cfg:         &MqttRef,
+    subscribe_topic: &str,
+    heat_prefix: &str,
+    tx:          &mpsc::Sender<SensorMqttEvent>,
+) -> anyhow::Result<()> {
+    let client_id = format!("daly-bms-venus-sensors-{}", uuid_short());
+    let mut opts = MqttOptions::new(client_id, &cfg.host, cfg.port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_clean_session(true);
+
+    if let (Some(user), Some(pass)) = (&cfg.username, &cfg.password) {
+        opts.set_credentials(user, pass);
+    }
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 64);
+
+    client
+        .subscribe(subscribe_topic, QoS::AtLeastOnce)
+        .await?;
+
+    info!("MQTT capteurs connecté, abonnement sur '{}'", subscribe_topic);
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Packet::Publish(pub_msg))) => {
+                let topic = &pub_msg.topic;
+                debug!(topic = %topic, "MQTT capteur message reçu");
+
+                if let Some(idx) = extract_mqtt_index(topic, heat_prefix) {
+                    match serde_json::from_slice::<HeatPayload>(&pub_msg.payload) {
+                        Ok(payload) => {
+                            let evt = SensorMqttEvent { mqtt_index: idx, payload };
+                            if tx.send(evt).await.is_err() {
+                                return Ok(());
+                            }
+                        }
+                        Err(e) => {
+                            warn!(topic = %topic, "Échec parsing payload capteur: {}", e);
+                        }
+                    }
+                }
+            }
+            Ok(Event::Incoming(Packet::ConnAck(_))) => {
+                info!("MQTT capteurs ConnAck reçu — broker connecté");
+            }
+            Ok(_) => {}
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,5 +244,7 @@ mod tests {
         assert_eq!(extract_mqtt_index("santuario/bms/2/status", "santuario/bms"), None);
         assert_eq!(extract_mqtt_index("other/1/venus", "santuario/bms"), None);
         assert_eq!(extract_mqtt_index("santuario/bms/255/venus", "santuario/bms"), Some(255));
+        assert_eq!(extract_mqtt_index("santuario/heat/1/venus", "santuario/heat"), Some(1));
+        assert_eq!(extract_mqtt_index("santuario/heat/2/venus", "santuario/heat"), Some(2));
     }
 }

--- a/crates/daly-bms-venus/src/sensor_manager.rs
+++ b/crates/daly-bms-venus/src/sensor_manager.rs
@@ -1,0 +1,169 @@
+//! Manager des services D-Bus température — orchestre N capteurs.
+//!
+//! Reçoit les événements `SensorMqttEvent` depuis `mqtt_source` et les route
+//! vers le `SensorServiceHandle` correspondant.  Gère la création dynamique
+//! des services D-Bus `com.victronenergy.temperature.{n}` et le watchdog.
+
+use crate::config::{SensorRef, VenusConfig};
+use crate::mqtt_source::SensorMqttEvent;
+use crate::temperature_service::{SensorServiceHandle, create_temperature_service};
+use anyhow::Result;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::time::interval;
+use tracing::{error, info, warn};
+
+// =============================================================================
+// Manager capteurs température
+// =============================================================================
+
+/// Gestionnaire des services D-Bus Venus OS pour tous les capteurs de température.
+pub struct SensorManager {
+    cfg:         VenusConfig,
+    sensor_refs: Vec<SensorRef>,
+    services:    HashMap<u8, SensorServiceHandle>,
+    rx:          mpsc::Receiver<SensorMqttEvent>,
+}
+
+impl SensorManager {
+    pub fn new(
+        cfg:         VenusConfig,
+        sensor_refs: Vec<SensorRef>,
+        rx:          mpsc::Receiver<SensorMqttEvent>,
+    ) -> Self {
+        Self {
+            cfg,
+            sensor_refs,
+            services: HashMap::new(),
+            rx,
+        }
+    }
+
+    /// Boucle principale : traite les événements MQTT et le watchdog.
+    pub async fn run(mut self) -> Result<()> {
+        if !self.cfg.enabled {
+            info!("Service capteurs D-Bus désactivé (enabled = false)");
+            while self.rx.recv().await.is_some() {}
+            return Ok(());
+        }
+
+        let watchdog_dur  = Duration::from_secs(self.cfg.watchdog_sec);
+        let republish_dur = Duration::from_secs(self.cfg.republish_sec);
+        let mut republish_tick = interval(republish_dur);
+
+        info!(
+            dbus_bus     = %self.cfg.dbus_bus,
+            prefix       = %self.cfg.service_prefix,
+            watchdog_sec = self.cfg.watchdog_sec,
+            sensors      = self.sensor_refs.len(),
+            "SensorManager démarré"
+        );
+
+        loop {
+            tokio::select! {
+                Some(evt) = self.rx.recv() => {
+                    if let Err(e) = self.handle_mqtt_event(evt).await {
+                        error!("Erreur traitement événement capteur MQTT : {:#}", e);
+                    }
+                }
+
+                _ = republish_tick.tick() => {
+                    self.republish_and_watchdog(watchdog_dur).await;
+                }
+            }
+        }
+    }
+
+    /// Traite un événement MQTT : crée le service si besoin, puis met à jour.
+    async fn handle_mqtt_event(&mut self, evt: SensorMqttEvent) -> Result<()> {
+        let idx = evt.mqtt_index;
+
+        if !self.services.contains_key(&idx) {
+            let handle = self.create_service_for_index(idx).await?;
+            self.services.insert(idx, handle);
+        }
+
+        if let Some(svc) = self.services.get(&idx) {
+            svc.update(&evt.payload).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Crée un service D-Bus température pour un mqtt_index donné.
+    async fn create_service_for_index(&self, idx: u8) -> Result<SensorServiceHandle> {
+        let service_suffix  = format!("{}_{}", self.cfg.service_prefix, idx);
+        let device_instance = self.device_instance_for_index(idx);
+        let product_name    = self.product_name_for_index(idx);
+        let custom_name     = self.custom_name_for_index(idx);
+        let default_type    = self.temperature_type_for_index(idx);
+
+        create_temperature_service(
+            &self.cfg.dbus_bus,
+            &service_suffix,
+            device_instance,
+            product_name,
+            custom_name,
+            default_type,
+        )
+        .await
+    }
+
+    fn device_instance_for_index(&self, idx: u8) -> u32 {
+        for (pos, s) in self.sensor_refs.iter().enumerate() {
+            let si = s.mqtt_index.unwrap_or((pos + 1) as u8);
+            if si == idx {
+                return s.device_instance.unwrap_or(si as u32);
+            }
+        }
+        idx as u32
+    }
+
+    fn product_name_for_index(&self, idx: u8) -> String {
+        for (pos, s) in self.sensor_refs.iter().enumerate() {
+            let si = s.mqtt_index.unwrap_or((pos + 1) as u8);
+            if si == idx {
+                if let Some(name) = &s.name {
+                    return name.clone();
+                }
+            }
+        }
+        format!("Temperature Sensor {}", idx)
+    }
+
+    fn custom_name_for_index(&self, idx: u8) -> String {
+        // Le custom_name par défaut est identique au product_name
+        self.product_name_for_index(idx)
+    }
+
+    fn temperature_type_for_index(&self, idx: u8) -> i32 {
+        for (pos, s) in self.sensor_refs.iter().enumerate() {
+            let si = s.mqtt_index.unwrap_or((pos + 1) as u8);
+            if si == idx {
+                return s.temperature_type.unwrap_or(2); // 2=generic par défaut
+            }
+        }
+        2
+    }
+
+    /// Republication forcée (keepalive Venus OS) + vérification watchdog.
+    async fn republish_and_watchdog(&self, watchdog_dur: Duration) {
+        let now = Instant::now();
+
+        for (idx, svc) in &self.services {
+            let last_update = {
+                let guard = svc.values.lock().unwrap();
+                guard.last_update
+            };
+
+            if now.duration_since(last_update) > watchdog_dur {
+                if let Err(e) = svc.set_disconnected().await {
+                    warn!(index = idx, "Erreur watchdog capteur disconnect : {:#}", e);
+                }
+            } else if let Err(e) = svc.republish().await {
+                warn!(index = idx, "Erreur republication keepalive capteur : {:#}", e);
+            }
+        }
+    }
+}

--- a/crates/daly-bms-venus/src/temperature_service.rs
+++ b/crates/daly-bms-venus/src/temperature_service.rs
@@ -1,0 +1,433 @@
+//! Service D-Bus `com.victronenergy.temperature.{name}` pour capteurs de température.
+//!
+//! Conforme au wiki Victron Venus OS — section Temperatures :
+//! <https://github.com/victronenergy/venus/wiki/dbus#temperatures>
+//!
+//! ## Chemins D-Bus exposés
+//!
+//! ```text
+//! /Temperature      — °C
+//! /TemperatureType  — 0=battery 1=fridge 2=generic 3=Room 4=Outdoor 5=WaterHeater 6=Freezer
+//! /CustomName       — nom libre (ex: "Température Extérieure")
+//! /Humidity         — % humidité relative (optionnel)
+//! /Pressure         — kPa (optionnel)
+//! /Status           — 0=OK, 1=Disconnected
+//! /Connected        — 0 ou 1
+//! /ProductName      — ex: "Temperature Sensor"
+//! /ProductId        — 0
+//! /DeviceInstance   — instance unique Venus OS / VRM
+//! /Mgmt/ProcessName
+//! /Mgmt/ProcessVersion
+//! /Mgmt/Connection
+//! ```
+
+use crate::types::HeatPayload;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tracing::{debug, info, warn};
+use zbus::{connection, object_server::SignalContext, Connection};
+use zvariant::{OwnedValue, Str};
+
+// =============================================================================
+// Constantes
+// =============================================================================
+
+const VICTRON_TEMPERATURE_PREFIX: &str = "com.victronenergy.temperature";
+
+// =============================================================================
+// Item D-Bus — paire (valeur, texte)
+// =============================================================================
+
+#[derive(Debug, Clone)]
+pub struct DbusItem {
+    pub value: serde_json::Value,
+    pub text:  String,
+}
+
+impl DbusItem {
+    pub fn f64(v: f64, unit: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: format!("{:.1} {}", v, unit) }
+    }
+    pub fn i32(v: i32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn str(v: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn u32(v: u32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+}
+
+fn json_to_owned(v: &serde_json::Value) -> OwnedValue {
+    match v {
+        serde_json::Value::Number(n) => {
+            if n.is_f64() {
+                OwnedValue::from(n.as_f64().unwrap_or(0.0))
+            } else if n.is_u64() {
+                OwnedValue::from(n.as_u64().unwrap_or(0) as u32)
+            } else {
+                let i = n.as_i64().unwrap_or(0);
+                if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                    OwnedValue::from(i as i32)
+                } else {
+                    OwnedValue::from(i)
+                }
+            }
+        }
+        serde_json::Value::String(s) => OwnedValue::from(Str::from(s.clone())),
+        _ => OwnedValue::from(0i32),
+    }
+}
+
+fn item_to_inner(item: &DbusItem) -> HashMap<String, OwnedValue> {
+    let mut d = HashMap::new();
+    d.insert("Value".to_string(), json_to_owned(&item.value));
+    d.insert("Text".to_string(), OwnedValue::from(Str::from(item.text.clone())));
+    d
+}
+
+type ItemsDict = HashMap<String, HashMap<String, OwnedValue>>;
+
+// =============================================================================
+// Valeurs courantes d'un capteur
+// =============================================================================
+
+/// État courant d'un capteur de température exposé sur D-Bus.
+#[derive(Debug, Clone)]
+pub struct SensorValues {
+    pub connected:        i32,
+    pub temperature:      f64,
+    pub temperature_type: i32,
+    pub humidity:         Option<f64>,
+    pub pressure:         Option<f64>,
+    pub custom_name:      String,
+    pub product_name:     String,
+    pub device_instance:  u32,
+    /// Timestamp de la dernière mise à jour (watchdog)
+    pub last_update:      Instant,
+}
+
+impl SensorValues {
+    /// État initial déconnecté.
+    pub fn disconnected(
+        device_instance:  u32,
+        product_name:     String,
+        custom_name:      String,
+        temperature_type: i32,
+    ) -> Self {
+        Self {
+            connected:        0,
+            temperature:      0.0,
+            temperature_type,
+            humidity:         None,
+            pressure:         None,
+            custom_name,
+            product_name,
+            device_instance,
+            last_update:      Instant::now(),
+        }
+    }
+
+    /// Met à jour depuis un payload MQTT ; le `temperature_type` de la config
+    /// a priorité sur celui du payload (0 = non défini côté payload).
+    pub fn from_payload(
+        payload:          &HeatPayload,
+        device_instance:  u32,
+        product_name:     String,
+        custom_name:      String,
+        default_type:     i32,
+    ) -> Self {
+        // La config a priorité; sinon on prend la valeur du payload
+        let temperature_type = if default_type != 0 {
+            default_type
+        } else {
+            payload.temperature_type
+        };
+
+        Self {
+            connected: 1,
+            temperature: payload.temperature,
+            temperature_type,
+            humidity: payload.humidity,
+            pressure: payload.pressure,
+            custom_name: payload.custom_name.clone().unwrap_or(custom_name),
+            product_name,
+            device_instance,
+            last_update: Instant::now(),
+        }
+    }
+
+    /// Construit le dictionnaire complet des items D-Bus.
+    pub fn to_items(&self) -> HashMap<String, DbusItem> {
+        let mut m = HashMap::new();
+
+        // Identification (commun à tous les services Victron)
+        m.insert("/Mgmt/ProcessName".into(),    DbusItem::str("daly-bms-venus"));
+        m.insert("/Mgmt/ProcessVersion".into(), DbusItem::str(env!("CARGO_PKG_VERSION")));
+        m.insert("/Mgmt/Connection".into(),     DbusItem::str("MQTT"));
+        m.insert("/ProductId".into(),           DbusItem::u32(0));
+        m.insert("/ProductName".into(),         DbusItem::str(&self.product_name));
+        m.insert("/DeviceInstance".into(),      DbusItem::u32(self.device_instance));
+        m.insert("/Connected".into(),           DbusItem::i32(self.connected));
+
+        // Status : 0=OK, 1=Disconnected
+        let status = if self.connected == 1 { 0 } else { 1 };
+        m.insert("/Status".into(), DbusItem::i32(status));
+
+        // Données température (chemins officiels Venus OS wiki)
+        m.insert("/Temperature".into(),     DbusItem::f64(self.temperature, "°C"));
+        m.insert("/TemperatureType".into(), DbusItem::i32(self.temperature_type));
+        m.insert("/CustomName".into(),      DbusItem::str(&self.custom_name));
+
+        // Optionnels — toujours publiés (0.0 si absent) pour que Venus OS
+        // les connaisse dès GetItems() et puisse les afficher dynamiquement.
+        if let Some(h) = self.humidity {
+            m.insert("/Humidity".into(), DbusItem::f64(h, "%"));
+        }
+        if let Some(p) = self.pressure {
+            m.insert("/Pressure".into(), DbusItem::f64(p, "kPa"));
+        }
+
+        m
+    }
+}
+
+// =============================================================================
+// Interface D-Bus — objet racine `/`
+// =============================================================================
+
+struct TemperatureRootIface {
+    values: Arc<Mutex<SensorValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl TemperatureRootIface {
+    fn get_items(&self) -> ItemsDict {
+        let guard = self.values.lock().unwrap();
+        guard
+            .to_items()
+            .iter()
+            .map(|(path, item)| (path.clone(), item_to_inner(item)))
+            .collect()
+    }
+
+    fn get_value(&self) -> OwnedValue {
+        OwnedValue::from(0i32)
+    }
+
+    fn get_text(&self) -> String {
+        String::new()
+    }
+
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 {
+        1
+    }
+
+    #[zbus(signal)]
+    async fn items_changed(
+        ctx:   &SignalContext<'_>,
+        items: ItemsDict,
+    ) -> zbus::Result<()>;
+}
+
+// =============================================================================
+// Interface D-Bus — objet feuille
+// =============================================================================
+
+struct BusItemLeaf {
+    path:   String,
+    values: Arc<Mutex<SensorValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl BusItemLeaf {
+    fn get_value(&self) -> OwnedValue {
+        let guard = self.values.lock().unwrap();
+        match guard.to_items().get(&self.path) {
+            Some(item) => json_to_owned(&item.value),
+            None       => OwnedValue::from(0i32),
+        }
+    }
+
+    fn get_text(&self) -> String {
+        let guard = self.values.lock().unwrap();
+        guard
+            .to_items()
+            .get(&self.path)
+            .map(|i| i.text.clone())
+            .unwrap_or_default()
+    }
+
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 {
+        1 // lecture seule
+    }
+}
+
+// =============================================================================
+// Handle vers un service actif
+// =============================================================================
+
+/// Référence à un service D-Bus temperature actif.
+pub struct SensorServiceHandle {
+    pub service_name:     String,
+    pub device_instance:  u32,
+    pub values:           Arc<Mutex<SensorValues>>,
+    /// La connexion maintient le service D-Bus vivant.
+    connection:           Connection,
+    /// Type par défaut (de la config [[sensors]])
+    pub default_type:     i32,
+    /// Nom produit (pour re-créer SensorValues depuis payload)
+    pub product_name:     String,
+    /// Nom personnalisé par défaut
+    pub custom_name:      String,
+}
+
+impl SensorServiceHandle {
+    /// Met à jour les valeurs et émet `ItemsChanged`.
+    pub async fn update(&self, payload: &HeatPayload) -> Result<()> {
+        let new_values = SensorValues::from_payload(
+            payload,
+            self.device_instance,
+            self.product_name.clone(),
+            self.custom_name.clone(),
+            self.default_type,
+        );
+        let items = new_values.to_items();
+
+        {
+            let mut guard = self.values.lock().unwrap();
+            *guard = new_values;
+        }
+
+        self.emit_items_changed(&items).await?;
+
+        debug!(
+            service = %self.service_name,
+            temperature = %payload.temperature,
+            "D-Bus ItemsChanged température émis"
+        );
+
+        Ok(())
+    }
+
+    /// Marque le capteur comme déconnecté (timeout watchdog).
+    pub async fn set_disconnected(&self) -> Result<()> {
+        let items = {
+            let mut guard = self.values.lock().unwrap();
+            guard.connected = 0;
+            guard.to_items()
+        };
+        warn!(service = %self.service_name, "Capteur déconnecté — watchdog timeout");
+        self.emit_items_changed(&items).await
+    }
+
+    /// Republication forcée (keepalive Venus OS).
+    pub async fn republish(&self) -> Result<()> {
+        let items = {
+            let guard = self.values.lock().unwrap();
+            guard.to_items()
+        };
+        self.emit_items_changed(&items).await
+    }
+
+    async fn emit_items_changed(&self, items: &HashMap<String, DbusItem>) -> Result<()> {
+        let dict: ItemsDict = items
+            .iter()
+            .map(|(path, item)| (path.clone(), item_to_inner(item)))
+            .collect();
+
+        let ctx = SignalContext::new(&self.connection, "/")?;
+
+        match TemperatureRootIface::items_changed(&ctx, dict).await {
+            Ok(_) => {
+                debug!(
+                    service = %self.service_name,
+                    count = items.len(),
+                    "ItemsChanged(a{{sa{{sv}}}}) température émis"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                warn!(service = %self.service_name, "ItemsChanged warning : {}", e);
+                Ok(())
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Création du service D-Bus
+// =============================================================================
+
+/// Crée et enregistre un service D-Bus `com.victronenergy.temperature.{suffix}`.
+pub async fn create_temperature_service(
+    dbus_bus:        &str,
+    service_suffix:  &str,
+    device_instance: u32,
+    product_name:    String,
+    custom_name:     String,
+    default_type:    i32,
+) -> Result<SensorServiceHandle> {
+    let service_name = format!("{}.{}", VICTRON_TEMPERATURE_PREFIX, service_suffix);
+
+    info!(
+        service = %service_name,
+        device_instance = device_instance,
+        temperature_type = default_type,
+        "Enregistrement service D-Bus température Venus OS"
+    );
+
+    let initial_values = Arc::new(Mutex::new(SensorValues::disconnected(
+        device_instance,
+        product_name.clone(),
+        custom_name.clone(),
+        default_type,
+    )));
+
+    let root = TemperatureRootIface { values: initial_values.clone() };
+
+    let builder = match dbus_bus {
+        "session" => connection::Builder::session()?,
+        _         => connection::Builder::system()?,
+    };
+
+    let conn = builder
+        .name(service_name.as_str())?
+        .serve_at("/", root)?
+        .build()
+        .await?;
+
+    // Enregistrer un objet feuille par chemin métrique
+    let leaf_paths: Vec<String> = {
+        let guard = initial_values.lock().unwrap();
+        guard.to_items().into_keys().collect()
+    };
+
+    for path in &leaf_paths {
+        let leaf = BusItemLeaf {
+            path:   path.clone(),
+            values: initial_values.clone(),
+        };
+        conn.object_server().at(path.as_str(), leaf).await?;
+    }
+
+    info!(
+        service = %service_name,
+        paths = leaf_paths.len(),
+        "Service D-Bus température enregistré ({} chemins + racine /)",
+        leaf_paths.len()
+    );
+
+    Ok(SensorServiceHandle {
+        service_name,
+        device_instance,
+        values: initial_values,
+        connection: conn,
+        default_type,
+        product_name,
+        custom_name,
+    })
+}

--- a/crates/daly-bms-venus/src/types.rs
+++ b/crates/daly-bms-venus/src/types.rs
@@ -5,6 +5,50 @@
 
 use serde::{Deserialize, Serialize};
 
+// =============================================================================
+// Payload capteurs de température (santuario/heat/{n}/venus)
+// =============================================================================
+
+/// Payload pour capteurs de température/chaleur.
+///
+/// Publié par Node-RED (Open-Meteo, capteurs physiques…) sur
+/// `santuario/heat/{n}/venus` et consommé par `SensorManager`.
+///
+/// Chemins D-Bus Venus OS cibles : `com.victronenergy.temperature.{n}`
+///   /Temperature      °C
+///   /TemperatureType  0=battery 1=fridge 2=generic 3=Room 4=Outdoor 5=WaterHeater 6=Freezer
+///   /Humidity         %
+///   /Pressure         kPa
+///   /CustomName       string
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeatPayload {
+    /// Température en degrés Celsius.
+    #[serde(rename = "Temperature")]
+    pub temperature: f64,
+
+    /// Type de capteur : 0=battery, 1=fridge, 2=generic, 3=Room,
+    /// 4=Outdoor, 5=WaterHeater, 6=Freezer.
+    /// Peut être surchargé par la config `[[sensors]]`.
+    #[serde(rename = "TemperatureType", default)]
+    pub temperature_type: i32,
+
+    /// Humidité relative en % (optionnelle — ex: sonde extérieure).
+    #[serde(rename = "Humidity", default)]
+    pub humidity: Option<f64>,
+
+    /// Pression atmosphérique en kPa (optionnelle).
+    #[serde(rename = "Pressure", default)]
+    pub pressure: Option<f64>,
+
+    /// Nom personnalisé affiché dans Venus OS (optionnel).
+    #[serde(rename = "CustomName", default)]
+    pub custom_name: Option<String>,
+}
+
+// =============================================================================
+// Payload batteries (santuario/bms/{n}/venus)
+// =============================================================================
+
 /// Payload complet au format Venus OS / dbus-mqtt-battery.
 ///
 /// Publié par `daly-bms-server` sur le topic `{prefix}/{n}/venus`.


### PR DESCRIPTION
Implements full Venus OS D-Bus registration for outdoor temperature and water heater sensors, mirroring the existing battery pack pattern.

Architecture:
- MQTT topic santuario/heat/{n}/venus → com.victronenergy.temperature.{n}
- Parallel to existing bms/{n}/venus → com.victronenergy.battery.{n}

New files:
- temperature_service.rs: D-Bus service with all Venus OS temperature paths (/Temperature, /TemperatureType, /Humidity, /Pressure, /CustomName, /Status, /Connected, /DeviceInstance…) matching https://github.com/victronenergy/venus/wiki/dbus#temperatures
- sensor_manager.rs: dynamic service creation + watchdog keepalive, same pattern as BatteryManager
- SensorMqttEvent + start_sensor_mqtt_source() in mqtt_source.rs
- HeatPayload in types.rs (Temperature, TemperatureType, Humidity, Pressure, CustomName)
- HeatConfig + SensorRef in config.rs

Config.toml: [heat] section + [[sensors]] examples for outdoor (type=4) and water heater (type=5), with DeviceInstance 20/21

main.rs now launches both bridges concurrently (battery + temperature).

https://claude.ai/code/session_01XsDVWy6q2pD8GUg3GZueYa