### PR TITLE
fix(deploy): SSH ControlMaster + arrêt service avant copie binaire

### DIFF
--- a/nanoPi/install-venus.sh
+++ b/nanoPi/install-venus.sh
@@ -3,18 +3,12 @@
 # install-venus.sh — Déploiement de daly-bms-venus sur Venus OS (NanoPi/GX)
 # =============================================================================
 #
-# Ce script installe UNIQUEMENT le bridge D-Bus sur le NanoPi.
-# Le service daly-bms-server (polling RS485 + dashboard HTTP) tourne sur le Pi5,
-# pas sur le NanoPi.
-#
-# Prérequis :
-#   - Accès SSH au GX (ssh root@<gx-ip>)
-#   - Binaire cross-compilé pour ARM64 (aarch64-unknown-linux-gnu)
-#     Commande : make build-venus
-#
 # Usage :
 #   ./nanoPi/install-venus.sh <gx-ip>
-#   ./nanoPi/install-venus.sh 192.168.1.120
+#   ARCH=armv7 ./nanoPi/install-venus.sh 192.168.1.120
+#
+# Prérequis (une seule fois) :
+#   ssh-copy-id root@192.168.1.120   # pour ne plus jamais saisir de mot de passe
 #
 # =============================================================================
 
@@ -27,6 +21,16 @@ INSTALL_DIR="/data/daly-bms"
 SERVICE_DIR="/data/etc/sv"
 ACTIVE_DIR="/service"
 
+# SSH ControlMaster : une seule connexion / une seule auth pour tout le script
+SSH_SOCKET="/tmp/ssh-nanopi-$$.sock"
+SSH_OPTS="-o ControlMaster=auto -o ControlPath=${SSH_SOCKET} -o ControlPersist=60 -o ConnectTimeout=10"
+SCP_OPTS="-o ControlMaster=auto -o ControlPath=${SSH_SOCKET} -o ControlPersist=60 -o ConnectTimeout=10"
+
+cleanup() {
+    ssh ${SSH_OPTS} -O exit "${GX_SSH}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
 # Architecture : armv7 (NanoPi 32-bit) ou aarch64 (64-bit, défaut)
 if [ "${ARCH:-}" = "armv7" ]; then
     TARGET="armv7-unknown-linux-gnueabihf"
@@ -35,22 +39,34 @@ else
 fi
 RELEASE_DIR="target/${TARGET}/release"
 
-echo "=== Déploiement daly-bms-venus sur Venus OS ${GX_IP} ==="
+echo "=== Déploiement daly-bms-venus sur Venus OS ${GX_IP} (${TARGET}) ==="
 
-# Vérifier que le binaire existe
 if [ ! -f "${RELEASE_DIR}/daly-bms-venus" ]; then
     echo "ERREUR: ${RELEASE_DIR}/daly-bms-venus introuvable."
-    echo "Lancer d'abord: make build-venus"
+    echo "Lancer d'abord: make build-venus-armv7"
     exit 1
 fi
 
-echo "1. Création des répertoires sur le GX..."
-ssh "${GX_SSH}" "mkdir -p ${INSTALL_DIR} ${SERVICE_DIR}/daly-bms-venus"
+# Ouvre la connexion SSH maîtresse (une seule demande de mot de passe)
+echo "Connexion SSH..."
+ssh ${SSH_OPTS} -fN "${GX_SSH}"
 
-echo "2. Suppression de daly-bms-server s'il est présent (ne doit pas tourner sur le NanoPi)..."
-ssh "${GX_SSH}" "
+echo "1. Création des répertoires sur le GX..."
+ssh ${SSH_OPTS} "${GX_SSH}" "mkdir -p ${INSTALL_DIR} ${SERVICE_DIR}/daly-bms-venus"
+
+echo "2. Arrêt du service daly-bms-venus avant mise à jour du binaire..."
+ssh ${SSH_OPTS} "${GX_SSH}" "
+    if [ -e ${ACTIVE_DIR}/daly-bms-venus ]; then
+        svc -d ${ACTIVE_DIR}/daly-bms-venus 2>/dev/null || true
+        sleep 1
+        echo '   service daly-bms-venus stoppé'
+    fi
+"
+
+echo "3. Suppression de daly-bms-server s'il est présent (ne doit pas tourner sur le NanoPi)..."
+ssh ${SSH_OPTS} "${GX_SSH}" "
     if [ -L ${ACTIVE_DIR}/daly-bms-server ]; then
-        sv -d ${ACTIVE_DIR}/daly-bms-server 2>/dev/null || true
+        svc -d ${ACTIVE_DIR}/daly-bms-server 2>/dev/null || true
         rm -f ${ACTIVE_DIR}/daly-bms-server
         echo '   symlink /service/daly-bms-server supprimé'
     fi
@@ -59,45 +75,38 @@ ssh "${GX_SSH}" "
     echo '   daly-bms-server retiré du NanoPi'
 "
 
-echo "3. Copie du binaire daly-bms-venus..."
-scp "${RELEASE_DIR}/daly-bms-venus" "${GX_SSH}:${INSTALL_DIR}/"
-ssh "${GX_SSH}" "chmod +x ${INSTALL_DIR}/daly-bms-venus"
+echo "4. Copie du binaire daly-bms-venus..."
+scp ${SCP_OPTS} "${RELEASE_DIR}/daly-bms-venus" "${GX_SSH}:${INSTALL_DIR}/"
+ssh ${SSH_OPTS} "${GX_SSH}" "chmod +x ${INSTALL_DIR}/daly-bms-venus"
 
-echo "4. Copie de la configuration..."
-if ! ssh "${GX_SSH}" "test -f ${INSTALL_DIR}/config.toml" 2>/dev/null; then
-    scp "Config.toml" "${GX_SSH}:${INSTALL_DIR}/config.toml"
+echo "5. Copie de la configuration..."
+if ! ssh ${SSH_OPTS} "${GX_SSH}" "test -f ${INSTALL_DIR}/config.toml" 2>/dev/null; then
+    scp ${SCP_OPTS} "Config.toml" "${GX_SSH}:${INSTALL_DIR}/config.toml"
     echo "   config.toml copié (éditer ${INSTALL_DIR}/config.toml si nécessaire)"
 else
     echo "   config.toml existant conservé"
 fi
 
-echo "5. Installation du service runit daly-bms-venus..."
-scp "nanoPi/sv/daly-bms-venus/run" "${GX_SSH}:${SERVICE_DIR}/daly-bms-venus/run"
-ssh "${GX_SSH}" "chmod +x ${SERVICE_DIR}/daly-bms-venus/run"
+echo "6. Installation du run script daemontools..."
+scp ${SCP_OPTS} "nanoPi/sv/daly-bms-venus/run" "${GX_SSH}:${SERVICE_DIR}/daly-bms-venus/run"
+ssh ${SSH_OPTS} "${GX_SSH}" "chmod +x ${SERVICE_DIR}/daly-bms-venus/run"
 
-echo "6. Activation du service (symlink dans /service/)..."
-ssh "${GX_SSH}" "
-    if [ ! -L ${ACTIVE_DIR}/daly-bms-venus ]; then
+echo "7. Activation / redémarrage du service..."
+ssh ${SSH_OPTS} "${GX_SSH}" "
+    if [ ! -L ${ACTIVE_DIR}/daly-bms-venus ] && [ ! -d ${ACTIVE_DIR}/daly-bms-venus ]; then
         ln -s ${SERVICE_DIR}/daly-bms-venus ${ACTIVE_DIR}/daly-bms-venus
         echo '   daly-bms-venus activé'
     else
-        sv restart ${ACTIVE_DIR}/daly-bms-venus
+        svc -u ${ACTIVE_DIR}/daly-bms-venus
         echo '   daly-bms-venus redémarré'
     fi
+    sleep 2
+    svstat ${ACTIVE_DIR}/daly-bms-venus
 "
 
 echo ""
-echo "=== Installation terminée ! ==="
-echo ""
-echo "Vérification du service :"
-echo "  ssh ${GX_SSH} 'sv status ${ACTIVE_DIR}/daly-bms-venus'"
+echo "=== Déploiement terminé ! ==="
 echo ""
 echo "Vérification D-Bus :"
 echo "  ssh ${GX_SSH} 'dbus -y com.victronenergy.battery.mqtt_1 /Soc GetValue'"
-echo "  ssh ${GX_SSH} 'dbus -y com.victronenergy.battery.mqtt_2 /Dc/0/Voltage GetValue'"
-echo ""
-echo "Logs :"
-echo "  ssh ${GX_SSH} 'logread | grep daly'"
-echo ""
-echo "Redémarrage si nécessaire :"
-echo "  ssh ${GX_SSH} 'sv restart ${ACTIVE_DIR}/daly-bms-venus'"
+echo "  ssh ${GX_SSH} 'dbus -y com.victronenergy.battery.mqtt_2 /Soc GetValue'"


### PR DESCRIPTION
- Une seule connexion SSH maîtresse → un seul mot de passe pour tout le script
- Arrêt de daly-bms-venus avant scp pour éviter "dest open Failure" (binaire verrouillé)
- Cleanup automatique du socket SSH en fin de script

https://claude.ai/code/session_01XsDVWy6q2pD8GUg3GZueYa