### PR TITLE
fix(nodered): topic pvinverter wildcard + flow correction baseline

### DIFF
--- a/flux-nodered/fix-pvinv-baseline.json
+++ b/flux-nodered/fix-pvinv-baseline.json
@@ -1,0 +1,111 @@
+[
+    {
+        "id": "fix_pvinv_tab",
+        "type": "tab",
+        "label": "FIX — PVInverter baseline",
+        "disabled": false,
+        "info": "Flow de correction à importer et exécuter UNE SEULE FOIS quand pvinv_baseline est incorrect (ex: reset fait en pleine journée).\n\n1. Importer ce flow dans Node-RED\n2. Vérifier les valeurs dans le nœud 'Fix PVInv Baseline'\n3. Cliquer Deploy\n4. Cliquer le bouton Inject\n5. Vérifier le statut : Total=X.XX kWh\n6. Supprimer ce flow après usage"
+    },
+
+    {
+        "id": "fix_pvinv_inject",
+        "type": "inject",
+        "z": "fix_pvinv_tab",
+        "name": "▶ Lancer la correction (1 fois)",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0,
+        "topic": "",
+        "x": 200,
+        "y": 100,
+        "wires": [
+            ["fix_pvinv_fn"]
+        ]
+    },
+
+    {
+        "id": "fix_pvinv_fn",
+        "type": "function",
+        "z": "fix_pvinv_tab",
+        "name": "Fix PVInv Baseline",
+        "func":
+            "// ─────────────────────────────────────────────────────\n" +
+            "// VALEURS À VÉRIFIER AVANT D'EXÉCUTER\n" +
+            "// currentCumul : lire sur NanoPi avec\n" +
+            "//   dbus -y com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2 /Ac/Energy/Forward GetValue\n" +
+            "// totalVictron : valeur 'Solaire' affichée dans Venus OS (MPPT + PVInverter)\n" +
+            "// ─────────────────────────────────────────────────────\n" +
+            "const currentCumul = 587.2;   // ← kWh cumulé PVInverter (NanoPi)\n" +
+            "const totalVictron  = 3.9;    // ← kWh 'Solaire' Victron (MPPT + PVInv)\n" +
+            "\n" +
+            "const mpptToday   = global.get('mppt_yield_today') || 0;\n" +
+            "const pvinvToday  = Math.max(0, parseFloat((totalVictron - mpptToday).toFixed(3)));\n" +
+            "const newBaseline = parseFloat((currentCumul - pvinvToday).toFixed(3));\n" +
+            "const total       = parseFloat((mpptToday + pvinvToday).toFixed(3));\n" +
+            "\n" +
+            "global.set('pvinv_baseline',    newBaseline);\n" +
+            "global.set('pvinv_yield_today', pvinvToday);\n" +
+            "global.set('total_yield_today', total);\n" +
+            "\n" +
+            "node.warn(`✅ Baseline fixée: ${newBaseline} kWh | MPPT: ${mpptToday.toFixed(2)} | PVInv: ${pvinvToday.toFixed(2)} | Total: ${total.toFixed(2)} kWh`);\n" +
+            "node.status({fill:'green', shape:'dot', text:`Total=${total.toFixed(2)} kWh — OK`});\n" +
+            "return msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 480,
+        "y": 100,
+        "wires": [
+            ["fix_pvinv_debug"]
+        ]
+    },
+
+    {
+        "id": "fix_pvinv_debug",
+        "type": "debug",
+        "z": "fix_pvinv_tab",
+        "name": "Résultat correction",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": true,
+        "complete": "true",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 720,
+        "y": 100,
+        "wires": []
+    },
+
+    {
+        "id": "fix_pvinv_comment",
+        "type": "comment",
+        "z": "fix_pvinv_tab",
+        "name": "PROCÉDURE",
+        "info":
+            "## Quand utiliser ce flow ?\n" +
+            "Quand le reset minuit a été déclenché manuellement en pleine journée,\n" +
+            "ou quand pvinv_yield_today = 0 alors que le PVInverter a produit.\n\n" +
+            "## Avant d'exécuter\n" +
+            "1. Sur NanoPi :\n" +
+            "   dbus -y com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2 /Ac/Energy/Forward GetValue\n" +
+            "   → noter la valeur (ex: 587.2)\n\n" +
+            "2. Sur Victron GUI :\n" +
+            "   Noter la valeur 'Solaire' (ex: 3.9 kWh)\n\n" +
+            "3. Mettre à jour les deux constantes dans le nœud 'Fix PVInv Baseline'\n\n" +
+            "## Vérification après\n" +
+            "Sur NanoPi :\n" +
+            "  mosquitto_sub -h 127.0.0.1 -p 1883 -t 'santuario/meteo/venus' -C 1\n" +
+            "  → TodaysYield doit afficher ~totalVictron\n\n" +
+            "## IMPORTANT\n" +
+            "Supprimer ce flow après usage pour ne pas l'exécuter par accident.",
+        "x": 200,
+        "y": 200,
+        "wires": []
+    }
+]

--- a/flux-nodered/meteo.json
+++ b/flux-nodered/meteo.json
@@ -153,7 +153,7 @@
         "type": "comment",
         "z": "e6e3a16384301f83",
         "name": "Production solaire du jour — MPPT History/Daily/0/Yield + PVInverter delta",
-        "info": "## Sources\n- MPPT SmartSolar → N/c0619ab9929a/solarcharger/+/History/Daily/0/Yield\n  Venus OS reset cette valeur automatiquement à minuit.\n- Micro-onduleurs → N/c0619ab9929a/pvinverter/32/Ac/Energy/Forward\n  Valeur cumulée depuis installation → on calcule le delta journalier.\n\n## Reset minuit\n  L'inject cron à 00h00 remet à zéro la baseline du PVInverter.\n  Le MPPT est géré automatiquement par Venus OS.\n\n## Contexte global utilisé\n  mppt_yields        — dict {topic: kWh} par MPPT\n  mppt_yield_today   — somme MPPT kWh/jour\n  pvinv_baseline     — énergie PVInverter au début du jour\n  pvinv_yield_today  — delta PVInverter kWh/jour\n  total_yield_today  — somme totale publiée dans TodaysYield",
+        "info": "## Sources\n- MPPT SmartSolar → N/c0619ab9929a/solarcharger/+/History/Daily/0/Yield\n  Venus OS reset cette valeur automatiquement à minuit.\n- Micro-onduleurs → N/c0619ab9929a/pvinverter/+/Ac/Energy/Forward\n  Service D-Bus réel : com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2\n  Wildcard + utilisé car instance peut changer. Valeur cumulée → delta journalier.\n\n## Reset minuit\n  L'inject cron à 00h00 remet à zéro la baseline du PVInverter.\n  Le MPPT est géré automatiquement par Venus OS.\n\n## Contexte global utilisé\n  mppt_yields        — dict {topic: kWh} par MPPT\n  mppt_yield_today   — somme MPPT kWh/jour\n  pvinv_baseline     — énergie PVInverter au début du jour\n  pvinv_yield_today  — delta PVInverter kWh/jour\n  total_yield_today  — somme totale publiée dans TodaysYield\n\n## Vérification NanoPi\n  dbus -y | grep pvinverter\n  dbus -y com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2 /Ac/Energy/Forward GetValue",
         "x": 300,
         "y": 360,
         "wires": []
@@ -206,7 +206,7 @@
         "type": "mqtt in",
         "z": "e6e3a16384301f83",
         "name": "PVInverter énergie totale (kWh cumulé)",
-        "topic": "N/c0619ab9929a/pvinverter/32/Ac/Energy/Forward",
+        "topic": "N/c0619ab9929a/pvinverter/+/Ac/Energy/Forward",
         "qos": "0",
         "datatype": "json",
         "broker": "pi5_mqtt_broker",


### PR DESCRIPTION
- meteo.json: pvinverter/32 → pvinverter/+ (service réel: cgwacs_ttyUSB0_mb2, instance inconnue)
- meteo.json: commentaire mis à jour avec nom service D-Bus réel
- fix-pvinv-baseline.json: flow à importer pour corriger pvinv_baseline quand reset fait en pleine journée

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH