### PR TITLE
feat(heatpump): intégration chauffe-eau LG ThinQ via Venus OS D-Bus

### DIFF
--- a/crates/daly-bms-venus/src/heatpump_service.rs
+++ b/crates/daly-bms-venus/src/heatpump_service.rs
@@ -174,14 +174,11 @@ impl HeatpumpValues {
         m.insert("/Ac/Power".into(),          DbusItem::f64(self.ac_power, "W"));
         m.insert("/Ac/Energy/Forward".into(), DbusItem::f64(self.ac_energy_forward, "kWh"));
 
-        // Températures — toujours publiées (0.0 si absentes) pour que
-        // Venus OS les connaisse dès GetItems()
-        if let Some(t) = self.temperature {
-            m.insert("/Temperature".into(), DbusItem::f64(t, "°C"));
-        }
-        if let Some(tt) = self.target_temperature {
-            m.insert("/TargetTemperature".into(), DbusItem::f64(tt, "°C"));
-        }
+        // Températures — toujours présentes (0.0 si absentes) pour que
+        // Venus OS enregistre les chemins D-Bus dès le démarrage
+        // (GetItems et GetValue fonctionnent même avant le 1er message MQTT)
+        m.insert("/Temperature".into(),       DbusItem::f64(self.temperature.unwrap_or(0.0),        "°C"));
+        m.insert("/TargetTemperature".into(), DbusItem::f64(self.target_temperature.unwrap_or(0.0), "°C"));
 
         m
     }

--- a/docs/VENUS-DEVICE-INTEGRATION.md
+++ b/docs/VENUS-DEVICE-INTEGRATION.md
@@ -347,6 +347,170 @@ ps | grep readproctitle
 
 ---
 
+---
+
+## Exemple complet : Chauffe-eau Victron HeatPump (LG ThinQ)
+
+### 1. Type D-Bus Victron utilisé
+
+`com.victronenergy.heatpump` — wiki Victron :
+<https://github.com/victronenergy/venus/wiki/dbus#heatpump>
+
+Chemins exposés (tous obligatoirement enregistrés au démarrage) :
+- `/State` — état de la pompe (enum, voir table ci-dessous)
+- `/Temperature` — température eau courante °C (0.0 si inconnu)
+- `/TargetTemperature` — température cible °C (0.0 si inconnue)
+- `/Ac/Power` — puissance consommée W
+- `/Ac/Energy/Forward` — énergie totale kWh
+- `/Position` — 0=AC Output, 1=AC Input
+
+### 2. Table State (mapping LG ThinQ → Victron)
+
+| Valeur | Signification | Mode LG ThinQ | Opération |
+|---|---|---|---|
+| 0 | Off / Vacation | VACATION ou POWER_OFF | — |
+| 1 | Heat Pump (normal) | HEAT_PUMP | POWER_ON |
+| 2 | Turbo / Boost | TURBO | POWER_ON |
+
+### 3. Configuration Config.toml
+
+```toml
+[heatpump]
+topic_prefix = "santuario/heatpump"
+
+[[heatpumps]]
+mqtt_index      = 1       # Topic : santuario/heatpump/1/venus
+name            = "Chauffe-eau"
+device_instance = 30      # DeviceInstance unique sur D-Bus
+```
+
+### 4. Topic MQTT
+
+```
+santuario/heatpump/1/venus
+```
+
+Payload JSON (publié par Node-RED) :
+```json
+{
+  "State": 1,
+  "Temperature": 60.0,
+  "TargetTemperature": 52.0,
+  "Position": 0
+}
+```
+
+Payload étendu (si puissance disponible via compteur externe) :
+```json
+{
+  "State": 1,
+  "Temperature": 60.0,
+  "TargetTemperature": 52.0,
+  "Ac": { "Power": 1200.0, "Energy": { "Forward": 125.5 } },
+  "Position": 0
+}
+```
+
+### 5. Nom du service D-Bus résultant
+
+```
+com.victronenergy.heatpump.mqtt_1
+```
+
+### 6. Source de données : LG ThinQ API
+
+L'état est récupéré toutes les 10 minutes via l'API REST LG ThinQ :
+
+```
+GET https://api-eic.lgthinq.com/devices/{device_id}/state
+Authorization: Bearer {thinqpat_token}
+```
+
+Réponse utilisée :
+```json
+{
+  "response": {
+    "waterHeaterJobMode": { "currentJobMode": "HEAT_PUMP" },
+    "operation":          { "waterHeaterOperationMode": "POWER_ON" },
+    "temperature":        { "currentTemperature": 60, "targetTemperature": 52 }
+  }
+}
+```
+
+### 7. Commandes SET disponibles dans Node-RED
+
+```
+POST https://api-eic.lgthinq.com/devices/{device_id}/control
+```
+
+| Commande | Payload |
+|---|---|
+| Activer mode HEAT_PUMP | `{"waterHeaterJobMode": {"currentJobMode": "HEAT_PUMP"}}` |
+| Activer mode TURBO | `{"waterHeaterJobMode": {"currentJobMode": "TURBO"}}` |
+| Régler température 40°C | `{"temperature": {"targetTemperature": 40}}` |
+| Régler température 55°C | `{"temperature": {"targetTemperature": 55}}` |
+
+### 8. Flux Node-RED (setwaterheater.json)
+
+**Structure :**
+```
+Inject (poll 600s + oneshot 5s)
+Inject (test manuel)
+    └─► Préparer GET état → GET /state LG ThinQ → Parser état → HeatpumpPayload
+            ├─► mqtt out : santuario/heatpump/1/venus    ◄─ keepalive 25s
+            └─► debug complet
+
+Inject keepalive 25s → Republier depuis global context → mqtt out (même nœud)
+
+Inject SET TURBO      → POST /control → debug
+Inject SET HEAT_PUMP  → POST /control → debug
+Inject SET 40°C Nuit  → POST /control → debug
+Inject SET 55°C Jour  → POST /control → debug
+```
+
+Fonction de parsing (extrait) :
+```javascript
+const stateMapping = { 'HEAT_PUMP': 1, 'TURBO': 2, 'VACATION': 0 };
+const isPoweredOn = operation === 'POWER_ON';
+const state = isPoweredOn ? (stateMapping[mode] ?? 1) : 0;
+
+const payload = {
+    State:             state,
+    Temperature:       currentTemp,
+    TargetTemperature: targetTemp,
+    Position:          0
+};
+global.set('heatpump_payload', payload);  // pour keepalive
+```
+
+### 9. Commandes de vérification D-Bus
+
+```bash
+# Lister tous les chemins du service
+dbus -y com.victronenergy.heatpump.mqtt_1 / GetItems
+
+# Valeurs individuelles
+dbus -y com.victronenergy.heatpump.mqtt_1 /State              GetValue
+dbus -y com.victronenergy.heatpump.mqtt_1 /Temperature        GetValue
+dbus -y com.victronenergy.heatpump.mqtt_1 /TargetTemperature  GetValue
+dbus -y com.victronenergy.heatpump.mqtt_1 /Ac/Power           GetValue
+dbus -y com.victronenergy.heatpump.mqtt_1 /Position           GetValue
+dbus -y com.victronenergy.heatpump.mqtt_1 /Connected          GetValue
+```
+
+### 10. Test MQTT direct (sans Node-RED)
+
+```bash
+# Depuis Pi5 ou NanoPi
+mosquitto_pub -h localhost -t "santuario/heatpump/1/venus" \
+  -m '{"State":1,"Temperature":60.0,"TargetTemperature":52.0,"Position":0}'
+
+# Vérifier la réception sur NanoPi
+mosquitto_sub -h localhost -t "santuario/heatpump/1/venus" -v
+```
+
+---
+
 ## Devices implémentés
 
 | Device | Service D-Bus | Topic MQTT | Index config |

--- a/flux-nodered/setwaterheater.json
+++ b/flux-nodered/setwaterheater.json
@@ -38,128 +38,34 @@
         "userProps": "",
         "sessionExpiry": ""
     },
+
     {
-        "id": "23efecea2e615363",
+        "id": "swh_comment_arch",
         "type": "comment",
         "z": "eca20a68bef0de32",
-        "name": "MQTT topics",
-        "info": "subscriptions:\n0: \"app/clients/Santuario-123456/push\"\n1: \"app/clients/Santuario-123456/inbox\"\npublications: array[1]\n0: \"app/clients/Santuario-123456/outbox\"\nurl: \"https://api-eic.lgthinq.com/client/certificate\"\n",
-        "x": 110,
+        "name": "Architecture : LG ThinQ API → Node-RED → MQTT → Rust → D-Bus Venus OS",
+        "info": "API LG ThinQ (HTTPS) → parse état → publish santuario/heatpump/1/venus\nBridge Mosquitto Pi5 → NanoPi (out) → service daly-bms-venus\nD-Bus : com.victronenergy.heatpump.mqtt_1\n\nPayload publié :\n{\n  \"State\": 1,               // 0=Off 1=HeatPump 2=Turbo\n  \"Temperature\": 60.0,      // température eau courante °C\n  \"TargetTemperature\": 52.0, // température cible °C\n  \"Position\": 0             // 0=AC Output\n}\n\nKeepalive : 25s (< watchdog Rust 30s)\nFetch API  : toutes les 10 min (600s)",
+        "x": 300,
         "y": 20,
         "wires": []
     },
+
     {
-        "id": "6777ad8d7d167c43",
+        "id": "swh_comment_state",
         "type": "comment",
         "z": "eca20a68bef0de32",
-        "name": "https://smartsolution.developer.lge.com/en/apiManage/thinq_connect#tag/Client-API/paths/~1client/delete",
-        "info": "https://smartsolution.developer.lge.com/en/apiManage/thinq_connect#tag/Client-API/paths/~1client/delete",
-        "x": 400,
+        "name": "State mapping : HEAT_PUMP=1  TURBO=2  VACATION=0  POWER_OFF=0",
+        "info": "Réponse API LG ThinQ (GET /state) :\n{\n  \"waterHeaterJobMode\": { \"currentJobMode\": \"HEAT_PUMP\" },\n  \"operation\":          { \"waterHeaterOperationMode\": \"POWER_ON\" },\n  \"temperature\":        { \"currentTemperature\": 60, \"targetTemperature\": 52, \"unit\": \"C\" }\n}",
+        "x": 300,
         "y": 60,
         "wires": []
     },
+
     {
-        "id": "f070bfd5caf24aba",
+        "id": "swh_inject_poll",
         "type": "inject",
         "z": "eca20a68bef0de32",
-        "name": "SET TURBO",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "x": 110,
-        "y": 120,
-        "wires": [
-            [
-                "61856555a9ed35b1"
-            ]
-        ]
-    },
-    {
-        "id": "61856555a9ed35b1",
-        "type": "function",
-        "z": "eca20a68bef0de32",
-        "name": "Prepare",
-        "func": "msg.headers = {\n    'Authorization': 'Bearer thinqpat_975d93159fdcf31033e33a3b9c49009ae1ffbf345dfa6dcb4e2f',\n    'x-message-id': 'fNvdZ1brTn-wWKUIWGoSVw',\n    'x-country': 'FR',\n    'x-client-id': 'Santuario-123456',\n    'x-api-key': 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3',\n    'Content-Type': 'application/json'\n};\n\nmsg.payload = {\n    \"waterHeaterJobMode\": {\n        \"currentJobMode\": \"TURBO\"\n    }\n};\n\nmsg.url = 'https://api-eic.lgthinq.com/devices/918c240ab4c6e3eee70a4e9ac015c18ddd8b4f933c3d9ff813446d8f8dddf720/control';\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": "",
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 310,
-        "y": 120,
-        "wires": [
-            [
-                "d986b3e45fbb5cc1"
-            ]
-        ]
-    },
-    {
-        "id": "d986b3e45fbb5cc1",
-        "type": "http request",
-        "z": "eca20a68bef0de32",
-        "name": "",
-        "method": "POST",
-        "ret": "obj",
-        "paytoqs": "ignore",
-        "url": "",
-        "tls": "",
-        "persist": false,
-        "proxy": "",
-        "insecureHTTPParser": false,
-        "authType": "",
-        "senderr": false,
-        "headers": [],
-        "x": 490,
-        "y": 120,
-        "wires": [
-            [
-                "e0ec9fd1d0a93579"
-            ]
-        ]
-    },
-    {
-        "id": "e0ec9fd1d0a93579",
-        "type": "debug",
-        "z": "eca20a68bef0de32",
-        "name": "",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "complete": "true",
-        "targetType": "full",
-        "x": 650,
-        "y": 120,
-        "wires": []
-    },
-    {
-        "id": "af7e78bfde9d59a5",
-        "type": "comment",
-        "z": "eca20a68bef0de32",
-        "name": "control temperature",
-        "info": "{\n    \"temperature\": {\n        \"targetTemperature\": 52\n    }\n}",
-        "x": 110,
-        "y": 180,
-        "wires": []
-    },
-    {
-        "id": "87dbc4cab978c04c",
-        "type": "comment",
-        "z": "eca20a68bef0de32",
-        "name": "state response",
-        "info": "{\n  \"messageId\": \"fNvdZ1brTn-wWKUlWGoSVw\",\n  \"timestamp\": \"2026-01-08T15:43:25.414259\",\n  \"response\": {\n    \"waterHeaterJobMode\": {\n      \"currentJobMode\": \"HEAT_PUMP\"\n    },\n    \"operation\": {\n      \"waterHeaterOperationMode\": \"POWER_ON\"\n    },\n    \"temperature\": {\n      \"currentTemperature\": 60,\n      \"targetTemperature\": 52,\n      \"unit\": \"C\"\n    },\n    \"temperatureInUnits\": [\n      {\n        \"currentTemperature\": 60,\n        \"targetTemperature\": 52,\n        \"unit\": \"C\"\n      },\n      {\n        \"currentTemperature\": 140,\n        \"targetTemperature\": 126,\n        \"unit\": \"F\"\n      }\n    ]\n  }\n}",
-        "x": 620,
-        "y": 180,
-        "wires": []
-    },
-    {
-        "id": "8e0e3c8068a3f54a",
-        "type": "inject",
-        "z": "eca20a68bef0de32",
-        "name": "get state (every 15 min)",
+        "name": "GET état (toutes les 10 min)",
         "props": [],
         "repeat": "600",
         "crontab": "",
@@ -167,15 +73,11 @@
         "onceDelay": "5",
         "topic": "",
         "x": 150,
-        "y": 240,
-        "wires": [
-            [
-                "7bb2a5727f5c2df1"
-            ]
-        ]
+        "y": 140,
+        "wires": [["swh_fn_prepare_get"]]
     },
     {
-        "id": "ecdba2928ba2d78b",
+        "id": "swh_inject_manual",
         "type": "inject",
         "z": "eca20a68bef0de32",
         "name": "Test manuel",
@@ -185,39 +87,31 @@
         "once": false,
         "onceDelay": "",
         "topic": "",
-        "x": 110,
-        "y": 340,
-        "wires": [
-            [
-                "7bb2a5727f5c2df1"
-            ]
-        ]
+        "x": 150,
+        "y": 200,
+        "wires": [["swh_fn_prepare_get"]]
     },
     {
-        "id": "7bb2a5727f5c2df1",
+        "id": "swh_fn_prepare_get",
         "type": "function",
         "z": "eca20a68bef0de32",
-        "name": "Prepare GET state",
-        "func": "msg.headers = {\n    'Authorization': 'Bearer thinqpat_975d93159fdcf31033e33a3b9c49009ae1ffbf345dfa6dcb4e2f',\n    'x-message-id': 'fNvdZ1brTn-wWKUIWGoSVw',\n    'x-country': 'FR',\n    'x-client-id': 'Santuario-123456',\n    'x-api-key': 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3',\n    'Content-Type': 'application/json'\n};\n\nmsg.url = 'https://api-eic.lgthinq.com/devices/918c240ab4c6e3eee70a4e9ac015c18ddd8b4f933c3d9ff813446d8f8dddf720/state';\n\nreturn msg;",
+        "name": "Préparer GET état",
+        "func": "msg.headers = {\n    'Authorization': 'Bearer thinqpat_975d93159fdcf31033e33a3b9c49009ae1ffbf345dfa6dcb4e2f',\n    'x-message-id': 'fNvdZ1brTn-wWKUIWGoSVw',\n    'x-country': 'FR',\n    'x-client-id': 'Santuario-123456',\n    'x-api-key': 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3',\n    'Content-Type': 'application/json'\n};\nmsg.url = 'https://api-eic.lgthinq.com/devices/918c240ab4c6e3eee70a4e9ac015c18ddd8b4f933c3d9ff813446d8f8dddf720/state';\nreturn msg;",
         "outputs": 1,
         "timeout": "",
         "noerr": 0,
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 350,
-        "y": 280,
-        "wires": [
-            [
-                "82a6dc3fa7e3e96d"
-            ]
-        ]
+        "x": 370,
+        "y": 170,
+        "wires": [["swh_http_get"]]
     },
     {
-        "id": "82a6dc3fa7e3e96d",
+        "id": "swh_http_get",
         "type": "http request",
         "z": "eca20a68bef0de32",
-        "name": "GET state",
+        "name": "GET /state LG ThinQ",
         "method": "GET",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -229,68 +123,35 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 540,
-        "y": 260,
-        "wires": [
-            [
-                "900587cea345a000"
-            ]
-        ]
+        "x": 570,
+        "y": 170,
+        "wires": [["swh_fn_parse"]]
     },
     {
-        "id": "900587cea345a000",
+        "id": "swh_fn_parse",
         "type": "function",
         "z": "eca20a68bef0de32",
-        "name": "Parse waterHeater state",
-        "func": "// Vérifier si la requête a réussi\nif (msg.statusCode !== 200) {\n    node.error(\"Erreur API: \" + msg.statusCode);\n    return null;\n}\n\nconst response = msg.payload.response;\n\n// Extraire les données\nconst mode = response.waterHeaterJobMode.currentJobMode;\nconst currentTemp = response.temperature.currentTemperature;\nconst targetTemp = response.temperature.targetTemperature;\n\n// Output 1: Température actuelle\nconst output1 = { payload: currentTemp };\n\n// Output 2: Nom personnalisé avec mode et target\nconst modeName = mode.replace('_', ' ');\nconst output2 = { payload: `${modeName} | Target: ${targetTemp}°C` };\n\n// Output 3: Status coloré selon le mode\nconst modeMapping = {\n    \"VACATION\": 0,\n    \"HEAT_PUMP\": 0,\n    \"TURBO\": 1\n};\nconst output3 = { payload: modeMapping[mode] || 0 };\n\n// Output 4: Debug complet\nconst output4 = {\n    payload: {\n        mode: mode,\n        currentTemperature: currentTemp,\n        targetTemperature: targetTemp,\n        operation: response.operation.waterHeaterOperationMode\n    }\n};\n\nnode.status({\n    fill: mode === \"TURBO\" ? \"red\" : mode === \"HEAT_PUMP\" ? \"green\" : \"yellow\",\n    shape: \"dot\",\n    text: `${mode} | ${currentTemp}°C → ${targetTemp}°C`\n});\n\nreturn [output1, output2, output3, output4];",
-        "outputs": 4,
+        "name": "Parser état → HeatpumpPayload",
+        "func": "if (msg.statusCode !== 200) {\n    node.error('Erreur API LG ThinQ: ' + msg.statusCode + ' ' + JSON.stringify(msg.payload));\n    return null;\n}\n\nconst r = msg.payload.response;\nif (!r || !r.waterHeaterJobMode || !r.temperature) {\n    node.error('Réponse API inattendue: ' + JSON.stringify(msg.payload));\n    return null;\n}\n\nconst mode        = r.waterHeaterJobMode.currentJobMode;    // 'HEAT_PUMP' | 'TURBO' | 'VACATION'\nconst operation   = r.operation ? r.operation.waterHeaterOperationMode : 'POWER_ON';\nconst currentTemp = r.temperature.currentTemperature;\nconst targetTemp  = r.temperature.targetTemperature;\n\n// State mapping → /State D-Bus Venus OS (com.victronenergy.heatpump)\n// 0 = Off / Vacation\n// 1 = Heat Pump (pompe à chaleur mode normal)\n// 2 = Turbo / Boost\nconst stateMapping = {\n    'HEAT_PUMP': 1,\n    'TURBO':     2,\n    'VACATION':  0\n};\nconst isPoweredOn = operation === 'POWER_ON';\nconst state = isPoweredOn ? (stateMapping[mode] ?? 1) : 0;\n\n// Payload Venus OS D-Bus heatpump\nconst payload = {\n    State:             state,\n    Temperature:       currentTemp,\n    TargetTemperature: targetTemp,\n    Position:          0          // 0 = AC Output\n};\n\n// Stocker dans le contexte global pour le keepalive\nglobal.set('heatpump_payload', payload);\n\n// Afficher le statut du nœud\nconst modeLabel = isPoweredOn ? mode : 'OFF';\nnode.status({\n    fill:  mode === 'TURBO' ? 'red' : mode === 'HEAT_PUMP' ? 'green' : 'yellow',\n    shape: 'dot',\n    text:  `${modeLabel} | ${currentTemp}°C → ${targetTemp}°C`\n});\n\n// Output 1 : payload MQTT pour Venus OS\n// Output 2 : debug complet\nconst out1 = { topic: 'santuario/heatpump/1/venus', payload: JSON.stringify(payload) };\nconst out2 = { payload: { mode, operation, state, currentTemp, targetTemp, rawResponse: r } };\n\nreturn [out1, out2];",
+        "outputs": 2,
         "timeout": 0,
         "noerr": 0,
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 370,
-        "y": 360,
+        "x": 800,
+        "y": 170,
         "wires": [
-            [
-                "wrap_temp_out"
-            ],
-            [
-                "wrap_name_out"
-            ],
-            [
-                "wrap_status_out"
-            ],
-            [
-                "39edfb8355493944"
-            ]
+            ["swh_mqtt_out"],
+            ["swh_debug_full"]
         ]
     },
     {
-        "id": "wrap_temp_out",
-        "type": "function",
-        "z": "eca20a68bef0de32",
-        "name": "Température actuelle",
-        "func": "const v = msg.payload;\nnode.status({fill:'green', shape:'dot', text: `${v}°C`});\nmsg.payload = {value: v};\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 620,
-        "y": 300,
-        "wires": [
-            [
-                "f40892d3456258a4"
-            ]
-        ]
-    },
-    {
-        "id": "f40892d3456258a4",
+        "id": "swh_mqtt_out",
         "type": "mqtt out",
         "z": "eca20a68bef0de32",
-        "name": "W temperature/101/TemperatureType",
-        "topic": "W/c0619ab9929a/temperature/101/TemperatureType",
+        "name": "santuario/heatpump/1/venus",
+        "topic": "santuario/heatpump/1/venus",
         "qos": "0",
         "retain": "false",
         "respTopic": "",
@@ -299,245 +160,206 @@
         "correl": "",
         "expiry": "",
         "broker": "pi5_mqtt_broker_swh",
-        "x": 870,
-        "y": 300,
+        "x": 1060,
+        "y": 140,
         "wires": []
     },
     {
-        "id": "wrap_name_out",
-        "type": "function",
-        "z": "eca20a68bef0de32",
-        "name": "Mode + Target",
-        "func": "const v = msg.payload;\nnode.status({fill:'green', shape:'dot', text: v});\nmsg.payload = {value: v};\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 610,
-        "y": 360,
-        "wires": [
-            [
-                "1bc326182065ca33"
-            ]
-        ]
-    },
-    {
-        "id": "1bc326182065ca33",
-        "type": "mqtt out",
-        "z": "eca20a68bef0de32",
-        "name": "W temperature/101/CustomName",
-        "topic": "W/c0619ab9929a/temperature/101/CustomName",
-        "qos": "0",
-        "retain": "false",
-        "respTopic": "",
-        "contentType": "",
-        "userProps": "",
-        "correl": "",
-        "expiry": "",
-        "broker": "pi5_mqtt_broker_swh",
-        "x": 840,
-        "y": 360,
-        "wires": []
-    },
-    {
-        "id": "wrap_status_out",
-        "type": "function",
-        "z": "eca20a68bef0de32",
-        "name": "Statut coloré",
-        "func": "const v = msg.payload;\nnode.status({fill: v === 1 ? 'red' : 'green', shape:'dot', text: v === 1 ? 'TURBO' : 'NORMAL'});\nmsg.payload = {value: v};\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 600,
-        "y": 420,
-        "wires": [
-            [
-                "6c932d2ba6b65f6a"
-            ]
-        ]
-    },
-    {
-        "id": "6c932d2ba6b65f6a",
-        "type": "mqtt out",
-        "z": "eca20a68bef0de32",
-        "name": "W temperature/101/Status",
-        "topic": "W/c0619ab9929a/temperature/101/Status",
-        "qos": "0",
-        "retain": "false",
-        "respTopic": "",
-        "contentType": "",
-        "userProps": "",
-        "correl": "",
-        "expiry": "",
-        "broker": "pi5_mqtt_broker_swh",
-        "x": 810,
-        "y": 420,
-        "wires": []
-    },
-    {
-        "id": "39edfb8355493944",
-        "type": "function",
-        "z": "eca20a68bef0de32",
-        "name": "Extract dashboard",
-        "func": "const data = msg.payload;\n\nconst msgMode = { payload: data.mode };\nconst msgCurrent = { payload: data.currentTemperature };\nconst msgTarget = { payload: data.targetTemperature };\n\nreturn [msgMode, msgCurrent, msgTarget];",
-        "outputs": 3,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 150,
-        "y": 480,
-        "wires": [
-            [],
-            [],
-            []
-        ]
-    },
-    {
-        "id": "15ebde54ddc29a1e",
-        "type": "comment",
-        "z": "eca20a68bef0de32",
-        "name": "Enregistrer le client",
-        "info": "",
-        "x": 110,
-        "y": 580,
-        "wires": []
-    },
-    {
-        "id": "356507781f925f50",
-        "type": "comment",
-        "z": "eca20a68bef0de32",
-        "name": "set temperature",
-        "info": "",
-        "x": 360,
-        "y": 680,
-        "wires": []
-    },
-    {
-        "id": "af9a45220f23a72f",
-        "type": "inject",
-        "z": "eca20a68bef0de32",
-        "name": "SET targetTemperature",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "x": 140,
-        "y": 640,
-        "wires": [
-            [
-                "d1049248c0b17e15"
-            ]
-        ]
-    },
-    {
-        "id": "d1049248c0b17e15",
-        "type": "function",
-        "z": "eca20a68bef0de32",
-        "name": "Set 40 °C Nuit",
-        "func": "msg.headers = {\n    'Authorization': 'Bearer thinqpat_975d93159fdcf31033e33a3b9c49009ae1ffbf345dfa6dcb4e2f',\n    'x-message-id': 'fNvdZ1brTn-wWKUIWGoSVw',\n    'x-country': 'FR',\n    'x-client-id': 'Santuario-123456',\n    'x-api-key': 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3',\n    'Content-Type': 'application/json'\n};\n\nmsg.payload = {\n    \"body\": {\n        \"type\": \"MQTT\",\n        \"service-code\": \"SVC202\",\n        \"device-type\": \"607\"\n    }\n\n};\n\nmsg.url = 'https://api-eic.lgthinq.com/client';\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": "",
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 360,
-        "y": 640,
-        "wires": [
-            [
-                "29843fa3927ca9a0"
-            ]
-        ]
-    },
-    {
-        "id": "29843fa3927ca9a0",
-        "type": "http request",
-        "z": "eca20a68bef0de32",
-        "name": "",
-        "method": "POST",
-        "ret": "obj",
-        "paytoqs": "ignore",
-        "url": "",
-        "tls": "",
-        "persist": false,
-        "proxy": "",
-        "insecureHTTPParser": false,
-        "authType": "",
-        "senderr": false,
-        "headers": [],
-        "x": 550,
-        "y": 640,
-        "wires": [
-            [
-                "cf3e64065ccd05c4"
-            ]
-        ]
-    },
-    {
-        "id": "cf3e64065ccd05c4",
+        "id": "swh_debug_full",
         "type": "debug",
         "z": "eca20a68bef0de32",
-        "name": "",
-        "active": false,
+        "name": "Debug état complet",
+        "active": true,
         "tosidebar": true,
         "console": false,
-        "complete": "true",
-        "targetType": "full",
-        "x": 710,
-        "y": 640,
+        "complete": "payload",
+        "targetType": "msg",
+        "x": 1060,
+        "y": 200,
+        "wires": []
+    },
+
+    {
+        "id": "swh_comment_keepalive",
+        "type": "comment",
+        "z": "eca20a68bef0de32",
+        "name": "Keepalive 25s (obligatoire : watchdog Rust = 30s — sinon /Connected = 0)",
+        "info": "Le service daly-bms-venus surveille l'activité MQTT.\nSi aucun message n'arrive pendant 30s (watchdog_sec), /Connected passe à 0\net le device disparaît du VRM. Ce keepalive republie le dernier état connu\ndepuis le contexte global toutes les 25s.",
+        "x": 270,
+        "y": 300,
         "wires": []
     },
     {
-        "id": "c067917d9663e579",
+        "id": "swh_inject_keepalive",
         "type": "inject",
         "z": "eca20a68bef0de32",
-        "name": "SET targetTemperature",
+        "name": "Keepalive 25s",
         "props": [],
-        "repeat": "",
+        "repeat": "25",
         "crontab": "",
         "once": false,
         "onceDelay": "",
         "topic": "",
-        "x": 140,
-        "y": 720,
-        "wires": [
-            [
-                "0eab5845f49d1210"
-            ]
-        ]
+        "x": 150,
+        "y": 360,
+        "wires": [["swh_fn_keepalive"]]
     },
     {
-        "id": "0eab5845f49d1210",
+        "id": "swh_fn_keepalive",
         "type": "function",
         "z": "eca20a68bef0de32",
-        "name": "Set 55°C Jour",
-        "func": "msg.headers = {\n    'Authorization': 'Bearer thinqpat_975d93159fdcf31033e33a3b9c49009ae1ffbf345dfa6dcb4e2f',\n    'x-message-id': 'fNvdZ1brTn-wWKUIWGoSVw',\n    'x-country': 'FR',\n    'x-client-id': 'Santuario-123456',\n    'x-api-key': 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3',\n    'Content-Type': 'application/json'\n};\n\nmsg.payload = {\n    \"temperature\": {\n        \"targetTemperature\": 55\n    }\n};\n\nmsg.url = 'https://api-eic.lgthinq.com/devices/918c240ab4c6e3eee70a4e9ac015c18ddd8b4f933c3d9ff813446d8f8dddf720/control';\n\nreturn msg;",
+        "name": "Republier depuis contexte",
+        "func": "const payload = global.get('heatpump_payload');\nif (!payload) {\n    node.status({ fill: 'grey', shape: 'ring', text: 'en attente du 1er fetch' });\n    return null;\n}\nnode.status({\n    fill:  'blue',\n    shape: 'ring',\n    text:  `keepalive | ${payload.Temperature}°C → ${payload.TargetTemperature}°C`\n});\nreturn {\n    topic:   'santuario/heatpump/1/venus',\n    payload: JSON.stringify(payload)\n};",
         "outputs": 1,
         "timeout": "",
         "noerr": 0,
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 360,
-        "y": 720,
-        "wires": [
-            [
-                "94525c748f0975a2"
-            ]
-        ]
+        "x": 380,
+        "y": 360,
+        "wires": [["swh_mqtt_out"]]
+    },
+
+    {
+        "id": "swh_comment_set",
+        "type": "comment",
+        "z": "eca20a68bef0de32",
+        "name": "Commandes SET (manuelles / futures automatisations)",
+        "info": "POST https://api-eic.lgthinq.com/devices/{id}/control\nExemples de payload :\n  Mode TURBO   : { \"waterHeaterJobMode\": { \"currentJobMode\": \"TURBO\" } }\n  Mode HEAT_PUMP : { \"waterHeaterJobMode\": { \"currentJobMode\": \"HEAT_PUMP\" } }\n  Temp 40°C    : { \"temperature\": { \"targetTemperature\": 40 } }\n  Temp 55°C    : { \"temperature\": { \"targetTemperature\": 55 } }",
+        "x": 200,
+        "y": 460,
+        "wires": []
     },
     {
-        "id": "94525c748f0975a2",
+        "id": "swh_inject_set_turbo",
+        "type": "inject",
+        "z": "eca20a68bef0de32",
+        "name": "SET TURBO",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "x": 130,
+        "y": 520,
+        "wires": [["swh_fn_set_turbo"]]
+    },
+    {
+        "id": "swh_fn_set_turbo",
+        "type": "function",
+        "z": "eca20a68bef0de32",
+        "name": "Préparer SET TURBO",
+        "func": "msg.headers = {\n    'Authorization': 'Bearer thinqpat_975d93159fdcf31033e33a3b9c49009ae1ffbf345dfa6dcb4e2f',\n    'x-message-id': 'fNvdZ1brTn-wWKUIWGoSVw',\n    'x-country': 'FR',\n    'x-client-id': 'Santuario-123456',\n    'x-api-key': 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3',\n    'Content-Type': 'application/json'\n};\nmsg.payload = { \"waterHeaterJobMode\": { \"currentJobMode\": \"TURBO\" } };\nmsg.url = 'https://api-eic.lgthinq.com/devices/918c240ab4c6e3eee70a4e9ac015c18ddd8b4f933c3d9ff813446d8f8dddf720/control';\nreturn msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 340,
+        "y": 520,
+        "wires": [["swh_http_set"]]
+    },
+    {
+        "id": "swh_inject_set_heatpump",
+        "type": "inject",
+        "z": "eca20a68bef0de32",
+        "name": "SET HEAT_PUMP",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "x": 130,
+        "y": 580,
+        "wires": [["swh_fn_set_heatpump"]]
+    },
+    {
+        "id": "swh_fn_set_heatpump",
+        "type": "function",
+        "z": "eca20a68bef0de32",
+        "name": "Préparer SET HEAT_PUMP",
+        "func": "msg.headers = {\n    'Authorization': 'Bearer thinqpat_975d93159fdcf31033e33a3b9c49009ae1ffbf345dfa6dcb4e2f',\n    'x-message-id': 'fNvdZ1brTn-wWKUIWGoSVw',\n    'x-country': 'FR',\n    'x-client-id': 'Santuario-123456',\n    'x-api-key': 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3',\n    'Content-Type': 'application/json'\n};\nmsg.payload = { \"waterHeaterJobMode\": { \"currentJobMode\": \"HEAT_PUMP\" } };\nmsg.url = 'https://api-eic.lgthinq.com/devices/918c240ab4c6e3eee70a4e9ac015c18ddd8b4f933c3d9ff813446d8f8dddf720/control';\nreturn msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 350,
+        "y": 580,
+        "wires": [["swh_http_set"]]
+    },
+    {
+        "id": "swh_inject_set_temp40",
+        "type": "inject",
+        "z": "eca20a68bef0de32",
+        "name": "SET 40°C (Nuit)",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "x": 130,
+        "y": 640,
+        "wires": [["swh_fn_set_temp40"]]
+    },
+    {
+        "id": "swh_fn_set_temp40",
+        "type": "function",
+        "z": "eca20a68bef0de32",
+        "name": "Préparer SET 40°C",
+        "func": "msg.headers = {\n    'Authorization': 'Bearer thinqpat_975d93159fdcf31033e33a3b9c49009ae1ffbf345dfa6dcb4e2f',\n    'x-message-id': 'fNvdZ1brTn-wWKUIWGoSVw',\n    'x-country': 'FR',\n    'x-client-id': 'Santuario-123456',\n    'x-api-key': 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3',\n    'Content-Type': 'application/json'\n};\nmsg.payload = { \"temperature\": { \"targetTemperature\": 40 } };\nmsg.url = 'https://api-eic.lgthinq.com/devices/918c240ab4c6e3eee70a4e9ac015c18ddd8b4f933c3d9ff813446d8f8dddf720/control';\nreturn msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 340,
+        "y": 640,
+        "wires": [["swh_http_set"]]
+    },
+    {
+        "id": "swh_inject_set_temp55",
+        "type": "inject",
+        "z": "eca20a68bef0de32",
+        "name": "SET 55°C (Jour)",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "x": 130,
+        "y": 700,
+        "wires": [["swh_fn_set_temp55"]]
+    },
+    {
+        "id": "swh_fn_set_temp55",
+        "type": "function",
+        "z": "eca20a68bef0de32",
+        "name": "Préparer SET 55°C",
+        "func": "msg.headers = {\n    'Authorization': 'Bearer thinqpat_975d93159fdcf31033e33a3b9c49009ae1ffbf345dfa6dcb4e2f',\n    'x-message-id': 'fNvdZ1brTn-wWKUIWGoSVw',\n    'x-country': 'FR',\n    'x-client-id': 'Santuario-123456',\n    'x-api-key': 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3',\n    'Content-Type': 'application/json'\n};\nmsg.payload = { \"temperature\": { \"targetTemperature\": 55 } };\nmsg.url = 'https://api-eic.lgthinq.com/devices/918c240ab4c6e3eee70a4e9ac015c18ddd8b4f933c3d9ff813446d8f8dddf720/control';\nreturn msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 340,
+        "y": 700,
+        "wires": [["swh_http_set"]]
+    },
+    {
+        "id": "swh_http_set",
         "type": "http request",
         "z": "eca20a68bef0de32",
-        "name": "",
+        "name": "POST /control LG ThinQ",
         "method": "POST",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -549,26 +371,22 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 530,
-        "y": 720,
-        "wires": [
-            [
-                "1dabe69425a7843e"
-            ]
-        ]
+        "x": 570,
+        "y": 610,
+        "wires": [["swh_debug_set"]]
     },
     {
-        "id": "1dabe69425a7843e",
+        "id": "swh_debug_set",
         "type": "debug",
         "z": "eca20a68bef0de32",
-        "name": "",
+        "name": "Debug réponse SET",
         "active": true,
         "tosidebar": true,
         "console": false,
         "complete": "true",
         "targetType": "full",
-        "x": 690,
-        "y": 720,
+        "x": 770,
+        "y": 610,
         "wires": []
     }
 ]


### PR DESCRIPTION
flux Node-RED setwaterheater.json :
- Remplace les anciens topics W/c0619ab9929a/temperature/101/... par un unique publish sur santuario/heatpump/1/venus (bridge → NanoPi)
- Payload HeatpumpPayload : {State, Temperature, TargetTemperature, Position}
- State mapping LG ThinQ : HEAT_PUMP=1, TURBO=2, VACATION/OFF=0
- Keepalive 25s depuis contexte global (< watchdog Rust 30s)
- Commandes SET conservées : HEAT_PUMP, TURBO, 40°C Nuit, 55°C Jour
- Détection POWER_OFF : forçage State=0 si waterHeaterOperationMode ≠ POWER_ON

fix(heatpump_service): /Temperature et /TargetTemperature toujours enregistrés
- unwrap_or(0.0) au lieu de if-let pour garantir l'enregistrement D-Bus au démarrage (GetValue sur chemin individuel ne retourne plus "Unknown object")

docs: section chauffe-eau LG ThinQ dans VENUS-DEVICE-INTEGRATION.md
- Table State mapping LG → Victron
- Payload complet + payload étendu (avec Ac/Power)
- API ThinQ GET /state et POST /control
- Flux Node-RED commenté
- Commandes dbus de vérification
- Commandes mosquitto_pub de test direct

https://claude.ai/code/session_01XsDVWy6q2pD8GUg3GZueYa