### PR TITLE
feat(dbus-mqtt-venus): ajouter switch, grid/acload, platform et batte…

### DIFF
--- a/crates/dbus-mqtt-venus/src/config.rs
+++ b/crates/dbus-mqtt-venus/src/config.rs
@@ -44,6 +44,26 @@ pub struct VenusServiceConfig {
     /// Configuration du service météo (irradiance RS485)
     #[serde(default)]
     pub meteo: MeteoConfig,
+
+    /// Configuration MQTT switch (ATS, relais)
+    #[serde(default)]
+    pub switch: SwitchConfig,
+
+    /// Configurations par switch/ATS
+    #[serde(default)]
+    pub switches: Vec<SwitchRef>,
+
+    /// Configuration MQTT compteurs réseau (grid / acload)
+    #[serde(default)]
+    pub grid: GridConfig,
+
+    /// Configurations par compteur réseau/acload
+    #[serde(default)]
+    pub grids: Vec<GridRef>,
+
+    /// Configuration du service platform (backup/restore Pi5)
+    #[serde(default)]
+    pub platform: PlatformConfig,
 }
 
 /// Référence à la config MQTT du serveur principal.
@@ -231,6 +251,116 @@ pub struct BmsRef {
     pub device_instance: Option<u32>,
     /// Capacité nominale (Ah) — utilisée comme InstalledCapacity si absente du payload
     pub capacity_ah: Option<f32>,
+}
+
+// =============================================================================
+// Configuration switch / ATS (switch)
+// =============================================================================
+
+/// Préfixe MQTT pour les switches/ATS.
+///
+/// Topic abonné : `{topic_prefix}/{n}/venus`
+/// Exemple : `santuario/switch/1/venus`
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SwitchConfig {
+    /// Préfixe des topics switch (ex: "santuario/switch")
+    pub topic_prefix: String,
+}
+
+impl Default for SwitchConfig {
+    fn default() -> Self {
+        Self { topic_prefix: "santuario/switch".to_string() }
+    }
+}
+
+/// Configuration d'un switch/ATS individuel.
+///
+/// Une section `[[switches]]` par switch dans le TOML.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SwitchRef {
+    /// Index dans le topic MQTT (ex: 1 → `santuario/switch/1/venus`).
+    pub mqtt_index: Option<u8>,
+
+    /// Nom affiché dans Venus OS (`/ProductName`).
+    pub name: Option<String>,
+
+    /// DeviceInstance Venus OS D-Bus.
+    pub device_instance: Option<u32>,
+}
+
+// =============================================================================
+// Configuration compteurs réseau / acload (grid)
+// =============================================================================
+
+/// Préfixe MQTT pour les compteurs réseau (grid/acload).
+///
+/// Topic abonné : `{topic_prefix}/{n}/venus`
+/// Exemple : `santuario/grid/1/venus`
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GridConfig {
+    /// Préfixe des topics grid/acload (ex: "santuario/grid")
+    pub topic_prefix: String,
+}
+
+impl Default for GridConfig {
+    fn default() -> Self {
+        Self { topic_prefix: "santuario/grid".to_string() }
+    }
+}
+
+/// Configuration d'un compteur réseau/acload individuel.
+///
+/// Une section `[[grids]]` par compteur dans le TOML.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct GridRef {
+    /// Index dans le topic MQTT (ex: 1 → `santuario/grid/1/venus`).
+    pub mqtt_index: Option<u8>,
+
+    /// Nom affiché dans Venus OS (`/ProductName`).
+    pub name: Option<String>,
+
+    /// DeviceInstance Venus OS D-Bus.
+    pub device_instance: Option<u32>,
+
+    /// Type D-Bus du service : "grid" ou "acload" (défaut: "grid").
+    /// "grid"   → `com.victronenergy.grid.{prefix}_{n}`
+    /// "acload" → `com.victronenergy.acload.{prefix}_{n}`
+    pub service_type: Option<String>,
+}
+
+// =============================================================================
+// Configuration platform / backup Pi5 (platform)
+// =============================================================================
+
+/// Configuration du service platform (backup/restore Pi5).
+///
+/// Topic MQTT fixe : `{topic}` (singleton, sans index).
+/// Exemple : `santuario/platform/venus`
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PlatformConfig {
+    /// Topic MQTT du service platform.
+    pub topic: String,
+
+    /// Nom affiché dans Venus OS.
+    pub product_name: String,
+
+    /// DeviceInstance Venus OS D-Bus.
+    pub device_instance: u32,
+
+    /// Activer ce service (false = désactivé).
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for PlatformConfig {
+    fn default() -> Self {
+        Self {
+            topic:           "santuario/platform/venus".to_string(),
+            product_name:    "Pi5 Platform".to_string(),
+            device_instance: 50,
+            enabled:         true,
+        }
+    }
 }
 
 // =============================================================================

--- a/crates/dbus-mqtt-venus/src/grid_manager.rs
+++ b/crates/dbus-mqtt-venus/src/grid_manager.rs
@@ -1,0 +1,132 @@
+//! Manager des services D-Bus grid/acload — orchestre N compteurs réseau.
+//!
+//! Reçoit les `GridMqttEvent` depuis `mqtt_source` et les route vers
+//! le `GridServiceHandle` correspondant.
+//! Topic MQTT : `santuario/grid/{n}/venus`
+//! Service D-Bus : `com.victronenergy.grid.{prefix}_{n}`
+//!            ou : `com.victronenergy.acload.{prefix}_{n}`
+
+use crate::config::{GridRef, VenusConfig};
+use crate::grid_service::{GridServiceHandle, create_grid_service};
+use crate::mqtt_source::GridMqttEvent;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::time::interval;
+use tracing::{error, info, warn};
+
+pub struct GridManager {
+    cfg:       VenusConfig,
+    grid_refs: Vec<GridRef>,
+    services:  HashMap<u8, GridServiceHandle>,
+    rx:        mpsc::Receiver<GridMqttEvent>,
+}
+
+impl GridManager {
+    pub fn new(
+        cfg:       VenusConfig,
+        grid_refs: Vec<GridRef>,
+        rx:        mpsc::Receiver<GridMqttEvent>,
+    ) -> Self {
+        Self { cfg, grid_refs, services: HashMap::new(), rx }
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        if !self.cfg.enabled {
+            info!("Service grid D-Bus désactivé (enabled = false)");
+            while self.rx.recv().await.is_some() {}
+            return Ok(());
+        }
+
+        let watchdog_dur  = Duration::from_secs(self.cfg.watchdog_sec);
+        let republish_dur = Duration::from_secs(self.cfg.republish_sec);
+        let mut tick      = interval(republish_dur);
+
+        info!(
+            dbus_bus     = %self.cfg.dbus_bus,
+            grids        = self.grid_refs.len(),
+            watchdog_sec = self.cfg.watchdog_sec,
+            "GridManager démarré"
+        );
+
+        loop {
+            tokio::select! {
+                Some(evt) = self.rx.recv() => {
+                    if let Err(e) = self.handle_event(evt).await {
+                        error!("Erreur événement grid MQTT : {:#}", e);
+                    }
+                }
+                _ = tick.tick() => {
+                    self.republish_and_watchdog(watchdog_dur).await;
+                }
+            }
+        }
+    }
+
+    async fn handle_event(&mut self, evt: GridMqttEvent) -> Result<()> {
+        let idx = evt.mqtt_index;
+        if !self.services.contains_key(&idx) {
+            let handle = self.create_service(idx).await?;
+            self.services.insert(idx, handle);
+        }
+        if let Some(svc) = self.services.get(&idx) {
+            svc.update(&evt.payload).await?;
+        }
+        Ok(())
+    }
+
+    async fn create_service(&self, idx: u8) -> Result<GridServiceHandle> {
+        let suffix          = format!("{}_{}", self.cfg.service_prefix, idx);
+        let device_instance = self.device_instance_for(idx);
+        let product_name    = self.product_name_for(idx);
+        let service_type    = self.service_type_for(idx);
+        create_grid_service(
+            &self.cfg.dbus_bus,
+            &suffix,
+            device_instance,
+            product_name,
+            &service_type,
+        ).await
+    }
+
+    fn device_instance_for(&self, idx: u8) -> u32 {
+        for (pos, g) in self.grid_refs.iter().enumerate() {
+            let gi = g.mqtt_index.unwrap_or((pos + 1) as u8);
+            if gi == idx { return g.device_instance.unwrap_or(gi as u32); }
+        }
+        idx as u32
+    }
+
+    fn product_name_for(&self, idx: u8) -> String {
+        for (pos, g) in self.grid_refs.iter().enumerate() {
+            let gi = g.mqtt_index.unwrap_or((pos + 1) as u8);
+            if gi == idx { if let Some(n) = &g.name { return n.clone(); } }
+        }
+        format!("Energy Meter {}", idx)
+    }
+
+    fn service_type_for(&self, idx: u8) -> String {
+        for (pos, g) in self.grid_refs.iter().enumerate() {
+            let gi = g.mqtt_index.unwrap_or((pos + 1) as u8);
+            if gi == idx {
+                if let Some(t) = &g.service_type { return t.clone(); }
+            }
+        }
+        "grid".to_string()
+    }
+
+    async fn republish_and_watchdog(&self, watchdog_dur: Duration) {
+        let now = Instant::now();
+        for (idx, svc) in &self.services {
+            let last = { svc.values.lock().unwrap().last_update };
+            if now.duration_since(last) > watchdog_dur {
+                if let Err(e) = svc.set_disconnected().await {
+                    warn!(index = idx, "Erreur watchdog grid : {:#}", e);
+                }
+            } else if let Err(e) = svc.republish().await {
+                warn!(index = idx, "Erreur republication grid : {:#}", e);
+            }
+        }
+    }
+}

--- a/crates/dbus-mqtt-venus/src/grid_service.rs
+++ b/crates/dbus-mqtt-venus/src/grid_service.rs
@@ -1,0 +1,392 @@
+//! Service D-Bus `com.victronenergy.grid.{name}` ou `com.victronenergy.acload.{name}`
+//! pour compteurs d'énergie AC (réseau, consommation).
+//!
+//! Conforme au wiki Victron Venus OS — section Grid/ACload meter :
+//! <https://github.com/victronenergy/venus/wiki/dbus#grid-and-acload-and-genset-meter>
+//!
+//! ## Chemins D-Bus exposés
+//!
+//! ```text
+//! /Ac/L1/Current         — A AC
+//! /Ac/L1/Energy/Forward  — kWh consommés (import)
+//! /Ac/L1/Energy/Reverse  — kWh injectés (export)
+//! /Ac/L1/Power           — W (puissance réelle)
+//! /Ac/L1/Voltage         — V AC
+//! /Ac/L2/...             — Phase 2 (même structure, enregistrée à 0.0 si monophasé)
+//! /Ac/L3/...             — Phase 3 (même structure, enregistrée à 0.0 si monophasé)
+//! /DeviceType            — type de compteur (340 = generic energy meter)
+//! /IsGenericEnergyMeter  — 1 si masquerade en genset/acload
+//! /Connected
+//! /ProductName
+//! /ProductId
+//! /DeviceInstance
+//! /Mgmt/ProcessName
+//! /Mgmt/ProcessVersion
+//! /Mgmt/Connection
+//! ```
+
+use crate::types::{GridPayload, GridPhasePayload};
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tracing::{debug, info, warn};
+use zbus::{connection, object_server::SignalContext, Connection};
+use zvariant::{OwnedValue, Str};
+
+// =============================================================================
+// Constantes
+// =============================================================================
+
+const VICTRON_GRID_PREFIX:   &str = "com.victronenergy.grid";
+const VICTRON_ACLOAD_PREFIX: &str = "com.victronenergy.acload";
+
+// =============================================================================
+// Item D-Bus
+// =============================================================================
+
+#[derive(Debug, Clone)]
+pub struct DbusItem {
+    pub value: serde_json::Value,
+    pub text:  String,
+}
+
+impl DbusItem {
+    pub fn f64(v: f64, unit: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: format!("{:.2} {}", v, unit) }
+    }
+    pub fn i32(v: i32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn str(v: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn u32(v: u32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+}
+
+fn json_to_owned(v: &serde_json::Value) -> OwnedValue {
+    match v {
+        serde_json::Value::Number(n) => {
+            if n.is_f64() {
+                OwnedValue::from(n.as_f64().unwrap_or(0.0))
+            } else if n.is_u64() {
+                OwnedValue::from(n.as_u64().unwrap_or(0) as u32)
+            } else {
+                let i = n.as_i64().unwrap_or(0);
+                if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                    OwnedValue::from(i as i32)
+                } else {
+                    OwnedValue::from(i)
+                }
+            }
+        }
+        serde_json::Value::String(s) => OwnedValue::from(Str::from(s.clone())),
+        _ => OwnedValue::from(0i32),
+    }
+}
+
+fn item_to_inner(item: &DbusItem) -> HashMap<String, OwnedValue> {
+    let mut d = HashMap::new();
+    d.insert("Value".to_string(), json_to_owned(&item.value));
+    d.insert("Text".to_string(), OwnedValue::from(Str::from(item.text.clone())));
+    d
+}
+
+type ItemsDict = HashMap<String, HashMap<String, OwnedValue>>;
+
+// =============================================================================
+// Valeurs par phase
+// =============================================================================
+
+#[derive(Debug, Clone, Default)]
+pub struct PhaseValues {
+    pub voltage:        f64,
+    pub current:        f64,
+    pub power:          f64,
+    pub energy_forward: f64,
+    pub energy_reverse: f64,
+}
+
+impl PhaseValues {
+    fn from_payload(p: &GridPhasePayload) -> Self {
+        Self {
+            voltage:        p.voltage,
+            current:        p.current,
+            power:          p.power,
+            energy_forward: p.energy.as_ref().map(|e| e.forward).unwrap_or(0.0),
+            energy_reverse: p.energy.as_ref().map(|e| e.reverse).unwrap_or(0.0),
+        }
+    }
+}
+
+// =============================================================================
+// Valeurs courantes
+// =============================================================================
+
+/// État courant d'un compteur réseau/acload exposé sur D-Bus.
+#[derive(Debug, Clone)]
+pub struct GridValues {
+    pub connected:              i32,
+    pub l1:                     PhaseValues,
+    pub l2:                     PhaseValues,
+    pub l3:                     PhaseValues,
+    pub device_type:            i32,
+    pub is_generic_energy_meter: i32,
+    pub product_name:           String,
+    pub device_instance:        u32,
+    pub last_update:            Instant,
+}
+
+impl GridValues {
+    pub fn disconnected(device_instance: u32, product_name: String) -> Self {
+        Self {
+            connected:              0,
+            l1:                     PhaseValues::default(),
+            l2:                     PhaseValues::default(),
+            l3:                     PhaseValues::default(),
+            device_type:            340,
+            is_generic_energy_meter: 0,
+            product_name,
+            device_instance,
+            last_update:            Instant::now(),
+        }
+    }
+
+    pub fn from_payload(
+        payload:         &GridPayload,
+        device_instance: u32,
+        product_name:    String,
+    ) -> Self {
+        let empty = GridPhasePayload::default();
+        Self {
+            connected: 1,
+            l1: PhaseValues::from_payload(payload.ac.l1.as_ref().unwrap_or(&empty)),
+            l2: PhaseValues::from_payload(payload.ac.l2.as_ref().unwrap_or(&empty)),
+            l3: PhaseValues::from_payload(payload.ac.l3.as_ref().unwrap_or(&empty)),
+            device_type:            payload.device_type,
+            is_generic_energy_meter: payload.is_generic_energy_meter,
+            product_name,
+            device_instance,
+            last_update:            Instant::now(),
+        }
+    }
+
+    fn phase_items(items: &mut HashMap<String, DbusItem>, prefix: &str, ph: &PhaseValues) {
+        items.insert(format!("{}/Voltage", prefix),        DbusItem::f64(ph.voltage,        "V"));
+        items.insert(format!("{}/Current", prefix),        DbusItem::f64(ph.current,        "A"));
+        items.insert(format!("{}/Power", prefix),          DbusItem::f64(ph.power,          "W"));
+        items.insert(format!("{}/Energy/Forward", prefix), DbusItem::f64(ph.energy_forward, "kWh"));
+        items.insert(format!("{}/Energy/Reverse", prefix), DbusItem::f64(ph.energy_reverse, "kWh"));
+    }
+
+    pub fn to_items(&self) -> HashMap<String, DbusItem> {
+        let mut m = HashMap::new();
+
+        // Identification
+        m.insert("/Mgmt/ProcessName".into(),    DbusItem::str("dbus-mqtt-venus"));
+        m.insert("/Mgmt/ProcessVersion".into(), DbusItem::str(env!("CARGO_PKG_VERSION")));
+        m.insert("/Mgmt/Connection".into(),     DbusItem::str("MQTT"));
+        m.insert("/ProductId".into(),           DbusItem::u32(0));
+        m.insert("/ProductName".into(),         DbusItem::str(&self.product_name));
+        m.insert("/DeviceInstance".into(),      DbusItem::u32(self.device_instance));
+        m.insert("/Connected".into(),           DbusItem::i32(self.connected));
+
+        // Metadata compteur
+        m.insert("/DeviceType".into(),            DbusItem::i32(self.device_type));
+        m.insert("/IsGenericEnergyMeter".into(),  DbusItem::i32(self.is_generic_energy_meter));
+
+        // Phases — toujours toutes les 3 présentes (0.0 si monophasé ou non reçu)
+        // Obligatoire : les chemins doivent être enregistrés dès le démarrage (GetValue)
+        Self::phase_items(&mut m, "/Ac/L1", &self.l1);
+        Self::phase_items(&mut m, "/Ac/L2", &self.l2);
+        Self::phase_items(&mut m, "/Ac/L3", &self.l3);
+
+        m
+    }
+}
+
+// =============================================================================
+// Interface D-Bus — objet racine `/`
+// =============================================================================
+
+struct GridRootIface {
+    values: Arc<Mutex<GridValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl GridRootIface {
+    fn get_items(&self) -> ItemsDict {
+        let guard = self.values.lock().unwrap();
+        guard
+            .to_items()
+            .iter()
+            .map(|(path, item)| (path.clone(), item_to_inner(item)))
+            .collect()
+    }
+
+    fn get_value(&self) -> OwnedValue { OwnedValue::from(0i32) }
+    fn get_text(&self) -> String { String::new() }
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+
+    #[zbus(signal)]
+    async fn items_changed(
+        ctx:   &SignalContext<'_>,
+        items: ItemsDict,
+    ) -> zbus::Result<()>;
+}
+
+// =============================================================================
+// Interface D-Bus — objet feuille
+// =============================================================================
+
+struct BusItemLeaf {
+    path:   String,
+    values: Arc<Mutex<GridValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl BusItemLeaf {
+    fn get_value(&self) -> OwnedValue {
+        let guard = self.values.lock().unwrap();
+        match guard.to_items().get(&self.path) {
+            Some(item) => json_to_owned(&item.value),
+            None       => OwnedValue::from(0i32),
+        }
+    }
+
+    fn get_text(&self) -> String {
+        let guard = self.values.lock().unwrap();
+        guard.to_items().get(&self.path).map(|i| i.text.clone()).unwrap_or_default()
+    }
+
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+}
+
+// =============================================================================
+// Handle
+// =============================================================================
+
+pub struct GridServiceHandle {
+    pub service_name:    String,
+    pub device_instance: u32,
+    pub values:          Arc<Mutex<GridValues>>,
+    connection:          Connection,
+    pub product_name:    String,
+}
+
+impl GridServiceHandle {
+    pub async fn update(&self, payload: &GridPayload) -> Result<()> {
+        let new_values = GridValues::from_payload(
+            payload,
+            self.device_instance,
+            self.product_name.clone(),
+        );
+        let items = new_values.to_items();
+        { *self.values.lock().unwrap() = new_values; }
+        self.emit_items_changed(&items).await?;
+        debug!(
+            service = %self.service_name,
+            power_l1 = payload.ac.l1.as_ref().map(|p| p.power).unwrap_or(0.0),
+            "D-Bus ItemsChanged grid/acload émis"
+        );
+        Ok(())
+    }
+
+    pub async fn set_disconnected(&self) -> Result<()> {
+        let items = {
+            let mut g = self.values.lock().unwrap();
+            g.connected = 0;
+            g.to_items()
+        };
+        warn!(service = %self.service_name, "Grid/acload déconnecté — watchdog timeout");
+        self.emit_items_changed(&items).await
+    }
+
+    pub async fn republish(&self) -> Result<()> {
+        let items = { self.values.lock().unwrap().to_items() };
+        self.emit_items_changed(&items).await
+    }
+
+    async fn emit_items_changed(&self, items: &HashMap<String, DbusItem>) -> Result<()> {
+        let dict: ItemsDict = items
+            .iter()
+            .map(|(p, i)| (p.clone(), item_to_inner(i)))
+            .collect();
+        let ctx = SignalContext::new(&self.connection, "/")?;
+        match GridRootIface::items_changed(&ctx, dict).await {
+            Ok(_)  => { debug!(service = %self.service_name, "ItemsChanged grid émis"); Ok(()) }
+            Err(e) => { warn!(service = %self.service_name, "ItemsChanged warning : {}", e); Ok(()) }
+        }
+    }
+}
+
+// =============================================================================
+// Création du service
+// =============================================================================
+
+/// Crée un service grid ou acload selon `service_type` ("grid" ou "acload").
+pub async fn create_grid_service(
+    dbus_bus:        &str,
+    service_suffix:  &str,
+    device_instance: u32,
+    product_name:    String,
+    service_type:    &str,
+) -> Result<GridServiceHandle> {
+    let prefix = if service_type == "acload" {
+        VICTRON_ACLOAD_PREFIX
+    } else {
+        VICTRON_GRID_PREFIX
+    };
+    let service_name = format!("{}.{}", prefix, service_suffix);
+
+    info!(
+        service = %service_name,
+        device_instance = device_instance,
+        service_type    = service_type,
+        "Enregistrement service D-Bus grid/acload Venus OS"
+    );
+
+    let initial_values = Arc::new(Mutex::new(
+        GridValues::disconnected(device_instance, product_name.clone())
+    ));
+
+    let root = GridRootIface { values: initial_values.clone() };
+
+    let builder = match dbus_bus {
+        "session" => connection::Builder::session()?,
+        _         => connection::Builder::system()?,
+    };
+
+    let conn = builder
+        .name(service_name.as_str())?
+        .serve_at("/", root)?
+        .build()
+        .await?;
+
+    let leaf_paths: Vec<String> = {
+        initial_values.lock().unwrap().to_items().into_keys().collect()
+    };
+
+    for path in &leaf_paths {
+        conn.object_server()
+            .at(path.as_str(), BusItemLeaf { path: path.clone(), values: initial_values.clone() })
+            .await?;
+    }
+
+    info!(
+        service = %service_name,
+        paths   = leaf_paths.len(),
+        "Service D-Bus grid/acload enregistré ({} chemins + racine /)",
+        leaf_paths.len()
+    );
+
+    Ok(GridServiceHandle {
+        service_name,
+        device_instance,
+        values: initial_values,
+        connection: conn,
+        product_name,
+    })
+}

--- a/crates/dbus-mqtt-venus/src/main.rs
+++ b/crates/dbus-mqtt-venus/src/main.rs
@@ -26,27 +26,37 @@
 
 mod battery_service;
 mod config;
+mod grid_manager;
+mod grid_service;
 mod heatpump_manager;
 mod heatpump_service;
 mod manager;
 mod meteo_manager;
 mod meteo_service;
 mod mqtt_source;
+mod platform_manager;
+mod platform_service;
 mod sensor_manager;
+mod switch_manager;
+mod switch_service;
 mod temperature_service;
 mod types;
 
 use anyhow::Result;
 use clap::Parser;
 use config::VenusServiceConfig;
+use grid_manager::GridManager;
 use heatpump_manager::HeatpumpManager;
 use manager::BatteryManager;
 use meteo_manager::MeteoManager;
 use mqtt_source::{
-    start_heatpump_mqtt_source, start_meteo_mqtt_source, start_mqtt_source,
-    start_sensor_mqtt_source,
+    start_grid_mqtt_source, start_heatpump_mqtt_source, start_meteo_mqtt_source,
+    start_mqtt_source, start_platform_mqtt_source, start_sensor_mqtt_source,
+    start_switch_mqtt_source,
 };
+use platform_manager::PlatformManager;
 use sensor_manager::SensorManager;
+use switch_manager::SwitchManager;
 use std::path::PathBuf;
 use tokio::sync::mpsc;
 use tracing::{error, info};
@@ -108,9 +118,14 @@ async fn main() -> Result<()> {
         heat_prefix      = %cfg.heat.topic_prefix,
         heatpump_prefix  = %cfg.heatpump.topic_prefix,
         meteo_topic      = %cfg.meteo.topic,
+        switch_prefix    = %cfg.switch.topic_prefix,
+        grid_prefix      = %cfg.grid.topic_prefix,
+        platform_topic   = %cfg.platform.topic,
         bms_count        = cfg.bms.len(),
         sensor_count     = cfg.sensors.len(),
         heatpump_count   = cfg.heatpumps.len(),
+        switch_count     = cfg.switches.len(),
+        grid_count       = cfg.grids.len(),
         "dbus-mqtt-venus démarrage"
     );
 
@@ -179,10 +194,61 @@ async fn main() -> Result<()> {
         start_meteo_mqtt_source(mqtt_cfg4, meteo_topic, meteo_tx).await;
     });
 
-    // Le MeteoManager est le dernier et bloque le thread principal
-    let meteo_manager = MeteoManager::new(cfg.venus, cfg.meteo, meteo_rx);
-    if let Err(e) = meteo_manager.run().await {
-        error!("MeteoManager terminé avec erreur : {:#}", e);
+    let meteo_manager = MeteoManager::new(cfg.venus.clone(), cfg.meteo, meteo_rx);
+    tokio::spawn(async move {
+        if let Err(e) = meteo_manager.run().await {
+            error!("MeteoManager terminé avec erreur : {:#}", e);
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // Bridge switch/ATS : MQTT santuario/switch/{n}/venus → D-Bus com.victronenergy.switch.{n}
+    // -------------------------------------------------------------------------
+    let (switch_tx, switch_rx) = mpsc::channel(32);
+    let mqtt_cfg5      = cfg.mqtt.clone();
+    let switch_prefix  = cfg.switch.topic_prefix.clone();
+    tokio::spawn(async move {
+        start_switch_mqtt_source(mqtt_cfg5, switch_prefix, switch_tx).await;
+    });
+
+    let switch_manager = SwitchManager::new(cfg.venus.clone(), cfg.switches, switch_rx);
+    tokio::spawn(async move {
+        if let Err(e) = switch_manager.run().await {
+            error!("SwitchManager terminé avec erreur : {:#}", e);
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // Bridge grid/acload : MQTT santuario/grid/{n}/venus → D-Bus com.victronenergy.grid.{n}
+    // -------------------------------------------------------------------------
+    let (grid_tx, grid_rx) = mpsc::channel(32);
+    let mqtt_cfg6    = cfg.mqtt.clone();
+    let grid_prefix  = cfg.grid.topic_prefix.clone();
+    tokio::spawn(async move {
+        start_grid_mqtt_source(mqtt_cfg6, grid_prefix, grid_tx).await;
+    });
+
+    let grid_manager = GridManager::new(cfg.venus.clone(), cfg.grids, grid_rx);
+    tokio::spawn(async move {
+        if let Err(e) = grid_manager.run().await {
+            error!("GridManager terminé avec erreur : {:#}", e);
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // Bridge platform : MQTT santuario/platform/venus → D-Bus com.victronenergy.platform
+    // Le PlatformManager est le dernier et bloque le thread principal
+    // -------------------------------------------------------------------------
+    let (platform_tx, platform_rx) = mpsc::channel(16);
+    let mqtt_cfg7      = cfg.mqtt.clone();
+    let platform_topic = cfg.platform.topic.clone();
+    tokio::spawn(async move {
+        start_platform_mqtt_source(mqtt_cfg7, platform_topic, platform_tx).await;
+    });
+
+    let platform_manager = PlatformManager::new(cfg.venus, cfg.platform, platform_rx);
+    if let Err(e) = platform_manager.run().await {
+        error!("PlatformManager terminé avec erreur : {:#}", e);
         std::process::exit(1);
     }
 

--- a/crates/dbus-mqtt-venus/src/mqtt_source.rs
+++ b/crates/dbus-mqtt-venus/src/mqtt_source.rs
@@ -6,7 +6,7 @@
 //! - `{heat_prefix}/+/venus` → capteurs température → `SensorMqttEvent`
 
 use crate::config::MqttRef;
-use crate::types::{HeatPayload, HeatpumpPayload, MeteoPayload, VenusPayload};
+use crate::types::{GridPayload, HeatPayload, HeatpumpPayload, MeteoPayload, PlatformPayload, SwitchPayload, VenusPayload};
 use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -48,6 +48,31 @@ pub struct HeatpumpMqttEvent {
 pub struct MeteoMqttEvent {
     /// Payload irradiance/météo parsé
     pub payload: MeteoPayload,
+}
+
+/// Événement switch/ATS reçu depuis MQTT (topic switch).
+#[derive(Debug)]
+pub struct SwitchMqttEvent {
+    /// Index du switch (déduit du topic : `prefix/1/venus` → `1`)
+    pub mqtt_index: u8,
+    /// Payload switch parsé
+    pub payload: SwitchPayload,
+}
+
+/// Événement compteur réseau/acload reçu depuis MQTT (topic grid).
+#[derive(Debug)]
+pub struct GridMqttEvent {
+    /// Index du compteur (déduit du topic : `prefix/1/venus` → `1`)
+    pub mqtt_index: u8,
+    /// Payload grid/acload parsé
+    pub payload: GridPayload,
+}
+
+/// Événement platform reçu depuis MQTT (topic fixe `santuario/platform/venus`).
+#[derive(Debug)]
+pub struct PlatformMqttEvent {
+    /// Payload platform parsé
+    pub payload: PlatformPayload,
 }
 
 // =============================================================================
@@ -373,6 +398,204 @@ async fn meteo_connect_and_run(
                 }
             }
             Ok(Event::Incoming(Packet::ConnAck(_))) => info!("MQTT météo ConnAck reçu"),
+            Ok(_) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+// =============================================================================
+// Source MQTT pour switches/ATS (santuario/switch/{n}/venus)
+// =============================================================================
+
+/// Démarre la source MQTT pour les switches/ATS.
+///
+/// S'abonne sur `{switch_prefix}/+/venus`, parse le `SwitchPayload`
+/// et émet des `SwitchMqttEvent` vers le `SwitchManager`.
+pub async fn start_switch_mqtt_source(
+    cfg:           MqttRef,
+    switch_prefix: String,
+    tx:            mpsc::Sender<SwitchMqttEvent>,
+) {
+    let subscribe_topic = format!("{}/+/venus", switch_prefix);
+
+    info!(
+        broker = %format!("{}:{}", cfg.host, cfg.port),
+        topic  = %subscribe_topic,
+        "Démarrage source MQTT switches/ATS"
+    );
+
+    loop {
+        match switch_connect_and_run(&cfg, &subscribe_topic, &switch_prefix, &tx).await {
+            Ok(())  => warn!("MQTT source switch terminée de façon inattendue, reconnexion dans 5s"),
+            Err(e)  => error!("MQTT source switch erreur : {:#}, reconnexion dans 5s", e),
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn switch_connect_and_run(
+    cfg:           &MqttRef,
+    subscribe_topic: &str,
+    switch_prefix: &str,
+    tx:            &mpsc::Sender<SwitchMqttEvent>,
+) -> anyhow::Result<()> {
+    let client_id = format!("dbus-mqtt-venus-switch-{}", uuid_short());
+    let mut opts = MqttOptions::new(client_id, &cfg.host, cfg.port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_clean_session(true);
+    if let (Some(u), Some(p)) = (&cfg.username, &cfg.password) { opts.set_credentials(u, p); }
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 64);
+    client.subscribe(subscribe_topic, QoS::AtLeastOnce).await?;
+    info!("MQTT switch connecté, abonnement sur '{}'", subscribe_topic);
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Packet::Publish(msg))) => {
+                let topic = &msg.topic;
+                debug!(topic = %topic, "MQTT switch message reçu");
+                if let Some(idx) = extract_mqtt_index(topic, switch_prefix) {
+                    match serde_json::from_slice::<SwitchPayload>(&msg.payload) {
+                        Ok(payload) => {
+                            let evt = SwitchMqttEvent { mqtt_index: idx, payload };
+                            if tx.send(evt).await.is_err() { return Ok(()); }
+                        }
+                        Err(e) => warn!(topic = %topic, "Échec parsing payload switch: {}", e),
+                    }
+                }
+            }
+            Ok(Event::Incoming(Packet::ConnAck(_))) => info!("MQTT switch ConnAck reçu"),
+            Ok(_) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+// =============================================================================
+// Source MQTT pour compteurs réseau/acload (santuario/grid/{n}/venus)
+// =============================================================================
+
+/// Démarre la source MQTT pour les compteurs réseau/acload.
+///
+/// S'abonne sur `{grid_prefix}/+/venus`, parse le `GridPayload`
+/// et émet des `GridMqttEvent` vers le `GridManager`.
+pub async fn start_grid_mqtt_source(
+    cfg:         MqttRef,
+    grid_prefix: String,
+    tx:          mpsc::Sender<GridMqttEvent>,
+) {
+    let subscribe_topic = format!("{}/+/venus", grid_prefix);
+
+    info!(
+        broker = %format!("{}:{}", cfg.host, cfg.port),
+        topic  = %subscribe_topic,
+        "Démarrage source MQTT compteurs réseau/acload"
+    );
+
+    loop {
+        match grid_connect_and_run(&cfg, &subscribe_topic, &grid_prefix, &tx).await {
+            Ok(())  => warn!("MQTT source grid terminée de façon inattendue, reconnexion dans 5s"),
+            Err(e)  => error!("MQTT source grid erreur : {:#}, reconnexion dans 5s", e),
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn grid_connect_and_run(
+    cfg:         &MqttRef,
+    subscribe_topic: &str,
+    grid_prefix: &str,
+    tx:          &mpsc::Sender<GridMqttEvent>,
+) -> anyhow::Result<()> {
+    let client_id = format!("dbus-mqtt-venus-grid-{}", uuid_short());
+    let mut opts = MqttOptions::new(client_id, &cfg.host, cfg.port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_clean_session(true);
+    if let (Some(u), Some(p)) = (&cfg.username, &cfg.password) { opts.set_credentials(u, p); }
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 64);
+    client.subscribe(subscribe_topic, QoS::AtLeastOnce).await?;
+    info!("MQTT grid connecté, abonnement sur '{}'", subscribe_topic);
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Packet::Publish(msg))) => {
+                let topic = &msg.topic;
+                debug!(topic = %topic, "MQTT grid message reçu");
+                if let Some(idx) = extract_mqtt_index(topic, grid_prefix) {
+                    match serde_json::from_slice::<GridPayload>(&msg.payload) {
+                        Ok(payload) => {
+                            let evt = GridMqttEvent { mqtt_index: idx, payload };
+                            if tx.send(evt).await.is_err() { return Ok(()); }
+                        }
+                        Err(e) => warn!(topic = %topic, "Échec parsing payload grid: {}", e),
+                    }
+                }
+            }
+            Ok(Event::Incoming(Packet::ConnAck(_))) => info!("MQTT grid ConnAck reçu"),
+            Ok(_) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+// =============================================================================
+// Source MQTT pour platform (santuario/platform/venus — topic fixe)
+// =============================================================================
+
+/// Démarre la source MQTT pour le service platform/backup Pi5.
+///
+/// S'abonne sur le topic FIXE `{platform_topic}`, parse le `PlatformPayload`
+/// et émet des `PlatformMqttEvent` vers le `PlatformManager`.
+pub async fn start_platform_mqtt_source(
+    cfg:            MqttRef,
+    platform_topic: String,
+    tx:             mpsc::Sender<PlatformMqttEvent>,
+) {
+    info!(
+        broker = %format!("{}:{}", cfg.host, cfg.port),
+        topic  = %platform_topic,
+        "Démarrage source MQTT platform"
+    );
+
+    loop {
+        match platform_connect_and_run(&cfg, &platform_topic, &tx).await {
+            Ok(())  => warn!("MQTT source platform terminée de façon inattendue, reconnexion dans 5s"),
+            Err(e)  => error!("MQTT source platform erreur : {:#}, reconnexion dans 5s", e),
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn platform_connect_and_run(
+    cfg:            &MqttRef,
+    platform_topic: &str,
+    tx:             &mpsc::Sender<PlatformMqttEvent>,
+) -> anyhow::Result<()> {
+    let client_id = format!("dbus-mqtt-venus-platform-{}", uuid_short());
+    let mut opts = MqttOptions::new(client_id, &cfg.host, cfg.port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_clean_session(true);
+    if let (Some(u), Some(p)) = (&cfg.username, &cfg.password) { opts.set_credentials(u, p); }
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 64);
+    client.subscribe(platform_topic, QoS::AtLeastOnce).await?;
+    info!("MQTT platform connecté, abonnement sur '{}'", platform_topic);
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Packet::Publish(msg))) => {
+                debug!(topic = %msg.topic, "MQTT platform message reçu");
+                match serde_json::from_slice::<PlatformPayload>(&msg.payload) {
+                    Ok(payload) => {
+                        let evt = PlatformMqttEvent { payload };
+                        if tx.send(evt).await.is_err() { return Ok(()); }
+                    }
+                    Err(e) => warn!(topic = %msg.topic, "Échec parsing payload platform: {}", e),
+                }
+            }
+            Ok(Event::Incoming(Packet::ConnAck(_))) => info!("MQTT platform ConnAck reçu"),
             Ok(_) => {}
             Err(e) => return Err(e.into()),
         }

--- a/crates/dbus-mqtt-venus/src/platform_manager.rs
+++ b/crates/dbus-mqtt-venus/src/platform_manager.rs
@@ -1,0 +1,92 @@
+//! Manager du service D-Bus platform (singleton).
+//!
+//! Reçoit les `PlatformMqttEvent` depuis `mqtt_source` et met à jour
+//! le `PlatformServiceHandle` unique (pas d'index — service singleton).
+//! Topic MQTT fixe : `santuario/platform/venus`
+//! Service D-Bus  : `com.victronenergy.platform`
+
+use crate::config::{PlatformConfig, VenusConfig};
+use crate::mqtt_source::PlatformMqttEvent;
+use crate::platform_service::{PlatformServiceHandle, create_platform_service};
+use anyhow::Result;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::time::interval;
+use tracing::{error, info, warn};
+
+pub struct PlatformManager {
+    cfg:            VenusConfig,
+    platform_cfg:   PlatformConfig,
+    service:        Option<PlatformServiceHandle>,
+    rx:             mpsc::Receiver<PlatformMqttEvent>,
+}
+
+impl PlatformManager {
+    pub fn new(
+        cfg:          VenusConfig,
+        platform_cfg: PlatformConfig,
+        rx:           mpsc::Receiver<PlatformMqttEvent>,
+    ) -> Self {
+        Self { cfg, platform_cfg, service: None, rx }
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        if !self.cfg.enabled || !self.platform_cfg.enabled {
+            info!("Service platform D-Bus désactivé");
+            while self.rx.recv().await.is_some() {}
+            return Ok(());
+        }
+
+        let watchdog_dur  = Duration::from_secs(self.cfg.watchdog_sec);
+        let republish_dur = Duration::from_secs(self.cfg.republish_sec);
+        let mut tick      = interval(republish_dur);
+
+        info!(
+            dbus_bus     = %self.cfg.dbus_bus,
+            topic        = %self.platform_cfg.topic,
+            watchdog_sec = self.cfg.watchdog_sec,
+            "PlatformManager démarré"
+        );
+
+        loop {
+            tokio::select! {
+                Some(evt) = self.rx.recv() => {
+                    if let Err(e) = self.handle_event(evt).await {
+                        error!("Erreur événement platform MQTT : {:#}", e);
+                    }
+                }
+                _ = tick.tick() => {
+                    self.republish_and_watchdog(watchdog_dur).await;
+                }
+            }
+        }
+    }
+
+    async fn handle_event(&mut self, evt: PlatformMqttEvent) -> Result<()> {
+        if self.service.is_none() {
+            let svc = create_platform_service(
+                &self.cfg.dbus_bus,
+                self.platform_cfg.device_instance,
+                self.platform_cfg.product_name.clone(),
+            ).await?;
+            self.service = Some(svc);
+        }
+        if let Some(svc) = &self.service {
+            svc.update(&evt.payload).await?;
+        }
+        Ok(())
+    }
+
+    async fn republish_and_watchdog(&self, watchdog_dur: Duration) {
+        let Some(svc) = &self.service else { return };
+        let last = { svc.values.lock().unwrap().last_update };
+        let now  = Instant::now();
+        if now.duration_since(last) > watchdog_dur {
+            if let Err(e) = svc.set_disconnected().await {
+                warn!("Erreur watchdog platform : {:#}", e);
+            }
+        } else if let Err(e) = svc.republish().await {
+            warn!("Erreur republication platform : {:#}", e);
+        }
+    }
+}

--- a/crates/dbus-mqtt-venus/src/platform_service.rs
+++ b/crates/dbus-mqtt-venus/src/platform_service.rs
@@ -1,0 +1,332 @@
+//! Service D-Bus `com.victronenergy.platform` (singleton).
+//!
+//! Service custom exposant l'état des opérations de backup/restore Pi5.
+//!
+//! ## Chemins D-Bus exposés
+//!
+//! ```text
+//! /Backup/Status      — 0=idle, 1=running, 2=OK, 3=error
+//! /Backup/LastRun     — timestamp Unix (secondes)
+//! /Restore/Status     — 0=idle, 1=running, 2=OK, 3=error
+//! /Restore/LastRun    — timestamp Unix (secondes)
+//! /Connected
+//! /ProductName
+//! /ProductId
+//! /DeviceInstance
+//! /Mgmt/ProcessName
+//! /Mgmt/ProcessVersion
+//! /Mgmt/Connection
+//! ```
+
+use crate::types::PlatformPayload;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tracing::{debug, info, warn};
+use zbus::{connection, object_server::SignalContext, Connection};
+use zvariant::{OwnedValue, Str};
+
+// =============================================================================
+// Constante
+// =============================================================================
+
+const VICTRON_PLATFORM_SERVICE: &str = "com.victronenergy.platform";
+
+// =============================================================================
+// Item D-Bus
+// =============================================================================
+
+#[derive(Debug, Clone)]
+pub struct DbusItem {
+    pub value: serde_json::Value,
+    pub text:  String,
+}
+
+impl DbusItem {
+    pub fn i32(v: i32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn i64(v: i64) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn str(v: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn u32(v: u32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+}
+
+fn json_to_owned(v: &serde_json::Value) -> OwnedValue {
+    match v {
+        serde_json::Value::Number(n) => {
+            if n.is_f64() {
+                OwnedValue::from(n.as_f64().unwrap_or(0.0))
+            } else if n.is_u64() {
+                OwnedValue::from(n.as_u64().unwrap_or(0) as u32)
+            } else {
+                let i = n.as_i64().unwrap_or(0);
+                if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                    OwnedValue::from(i as i32)
+                } else {
+                    OwnedValue::from(i)
+                }
+            }
+        }
+        serde_json::Value::String(s) => OwnedValue::from(Str::from(s.clone())),
+        _ => OwnedValue::from(0i32),
+    }
+}
+
+fn item_to_inner(item: &DbusItem) -> HashMap<String, OwnedValue> {
+    let mut d = HashMap::new();
+    d.insert("Value".to_string(), json_to_owned(&item.value));
+    d.insert("Text".to_string(), OwnedValue::from(Str::from(item.text.clone())));
+    d
+}
+
+type ItemsDict = HashMap<String, HashMap<String, OwnedValue>>;
+
+// =============================================================================
+// Valeurs courantes
+// =============================================================================
+
+/// État courant du service platform exposé sur D-Bus.
+#[derive(Debug, Clone)]
+pub struct PlatformValues {
+    pub connected:       i32,
+    pub backup_status:   i32,
+    pub backup_last_run: i64,
+    pub restore_status:  i32,
+    pub restore_last_run: i64,
+    pub product_name:    String,
+    pub device_instance: u32,
+    pub last_update:     Instant,
+}
+
+impl PlatformValues {
+    pub fn disconnected(device_instance: u32, product_name: String) -> Self {
+        Self {
+            connected:        0,
+            backup_status:    0,
+            backup_last_run:  0,
+            restore_status:   0,
+            restore_last_run: 0,
+            product_name,
+            device_instance,
+            last_update:      Instant::now(),
+        }
+    }
+
+    pub fn from_payload(
+        payload:         &PlatformPayload,
+        device_instance: u32,
+        product_name:    String,
+    ) -> Self {
+        Self {
+            connected:        1,
+            backup_status:    payload.backup.as_ref().map(|b| b.status).unwrap_or(0),
+            backup_last_run:  payload.backup.as_ref().map(|b| b.last_run).unwrap_or(0),
+            restore_status:   payload.restore.as_ref().map(|r| r.status).unwrap_or(0),
+            restore_last_run: payload.restore.as_ref().map(|r| r.last_run).unwrap_or(0),
+            product_name,
+            device_instance,
+            last_update:      Instant::now(),
+        }
+    }
+
+    pub fn to_items(&self) -> HashMap<String, DbusItem> {
+        let mut m = HashMap::new();
+
+        // Identification
+        m.insert("/Mgmt/ProcessName".into(),    DbusItem::str("dbus-mqtt-venus"));
+        m.insert("/Mgmt/ProcessVersion".into(), DbusItem::str(env!("CARGO_PKG_VERSION")));
+        m.insert("/Mgmt/Connection".into(),     DbusItem::str("MQTT"));
+        m.insert("/ProductId".into(),           DbusItem::u32(0));
+        m.insert("/ProductName".into(),         DbusItem::str(&self.product_name));
+        m.insert("/DeviceInstance".into(),      DbusItem::u32(self.device_instance));
+        m.insert("/Connected".into(),           DbusItem::i32(self.connected));
+
+        // Backup Pi5
+        m.insert("/Backup/Status".into(),   DbusItem::i32(self.backup_status));
+        m.insert("/Backup/LastRun".into(),  DbusItem::i64(self.backup_last_run));
+
+        // Restore Pi5
+        m.insert("/Restore/Status".into(),  DbusItem::i32(self.restore_status));
+        m.insert("/Restore/LastRun".into(), DbusItem::i64(self.restore_last_run));
+
+        m
+    }
+}
+
+// =============================================================================
+// Interface D-Bus — objet racine `/`
+// =============================================================================
+
+struct PlatformRootIface {
+    values: Arc<Mutex<PlatformValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl PlatformRootIface {
+    fn get_items(&self) -> ItemsDict {
+        let guard = self.values.lock().unwrap();
+        guard
+            .to_items()
+            .iter()
+            .map(|(path, item)| (path.clone(), item_to_inner(item)))
+            .collect()
+    }
+
+    fn get_value(&self) -> OwnedValue { OwnedValue::from(0i32) }
+    fn get_text(&self) -> String { String::new() }
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+
+    #[zbus(signal)]
+    async fn items_changed(
+        ctx:   &SignalContext<'_>,
+        items: ItemsDict,
+    ) -> zbus::Result<()>;
+}
+
+// =============================================================================
+// Interface D-Bus — objet feuille
+// =============================================================================
+
+struct BusItemLeaf {
+    path:   String,
+    values: Arc<Mutex<PlatformValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl BusItemLeaf {
+    fn get_value(&self) -> OwnedValue {
+        let guard = self.values.lock().unwrap();
+        match guard.to_items().get(&self.path) {
+            Some(item) => json_to_owned(&item.value),
+            None       => OwnedValue::from(0i32),
+        }
+    }
+
+    fn get_text(&self) -> String {
+        let guard = self.values.lock().unwrap();
+        guard.to_items().get(&self.path).map(|i| i.text.clone()).unwrap_or_default()
+    }
+
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+}
+
+// =============================================================================
+// Handle
+// =============================================================================
+
+pub struct PlatformServiceHandle {
+    pub service_name:    String,
+    pub device_instance: u32,
+    pub values:          Arc<Mutex<PlatformValues>>,
+    connection:          Connection,
+    pub product_name:    String,
+}
+
+impl PlatformServiceHandle {
+    pub async fn update(&self, payload: &PlatformPayload) -> Result<()> {
+        let new_values = PlatformValues::from_payload(
+            payload,
+            self.device_instance,
+            self.product_name.clone(),
+        );
+        let items = new_values.to_items();
+        { *self.values.lock().unwrap() = new_values; }
+        self.emit_items_changed(&items).await?;
+        debug!(service = %self.service_name, "D-Bus ItemsChanged platform émis");
+        Ok(())
+    }
+
+    pub async fn set_disconnected(&self) -> Result<()> {
+        let items = {
+            let mut g = self.values.lock().unwrap();
+            g.connected = 0;
+            g.to_items()
+        };
+        warn!(service = %self.service_name, "Platform déconnectée — watchdog timeout");
+        self.emit_items_changed(&items).await
+    }
+
+    pub async fn republish(&self) -> Result<()> {
+        let items = { self.values.lock().unwrap().to_items() };
+        self.emit_items_changed(&items).await
+    }
+
+    async fn emit_items_changed(&self, items: &HashMap<String, DbusItem>) -> Result<()> {
+        let dict: ItemsDict = items
+            .iter()
+            .map(|(p, i)| (p.clone(), item_to_inner(i)))
+            .collect();
+        let ctx = SignalContext::new(&self.connection, "/")?;
+        match PlatformRootIface::items_changed(&ctx, dict).await {
+            Ok(_)  => { debug!(service = %self.service_name, "ItemsChanged platform émis"); Ok(()) }
+            Err(e) => { warn!(service = %self.service_name, "ItemsChanged warning : {}", e); Ok(()) }
+        }
+    }
+}
+
+// =============================================================================
+// Création du service
+// =============================================================================
+
+pub async fn create_platform_service(
+    dbus_bus:        &str,
+    device_instance: u32,
+    product_name:    String,
+) -> Result<PlatformServiceHandle> {
+    let service_name = VICTRON_PLATFORM_SERVICE.to_string();
+
+    info!(
+        service = %service_name,
+        device_instance = device_instance,
+        "Enregistrement service D-Bus platform Venus OS"
+    );
+
+    let initial_values = Arc::new(Mutex::new(
+        PlatformValues::disconnected(device_instance, product_name.clone())
+    ));
+
+    let root = PlatformRootIface { values: initial_values.clone() };
+
+    let builder = match dbus_bus {
+        "session" => connection::Builder::session()?,
+        _         => connection::Builder::system()?,
+    };
+
+    let conn = builder
+        .name(service_name.as_str())?
+        .serve_at("/", root)?
+        .build()
+        .await?;
+
+    let leaf_paths: Vec<String> = {
+        initial_values.lock().unwrap().to_items().into_keys().collect()
+    };
+
+    for path in &leaf_paths {
+        conn.object_server()
+            .at(path.as_str(), BusItemLeaf { path: path.clone(), values: initial_values.clone() })
+            .await?;
+    }
+
+    info!(
+        service = %service_name,
+        paths   = leaf_paths.len(),
+        "Service D-Bus platform enregistré ({} chemins + racine /)",
+        leaf_paths.len()
+    );
+
+    Ok(PlatformServiceHandle {
+        service_name,
+        device_instance,
+        values: initial_values,
+        connection: conn,
+        product_name,
+    })
+}

--- a/crates/dbus-mqtt-venus/src/switch_manager.rs
+++ b/crates/dbus-mqtt-venus/src/switch_manager.rs
@@ -1,0 +1,114 @@
+//! Manager des services D-Bus switch — orchestre N switches/ATS.
+//!
+//! Reçoit les `SwitchMqttEvent` depuis `mqtt_source` et les route vers
+//! le `SwitchServiceHandle` correspondant.
+//! Topic MQTT : `santuario/switch/{n}/venus`
+//! Service D-Bus : `com.victronenergy.switch.{prefix}_{n}`
+
+use crate::config::{SwitchRef, VenusConfig};
+use crate::mqtt_source::SwitchMqttEvent;
+use crate::switch_service::{SwitchServiceHandle, create_switch_service};
+use anyhow::Result;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::time::interval;
+use tracing::{error, info, warn};
+
+pub struct SwitchManager {
+    cfg:         VenusConfig,
+    switch_refs: Vec<SwitchRef>,
+    services:    HashMap<u8, SwitchServiceHandle>,
+    rx:          mpsc::Receiver<SwitchMqttEvent>,
+}
+
+impl SwitchManager {
+    pub fn new(
+        cfg:         VenusConfig,
+        switch_refs: Vec<SwitchRef>,
+        rx:          mpsc::Receiver<SwitchMqttEvent>,
+    ) -> Self {
+        Self { cfg, switch_refs, services: HashMap::new(), rx }
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        if !self.cfg.enabled {
+            info!("Service switch D-Bus désactivé (enabled = false)");
+            while self.rx.recv().await.is_some() {}
+            return Ok(());
+        }
+
+        let watchdog_dur  = Duration::from_secs(self.cfg.watchdog_sec);
+        let republish_dur = Duration::from_secs(self.cfg.republish_sec);
+        let mut tick      = interval(republish_dur);
+
+        info!(
+            dbus_bus     = %self.cfg.dbus_bus,
+            switches     = self.switch_refs.len(),
+            watchdog_sec = self.cfg.watchdog_sec,
+            "SwitchManager démarré"
+        );
+
+        loop {
+            tokio::select! {
+                Some(evt) = self.rx.recv() => {
+                    if let Err(e) = self.handle_event(evt).await {
+                        error!("Erreur événement switch MQTT : {:#}", e);
+                    }
+                }
+                _ = tick.tick() => {
+                    self.republish_and_watchdog(watchdog_dur).await;
+                }
+            }
+        }
+    }
+
+    async fn handle_event(&mut self, evt: SwitchMqttEvent) -> Result<()> {
+        let idx = evt.mqtt_index;
+        if !self.services.contains_key(&idx) {
+            let handle = self.create_service(idx).await?;
+            self.services.insert(idx, handle);
+        }
+        if let Some(svc) = self.services.get(&idx) {
+            svc.update(&evt.payload).await?;
+        }
+        Ok(())
+    }
+
+    async fn create_service(&self, idx: u8) -> Result<SwitchServiceHandle> {
+        let suffix          = format!("{}_{}", self.cfg.service_prefix, idx);
+        let device_instance = self.device_instance_for(idx);
+        let product_name    = self.product_name_for(idx);
+        create_switch_service(&self.cfg.dbus_bus, &suffix, device_instance, product_name).await
+    }
+
+    fn device_instance_for(&self, idx: u8) -> u32 {
+        for (pos, s) in self.switch_refs.iter().enumerate() {
+            let si = s.mqtt_index.unwrap_or((pos + 1) as u8);
+            if si == idx { return s.device_instance.unwrap_or(si as u32); }
+        }
+        idx as u32
+    }
+
+    fn product_name_for(&self, idx: u8) -> String {
+        for (pos, s) in self.switch_refs.iter().enumerate() {
+            let si = s.mqtt_index.unwrap_or((pos + 1) as u8);
+            if si == idx { if let Some(n) = &s.name { return n.clone(); } }
+        }
+        format!("Switch {}", idx)
+    }
+
+    async fn republish_and_watchdog(&self, watchdog_dur: Duration) {
+        let now = Instant::now();
+        for (idx, svc) in &self.services {
+            let last = { svc.values.lock().unwrap().last_update };
+            if now.duration_since(last) > watchdog_dur {
+                if let Err(e) = svc.set_disconnected().await {
+                    warn!(index = idx, "Erreur watchdog switch : {:#}", e);
+                }
+            } else if let Err(e) = svc.republish().await {
+                warn!(index = idx, "Erreur republication switch : {:#}", e);
+            }
+        }
+    }
+}

--- a/crates/dbus-mqtt-venus/src/switch_service.rs
+++ b/crates/dbus-mqtt-venus/src/switch_service.rs
@@ -1,0 +1,323 @@
+//! Service D-Bus `com.victronenergy.switch.{name}` pour commutateurs automatiques (ATS).
+//!
+//! Conforme au wiki Victron Venus OS — section Switch :
+//! <https://github.com/victronenergy/venus/wiki/dbus#switches>
+//!
+//! ## Chemins D-Bus exposés
+//!
+//! ```text
+//! /Position   — 0=AC1 (réseau), 1=AC2 (générateur/onduleur)
+//! /State      — 0=inactive, 1=active, 2=alerted
+//! /Connected  — 0 ou 1
+//! /ProductName
+//! /ProductId
+//! /DeviceInstance
+//! /Mgmt/ProcessName
+//! /Mgmt/ProcessVersion
+//! /Mgmt/Connection
+//! ```
+//!
+//! Utilisé pour :
+//! - ATS CHINT (commutation réseau ↔ onduleur)
+//! - Relais généraux commandés via Node-RED
+
+use crate::types::SwitchPayload;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tracing::{debug, info, warn};
+use zbus::{connection, object_server::SignalContext, Connection};
+use zvariant::{OwnedValue, Str};
+
+// =============================================================================
+// Constante
+// =============================================================================
+
+const VICTRON_SWITCH_PREFIX: &str = "com.victronenergy.switch";
+
+// =============================================================================
+// Item D-Bus
+// =============================================================================
+
+#[derive(Debug, Clone)]
+pub struct DbusItem {
+    pub value: serde_json::Value,
+    pub text:  String,
+}
+
+impl DbusItem {
+    pub fn i32(v: i32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn str(v: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn u32(v: u32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+}
+
+fn json_to_owned(v: &serde_json::Value) -> OwnedValue {
+    match v {
+        serde_json::Value::Number(n) => {
+            if n.is_f64() {
+                OwnedValue::from(n.as_f64().unwrap_or(0.0))
+            } else if n.is_u64() {
+                OwnedValue::from(n.as_u64().unwrap_or(0) as u32)
+            } else {
+                let i = n.as_i64().unwrap_or(0);
+                if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                    OwnedValue::from(i as i32)
+                } else {
+                    OwnedValue::from(i)
+                }
+            }
+        }
+        serde_json::Value::String(s) => OwnedValue::from(Str::from(s.clone())),
+        _ => OwnedValue::from(0i32),
+    }
+}
+
+fn item_to_inner(item: &DbusItem) -> HashMap<String, OwnedValue> {
+    let mut d = HashMap::new();
+    d.insert("Value".to_string(), json_to_owned(&item.value));
+    d.insert("Text".to_string(), OwnedValue::from(Str::from(item.text.clone())));
+    d
+}
+
+type ItemsDict = HashMap<String, HashMap<String, OwnedValue>>;
+
+// =============================================================================
+// Valeurs courantes
+// =============================================================================
+
+/// État courant d'un switch/ATS exposé sur D-Bus.
+#[derive(Debug, Clone)]
+pub struct SwitchValues {
+    pub connected:       i32,
+    pub position:        i32,
+    pub state:           i32,
+    pub product_name:    String,
+    pub device_instance: u32,
+    pub last_update:     Instant,
+}
+
+impl SwitchValues {
+    pub fn disconnected(device_instance: u32, product_name: String) -> Self {
+        Self {
+            connected:       0,
+            position:        0,
+            state:           0,
+            product_name,
+            device_instance,
+            last_update:     Instant::now(),
+        }
+    }
+
+    pub fn from_payload(
+        payload:         &SwitchPayload,
+        device_instance: u32,
+        product_name:    String,
+    ) -> Self {
+        Self {
+            connected:       1,
+            position:        payload.position,
+            state:           payload.state,
+            product_name,
+            device_instance,
+            last_update:     Instant::now(),
+        }
+    }
+
+    pub fn to_items(&self) -> HashMap<String, DbusItem> {
+        let mut m = HashMap::new();
+
+        // Identification
+        m.insert("/Mgmt/ProcessName".into(),    DbusItem::str("dbus-mqtt-venus"));
+        m.insert("/Mgmt/ProcessVersion".into(), DbusItem::str(env!("CARGO_PKG_VERSION")));
+        m.insert("/Mgmt/Connection".into(),     DbusItem::str("MQTT"));
+        m.insert("/ProductId".into(),           DbusItem::u32(0));
+        m.insert("/ProductName".into(),         DbusItem::str(&self.product_name));
+        m.insert("/DeviceInstance".into(),      DbusItem::u32(self.device_instance));
+        m.insert("/Connected".into(),           DbusItem::i32(self.connected));
+
+        // Switch (chemins officiels wiki Victron)
+        m.insert("/Position".into(), DbusItem::i32(self.position));
+        m.insert("/State".into(),    DbusItem::i32(self.state));
+
+        m
+    }
+}
+
+// =============================================================================
+// Interface D-Bus — objet racine `/`
+// =============================================================================
+
+struct SwitchRootIface {
+    values: Arc<Mutex<SwitchValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl SwitchRootIface {
+    fn get_items(&self) -> ItemsDict {
+        let guard = self.values.lock().unwrap();
+        guard
+            .to_items()
+            .iter()
+            .map(|(path, item)| (path.clone(), item_to_inner(item)))
+            .collect()
+    }
+
+    fn get_value(&self) -> OwnedValue { OwnedValue::from(0i32) }
+    fn get_text(&self) -> String { String::new() }
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+
+    #[zbus(signal)]
+    async fn items_changed(
+        ctx:   &SignalContext<'_>,
+        items: ItemsDict,
+    ) -> zbus::Result<()>;
+}
+
+// =============================================================================
+// Interface D-Bus — objet feuille
+// =============================================================================
+
+struct BusItemLeaf {
+    path:   String,
+    values: Arc<Mutex<SwitchValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl BusItemLeaf {
+    fn get_value(&self) -> OwnedValue {
+        let guard = self.values.lock().unwrap();
+        match guard.to_items().get(&self.path) {
+            Some(item) => json_to_owned(&item.value),
+            None       => OwnedValue::from(0i32),
+        }
+    }
+
+    fn get_text(&self) -> String {
+        let guard = self.values.lock().unwrap();
+        guard.to_items().get(&self.path).map(|i| i.text.clone()).unwrap_or_default()
+    }
+
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+}
+
+// =============================================================================
+// Handle
+// =============================================================================
+
+pub struct SwitchServiceHandle {
+    pub service_name:    String,
+    pub device_instance: u32,
+    pub values:          Arc<Mutex<SwitchValues>>,
+    connection:          Connection,
+    pub product_name:    String,
+}
+
+impl SwitchServiceHandle {
+    pub async fn update(&self, payload: &SwitchPayload) -> Result<()> {
+        let new_values = SwitchValues::from_payload(
+            payload,
+            self.device_instance,
+            self.product_name.clone(),
+        );
+        let items = new_values.to_items();
+        { *self.values.lock().unwrap() = new_values; }
+        self.emit_items_changed(&items).await?;
+        debug!(service = %self.service_name, position = payload.position, state = payload.state, "D-Bus ItemsChanged switch émis");
+        Ok(())
+    }
+
+    pub async fn set_disconnected(&self) -> Result<()> {
+        let items = {
+            let mut g = self.values.lock().unwrap();
+            g.connected = 0;
+            g.to_items()
+        };
+        warn!(service = %self.service_name, "Switch déconnecté — watchdog timeout");
+        self.emit_items_changed(&items).await
+    }
+
+    pub async fn republish(&self) -> Result<()> {
+        let items = { self.values.lock().unwrap().to_items() };
+        self.emit_items_changed(&items).await
+    }
+
+    async fn emit_items_changed(&self, items: &HashMap<String, DbusItem>) -> Result<()> {
+        let dict: ItemsDict = items
+            .iter()
+            .map(|(p, i)| (p.clone(), item_to_inner(i)))
+            .collect();
+        let ctx = SignalContext::new(&self.connection, "/")?;
+        match SwitchRootIface::items_changed(&ctx, dict).await {
+            Ok(_)  => { debug!(service = %self.service_name, "ItemsChanged switch émis"); Ok(()) }
+            Err(e) => { warn!(service = %self.service_name, "ItemsChanged warning : {}", e); Ok(()) }
+        }
+    }
+}
+
+// =============================================================================
+// Création du service
+// =============================================================================
+
+pub async fn create_switch_service(
+    dbus_bus:        &str,
+    service_suffix:  &str,
+    device_instance: u32,
+    product_name:    String,
+) -> Result<SwitchServiceHandle> {
+    let service_name = format!("{}.{}", VICTRON_SWITCH_PREFIX, service_suffix);
+
+    info!(
+        service = %service_name,
+        device_instance = device_instance,
+        "Enregistrement service D-Bus switch Venus OS"
+    );
+
+    let initial_values = Arc::new(Mutex::new(
+        SwitchValues::disconnected(device_instance, product_name.clone())
+    ));
+
+    let root = SwitchRootIface { values: initial_values.clone() };
+
+    let builder = match dbus_bus {
+        "session" => connection::Builder::session()?,
+        _         => connection::Builder::system()?,
+    };
+
+    let conn = builder
+        .name(service_name.as_str())?
+        .serve_at("/", root)?
+        .build()
+        .await?;
+
+    let leaf_paths: Vec<String> = {
+        initial_values.lock().unwrap().to_items().into_keys().collect()
+    };
+
+    for path in &leaf_paths {
+        conn.object_server()
+            .at(path.as_str(), BusItemLeaf { path: path.clone(), values: initial_values.clone() })
+            .await?;
+    }
+
+    info!(
+        service = %service_name,
+        paths   = leaf_paths.len(),
+        "Service D-Bus switch enregistré ({} chemins + racine /)",
+        leaf_paths.len()
+    );
+
+    Ok(SwitchServiceHandle {
+        service_name,
+        device_instance,
+        values: initial_values,
+        connection: conn,
+        product_name,
+    })
+}

--- a/crates/dbus-mqtt-venus/src/types.rs
+++ b/crates/dbus-mqtt-venus/src/types.rs
@@ -128,6 +128,160 @@ pub struct MeteoPayload {
 }
 
 // =============================================================================
+// Payload switch / ATS (santuario/switch/{n}/venus)
+// =============================================================================
+
+/// Payload pour commutateurs automatiques (ATS CHINT, relais, etc.).
+///
+/// Publié par Node-RED sur `santuario/switch/{n}/venus`.
+/// Cible D-Bus : `com.victronenergy.switch.{n}`
+///
+/// Chemins D-Bus exposés (wiki Victron) :
+///   /Position  — 0=AC1/Réseau, 1=AC2/Générateur, 2=AC3
+///   /State     — 0=inactive, 1=active, 2=alerted
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwitchPayload {
+    /// Position du commutateur : 0=AC1 (réseau), 1=AC2 (générateur/onduleur).
+    #[serde(rename = "Position", default)]
+    pub position: i32,
+
+    /// État : 0=inactif, 1=actif, 2=alerte.
+    #[serde(rename = "State", default)]
+    pub state: i32,
+}
+
+// =============================================================================
+// Payload compteur réseau / consommation AC (santuario/grid/{n}/venus)
+// =============================================================================
+
+/// Payload pour compteurs d'énergie AC (réseau, consommation).
+///
+/// Publié par Node-RED sur `santuario/grid/{n}/venus` ou `santuario/acload/{n}/venus`.
+/// Cible D-Bus : `com.victronenergy.grid.{n}` ou `com.victronenergy.acload.{n}`
+///
+/// Chemins D-Bus exposés (wiki Victron — Grid/ACload meter) :
+///   /Ac/L1/Current         — A AC
+///   /Ac/L1/Energy/Forward  — kWh consommés
+///   /Ac/L1/Energy/Reverse  — kWh injectés (optionnel)
+///   /Ac/L1/Power           — W (puissance réelle)
+///   /Ac/L1/Voltage         — V AC
+///   /Ac/L2/...             — Phase 2 (optionnel)
+///   /Ac/L3/...             — Phase 3 (optionnel)
+///   /DeviceType            — type de compteur
+///   /IsGenericEnergyMeter  — 1 si compteur générique masquerade en grid/acload
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GridPayload {
+    /// Données phase L1.
+    #[serde(rename = "Ac")]
+    pub ac: GridAcPayload,
+
+    /// Type de device (ex: 340 = generic energy meter).
+    #[serde(rename = "DeviceType", default)]
+    pub device_type: i32,
+
+    /// 1 si compteur générique masquerade en genset ou acload.
+    #[serde(rename = "IsGenericEnergyMeter", default)]
+    pub is_generic_energy_meter: i32,
+}
+
+/// Données AC triphasées (L1, L2, L3).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GridAcPayload {
+    /// Phase L1.
+    #[serde(rename = "L1", default)]
+    pub l1: Option<GridPhasePayload>,
+
+    /// Phase L2 (optionnelle — triphasé).
+    #[serde(rename = "L2", default)]
+    pub l2: Option<GridPhasePayload>,
+
+    /// Phase L3 (optionnelle — triphasé).
+    #[serde(rename = "L3", default)]
+    pub l3: Option<GridPhasePayload>,
+}
+
+/// Données d'une phase AC.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GridPhasePayload {
+    /// Tension en V AC.
+    #[serde(rename = "Voltage", default)]
+    pub voltage: f64,
+
+    /// Courant en A.
+    #[serde(rename = "Current", default)]
+    pub current: f64,
+
+    /// Puissance réelle en W.
+    #[serde(rename = "Power", default)]
+    pub power: f64,
+
+    /// Énergie consommée (Forward) en kWh.
+    #[serde(rename = "Energy", default)]
+    pub energy: Option<GridPhaseEnergyPayload>,
+}
+
+/// Sous-payload énergie par phase.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GridPhaseEnergyPayload {
+    /// Énergie consommée en kWh.
+    #[serde(rename = "Forward", default)]
+    pub forward: f64,
+
+    /// Énergie injectée (export) en kWh.
+    #[serde(rename = "Reverse", default)]
+    pub reverse: f64,
+}
+
+// =============================================================================
+// Payload platform / backup Pi5 (santuario/platform/venus)
+// =============================================================================
+
+/// Payload pour le service de backup/restore Pi5.
+///
+/// Publié par Node-RED sur `santuario/platform/venus` (topic fixe).
+/// Cible D-Bus : `com.victronenergy.platform` (singleton)
+///
+/// Chemins D-Bus exposés (service custom) :
+///   /Backup/Status   — 0=idle, 1=running, 2=OK, 3=error
+///   /Backup/LastRun  — timestamp Unix (secondes)
+///   /Restore/Status  — 0=idle, 1=running, 2=OK, 3=error
+///   /Restore/LastRun — timestamp Unix (secondes)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlatformPayload {
+    /// Sous-section backup.
+    #[serde(rename = "Backup", default)]
+    pub backup: Option<PlatformBackupPayload>,
+
+    /// Sous-section restore.
+    #[serde(rename = "Restore", default)]
+    pub restore: Option<PlatformRestorePayload>,
+}
+
+/// État du backup Pi5.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PlatformBackupPayload {
+    /// 0=idle, 1=running, 2=OK, 3=error.
+    #[serde(rename = "Status", default)]
+    pub status: i32,
+
+    /// Timestamp Unix du dernier backup terminé.
+    #[serde(rename = "LastRun", default)]
+    pub last_run: i64,
+}
+
+/// État du restore Pi5.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PlatformRestorePayload {
+    /// 0=idle, 1=running, 2=OK, 3=error.
+    #[serde(rename = "Status", default)]
+    pub status: i32,
+
+    /// Timestamp Unix du dernier restore terminé.
+    #[serde(rename = "LastRun", default)]
+    pub last_run: i64,
+}
+
+// =============================================================================
 // Payload batteries (santuario/bms/{n}/venus)
 // =============================================================================
 

--- a/docker/mosquitto/config/mosquitto.conf
+++ b/docker/mosquitto/config/mosquitto.conf
@@ -63,6 +63,10 @@ topic santuario/# in 0
 
 # Capteurs → NanoPi — commandes Node-RED vers service Rust (Pi5 → NanoPi)
 # heat = température extérieure, heatpump = chauffe-eau, meteo = irradiance
-topic santuario/heat/# out 0
+# switch = ATS/relais, grid = compteur réseau/acload, platform = backup Pi5
+topic santuario/heat/#     out 0
 topic santuario/heatpump/# out 0
-topic santuario/meteo/# out 0
+topic santuario/meteo/#    out 0
+topic santuario/switch/#   out 0
+topic santuario/grid/#     out 0
+topic santuario/platform/# out 0

--- a/docs/VENUS-DEVICE-INTEGRATION.md
+++ b/docs/VENUS-DEVICE-INTEGRATION.md
@@ -551,10 +551,241 @@ mosquitto_sub -h localhost -t "santuario/heatpump/1/venus" -v
 
 | Device | Service D-Bus | Topic MQTT | Index config |
 |---|---|---|---|
-| Batterie Daly | `com.victronenergy.battery.mqtt_{n}` | `santuario/bms/{n}/venus` | `[[bms]]` |
-| Température extérieure | `com.victronenergy.temperature.mqtt_{n}` | `santuario/heat/{n}/venus` | `[[sensors]]` |
+| Batterie Daly (360Ah, 320Ah, 628Ah) | `com.victronenergy.battery.mqtt_{n}` | `santuario/bms/{n}/venus` | `[[bms]]` |
+| Température / Humidité | `com.victronenergy.temperature.mqtt_{n}` | `santuario/heat/{n}/venus` | `[[sensors]]` |
 | Chauffe-eau (HeatPump) | `com.victronenergy.heatpump.mqtt_{n}` | `santuario/heatpump/{n}/venus` | `[[heatpumps]]` |
 | Irradiance (Meteo) | `com.victronenergy.meteo` | `santuario/meteo/venus` | `[meteo]` |
+| Switch / ATS CHINT | `com.victronenergy.switch.mqtt_{n}` | `santuario/switch/{n}/venus` | `[[switches]]` |
+| Compteur réseau (Grid) | `com.victronenergy.grid.mqtt_{n}` | `santuario/grid/{n}/venus` | `[[grids]]` |
+| Compteur consommation (ACload) | `com.victronenergy.acload.mqtt_{n}` | `santuario/grid/{n}/venus` | `[[grids]]` (service_type="acload") |
+| Backup/Restore Pi5 | `com.victronenergy.platform` | `santuario/platform/venus` | `[platform]` |
+
+---
+
+## Exemple : Switch / ATS CHINT
+
+### 1. Type D-Bus utilisé
+
+`com.victronenergy.switch` — wiki Victron :
+<https://github.com/victronenergy/venus/wiki/dbus#switches>
+
+Chemins exposés :
+- `/Position` — 0=AC1 (réseau), 1=AC2 (générateur/onduleur)
+- `/State` — 0=inactive, 1=active, 2=alerted
+- `/Connected`, `/ProductName`, `/DeviceInstance`
+
+### 2. Configuration Config.toml
+
+```toml
+[switch]
+topic_prefix = "santuario/switch"
+
+[[switches]]
+mqtt_index      = 1
+name            = "ATS CHINT"
+device_instance = 60
+```
+
+### 3. Topic MQTT
+
+```
+santuario/switch/1/venus
+```
+
+Payload JSON (publié par Node-RED) :
+```json
+{"Position": 0, "State": 1}
+```
+
+| Position | Signification |
+|---|---|
+| 0 | AC1 — réseau EDF |
+| 1 | AC2 — onduleur / groupe |
+
+### 4. Service D-Bus résultant
+
+```
+com.victronenergy.switch.mqtt_1
+```
+
+### 5. Vérification D-Bus
+
+```bash
+dbus -y com.victronenergy.switch.mqtt_1 / GetItems
+dbus -y com.victronenergy.switch.mqtt_1 /Position GetValue
+dbus -y com.victronenergy.switch.mqtt_1 /State    GetValue
+```
+
+---
+
+## Exemple : Compteur réseau (Grid / ACload)
+
+### 1. Type D-Bus utilisé
+
+`com.victronenergy.grid` ou `com.victronenergy.acload` :
+<https://github.com/victronenergy/venus/wiki/dbus#grid-and-acload-and-genset-meter>
+
+Chemins exposés (L1, L2, L3 — tous enregistrés dès le démarrage) :
+- `/Ac/L1/Voltage` — V AC
+- `/Ac/L1/Current` — A
+- `/Ac/L1/Power` — W (puissance réelle)
+- `/Ac/L1/Energy/Forward` — kWh consommés
+- `/Ac/L1/Energy/Reverse` — kWh injectés
+- `/Ac/L2/...` et `/Ac/L3/...` — même structure (0.0 si monophasé)
+- `/DeviceType` — 340 = generic energy meter
+- `/IsGenericEnergyMeter` — 1 si compteur générique masquerade
+
+### 2. Configuration Config.toml
+
+```toml
+[grid]
+topic_prefix = "santuario/grid"
+
+[[grids]]
+mqtt_index      = 1
+name            = "Compteur EDF"
+device_instance = 70
+service_type    = "grid"    # ou "acload"
+
+[[grids]]
+mqtt_index      = 2
+name            = "Consommation AC"
+device_instance = 71
+service_type    = "acload"
+```
+
+### 3. Topic MQTT
+
+```
+santuario/grid/1/venus
+```
+
+Payload JSON monophasé :
+```json
+{
+  "Ac": {
+    "L1": {
+      "Voltage": 230.0,
+      "Current": 5.2,
+      "Power": 1196.0,
+      "Energy": {"Forward": 1234.5, "Reverse": 0.0}
+    }
+  },
+  "DeviceType": 340,
+  "IsGenericEnergyMeter": 0
+}
+```
+
+Payload JSON triphasé :
+```json
+{
+  "Ac": {
+    "L1": {"Voltage": 230.0, "Current": 5.2, "Power": 1196.0, "Energy": {"Forward": 400.0}},
+    "L2": {"Voltage": 231.0, "Current": 4.8, "Power": 1108.8, "Energy": {"Forward": 380.0}},
+    "L3": {"Voltage": 229.0, "Current": 6.1, "Power": 1396.9, "Energy": {"Forward": 450.0}}
+  }
+}
+```
+
+### 4. Service D-Bus résultant
+
+```
+com.victronenergy.grid.mqtt_1     (si service_type = "grid")
+com.victronenergy.acload.mqtt_2   (si service_type = "acload")
+```
+
+### 5. Vérification D-Bus
+
+```bash
+dbus -y com.victronenergy.grid.mqtt_1 / GetItems
+dbus -y com.victronenergy.grid.mqtt_1 /Ac/L1/Power   GetValue
+dbus -y com.victronenergy.grid.mqtt_1 /Ac/L1/Voltage GetValue
+```
+
+---
+
+## Exemple : Platform Backup/Restore Pi5
+
+### 1. Service D-Bus utilisé
+
+`com.victronenergy.platform` (singleton — service custom)
+
+Chemins exposés :
+- `/Backup/Status` — 0=idle, 1=running, 2=OK, 3=error
+- `/Backup/LastRun` — timestamp Unix (secondes)
+- `/Restore/Status` — 0=idle, 1=running, 2=OK, 3=error
+- `/Restore/LastRun` — timestamp Unix (secondes)
+
+### 2. Configuration Config.toml
+
+```toml
+[platform]
+topic           = "santuario/platform/venus"
+product_name    = "Pi5 Platform"
+device_instance = 50
+enabled         = true
+```
+
+### 3. Topic MQTT
+
+```
+santuario/platform/venus
+```
+
+Payload JSON :
+```json
+{
+  "Backup":  {"Status": 2, "LastRun": 1710000000},
+  "Restore": {"Status": 0, "LastRun": 0}
+}
+```
+
+### 4. Flux Node-RED (exemple)
+
+```javascript
+// Déclencher un backup Pi5 via script SSH ou API
+// Puis publier le statut :
+return {
+  topic:   'santuario/platform/venus',
+  payload: JSON.stringify({
+    Backup:  { Status: 2, LastRun: Math.floor(Date.now() / 1000) },
+    Restore: { Status: 0, LastRun: 0 }
+  })
+};
+```
+
+### 5. Vérification D-Bus
+
+```bash
+dbus -y com.victronenergy.platform / GetItems
+dbus -y com.victronenergy.platform /Backup/Status  GetValue
+dbus -y com.victronenergy.platform /Backup/LastRun GetValue
+```
+
+---
+
+## Batterie agrégée 628Ah (BMS-3 virtuel)
+
+La batterie 628Ah est une batterie **virtuelle agrégée** calculée par Node-RED
+à partir des données BMS-1 (360Ah) et BMS-2 (268Ah) ou des deux BMS réels.
+
+Configuration dans Config.toml :
+
+```toml
+[[bms]]
+address         = "0x03"
+name            = "BMS-628Ah"
+capacity_ah     = 628.0
+mqtt_index      = 3
+device_instance = 143
+```
+
+Flux Node-RED — calcul agrégé et publication sur `santuario/bms/3/venus` :
+```javascript
+const bms1 = global.get('bms1_snapshot');
+const bms2 = global.get('bms2_snapshot');
+// Combiner les données et publier le payload VenusPayload agrégé
+```
 
 ---
 


### PR DESCRIPTION
…rie 628Ah

Nouveaux services D-Bus Venus OS implémentés :

- com.victronenergy.switch.mqtt_{n} ATS CHINT et relais commandés via Node-RED Topic: santuario/switch/{n}/venus Paths: /Position, /State, /Connected, /ProductName, /DeviceInstance

- com.victronenergy.grid.mqtt_{n} Compteur réseau triphasé (L1/L2/L3) Topic: santuario/grid/{n}/venus Paths: /Ac/L{1,2,3}/Voltage, /Current, /Power, /Energy/Forward, /Energy/Reverse /DeviceType, /IsGenericEnergyMeter

- com.victronenergy.acload.mqtt_{n} Même structure que grid, service_type="acload" dans [[grids]]

- com.victronenergy.platform (singleton) Backup/Restore Pi5 — service custom Topic: santuario/platform/venus Paths: /Backup/Status, /Backup/LastRun, /Restore/Status, /Restore/LastRun

Fichiers créés :
  switch_service.rs, switch_manager.rs grid_service.rs, grid_manager.rs platform_service.rs, platform_manager.rs

Fichiers modifiés :
  types.rs     — SwitchPayload, GridPayload, PlatformPayload
  config.rs    — SwitchConfig/SwitchRef, GridConfig/GridRef, PlatformConfig
  mqtt_source.rs — 3 nouvelles sources MQTT (switch, grid, platform)
  main.rs      — spawn des 3 nouveaux managers
  mosquitto.conf — bridge out: santuario/switch/#, santuario/grid/#, santuario/platform/#
  VENUS-DEVICE-INTEGRATION.md — exemples complets pour chaque nouveau device

Batterie 628Ah : support existant via [[bms]] mqtt_index=3, doc ajoutée.

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH