### PR TITLE
fix(temperature_service): toujours enregistrer /Humidity et /Pressure…

### DIFF
--- a/crates/daly-bms-venus/src/temperature_service.rs
+++ b/crates/daly-bms-venus/src/temperature_service.rs
@@ -182,14 +182,10 @@ impl SensorValues {
         m.insert("/TemperatureType".into(), DbusItem::i32(self.temperature_type));
         m.insert("/CustomName".into(),      DbusItem::str(&self.custom_name));
 
-        // Optionnels — toujours publiés (0.0 si absent) pour que Venus OS
-        // les connaisse dès GetItems() et puisse les afficher dynamiquement.
-        if let Some(h) = self.humidity {
-            m.insert("/Humidity".into(), DbusItem::f64(h, "%"));
-        }
-        if let Some(p) = self.pressure {
-            m.insert("/Pressure".into(), DbusItem::f64(p, "kPa"));
-        }
+        // Toujours enregistrés (0.0 si absent) pour que le chemin D-Bus existe
+        // dès la création du service et soit interrogeable immédiatement.
+        m.insert("/Humidity".into(), DbusItem::f64(self.humidity.unwrap_or(0.0), "%"));
+        m.insert("/Pressure".into(), DbusItem::f64(self.pressure.unwrap_or(0.0), "kPa"));
 
         m
     }


### PR DESCRIPTION
… sur D-Bus

Les chemins sont enregistrés une seule fois à la création du service depuis l'état disconnected() qui avait humidity/pressure = None. Les objets D-Bus n'étaient donc jamais créés et retournaient "Unknown object".

Correction : utiliser unwrap_or(0.0) pour toujours inclure ces chemins dans to_items(), garantissant leur enregistrement dès le démarrage du service.

https://claude.ai/code/session_01XsDVWy6q2pD8GUg3GZueYa