### PR TITLE
fix(nodered/meteo): WindSpeed en m/s — ajouter wind_speed_unit=ms dan…

### DIFF
--- a/flux-nodered/meteo.json
+++ b/flux-nodered/meteo.json
@@ -35,7 +35,7 @@
         "method": "GET",
         "ret": "obj",
         "paytoqs": "ignore",
-        "url": "https://api.open-meteo.com/v1/forecast?latitude=43.8833&longitude=7.8667&current=temperature_2m,relative_humidity_2m,pressure_msl,wind_speed_10m,wind_direction_10m&timezone=Europe%2FRome",
+        "url": "https://api.open-meteo.com/v1/forecast?latitude=43.8833&longitude=7.8667&current=temperature_2m,relative_humidity_2m,pressure_msl,wind_speed_10m,wind_direction_10m&timezone=Europe%2FRome&wind_speed_unit=ms",
         "tls": "",
         "persist": false,
         "proxy": "",


### PR DESCRIPTION
…s URL Open-Meteo

Open-Meteo retourne wind_speed_10m en km/h par défaut. Victron com.victronenergy.meteo attend WindSpeed en m/s. Sans ce paramètre, 6.5 km/h était transmis comme 6.5 m/s (+3.6x).

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH