### PR TITLE
fix(nanopi): switch device_instance 301 → 60 (cohérent avec plage 20-60)

### DIFF
--- a/nanoPi/config-nanopi.toml
+++ b/nanoPi/config-nanopi.toml
@@ -124,7 +124,7 @@ topic_prefix = "santuario/switch"
 [[switches]]
 mqtt_index      = 1
 name            = "ATS CHINT"
-device_instance = 301
+device_instance = 60
 
 # -----------------------------------------------------------------------------
 # Compteurs réseau / consommation AC


### PR DESCRIPTION
Alignement avec les autres instances :
  temperature : 20
  heatpump    : 30
  meteo       : 40
  platform    : 50
  switch      : 60  ← était 301 (arbitraire)

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH