### PR TITLE
fix(meteo): supprimer champ external_temperature de MeteoValues (dead…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -869,15 +869,14 @@ dbus -y com.victronenergy.battery.mqtt_1 /Soc GetValue
 dbus -y com.victronenergy.battery.mqtt_2 /Soc GetValue
 ```
 
-### Architecture température (décision 2026-03-22)
+### Architecture température (décision définitive 2026-03-22)
 
 La température extérieure est publiée **uniquement** via `com.victronenergy.temperature.mqtt_1` (type 4=Outdoor).
 
-- `/ExternalTemperature` a été **retiré** de `com.victronenergy.meteo` (commit `939595f`).
-  - Cause : Venus OS affichait "Température: -" dans le widget météo sans pouvoir corriger (limitation firmware).
-  - Solution : supprimer le chemin D-Bus → le champ disparaît du widget.
-- La température reste accessible dans la liste des capteurs Victron via `temperature.mqtt_1`.
-- **NE PAS réajouter** `/ExternalTemperature` dans `meteo_service.rs`.
+- `/ExternalTemperature` est **absent** de `com.victronenergy.meteo` et du struct `MeteoValues`.
+- **"Température: -"** dans le widget météo Venus OS est **inévitable** : le champ est codé en dur dans le QML Venus OS et s'affiche toujours, que le chemin D-Bus existe ou non. Aucun contournement possible depuis notre code.
+- La température réelle est accessible via `com.victronenergy.temperature.mqtt_1` (Connected=1, ~8.8°C).
+- **NE PAS réajouter** `external_temperature` dans `MeteoValues` ni `meteo_service.rs`.
 
 ### Limitations connues Venus OS
 

--- a/crates/dbus-mqtt-venus/src/meteo_service.rs
+++ b/crates/dbus-mqtt-venus/src/meteo_service.rs
@@ -104,7 +104,6 @@ pub struct MeteoValues {
     pub connected:            i32,
     pub irradiance:           f64,
     pub todays_yield:         f64,
-    pub external_temperature: Option<f64>,
     pub wind_direction:       Option<f64>,
     pub wind_speed:           Option<f64>,
     pub product_name:         String,
@@ -115,15 +114,14 @@ pub struct MeteoValues {
 impl MeteoValues {
     pub fn disconnected(device_instance: u32, product_name: String) -> Self {
         Self {
-            connected:            0,
-            irradiance:           0.0,
-            todays_yield:         0.0,
-            external_temperature: None,
-            wind_direction:       None,
-            wind_speed:           None,
+            connected:       0,
+            irradiance:      0.0,
+            todays_yield:    0.0,
+            wind_direction:  None,
+            wind_speed:      None,
             product_name,
             device_instance,
-            last_update:          Instant::now(),
+            last_update:     Instant::now(),
         }
     }
 
@@ -133,15 +131,14 @@ impl MeteoValues {
         product_name:    String,
     ) -> Self {
         Self {
-            connected:            1,
-            irradiance:           payload.irradiance,
-            todays_yield:         payload.todays_yield,
-            external_temperature: payload.external_temperature,
-            wind_direction:       payload.wind_direction,
-            wind_speed:           payload.wind_speed,
+            connected:      1,
+            irradiance:     payload.irradiance,
+            todays_yield:   payload.todays_yield,
+            wind_direction: payload.wind_direction,
+            wind_speed:     payload.wind_speed,
             product_name,
             device_instance,
-            last_update:          Instant::now(),
+            last_update:    Instant::now(),
         }
     }
 


### PR DESCRIPTION
…_code)

Le champ n'est plus utilise depuis la suppression de /ExternalTemperature du D-Bus. Le widget Venus OS affiche toujours 'Temperature: -' (QML code en dur) independamment de la presence du chemin D-Bus — limitation Venus OS incontournable, documentee.

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH