### PR TITLE
feat(nodered): persistance production solaire via InfluxDB + deploy-n…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,18 @@ deploy: build-arm
 	@echo "✓ Déployé sur $(PI_HOST)"
 
 # =============================================================================
+# Node-RED — Déploiement des flows depuis git
+# =============================================================================
+
+NODERED_URL ?= http://localhost:1880
+
+.PHONY: deploy-nodered
+
+deploy-nodered:
+	@echo "Déploiement des flows Node-RED depuis flux-nodered/ ..."
+	NODERED_URL=$(NODERED_URL) python3 contrib/deploy-nodered-flows.py
+
+# =============================================================================
 # Dashboard (React)
 # =============================================================================
 
@@ -243,5 +255,7 @@ help:
 	@echo ""
 	@echo "  Déploiement :"
 	@echo "    make install       Installer le service systemd"
-	@echo "    make deploy                           Déployer sur pi5compute@192.168.1.141"
+	@echo "    make deploy        Déployer daly-bms-server sur pi5compute@192.168.1.141"
+	@echo "    make deploy-nodered  Pousser flows Node-RED depuis git vers Node-RED (port 1880)"
+	@echo "    make install-venus-v7  Déployer dbus-mqtt-venus sur NanoPi (armv7)"
 	@echo ""

--- a/contrib/deploy-nodered-flows.py
+++ b/contrib/deploy-nodered-flows.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+deploy-nodered-flows.py
+Déploie les flows Node-RED depuis flux-nodered/*.json vers Node-RED via l'API REST.
+
+Usage :
+  python3 contrib/deploy-nodered-flows.py
+  NODERED_URL=http://192.168.1.141:1880 python3 contrib/deploy-nodered-flows.py
+
+Principe :
+  1. GET /flows          → récupère tous les flows actuels de Node-RED
+  2. Lit flux-nodered/*.json → nouveaux flows depuis git
+  3. Fusionne : les nœuds git écrasent/complètent les nœuds existants (par ID)
+  4. POST /flows         → déploie (équivalent du bouton "Deploy" dans l'UI)
+
+Pas de redémarrage Docker nécessaire.
+"""
+
+import json
+import os
+import glob
+import sys
+import urllib.request
+import urllib.error
+import time
+
+NODERED_URL = os.environ.get("NODERED_URL", "http://localhost:1880")
+FLOWS_DIR   = os.path.join(os.path.dirname(__file__), "..", "flux-nodered")
+
+
+def get_flows():
+    """Récupère tous les flows actuels depuis Node-RED."""
+    req = urllib.request.Request(f"{NODERED_URL}/flows")
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            # v1 API → array, v2 API → {"flows": [...]}
+            return data if isinstance(data, list) else data.get("flows", [])
+    except urllib.error.URLError as e:
+        print(f"ERREUR : impossible de joindre Node-RED ({NODERED_URL}) : {e}")
+        print("  → Vérifier que Node-RED est démarré (make up)")
+        sys.exit(1)
+
+
+def post_flows(flows):
+    """Envoie les flows fusionnés à Node-RED et déclenche un déploiement complet."""
+    body = json.dumps(flows).encode("utf-8")
+    req  = urllib.request.Request(f"{NODERED_URL}/flows", data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Node-RED-Deployment-Type", "full")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        print(f"ERREUR HTTP {e.code} lors du déploiement : {e.read().decode()}")
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"ERREUR réseau lors du déploiement : {e}")
+        sys.exit(1)
+
+
+def load_git_flows():
+    """Lit tous les *.json depuis flux-nodered/ et fusionne en une seule liste dédupliquée."""
+    pattern = os.path.join(FLOWS_DIR, "*.json")
+    files   = sorted(glob.glob(pattern))
+    if not files:
+        print(f"ERREUR : aucun fichier .json dans {FLOWS_DIR}")
+        sys.exit(1)
+
+    nodes_by_id = {}  # déduplication par ID (dernier lu gagne)
+    for fpath in files:
+        fname = os.path.basename(fpath)
+        try:
+            with open(fpath, encoding="utf-8") as f:
+                nodes = json.load(f)
+            if not isinstance(nodes, list):
+                print(f"  [SKIP] {fname} : format inattendu (pas un tableau)")
+                continue
+            for node in nodes:
+                if "id" in node:
+                    nodes_by_id[node["id"]] = node
+            print(f"  [OK]   {fname} ({len(nodes)} nœuds)")
+        except Exception as e:
+            print(f"  [ERR]  {fname} : {e}")
+
+    return nodes_by_id
+
+
+def merge(current_flows, git_nodes_by_id):
+    """
+    Stratégie de fusion :
+    - Les nœuds présents dans git (par ID) écrasent ceux de Node-RED.
+    - Les nœuds NOT présents dans git sont conservés (autres tabs non gérés par git).
+    - Les nœuds dont le 'z' (tab parent) est géré par git sont retirés,
+      sauf s'ils existent déjà dans git (ils seraient déjà inclus).
+    """
+    git_ids     = set(git_nodes_by_id.keys())
+    git_tab_ids = {n["id"] for n in git_nodes_by_id.values() if n.get("type") == "tab"}
+
+    # Garder les nœuds courants qui :
+    #  - ne sont pas dans git (pas de remplacement prévu)
+    #  - n'appartiennent pas à un tab géré par git (évite les doublons)
+    kept = [
+        n for n in current_flows
+        if n.get("id") not in git_ids
+        and n.get("z") not in git_tab_ids
+    ]
+
+    merged = kept + list(git_nodes_by_id.values())
+    return merged, len(kept), len(git_nodes_by_id)
+
+
+def wait_for_nodered(max_wait=30):
+    """Attend que Node-RED soit disponible."""
+    print(f"Attente de Node-RED ({NODERED_URL})...", end="", flush=True)
+    for _ in range(max_wait):
+        try:
+            urllib.request.urlopen(f"{NODERED_URL}", timeout=2)
+            print(" OK")
+            return
+        except Exception:
+            print(".", end="", flush=True)
+            time.sleep(1)
+    print("\nErreur : Node-RED n'a pas répondu dans les délais.")
+    sys.exit(1)
+
+
+def main():
+    print("=" * 60)
+    print("Déploiement des flows Node-RED depuis git")
+    print(f"  Source  : {os.path.abspath(FLOWS_DIR)}")
+    print(f"  Cible   : {NODERED_URL}")
+    print("=" * 60)
+
+    wait_for_nodered()
+
+    print("\nLecture des flows depuis git :")
+    git_nodes = load_git_flows()
+    print(f"  Total : {len(git_nodes)} nœuds uniques")
+
+    print("\nRécupération des flows Node-RED actuels...")
+    current = get_flows()
+    print(f"  Flows actuels : {len(current)} nœuds")
+
+    merged, kept, added = merge(current, git_nodes)
+    print(f"\nFusion : {kept} nœuds conservés + {added} nœuds git = {len(merged)} total")
+
+    print("\nDéploiement...")
+    status = post_flows(merged)
+    print(f"\n{'='*60}")
+    print(f"✓ Flows déployés avec succès (HTTP {status})")
+    print(f"  Ouvrir http://192.168.1.141:1880 pour vérifier")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -81,6 +81,10 @@ services:
       - "1880:1880"
     environment:
       - TZ=Europe/Paris
+      # Transmis aux flows pour les requêtes InfluxDB (persistance production solaire)
+      - INFLUX_TOKEN=${INFLUX_TOKEN}
+      - INFLUX_ORG=${INFLUX_ORG:-santuario}
+      - INFLUX_BUCKET=${INFLUX_BUCKET:-daly_bms}
     volumes:
       - nodered-data:/data
     depends_on:

--- a/flux-nodered/meteo.json
+++ b/flux-nodered/meteo.json
@@ -185,8 +185,8 @@
         "type": "function",
         "z": "e6e3a16384301f83",
         "name": "Accumuler MPPT yields",
-        "func": "const val = msg.payload && msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nif (val === null || val === undefined || isNaN(val)) return null;\n\nlet mpptYields = global.get('mppt_yields') || {};\nmpptYields[msg.topic] = parseFloat(val) || 0;\nglobal.set('mppt_yields', mpptYields);\n\nconst mpptTotal = Object.values(mpptYields).reduce((a, b) => a + b, 0);\nglobal.set('mppt_yield_today', mpptTotal);\n\nconst pvinvYield = global.get('pvinv_yield_today') || 0;\nconst total = parseFloat((mpptTotal + pvinvYield).toFixed(3));\nglobal.set('total_yield_today', total);\n\nnode.status({fill:'green', shape:'dot', text:`MPPT: ${mpptTotal.toFixed(2)} kWh | Total: ${total.toFixed(2)} kWh`});\nreturn msg;",
-        "outputs": 1,
+        "func": "const val = msg.payload && msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nif (val === null || val === undefined || isNaN(val)) return null;\n\nlet mpptYields = global.get('mppt_yields') || {};\nmpptYields[msg.topic] = parseFloat(val) || 0;\nglobal.set('mppt_yields', mpptYields);\n\nconst mpptTotal = Object.values(mpptYields).reduce((a, b) => a + b, 0);\nglobal.set('mppt_yield_today', mpptTotal);\n\nconst pvinvYield = global.get('pvinv_yield_today') || 0;\nconst total = parseFloat((mpptTotal + pvinvYield).toFixed(3));\nglobal.set('total_yield_today', total);\n\nnode.status({fill:'green', shape:'dot', text:`MPPT: ${mpptTotal.toFixed(2)} kWh | Total: ${total.toFixed(2)} kWh`});\n// Output 1 → debug_yield, Output 2 → InfluxDB persist\nreturn [msg, {}];",
+        "outputs": 2,
         "timeout": "",
         "noerr": 0,
         "initialize": "",
@@ -197,6 +197,9 @@
         "wires": [
             [
                 "debug_yield"
+            ],
+            [
+                "influx_write_fn"
             ]
         ]
     },
@@ -228,7 +231,7 @@
         "z": "e6e3a16384301f83",
         "name": "Delta journalier PVInverter",
         "func": "const val = msg.payload && msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nif (val === null || val === undefined || isNaN(val)) return null;\n\nconst current = parseFloat(val);\n\nlet baseline = global.get('pvinv_baseline');\nif (baseline === null || baseline === undefined) {\n    // Premier message du jour (ou après reset minuit) : poser la baseline\n    global.set('pvinv_baseline', current);\n    baseline = current;\n}\n\nconst dailyYield = Math.max(0, parseFloat((current - baseline).toFixed(3)));\nglobal.set('pvinv_yield_today', dailyYield);\n\nconst mpptYield = global.get('mppt_yield_today') || 0;\nconst total = parseFloat((mpptYield + dailyYield).toFixed(3));\nglobal.set('total_yield_today', total);\n\nnode.status({fill:'blue', shape:'dot', text:`PVInv: ${dailyYield.toFixed(2)} kWh | Total: ${total.toFixed(2)} kWh`});\n\n// Output 1 → debug_yield\n// Output 2 → persist baseline dans Mosquitto (retain)\nreturn [msg, {payload: baseline}];",
-        "outputs": 2,
+        "outputs": 3,
         "timeout": "",
         "noerr": 0,
         "initialize": "",
@@ -242,6 +245,9 @@
             ],
             [
                 "pvinv_persist_out"
+            ],
+            [
+                "influx_write_fn"
             ]
         ]
     },
@@ -371,6 +377,142 @@
         "x": 870,
         "y": 560,
         "wires": []
+    },
+
+    {
+        "id": "influx_comment",
+        "type": "comment",
+        "z": "e6e3a16384301f83",
+        "name": "PERSISTANCE InfluxDB — solar_persist (pvinv_baseline + production du jour)",
+        "info": "## Principe (solution pérenne)\npvinv_baseline, mppt_yield_today, pvinv_yield_today, total_yield_today\nsont écrits dans InfluxDB (measurement: solar_persist) avec un tag 'day' = date locale Paris.\n\n## Au démarrage (+5s)\n  influx_startup_inject → influx_restore_fn → influx_query_req → influx_restore_result_fn\n  Requête Flux : dernier enregistrement solar_persist pour aujourd'hui (tag day=YYYY-MM-DD)\n  → pvinv_baseline restaurée → 1er PVInverter calcule delta correct ✓\n\n## Écriture\n  mppt_yield_fn (output 2) → influx_write_fn → influx_write_req\n  pvinv_daily_fn (output 3) → influx_write_fn → influx_write_req\n  Line protocol : solar_persist,day=2026-03-22,host=pi5 pvinv_baseline=587.2,...\n\n## Variables d'environnement requises dans docker-compose.infra.yml\n  INFLUX_TOKEN, INFLUX_ORG, INFLUX_BUCKET\n\n## Vérification (Pi5)\n  # Voir les derniers enregistrements\n  docker exec dalybms-influxdb influx query \\\n    'from(bucket:\"daly_bms\") |> range(start:-2h) |> filter(fn:(r)=>r._measurement==\"solar_persist\") |> last()'",
+        "x": 310,
+        "y": 860,
+        "wires": []
+    },
+
+    {
+        "id": "influx_startup_inject",
+        "type": "inject",
+        "z": "e6e3a16384301f83",
+        "name": "Restaurer depuis InfluxDB (démarrage +5s)",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 5,
+        "topic": "",
+        "x": 230,
+        "y": 940,
+        "wires": [
+            [
+                "influx_restore_fn"
+            ]
+        ]
+    },
+    {
+        "id": "influx_restore_fn",
+        "type": "function",
+        "z": "e6e3a16384301f83",
+        "name": "Préparer requête Flux (restore baseline)",
+        "func": "// Date locale Paris pour filtrer uniquement les données d'aujourd'hui\nconst now = new Date();\nconst parisISO = now.toLocaleString('sv-SE', {timeZone: 'Europe/Paris'});\nconst today = parisISO.substring(0, 10); // YYYY-MM-DD\n\nconst token = env.get('INFLUX_TOKEN');\nif (!token) {\n    node.status({fill:'red', shape:'ring', text:'INFLUX_TOKEN manquant dans docker-compose'});\n    return null;\n}\n\nconst org    = env.get('INFLUX_ORG')    || 'santuario';\nconst bucket = env.get('INFLUX_BUCKET') || 'daly_bms';\n\n// range -30h pour couvrir les décalages de fuseau horaire\n// tag 'day' garantit qu'on ne récupère QUE les données du jour Paris\nconst fluxQuery = [\n    'from(bucket: \"' + bucket + '\")',\n    '  |> range(start: -30h)',\n    '  |> filter(fn: (r) => r._measurement == \"solar_persist\")',\n    '  |> filter(fn: (r) => r.day == \"' + today + '\")',\n    '  |> last()'\n].join('\\n');\n\nmsg.url     = 'http://dalybms-influxdb:8086/api/v2/query?org=' + org;\nmsg.method  = 'POST';\nmsg.payload = fluxQuery;\nmsg.headers = {\n    'Authorization': 'Token ' + token,\n    'Content-Type': 'application/vnd.flux',\n    'Accept': 'application/csv'\n};\nnode.status({fill:'blue', shape:'dot', text:'Requête Flux pour ' + today});\nreturn msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 540,
+        "y": 940,
+        "wires": [
+            [
+                "influx_query_req"
+            ]
+        ]
+    },
+    {
+        "id": "influx_query_req",
+        "type": "http request",
+        "z": "e6e3a16384301f83",
+        "name": "InfluxDB Query (Flux)",
+        "method": "use",
+        "ret": "txt",
+        "paytoqs": "ignore",
+        "url": "",
+        "tls": "",
+        "persist": false,
+        "proxy": "",
+        "insecureHTTPParser": false,
+        "authType": "",
+        "senderr": false,
+        "headers": [],
+        "x": 820,
+        "y": 940,
+        "wires": [
+            [
+                "influx_restore_result_fn"
+            ]
+        ]
+    },
+    {
+        "id": "influx_restore_result_fn",
+        "type": "function",
+        "z": "e6e3a16384301f83",
+        "name": "Restaurer globals depuis CSV Flux",
+        "func": "const csv = msg.payload || '';\n\n// InfluxDB2 retourne du CSV annoté (lignes #datatype, #group, #default + header + données)\nconst lines = csv.split('\\n').filter(l => l.trim() && !l.startsWith('#'));\nif (lines.length < 2) {\n    node.status({fill:'grey', shape:'ring', text:'Pas de données InfluxDB pour aujourd\\'hui'});\n    return null;\n}\n\nconst header = lines[0].split(',');\nconst fieldIdx = header.findIndex(h => h.trim() === '_field');\nconst valueIdx = header.findIndex(h => h.trim() === '_value');\n\nif (fieldIdx === -1 || valueIdx === -1) {\n    node.error('CSV inattendu: ' + header.join(','));\n    node.status({fill:'red', text:'Erreur format CSV InfluxDB'});\n    return null;\n}\n\nconst data = {};\nfor (let i = 1; i < lines.length; i++) {\n    const cols = lines[i].split(',');\n    const field = (cols[fieldIdx] || '').trim();\n    const value = parseFloat((cols[valueIdx] || '').trim());\n    if (field && !isNaN(value)) data[field] = value;\n}\n\n// Restaurer pvinv_baseline — valeur critique\nif (data.pvinv_baseline !== undefined && data.pvinv_baseline > 0) {\n    global.set('pvinv_baseline', data.pvinv_baseline);\n}\nif (data.mppt_yield_today !== undefined)  global.set('mppt_yield_today',  data.mppt_yield_today || 0);\nif (data.pvinv_yield_today !== undefined) global.set('pvinv_yield_today', data.pvinv_yield_today || 0);\nif (data.total_yield_today !== undefined) global.set('total_yield_today', data.total_yield_today || 0);\n\nconst baseline = data.pvinv_baseline;\nconst total    = data.total_yield_today || 0;\nif (baseline && baseline > 0) {\n    node.status({fill:'green', shape:'dot',\n        text: `Restauré ✓ baseline=${baseline.toFixed(1)} total=${total.toFixed(2)} kWh`});\n} else {\n    node.status({fill:'yellow', shape:'ring', text:'Pas de baseline (1er jour ou après reset minuit)'});\n}\nreturn null;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 560,
+        "y": 1020,
+        "wires": [
+            []
+        ]
+    },
+
+    {
+        "id": "influx_write_fn",
+        "type": "function",
+        "z": "e6e3a16384301f83",
+        "name": "Formater line protocol InfluxDB",
+        "func": "const token  = env.get('INFLUX_TOKEN');\nconst org    = env.get('INFLUX_ORG')    || 'santuario';\nconst bucket = env.get('INFLUX_BUCKET') || 'daly_bms';\n\nif (!token) return null;\n\nconst baseline = global.get('pvinv_baseline');\n// Ne pas écrire si la baseline n'est pas encore établie (début de journée)\nif (baseline === null || baseline === undefined) return null;\n\nconst mppt  = global.get('mppt_yield_today')  || 0;\nconst pvinv = global.get('pvinv_yield_today') || 0;\nconst total = global.get('total_yield_today') || 0;\n\n// Tag 'day' = date locale Paris → permet de filtrer par jour au redémarrage\nconst now = new Date();\nconst parisISO = now.toLocaleString('sv-SE', {timeZone: 'Europe/Paris'});\nconst day = parisISO.substring(0, 10); // YYYY-MM-DD\n\nconst ts   = Math.floor(Date.now() / 1000);\nconst line = `solar_persist,day=${day},host=pi5 pvinv_baseline=${baseline},mppt_yield_today=${mppt},pvinv_yield_today=${pvinv},total_yield_today=${total} ${ts}`;\n\nmsg.url     = `http://dalybms-influxdb:8086/api/v2/write?org=${org}&bucket=${bucket}&precision=s`;\nmsg.method  = 'POST';\nmsg.payload = line;\nmsg.headers = {\n    'Authorization': 'Token ' + token,\n    'Content-Type': 'text/plain; charset=utf-8'\n};\nreturn msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 780,
+        "y": 540,
+        "wires": [
+            [
+                "influx_write_req"
+            ]
+        ]
+    },
+    {
+        "id": "influx_write_req",
+        "type": "http request",
+        "z": "e6e3a16384301f83",
+        "name": "InfluxDB Write (solar_persist)",
+        "method": "use",
+        "ret": "txt",
+        "paytoqs": "ignore",
+        "url": "",
+        "tls": "",
+        "persist": false,
+        "proxy": "",
+        "insecureHTTPParser": false,
+        "authType": "",
+        "senderr": false,
+        "headers": [],
+        "x": 1000,
+        "y": 540,
+        "wires": [
+            []
+        ]
     },
 
     {


### PR DESCRIPTION
…odered

Problème : TodaysYield = 0 kWh après chaque redémarrage Node-RED car pvinv_baseline (global mémoire) est perdue.

Solution pérenne : écriture/lecture dans InfluxDB (measurement solar_persist)
- Tag 'day' = date locale Paris → filtre exact par journée au redémarrage
- Au démarrage (+5s) : requête Flux → restaure pvinv_baseline + production
- À chaque update MPPT ou PVInverter : écriture line protocol dans InfluxDB
- Fallback MQTT retained conservé en backup

Fichiers modifiés :
- flux-nodered/meteo.json : +6 nœuds InfluxDB (write + restore startup) mppt_yield_fn outputs 1→2, pvinv_daily_fn outputs 2→3
- docker-compose.infra.yml : INFLUX_TOKEN/ORG/BUCKET passés à Node-RED
- Makefile : cible deploy-nodered + help mis à jour
- contrib/deploy-nodered-flows.py : script Python deploy flows via API REST

Procédure d'activation (sur Pi5) :
  git pull origin claude/review-venus-integration-35qN7
  make down && make up           # recrée le container avec les env vars
  make deploy-nodered            # pousse meteo.json vers Node-RED

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH