### PR TITLE
feat(venus): add com.victronenergy.heatpump and com.victronenergy.met…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -130,10 +130,10 @@ republish_sec = 25
 
 
 # =============================================================================
-# Capteurs de température (daly-bms-venus → com.victronenergy.temperature.{n})
+# Capteurs de température extérieure (com.victronenergy.temperature.{n})
 # =============================================================================
 # Topic MQTT source : santuario/heat/{n}/venus
-# Payload attendu (publié par Node-RED) :
+# Payload attendu (publié par Node-RED depuis Open-Meteo) :
 #   { "Temperature": 15.3, "TemperatureType": 4, "Humidity": 65.0, "Pressure": 101.3 }
 #
 # TemperatureType : 0=battery 1=fridge 2=generic 3=Room 4=Outdoor 5=WaterHeater 6=Freezer
@@ -149,11 +149,50 @@ name             = "Temperature Exterieure"
 temperature_type = 4       # 4 = Outdoor
 device_instance  = 20      # DeviceInstance Venus OS / VRM
 
-[[sensors]]
-mqtt_index       = 2       # Topic : santuario/heat/2/venus
-name             = "Chauffe-eau"
-temperature_type = 5       # 5 = WaterHeater
-device_instance  = 21      # DeviceInstance Venus OS / VRM
+# =============================================================================
+# Pompes à chaleur / chauffe-eau (com.victronenergy.heatpump.{n})
+# =============================================================================
+# Topic MQTT source : santuario/heatpump/{n}/venus
+# Payload attendu (publié par Node-RED) :
+#   { "State": 0, "Temperature": 55.0, "TargetTemperature": 60.0,
+#     "Ac": { "Power": 1200.0, "Energy": { "Forward": 125.5 } }, "Position": 0 }
+#
+# /State             — enum état (TBD Victron)
+# /Temperature       — température eau courante °C
+# /TargetTemperature — température eau cible °C
+# /Ac/Power          — puissance consommée W
+# /Ac/Energy/Forward — énergie totale kWh
+# /Position          — 0=AC Output, 1=AC Input
+
+[heatpump]
+# Préfixe des topics heatpump
+topic_prefix = "santuario/heatpump"
+
+[[heatpumps]]
+mqtt_index      = 1       # Topic : santuario/heatpump/1/venus
+name            = "Chauffe-eau"
+device_instance = 30      # DeviceInstance Venus OS / VRM
+
+# Pompe à chaleur LG (future intégration — même service D-Bus)
+# [[heatpumps]]
+# mqtt_index      = 2     # Topic : santuario/heatpump/2/venus
+# name            = "PAC LG Climatisation"
+# device_instance = 31
+
+# =============================================================================
+# Capteur météo / irradiance RS485 (com.victronenergy.meteo)
+# =============================================================================
+# Topic MQTT source FIXE : santuario/meteo/venus (sans index — un seul capteur)
+# Payload attendu (publié par Node-RED depuis capteur RS485 Pi5) :
+#   { "Irradiance": 750.0, "TodaysYield": 12.5 }
+#
+# /Irradiance    — irradiance courante W/m²
+# /TodaysYield   — production du jour kWh (depuis le lever du soleil)
+
+[meteo]
+topic           = "santuario/meteo/venus"
+product_name    = "Capteur Irradiance"
+device_instance = 40      # DeviceInstance Venus OS / VRM
 
 
 [influxdb]

--- a/crates/daly-bms-venus/src/config.rs
+++ b/crates/daly-bms-venus/src/config.rs
@@ -25,13 +25,25 @@ pub struct VenusServiceConfig {
     #[serde(default)]
     pub bms: Vec<BmsRef>,
 
-    /// Configuration du préfixe MQTT heat (capteurs température)
+    /// Configuration du préfixe MQTT heat (capteurs température outdoor)
     #[serde(default)]
     pub heat: HeatConfig,
 
     /// Configurations par capteur de température
     #[serde(default)]
     pub sensors: Vec<SensorRef>,
+
+    /// Configuration MQTT heatpump (pompes à chaleur / chauffe-eau)
+    #[serde(default)]
+    pub heatpump: HeatpumpConfig,
+
+    /// Configurations par pompe à chaleur
+    #[serde(default)]
+    pub heatpumps: Vec<HeatpumpRef>,
+
+    /// Configuration du service météo (irradiance RS485)
+    #[serde(default)]
+    pub meteo: MeteoConfig,
 }
 
 /// Référence à la config MQTT du serveur principal.
@@ -133,6 +145,71 @@ pub struct SensorRef {
     /// DeviceInstance Venus OS D-Bus (affiché dans VRM).
     /// Si absent, utilise `mqtt_index` comme fallback.
     pub device_instance: Option<u32>,
+}
+
+// =============================================================================
+// Configuration pompes à chaleur / chauffe-eau (heatpump)
+// =============================================================================
+
+/// Préfixe MQTT pour les pompes à chaleur.
+///
+/// Topic abonné : `{topic_prefix}/{n}/venus`
+/// Exemple : `santuario/heatpump/1/venus`
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HeatpumpConfig {
+    /// Préfixe des topics heatpump (ex: "santuario/heatpump")
+    pub topic_prefix: String,
+}
+
+impl Default for HeatpumpConfig {
+    fn default() -> Self {
+        Self { topic_prefix: "santuario/heatpump".to_string() }
+    }
+}
+
+/// Configuration d'une pompe à chaleur individuelle.
+///
+/// Une section `[[heatpumps]]` par appareil dans le TOML.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct HeatpumpRef {
+    /// Index dans le topic MQTT (ex: 1 → `santuario/heatpump/1/venus`).
+    pub mqtt_index: Option<u8>,
+
+    /// Nom affiché dans Venus OS (`/ProductName`).
+    pub name: Option<String>,
+
+    /// DeviceInstance Venus OS D-Bus.
+    pub device_instance: Option<u32>,
+}
+
+// =============================================================================
+// Configuration capteur météo / irradiance (meteo)
+// =============================================================================
+
+/// Configuration du service météo D-Bus.
+///
+/// Topic MQTT fixe : `{topic}` (sans index, un seul capteur).
+/// Exemple : `santuario/meteo/venus`
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MeteoConfig {
+    /// Topic MQTT fixe du capteur météo (ex: "santuario/meteo/venus")
+    pub topic: String,
+
+    /// Nom affiché dans Venus OS
+    pub product_name: String,
+
+    /// DeviceInstance Venus OS D-Bus
+    pub device_instance: u32,
+}
+
+impl Default for MeteoConfig {
+    fn default() -> Self {
+        Self {
+            topic:           "santuario/meteo/venus".to_string(),
+            product_name:    "Irradiance Sensor".to_string(),
+            device_instance: 30,
+        }
+    }
 }
 
 // =============================================================================

--- a/crates/daly-bms-venus/src/heatpump_manager.rs
+++ b/crates/daly-bms-venus/src/heatpump_manager.rs
@@ -1,0 +1,114 @@
+//! Manager des services D-Bus heatpump — orchestre N pompes à chaleur.
+//!
+//! Reçoit les `HeatpumpMqttEvent` depuis `mqtt_source` et les route vers
+//! le `HeatpumpServiceHandle` correspondant.
+//! Topic MQTT : `santuario/heatpump/{n}/venus`
+//! Service D-Bus : `com.victronenergy.heatpump.{prefix}_{n}`
+
+use crate::config::{HeatpumpRef, VenusConfig};
+use crate::heatpump_service::{HeatpumpServiceHandle, create_heatpump_service};
+use crate::mqtt_source::HeatpumpMqttEvent;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::time::interval;
+use tracing::{error, info, warn};
+
+pub struct HeatpumpManager {
+    cfg:           VenusConfig,
+    heatpump_refs: Vec<HeatpumpRef>,
+    services:      HashMap<u8, HeatpumpServiceHandle>,
+    rx:            mpsc::Receiver<HeatpumpMqttEvent>,
+}
+
+impl HeatpumpManager {
+    pub fn new(
+        cfg:           VenusConfig,
+        heatpump_refs: Vec<HeatpumpRef>,
+        rx:            mpsc::Receiver<HeatpumpMqttEvent>,
+    ) -> Self {
+        Self { cfg, heatpump_refs, services: HashMap::new(), rx }
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        if !self.cfg.enabled {
+            info!("Service heatpump D-Bus désactivé (enabled = false)");
+            while self.rx.recv().await.is_some() {}
+            return Ok(());
+        }
+
+        let watchdog_dur  = Duration::from_secs(self.cfg.watchdog_sec);
+        let republish_dur = Duration::from_secs(self.cfg.republish_sec);
+        let mut tick      = interval(republish_dur);
+
+        info!(
+            dbus_bus     = %self.cfg.dbus_bus,
+            heatpumps    = self.heatpump_refs.len(),
+            watchdog_sec = self.cfg.watchdog_sec,
+            "HeatpumpManager démarré"
+        );
+
+        loop {
+            tokio::select! {
+                Some(evt) = self.rx.recv() => {
+                    if let Err(e) = self.handle_event(evt).await {
+                        error!("Erreur événement heatpump MQTT : {:#}", e);
+                    }
+                }
+                _ = tick.tick() => {
+                    self.republish_and_watchdog(watchdog_dur).await;
+                }
+            }
+        }
+    }
+
+    async fn handle_event(&mut self, evt: HeatpumpMqttEvent) -> Result<()> {
+        let idx = evt.mqtt_index;
+        if !self.services.contains_key(&idx) {
+            let handle = self.create_service(idx).await?;
+            self.services.insert(idx, handle);
+        }
+        if let Some(svc) = self.services.get(&idx) {
+            svc.update(&evt.payload).await?;
+        }
+        Ok(())
+    }
+
+    async fn create_service(&self, idx: u8) -> Result<HeatpumpServiceHandle> {
+        let suffix          = format!("{}_{}", self.cfg.service_prefix, idx);
+        let device_instance = self.device_instance_for(idx);
+        let product_name    = self.product_name_for(idx);
+        create_heatpump_service(&self.cfg.dbus_bus, &suffix, device_instance, product_name).await
+    }
+
+    fn device_instance_for(&self, idx: u8) -> u32 {
+        for (pos, h) in self.heatpump_refs.iter().enumerate() {
+            let hi = h.mqtt_index.unwrap_or((pos + 1) as u8);
+            if hi == idx { return h.device_instance.unwrap_or(hi as u32); }
+        }
+        idx as u32
+    }
+
+    fn product_name_for(&self, idx: u8) -> String {
+        for (pos, h) in self.heatpump_refs.iter().enumerate() {
+            let hi = h.mqtt_index.unwrap_or((pos + 1) as u8);
+            if hi == idx { if let Some(n) = &h.name { return n.clone(); } }
+        }
+        format!("Heat Pump {}", idx)
+    }
+
+    async fn republish_and_watchdog(&self, watchdog_dur: Duration) {
+        let now = Instant::now();
+        for (idx, svc) in &self.services {
+            let last = { svc.values.lock().unwrap().last_update };
+            if now.duration_since(last) > watchdog_dur {
+                if let Err(e) = svc.set_disconnected().await {
+                    warn!(index = idx, "Erreur watchdog heatpump : {:#}", e);
+                }
+            } else if let Err(e) = svc.republish().await {
+                warn!(index = idx, "Erreur republication heatpump : {:#}", e);
+            }
+        }
+    }
+}

--- a/crates/daly-bms-venus/src/heatpump_service.rs
+++ b/crates/daly-bms-venus/src/heatpump_service.rs
@@ -1,0 +1,360 @@
+//! Service D-Bus `com.victronenergy.heatpump.{name}` pour pompes à chaleur
+//! et chauffe-eau.
+//!
+//! Conforme au wiki Victron Venus OS — section Heatpump :
+//! <https://github.com/victronenergy/venus/wiki/dbus#heatpump>
+//!
+//! ## Chemins D-Bus exposés
+//!
+//! ```text
+//! /State              — état de la pompe à chaleur (enum Victron TBD)
+//! /Temperature        — température eau courante °C (optionnel)
+//! /TargetTemperature  — température eau cible °C (optionnel)
+//! /Ac/Power           — puissance consommée W
+//! /Ac/Energy/Forward  — énergie totale consommée kWh
+//! /Position           — 0=AC Output, 1=AC Input
+//! /Connected          — 0 ou 1
+//! /ProductName
+//! /ProductId
+//! /DeviceInstance
+//! /Mgmt/ProcessName
+//! /Mgmt/ProcessVersion
+//! /Mgmt/Connection
+//! ```
+//!
+//! Utilisé pour :
+//! - Chauffe-eau (avec sonde de température et contrôle cible)
+//! - Pompe à chaleur LG (future intégration)
+
+use crate::types::HeatpumpPayload;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tracing::{debug, info, warn};
+use zbus::{connection, object_server::SignalContext, Connection};
+use zvariant::{OwnedValue, Str};
+
+// =============================================================================
+// Constante
+// =============================================================================
+
+const VICTRON_HEATPUMP_PREFIX: &str = "com.victronenergy.heatpump";
+
+// =============================================================================
+// Item D-Bus
+// =============================================================================
+
+#[derive(Debug, Clone)]
+pub struct DbusItem {
+    pub value: serde_json::Value,
+    pub text:  String,
+}
+
+impl DbusItem {
+    pub fn f64(v: f64, unit: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: format!("{:.1} {}", v, unit) }
+    }
+    pub fn i32(v: i32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn str(v: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn u32(v: u32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+}
+
+fn json_to_owned(v: &serde_json::Value) -> OwnedValue {
+    match v {
+        serde_json::Value::Number(n) => {
+            if n.is_f64() {
+                OwnedValue::from(n.as_f64().unwrap_or(0.0))
+            } else if n.is_u64() {
+                OwnedValue::from(n.as_u64().unwrap_or(0) as u32)
+            } else {
+                let i = n.as_i64().unwrap_or(0);
+                if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                    OwnedValue::from(i as i32)
+                } else {
+                    OwnedValue::from(i)
+                }
+            }
+        }
+        serde_json::Value::String(s) => OwnedValue::from(Str::from(s.clone())),
+        _ => OwnedValue::from(0i32),
+    }
+}
+
+fn item_to_inner(item: &DbusItem) -> HashMap<String, OwnedValue> {
+    let mut d = HashMap::new();
+    d.insert("Value".to_string(), json_to_owned(&item.value));
+    d.insert("Text".to_string(), OwnedValue::from(Str::from(item.text.clone())));
+    d
+}
+
+type ItemsDict = HashMap<String, HashMap<String, OwnedValue>>;
+
+// =============================================================================
+// Valeurs courantes
+// =============================================================================
+
+/// État courant d'une pompe à chaleur / chauffe-eau exposé sur D-Bus.
+#[derive(Debug, Clone)]
+pub struct HeatpumpValues {
+    pub connected:          i32,
+    pub state:              i32,
+    pub temperature:        Option<f64>,
+    pub target_temperature: Option<f64>,
+    pub ac_power:           f64,
+    pub ac_energy_forward:  f64,
+    pub position:           i32,
+    pub product_name:       String,
+    pub device_instance:    u32,
+    pub last_update:        Instant,
+}
+
+impl HeatpumpValues {
+    pub fn disconnected(device_instance: u32, product_name: String) -> Self {
+        Self {
+            connected:          0,
+            state:              0,
+            temperature:        None,
+            target_temperature: None,
+            ac_power:           0.0,
+            ac_energy_forward:  0.0,
+            position:           0,
+            product_name,
+            device_instance,
+            last_update:        Instant::now(),
+        }
+    }
+
+    pub fn from_payload(
+        payload:         &HeatpumpPayload,
+        device_instance: u32,
+        product_name:    String,
+    ) -> Self {
+        let ac_power         = payload.ac.as_ref().map(|a| a.power).unwrap_or(0.0);
+        let ac_energy_forward = payload.ac.as_ref()
+            .and_then(|a| a.energy.as_ref())
+            .map(|e| e.forward)
+            .unwrap_or(0.0);
+
+        Self {
+            connected: 1,
+            state: payload.state,
+            temperature: payload.temperature,
+            target_temperature: payload.target_temperature,
+            ac_power,
+            ac_energy_forward,
+            position: payload.position,
+            product_name,
+            device_instance,
+            last_update: Instant::now(),
+        }
+    }
+
+    pub fn to_items(&self) -> HashMap<String, DbusItem> {
+        let mut m = HashMap::new();
+
+        // Identification
+        m.insert("/Mgmt/ProcessName".into(),    DbusItem::str("daly-bms-venus"));
+        m.insert("/Mgmt/ProcessVersion".into(), DbusItem::str(env!("CARGO_PKG_VERSION")));
+        m.insert("/Mgmt/Connection".into(),     DbusItem::str("MQTT"));
+        m.insert("/ProductId".into(),           DbusItem::u32(0));
+        m.insert("/ProductName".into(),         DbusItem::str(&self.product_name));
+        m.insert("/DeviceInstance".into(),      DbusItem::u32(self.device_instance));
+        m.insert("/Connected".into(),           DbusItem::i32(self.connected));
+
+        // Heatpump (chemins officiels wiki Victron)
+        m.insert("/State".into(),    DbusItem::i32(self.state));
+        m.insert("/Position".into(), DbusItem::i32(self.position));
+        m.insert("/Ac/Power".into(),          DbusItem::f64(self.ac_power, "W"));
+        m.insert("/Ac/Energy/Forward".into(), DbusItem::f64(self.ac_energy_forward, "kWh"));
+
+        // Températures — toujours publiées (0.0 si absentes) pour que
+        // Venus OS les connaisse dès GetItems()
+        if let Some(t) = self.temperature {
+            m.insert("/Temperature".into(), DbusItem::f64(t, "°C"));
+        }
+        if let Some(tt) = self.target_temperature {
+            m.insert("/TargetTemperature".into(), DbusItem::f64(tt, "°C"));
+        }
+
+        m
+    }
+}
+
+// =============================================================================
+// Interface D-Bus — objet racine `/`
+// =============================================================================
+
+struct HeatpumpRootIface {
+    values: Arc<Mutex<HeatpumpValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl HeatpumpRootIface {
+    fn get_items(&self) -> ItemsDict {
+        let guard = self.values.lock().unwrap();
+        guard
+            .to_items()
+            .iter()
+            .map(|(path, item)| (path.clone(), item_to_inner(item)))
+            .collect()
+    }
+
+    fn get_value(&self) -> OwnedValue { OwnedValue::from(0i32) }
+    fn get_text(&self) -> String { String::new() }
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+
+    #[zbus(signal)]
+    async fn items_changed(
+        ctx:   &SignalContext<'_>,
+        items: ItemsDict,
+    ) -> zbus::Result<()>;
+}
+
+// =============================================================================
+// Interface D-Bus — objet feuille
+// =============================================================================
+
+struct BusItemLeaf {
+    path:   String,
+    values: Arc<Mutex<HeatpumpValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl BusItemLeaf {
+    fn get_value(&self) -> OwnedValue {
+        let guard = self.values.lock().unwrap();
+        match guard.to_items().get(&self.path) {
+            Some(item) => json_to_owned(&item.value),
+            None       => OwnedValue::from(0i32),
+        }
+    }
+
+    fn get_text(&self) -> String {
+        let guard = self.values.lock().unwrap();
+        guard.to_items().get(&self.path).map(|i| i.text.clone()).unwrap_or_default()
+    }
+
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+}
+
+// =============================================================================
+// Handle
+// =============================================================================
+
+pub struct HeatpumpServiceHandle {
+    pub service_name:    String,
+    pub device_instance: u32,
+    pub values:          Arc<Mutex<HeatpumpValues>>,
+    connection:          Connection,
+    pub product_name:    String,
+}
+
+impl HeatpumpServiceHandle {
+    pub async fn update(&self, payload: &HeatpumpPayload) -> Result<()> {
+        let new_values = HeatpumpValues::from_payload(
+            payload,
+            self.device_instance,
+            self.product_name.clone(),
+        );
+        let items = new_values.to_items();
+        { *self.values.lock().unwrap() = new_values; }
+        self.emit_items_changed(&items).await?;
+        debug!(service = %self.service_name, state = payload.state, "D-Bus ItemsChanged heatpump émis");
+        Ok(())
+    }
+
+    pub async fn set_disconnected(&self) -> Result<()> {
+        let items = {
+            let mut g = self.values.lock().unwrap();
+            g.connected = 0;
+            g.to_items()
+        };
+        warn!(service = %self.service_name, "Heatpump déconnectée — watchdog timeout");
+        self.emit_items_changed(&items).await
+    }
+
+    pub async fn republish(&self) -> Result<()> {
+        let items = { self.values.lock().unwrap().to_items() };
+        self.emit_items_changed(&items).await
+    }
+
+    async fn emit_items_changed(&self, items: &HashMap<String, DbusItem>) -> Result<()> {
+        let dict: ItemsDict = items
+            .iter()
+            .map(|(p, i)| (p.clone(), item_to_inner(i)))
+            .collect();
+        let ctx = SignalContext::new(&self.connection, "/")?;
+        match HeatpumpRootIface::items_changed(&ctx, dict).await {
+            Ok(_)  => { debug!(service = %self.service_name, "ItemsChanged heatpump émis"); Ok(()) }
+            Err(e) => { warn!(service = %self.service_name, "ItemsChanged warning : {}", e); Ok(()) }
+        }
+    }
+}
+
+// =============================================================================
+// Création du service
+// =============================================================================
+
+pub async fn create_heatpump_service(
+    dbus_bus:        &str,
+    service_suffix:  &str,
+    device_instance: u32,
+    product_name:    String,
+) -> Result<HeatpumpServiceHandle> {
+    let service_name = format!("{}.{}", VICTRON_HEATPUMP_PREFIX, service_suffix);
+
+    info!(
+        service = %service_name,
+        device_instance = device_instance,
+        "Enregistrement service D-Bus heatpump Venus OS"
+    );
+
+    let initial_values = Arc::new(Mutex::new(
+        HeatpumpValues::disconnected(device_instance, product_name.clone())
+    ));
+
+    let root = HeatpumpRootIface { values: initial_values.clone() };
+
+    let builder = match dbus_bus {
+        "session" => connection::Builder::session()?,
+        _         => connection::Builder::system()?,
+    };
+
+    let conn = builder
+        .name(service_name.as_str())?
+        .serve_at("/", root)?
+        .build()
+        .await?;
+
+    let leaf_paths: Vec<String> = {
+        initial_values.lock().unwrap().to_items().into_keys().collect()
+    };
+
+    for path in &leaf_paths {
+        conn.object_server()
+            .at(path.as_str(), BusItemLeaf { path: path.clone(), values: initial_values.clone() })
+            .await?;
+    }
+
+    info!(
+        service = %service_name,
+        paths   = leaf_paths.len(),
+        "Service D-Bus heatpump enregistré ({} chemins + racine /)",
+        leaf_paths.len()
+    );
+
+    Ok(HeatpumpServiceHandle {
+        service_name,
+        device_instance,
+        values: initial_values,
+        connection: conn,
+        product_name,
+    })
+}

--- a/crates/daly-bms-venus/src/main.rs
+++ b/crates/daly-bms-venus/src/main.rs
@@ -26,7 +26,11 @@
 
 mod battery_service;
 mod config;
+mod heatpump_manager;
+mod heatpump_service;
 mod manager;
+mod meteo_manager;
+mod meteo_service;
 mod mqtt_source;
 mod sensor_manager;
 mod temperature_service;
@@ -35,8 +39,13 @@ mod types;
 use anyhow::Result;
 use clap::Parser;
 use config::VenusServiceConfig;
+use heatpump_manager::HeatpumpManager;
 use manager::BatteryManager;
-use mqtt_source::{start_mqtt_source, start_sensor_mqtt_source};
+use meteo_manager::MeteoManager;
+use mqtt_source::{
+    start_heatpump_mqtt_source, start_meteo_mqtt_source, start_mqtt_source,
+    start_sensor_mqtt_source,
+};
 use sensor_manager::SensorManager;
 use std::path::PathBuf;
 use tokio::sync::mpsc;
@@ -92,13 +101,16 @@ async fn main() -> Result<()> {
     }
 
     info!(
-        version     = env!("CARGO_PKG_VERSION"),
-        dbus_bus    = %cfg.venus.dbus_bus,
-        mqtt_host   = %cfg.mqtt.host,
-        bms_prefix  = %cfg.mqtt.topic_prefix,
-        heat_prefix = %cfg.heat.topic_prefix,
-        bms_count   = cfg.bms.len(),
-        sensor_count = cfg.sensors.len(),
+        version          = env!("CARGO_PKG_VERSION"),
+        dbus_bus         = %cfg.venus.dbus_bus,
+        mqtt_host        = %cfg.mqtt.host,
+        bms_prefix       = %cfg.mqtt.topic_prefix,
+        heat_prefix      = %cfg.heat.topic_prefix,
+        heatpump_prefix  = %cfg.heatpump.topic_prefix,
+        meteo_topic      = %cfg.meteo.topic,
+        bms_count        = cfg.bms.len(),
+        sensor_count     = cfg.sensors.len(),
+        heatpump_count   = cfg.heatpumps.len(),
         "daly-bms-venus démarrage"
     );
 
@@ -133,9 +145,44 @@ async fn main() -> Result<()> {
         start_sensor_mqtt_source(mqtt_cfg2, heat_prefix, sensor_tx).await;
     });
 
-    let sensor_manager = SensorManager::new(cfg.venus, cfg.sensors, sensor_rx);
-    if let Err(e) = sensor_manager.run().await {
-        error!("SensorManager terminé avec erreur : {:#}", e);
+    let sensor_manager = SensorManager::new(cfg.venus.clone(), cfg.sensors, sensor_rx);
+    tokio::spawn(async move {
+        if let Err(e) = sensor_manager.run().await {
+            error!("SensorManager terminé avec erreur : {:#}", e);
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // Bridge heatpump : MQTT heatpump/{n}/venus → D-Bus heatpump.{n}
+    // -------------------------------------------------------------------------
+    let (heatpump_tx, heatpump_rx) = mpsc::channel(64);
+    let mqtt_cfg3       = cfg.mqtt.clone();
+    let heatpump_prefix = cfg.heatpump.topic_prefix.clone();
+    tokio::spawn(async move {
+        start_heatpump_mqtt_source(mqtt_cfg3, heatpump_prefix, heatpump_tx).await;
+    });
+
+    let heatpump_manager = HeatpumpManager::new(cfg.venus.clone(), cfg.heatpumps, heatpump_rx);
+    tokio::spawn(async move {
+        if let Err(e) = heatpump_manager.run().await {
+            error!("HeatpumpManager terminé avec erreur : {:#}", e);
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // Bridge météo : MQTT santuario/meteo/venus → D-Bus com.victronenergy.meteo
+    // -------------------------------------------------------------------------
+    let (meteo_tx, meteo_rx) = mpsc::channel(16);
+    let mqtt_cfg4    = cfg.mqtt.clone();
+    let meteo_topic  = cfg.meteo.topic.clone();
+    tokio::spawn(async move {
+        start_meteo_mqtt_source(mqtt_cfg4, meteo_topic, meteo_tx).await;
+    });
+
+    // Le MeteoManager est le dernier et bloque le thread principal
+    let meteo_manager = MeteoManager::new(cfg.venus, cfg.meteo, meteo_rx);
+    if let Err(e) = meteo_manager.run().await {
+        error!("MeteoManager terminé avec erreur : {:#}", e);
         std::process::exit(1);
     }
 

--- a/crates/daly-bms-venus/src/meteo_manager.rs
+++ b/crates/daly-bms-venus/src/meteo_manager.rs
@@ -1,0 +1,93 @@
+//! Manager du service D-Bus météo — gère le service unique `com.victronenergy.meteo`.
+//!
+//! Reçoit les `MeteoMqttEvent` depuis `mqtt_source` (topic `santuario/meteo/venus`)
+//! et maintient le service D-Bus avec watchdog + keepalive.
+
+use crate::config::{MeteoConfig, VenusConfig};
+use crate::meteo_service::{MeteoServiceHandle, create_meteo_service};
+use crate::mqtt_source::MeteoMqttEvent;
+use anyhow::Result;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::time::interval;
+use tracing::{error, info, warn};
+
+pub struct MeteoManager {
+    cfg:        VenusConfig,
+    meteo_cfg:  MeteoConfig,
+    service:    Option<MeteoServiceHandle>,
+    rx:         mpsc::Receiver<MeteoMqttEvent>,
+}
+
+impl MeteoManager {
+    pub fn new(
+        cfg:       VenusConfig,
+        meteo_cfg: MeteoConfig,
+        rx:        mpsc::Receiver<MeteoMqttEvent>,
+    ) -> Self {
+        Self { cfg, meteo_cfg, service: None, rx }
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        if !self.cfg.enabled {
+            info!("Service météo D-Bus désactivé (enabled = false)");
+            while self.rx.recv().await.is_some() {}
+            return Ok(());
+        }
+
+        let watchdog_dur  = Duration::from_secs(self.cfg.watchdog_sec);
+        let republish_dur = Duration::from_secs(self.cfg.republish_sec);
+        let mut tick      = interval(republish_dur);
+
+        info!(
+            dbus_bus     = %self.cfg.dbus_bus,
+            device_instance = self.meteo_cfg.device_instance,
+            watchdog_sec = self.cfg.watchdog_sec,
+            "MeteoManager démarré"
+        );
+
+        loop {
+            tokio::select! {
+                Some(evt) = self.rx.recv() => {
+                    if let Err(e) = self.handle_event(evt).await {
+                        error!("Erreur événement météo MQTT : {:#}", e);
+                    }
+                }
+                _ = tick.tick() => {
+                    self.republish_and_watchdog(watchdog_dur).await;
+                }
+            }
+        }
+    }
+
+    async fn handle_event(&mut self, evt: MeteoMqttEvent) -> Result<()> {
+        // Créer le service D-Bus au premier message reçu
+        if self.service.is_none() {
+            let svc = create_meteo_service(
+                &self.cfg.dbus_bus,
+                self.meteo_cfg.device_instance,
+                self.meteo_cfg.product_name.clone(),
+            )
+            .await?;
+            self.service = Some(svc);
+        }
+
+        if let Some(svc) = &self.service {
+            svc.update(&evt.payload).await?;
+        }
+        Ok(())
+    }
+
+    async fn republish_and_watchdog(&self, watchdog_dur: Duration) {
+        if let Some(svc) = &self.service {
+            let last = { svc.values.lock().unwrap().last_update };
+            if Instant::now().duration_since(last) > watchdog_dur {
+                if let Err(e) = svc.set_disconnected().await {
+                    warn!("Erreur watchdog météo : {:#}", e);
+                }
+            } else if let Err(e) = svc.republish().await {
+                warn!("Erreur republication météo : {:#}", e);
+            }
+        }
+    }
+}

--- a/crates/daly-bms-venus/src/meteo_service.rs
+++ b/crates/daly-bms-venus/src/meteo_service.rs
@@ -1,0 +1,311 @@
+//! Service D-Bus `com.victronenergy.meteo` pour capteur d'irradiance.
+//!
+//! Conforme au wiki Victron Venus OS — section Meteo :
+//! <https://github.com/victronenergy/venus/wiki/dbus#meteo>
+//!
+//! ## Chemins D-Bus exposés
+//!
+//! ```text
+//! /Irradiance     — irradiance courante en W/m²
+//! /TodaysYield    — production du jour en kWh (depuis le lever du soleil)
+//! /Connected      — 0 ou 1
+//! /ProductName
+//! /ProductId
+//! /DeviceInstance
+//! /Mgmt/ProcessName
+//! /Mgmt/ProcessVersion
+//! /Mgmt/Connection
+//! ```
+//!
+//! Utilisé pour :
+//! - Capteur d'irradiance RS485 connecté au Pi5
+//! - Topic MQTT source : `santuario/meteo/venus` (topic fixe, sans index)
+
+use crate::types::MeteoPayload;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tracing::{debug, info, warn};
+use zbus::{connection, object_server::SignalContext, Connection};
+use zvariant::{OwnedValue, Str};
+
+// =============================================================================
+// Constante
+// =============================================================================
+
+const VICTRON_METEO_SERVICE: &str = "com.victronenergy.meteo";
+
+// =============================================================================
+// Item D-Bus
+// =============================================================================
+
+#[derive(Debug, Clone)]
+pub struct DbusItem {
+    pub value: serde_json::Value,
+    pub text:  String,
+}
+
+impl DbusItem {
+    pub fn f64(v: f64, unit: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: format!("{:.1} {}", v, unit) }
+    }
+    pub fn i32(v: i32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn str(v: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn u32(v: u32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+}
+
+fn json_to_owned(v: &serde_json::Value) -> OwnedValue {
+    match v {
+        serde_json::Value::Number(n) => {
+            if n.is_f64() {
+                OwnedValue::from(n.as_f64().unwrap_or(0.0))
+            } else if n.is_u64() {
+                OwnedValue::from(n.as_u64().unwrap_or(0) as u32)
+            } else {
+                let i = n.as_i64().unwrap_or(0);
+                if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                    OwnedValue::from(i as i32)
+                } else {
+                    OwnedValue::from(i)
+                }
+            }
+        }
+        serde_json::Value::String(s) => OwnedValue::from(Str::from(s.clone())),
+        _ => OwnedValue::from(0i32),
+    }
+}
+
+fn item_to_inner(item: &DbusItem) -> HashMap<String, OwnedValue> {
+    let mut d = HashMap::new();
+    d.insert("Value".to_string(), json_to_owned(&item.value));
+    d.insert("Text".to_string(), OwnedValue::from(Str::from(item.text.clone())));
+    d
+}
+
+type ItemsDict = HashMap<String, HashMap<String, OwnedValue>>;
+
+// =============================================================================
+// Valeurs courantes
+// =============================================================================
+
+#[derive(Debug, Clone)]
+pub struct MeteoValues {
+    pub connected:       i32,
+    pub irradiance:      f64,
+    pub todays_yield:    f64,
+    pub product_name:    String,
+    pub device_instance: u32,
+    pub last_update:     Instant,
+}
+
+impl MeteoValues {
+    pub fn disconnected(device_instance: u32, product_name: String) -> Self {
+        Self {
+            connected:       0,
+            irradiance:      0.0,
+            todays_yield:    0.0,
+            product_name,
+            device_instance,
+            last_update:     Instant::now(),
+        }
+    }
+
+    pub fn from_payload(
+        payload:         &MeteoPayload,
+        device_instance: u32,
+        product_name:    String,
+    ) -> Self {
+        Self {
+            connected:    1,
+            irradiance:   payload.irradiance,
+            todays_yield: payload.todays_yield,
+            product_name,
+            device_instance,
+            last_update:  Instant::now(),
+        }
+    }
+
+    pub fn to_items(&self) -> HashMap<String, DbusItem> {
+        let mut m = HashMap::new();
+
+        // Identification
+        m.insert("/Mgmt/ProcessName".into(),    DbusItem::str("daly-bms-venus"));
+        m.insert("/Mgmt/ProcessVersion".into(), DbusItem::str(env!("CARGO_PKG_VERSION")));
+        m.insert("/Mgmt/Connection".into(),     DbusItem::str("MQTT"));
+        m.insert("/ProductId".into(),           DbusItem::u32(0));
+        m.insert("/ProductName".into(),         DbusItem::str(&self.product_name));
+        m.insert("/DeviceInstance".into(),      DbusItem::u32(self.device_instance));
+        m.insert("/Connected".into(),           DbusItem::i32(self.connected));
+
+        // Données météo (chemins officiels wiki Victron)
+        m.insert("/Irradiance".into(),   DbusItem::f64(self.irradiance, "W/m²"));
+        m.insert("/TodaysYield".into(),  DbusItem::f64(self.todays_yield, "kWh"));
+
+        m
+    }
+}
+
+// =============================================================================
+// Interface D-Bus — objet racine `/`
+// =============================================================================
+
+struct MeteoRootIface {
+    values: Arc<Mutex<MeteoValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl MeteoRootIface {
+    fn get_items(&self) -> ItemsDict {
+        let guard = self.values.lock().unwrap();
+        guard.to_items().iter().map(|(p, i)| (p.clone(), item_to_inner(i))).collect()
+    }
+
+    fn get_value(&self) -> OwnedValue { OwnedValue::from(0i32) }
+    fn get_text(&self) -> String { String::new() }
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+
+    #[zbus(signal)]
+    async fn items_changed(ctx: &SignalContext<'_>, items: ItemsDict) -> zbus::Result<()>;
+}
+
+// =============================================================================
+// Interface D-Bus — objet feuille
+// =============================================================================
+
+struct BusItemLeaf {
+    path:   String,
+    values: Arc<Mutex<MeteoValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl BusItemLeaf {
+    fn get_value(&self) -> OwnedValue {
+        let guard = self.values.lock().unwrap();
+        guard.to_items().get(&self.path).map(|i| json_to_owned(&i.value)).unwrap_or(OwnedValue::from(0i32))
+    }
+
+    fn get_text(&self) -> String {
+        let guard = self.values.lock().unwrap();
+        guard.to_items().get(&self.path).map(|i| i.text.clone()).unwrap_or_default()
+    }
+
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+}
+
+// =============================================================================
+// Handle
+// =============================================================================
+
+pub struct MeteoServiceHandle {
+    pub service_name:    String,
+    pub device_instance: u32,
+    pub values:          Arc<Mutex<MeteoValues>>,
+    connection:          Connection,
+    pub product_name:    String,
+}
+
+impl MeteoServiceHandle {
+    pub async fn update(&self, payload: &MeteoPayload) -> Result<()> {
+        let new_values = MeteoValues::from_payload(payload, self.device_instance, self.product_name.clone());
+        let items = new_values.to_items();
+        { *self.values.lock().unwrap() = new_values; }
+        self.emit_items_changed(&items).await?;
+        debug!(service = %self.service_name, irradiance = payload.irradiance, "D-Bus ItemsChanged météo émis");
+        Ok(())
+    }
+
+    pub async fn set_disconnected(&self) -> Result<()> {
+        let items = {
+            let mut g = self.values.lock().unwrap();
+            g.connected = 0;
+            g.to_items()
+        };
+        warn!(service = %self.service_name, "Capteur météo déconnecté — watchdog timeout");
+        self.emit_items_changed(&items).await
+    }
+
+    pub async fn republish(&self) -> Result<()> {
+        let items = { self.values.lock().unwrap().to_items() };
+        self.emit_items_changed(&items).await
+    }
+
+    async fn emit_items_changed(&self, items: &HashMap<String, DbusItem>) -> Result<()> {
+        let dict: ItemsDict = items.iter().map(|(p, i)| (p.clone(), item_to_inner(i))).collect();
+        let ctx = SignalContext::new(&self.connection, "/")?;
+        match MeteoRootIface::items_changed(&ctx, dict).await {
+            Ok(_)  => { debug!(service = %self.service_name, "ItemsChanged météo émis"); Ok(()) }
+            Err(e) => { warn!(service = %self.service_name, "ItemsChanged warning : {}", e); Ok(()) }
+        }
+    }
+}
+
+// =============================================================================
+// Création du service
+// =============================================================================
+
+/// Crée et enregistre le service D-Bus `com.victronenergy.meteo`.
+///
+/// Contrairement aux batteries et heatpumps, le service meteo est UNIQUE
+/// (pas d'index) — la connexion porte directement le nom de service fixe.
+pub async fn create_meteo_service(
+    dbus_bus:        &str,
+    device_instance: u32,
+    product_name:    String,
+) -> Result<MeteoServiceHandle> {
+    let service_name = VICTRON_METEO_SERVICE.to_string();
+
+    info!(
+        service = %service_name,
+        device_instance = device_instance,
+        "Enregistrement service D-Bus météo Venus OS"
+    );
+
+    let initial_values = Arc::new(Mutex::new(
+        MeteoValues::disconnected(device_instance, product_name.clone())
+    ));
+
+    let root = MeteoRootIface { values: initial_values.clone() };
+
+    let builder = match dbus_bus {
+        "session" => connection::Builder::session()?,
+        _         => connection::Builder::system()?,
+    };
+
+    let conn = builder
+        .name(service_name.as_str())?
+        .serve_at("/", root)?
+        .build()
+        .await?;
+
+    let leaf_paths: Vec<String> = {
+        initial_values.lock().unwrap().to_items().into_keys().collect()
+    };
+
+    for path in &leaf_paths {
+        conn.object_server()
+            .at(path.as_str(), BusItemLeaf { path: path.clone(), values: initial_values.clone() })
+            .await?;
+    }
+
+    info!(
+        service = %service_name,
+        paths   = leaf_paths.len(),
+        "Service D-Bus météo enregistré ({} chemins + racine /)",
+        leaf_paths.len()
+    );
+
+    Ok(MeteoServiceHandle {
+        service_name,
+        device_instance,
+        values: initial_values,
+        connection: conn,
+        product_name,
+    })
+}

--- a/crates/daly-bms-venus/src/mqtt_source.rs
+++ b/crates/daly-bms-venus/src/mqtt_source.rs
@@ -6,7 +6,7 @@
 //! - `{heat_prefix}/+/venus` → capteurs température → `SensorMqttEvent`
 
 use crate::config::MqttRef;
-use crate::types::{HeatPayload, VenusPayload};
+use crate::types::{HeatPayload, HeatpumpPayload, MeteoPayload, VenusPayload};
 use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -32,6 +32,22 @@ pub struct SensorMqttEvent {
     pub mqtt_index: u8,
     /// Payload température parsé
     pub payload: HeatPayload,
+}
+
+/// Événement pompe à chaleur reçu depuis MQTT (topic heatpump).
+#[derive(Debug)]
+pub struct HeatpumpMqttEvent {
+    /// Index (ex: `santuario/heatpump/1/venus` → `1`)
+    pub mqtt_index: u8,
+    /// Payload pompe à chaleur parsé
+    pub payload: HeatpumpPayload,
+}
+
+/// Événement capteur météo reçu depuis MQTT (topic fixe `santuario/meteo/venus`).
+#[derive(Debug)]
+pub struct MeteoMqttEvent {
+    /// Payload irradiance/météo parsé
+    pub payload: MeteoPayload,
 }
 
 // =============================================================================
@@ -229,6 +245,136 @@ async fn sensor_connect_and_run(
             Err(e) => {
                 return Err(e.into());
             }
+        }
+    }
+}
+
+// =============================================================================
+// Source MQTT pour pompes à chaleur (santuario/heatpump/{n}/venus)
+// =============================================================================
+
+/// Démarre la source MQTT pour les pompes à chaleur / chauffe-eau.
+///
+/// S'abonne sur `{heatpump_prefix}/+/venus`, parse le `HeatpumpPayload`
+/// et émet des `HeatpumpMqttEvent` vers le `HeatpumpManager`.
+pub async fn start_heatpump_mqtt_source(
+    cfg:              MqttRef,
+    heatpump_prefix:  String,
+    tx:               mpsc::Sender<HeatpumpMqttEvent>,
+) {
+    let subscribe_topic = format!("{}/+/venus", heatpump_prefix);
+
+    info!(
+        broker = %format!("{}:{}", cfg.host, cfg.port),
+        topic  = %subscribe_topic,
+        "Démarrage source MQTT pompes à chaleur"
+    );
+
+    loop {
+        match heatpump_connect_and_run(&cfg, &subscribe_topic, &heatpump_prefix, &tx).await {
+            Ok(())  => warn!("MQTT source heatpump terminée de façon inattendue, reconnexion dans 5s"),
+            Err(e)  => error!("MQTT source heatpump erreur : {:#}, reconnexion dans 5s", e),
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn heatpump_connect_and_run(
+    cfg:              &MqttRef,
+    subscribe_topic:  &str,
+    heatpump_prefix:  &str,
+    tx:               &mpsc::Sender<HeatpumpMqttEvent>,
+) -> anyhow::Result<()> {
+    let client_id = format!("daly-bms-venus-heatpump-{}", uuid_short());
+    let mut opts = MqttOptions::new(client_id, &cfg.host, cfg.port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_clean_session(true);
+    if let (Some(u), Some(p)) = (&cfg.username, &cfg.password) { opts.set_credentials(u, p); }
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 64);
+    client.subscribe(subscribe_topic, QoS::AtLeastOnce).await?;
+    info!("MQTT heatpump connecté, abonnement sur '{}'", subscribe_topic);
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Packet::Publish(msg))) => {
+                let topic = &msg.topic;
+                debug!(topic = %topic, "MQTT heatpump message reçu");
+                if let Some(idx) = extract_mqtt_index(topic, heatpump_prefix) {
+                    match serde_json::from_slice::<HeatpumpPayload>(&msg.payload) {
+                        Ok(payload) => {
+                            let evt = HeatpumpMqttEvent { mqtt_index: idx, payload };
+                            if tx.send(evt).await.is_err() { return Ok(()); }
+                        }
+                        Err(e) => warn!(topic = %topic, "Échec parsing payload heatpump: {}", e),
+                    }
+                }
+            }
+            Ok(Event::Incoming(Packet::ConnAck(_))) => info!("MQTT heatpump ConnAck reçu"),
+            Ok(_) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+// =============================================================================
+// Source MQTT pour capteur météo (santuario/meteo/venus — topic fixe)
+// =============================================================================
+
+/// Démarre la source MQTT pour le capteur météo/irradiance.
+///
+/// S'abonne sur le topic FIXE `{meteo_topic}` (ex: `santuario/meteo/venus`),
+/// parse le `MeteoPayload` et émet des `MeteoMqttEvent` vers le `MeteoManager`.
+pub async fn start_meteo_mqtt_source(
+    cfg:         MqttRef,
+    meteo_topic: String,
+    tx:          mpsc::Sender<MeteoMqttEvent>,
+) {
+    info!(
+        broker = %format!("{}:{}", cfg.host, cfg.port),
+        topic  = %meteo_topic,
+        "Démarrage source MQTT capteur météo"
+    );
+
+    loop {
+        match meteo_connect_and_run(&cfg, &meteo_topic, &tx).await {
+            Ok(())  => warn!("MQTT source météo terminée de façon inattendue, reconnexion dans 5s"),
+            Err(e)  => error!("MQTT source météo erreur : {:#}, reconnexion dans 5s", e),
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn meteo_connect_and_run(
+    cfg:         &MqttRef,
+    meteo_topic: &str,
+    tx:          &mpsc::Sender<MeteoMqttEvent>,
+) -> anyhow::Result<()> {
+    let client_id = format!("daly-bms-venus-meteo-{}", uuid_short());
+    let mut opts = MqttOptions::new(client_id, &cfg.host, cfg.port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_clean_session(true);
+    if let (Some(u), Some(p)) = (&cfg.username, &cfg.password) { opts.set_credentials(u, p); }
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 64);
+    client.subscribe(meteo_topic, QoS::AtLeastOnce).await?;
+    info!("MQTT météo connecté, abonnement sur '{}'", meteo_topic);
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Packet::Publish(msg))) => {
+                debug!(topic = %msg.topic, "MQTT météo message reçu");
+                match serde_json::from_slice::<MeteoPayload>(&msg.payload) {
+                    Ok(payload) => {
+                        let evt = MeteoMqttEvent { payload };
+                        if tx.send(evt).await.is_err() { return Ok(()); }
+                    }
+                    Err(e) => warn!(topic = %msg.topic, "Échec parsing payload météo: {}", e),
+                }
+            }
+            Ok(Event::Incoming(Packet::ConnAck(_))) => info!("MQTT météo ConnAck reçu"),
+            Ok(_) => {}
+            Err(e) => return Err(e.into()),
         }
     }
 }

--- a/crates/daly-bms-venus/src/types.rs
+++ b/crates/daly-bms-venus/src/types.rs
@@ -46,6 +46,88 @@ pub struct HeatPayload {
 }
 
 // =============================================================================
+// Payload pompe à chaleur / chauffe-eau (santuario/heatpump/{n}/venus)
+// =============================================================================
+
+/// Payload pour pompes à chaleur et chauffe-eau.
+///
+/// Publié par Node-RED sur `santuario/heatpump/{n}/venus`.
+/// Cible D-Bus : `com.victronenergy.heatpump.{n}`
+///
+/// Chemins D-Bus exposés (wiki Victron — Heatpump) :
+///   /State              enum état de la pompe (TBD Victron)
+///   /Temperature        température eau courante °C (optionnelle)
+///   /TargetTemperature  température eau cible °C (optionnelle)
+///   /Ac/Power           puissance consommée W
+///   /Ac/Energy/Forward  énergie totale consommée kWh
+///   /Position           0=AC Output, 1=AC Input
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeatpumpPayload {
+    /// État de la pompe à chaleur (enum Victron, TBD).
+    #[serde(rename = "State", default)]
+    pub state: i32,
+
+    /// Température eau courante °C (optionnelle).
+    #[serde(rename = "Temperature", default)]
+    pub temperature: Option<f64>,
+
+    /// Température eau cible °C (optionnelle).
+    #[serde(rename = "TargetTemperature", default)]
+    pub target_temperature: Option<f64>,
+
+    /// Données électriques AC.
+    #[serde(rename = "Ac", default)]
+    pub ac: Option<HeatpumpAcPayload>,
+
+    /// Position : 0=AC Output, 1=AC Input.
+    #[serde(rename = "Position", default)]
+    pub position: i32,
+}
+
+/// Sous-payload AC pour la pompe à chaleur.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HeatpumpAcPayload {
+    /// Puissance consommée en W.
+    #[serde(rename = "Power", default)]
+    pub power: f64,
+
+    /// Énergie totale consommée.
+    #[serde(rename = "Energy", default)]
+    pub energy: Option<HeatpumpEnergyPayload>,
+}
+
+/// Sous-payload énergie pour la pompe à chaleur.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HeatpumpEnergyPayload {
+    /// Énergie totale consommée en kWh.
+    #[serde(rename = "Forward", default)]
+    pub forward: f64,
+}
+
+// =============================================================================
+// Payload capteur météo / irradiance (santuario/meteo/venus)
+// =============================================================================
+
+/// Payload pour capteur d'irradiance et données météo.
+///
+/// Publié par Node-RED (capteur RS485 sur Pi5) sur `santuario/meteo/venus`.
+/// Cible D-Bus : `com.victronenergy.meteo`
+///
+/// Chemins D-Bus exposés (wiki Victron — Meteo) :
+///   /Irradiance    irradiance courante en W/m²
+///   /TodaysYield   production du jour en kWh (depuis le lever du soleil)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeteoPayload {
+    /// Irradiance courante en W/m².
+    #[serde(rename = "Irradiance", default)]
+    pub irradiance: f64,
+
+    /// Production du jour en kWh (depuis le lever du soleil).
+    #[serde(rename = "TodaysYield", default)]
+    pub todays_yield: f64,
+}
+
+// =============================================================================
 // Payload batteries (santuario/bms/{n}/venus)
 // =============================================================================
 


### PR DESCRIPTION
…eo D-Bus services

Extends the Venus OS bridge with two new service types, following the same MQTT → D-Bus pattern as the battery bridge.

## Heatpump (com.victronenergy.heatpump.{n})
- Topic: santuario/heatpump/{n}/venus
- Paths: /State /Temperature /TargetTemperature /Ac/Power /Ac/Energy/Forward /Position
- Used for: water heater (index 1), future LG heat pump (index 2)
- Config: [[heatpumps]] sections in Config.toml

## Meteo (com.victronenergy.meteo)
- Topic: santuario/meteo/venus (fixed, no index — single sensor)
- Paths: /Irradiance (W/m²) /TodaysYield (kWh)
- Used for: irradiance sensor connected via RS485 to Pi5
- Config: [meteo] section in Config.toml

## Changes
- types.rs: HeatpumpPayload, HeatpumpAcPayload, HeatpumpEnergyPayload, MeteoPayload
- heatpump_service.rs: D-Bus service com.victronenergy.heatpump
- heatpump_manager.rs: dynamic service creation + watchdog keepalive
- meteo_service.rs: D-Bus service com.victronenergy.meteo (unique, no index)
- meteo_manager.rs: single service management + watchdog keepalive
- mqtt_source.rs: HeatpumpMqttEvent, MeteoMqttEvent, start_heatpump/meteo_mqtt_source()
- config.rs: HeatpumpConfig, HeatpumpRef, MeteoConfig
- main.rs: all 4 bridges launched concurrently (battery/sensor/heatpump/meteo)
- Config.toml: [[heatpumps]] water heater example, [meteo] irradiance config

Temperature sensors [[sensors]] now only contains outdoor sensor (type=4). Water heater moved to [[heatpumps]] using com.victronenergy.heatpump.

https://claude.ai/code/session_01XsDVWy6q2pD8GUg3GZueYa