### PR TITLE
fix(mosquitto): ajouter bridge out pour capteurs Pi5 → NanoPi

### DIFF
--- a/docker/mosquitto/config/mosquitto.conf
+++ b/docker/mosquitto/config/mosquitto.conf
@@ -60,3 +60,9 @@ topic shellypro2pm-ec62608840a4/# both 0
 
 # BMS data — lecture depuis NanoPi (publié par santuario-venus-bridge Rust)
 topic santuario/# in 0
+
+# Capteurs → NanoPi — commandes Node-RED vers service Rust (Pi5 → NanoPi)
+# heat = température extérieure, heatpump = chauffe-eau, meteo = irradiance
+topic santuario/heat/# out 0
+topic santuario/heatpump/# out 0
+topic santuario/meteo/# out 0


### PR DESCRIPTION
Les topics santuario/heat/#, santuario/heatpump/#, santuario/meteo/# sont publiés par Node-RED sur Pi5 et consommés par le service Rust sur NanoPi. La règle existante `santuario/# in` ne couvrait que la direction NanoPi→Pi5. Les nouvelles règles `out` permettent le transfert dans l'autre sens.

https://claude.ai/code/session_01XsDVWy6q2pD8GUg3GZueYa