### PR TITLE
fix(deploy): git = source de vérité, suppression de la fusion Node-RED

### DIFF
--- a/contrib/deploy-nodered-flows.py
+++ b/contrib/deploy-nodered-flows.py
@@ -3,15 +3,16 @@
 deploy-nodered-flows.py
 Déploie les flows Node-RED depuis flux-nodered/*.json vers Node-RED via l'API REST.
 
+GIT = SOURCE DE VÉRITÉ : les flows git remplacent ENTIÈREMENT Node-RED.
+Aucune fusion, aucun nœud "conservé" depuis l'état courant.
+
 Usage :
   python3 contrib/deploy-nodered-flows.py
   NODERED_URL=http://192.168.1.141:1880 python3 contrib/deploy-nodered-flows.py
 
 Principe :
-  1. GET /flows          → récupère tous les flows actuels de Node-RED
-  2. Lit flux-nodered/*.json → nouveaux flows depuis git
-  3. Fusionne : les nœuds git écrasent/complètent les nœuds existants (par ID)
-  4. POST /flows         → déploie (équivalent du bouton "Deploy" dans l'UI)
+  1. Lit flux-nodered/*.json → flows git (déduplication par ID)
+  2. POST /flows         → remplacement complet (équivalent "Deploy All")
 
 Pas de redémarrage Docker nécessaire.
 """
@@ -28,23 +29,8 @@ NODERED_URL = os.environ.get("NODERED_URL", "http://localhost:1880")
 FLOWS_DIR   = os.path.join(os.path.dirname(__file__), "..", "flux-nodered")
 
 
-def get_flows():
-    """Récupère tous les flows actuels depuis Node-RED."""
-    req = urllib.request.Request(f"{NODERED_URL}/flows")
-    req.add_header("Accept", "application/json")
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            data = json.loads(resp.read())
-            # v1 API → array, v2 API → {"flows": [...]}
-            return data if isinstance(data, list) else data.get("flows", [])
-    except urllib.error.URLError as e:
-        print(f"ERREUR : impossible de joindre Node-RED ({NODERED_URL}) : {e}")
-        print("  → Vérifier que Node-RED est démarré (make up)")
-        sys.exit(1)
-
-
 def post_flows(flows):
-    """Envoie les flows fusionnés à Node-RED et déclenche un déploiement complet."""
+    """Envoie les flows à Node-RED et déclenche un déploiement complet."""
     body = json.dumps(flows).encode("utf-8")
     req  = urllib.request.Request(f"{NODERED_URL}/flows", data=body, method="POST")
     req.add_header("Content-Type", "application/json")
@@ -84,31 +70,7 @@ def load_git_flows():
         except Exception as e:
             print(f"  [ERR]  {fname} : {e}")
 
-    return nodes_by_id
-
-
-def merge(current_flows, git_nodes_by_id):
-    """
-    Stratégie de fusion :
-    - Les nœuds présents dans git (par ID) écrasent ceux de Node-RED.
-    - Les nœuds NOT présents dans git sont conservés (autres tabs non gérés par git).
-    - Les nœuds dont le 'z' (tab parent) est géré par git sont retirés,
-      sauf s'ils existent déjà dans git (ils seraient déjà inclus).
-    """
-    git_ids     = set(git_nodes_by_id.keys())
-    git_tab_ids = {n["id"] for n in git_nodes_by_id.values() if n.get("type") == "tab"}
-
-    # Garder les nœuds courants qui :
-    #  - ne sont pas dans git (pas de remplacement prévu)
-    #  - n'appartiennent pas à un tab géré par git (évite les doublons)
-    kept = [
-        n for n in current_flows
-        if n.get("id") not in git_ids
-        and n.get("z") not in git_tab_ids
-    ]
-
-    merged = kept + list(git_nodes_by_id.values())
-    return merged, len(kept), len(git_nodes_by_id)
+    return list(nodes_by_id.values())
 
 
 def wait_for_nodered(max_wait=30):
@@ -131,6 +93,7 @@ def main():
     print("Déploiement des flows Node-RED depuis git")
     print(f"  Source  : {os.path.abspath(FLOWS_DIR)}")
     print(f"  Cible   : {NODERED_URL}")
+    print("  Mode    : REMPLACEMENT COMPLET (git = source de vérité)")
     print("=" * 60)
 
     wait_for_nodered()
@@ -139,15 +102,8 @@ def main():
     git_nodes = load_git_flows()
     print(f"  Total : {len(git_nodes)} nœuds uniques")
 
-    print("\nRécupération des flows Node-RED actuels...")
-    current = get_flows()
-    print(f"  Flows actuels : {len(current)} nœuds")
-
-    merged, kept, added = merge(current, git_nodes)
-    print(f"\nFusion : {kept} nœuds conservés + {added} nœuds git = {len(merged)} total")
-
-    print("\nDéploiement...")
-    status = post_flows(merged)
+    print(f"\nDéploiement ({len(git_nodes)} nœuds) → Node-RED...")
+    status = post_flows(git_nodes)
     print(f"\n{'='*60}")
     print(f"✓ Flows déployés avec succès (HTTP {status})")
     print(f"  Ouvrir http://192.168.1.141:1880 pour vérifier")


### PR DESCRIPTION
Problème : le script conservait les nœuds "actuels" de Node-RED non présents dans git à chaque exécution → accumulation de doublons (66 nœuds conservés
+ 250 git = 316 au lieu de 250).

Conséquence : nœuds dupliqués en concurrence (2× pvinv_daily_fn, 2× MQTT in) → interférence → TodaysYield = 0 kWh dans le widget Victron.

Fix : remplacement complet (POST /flows avec uniquement les nœuds git). Tous les fichiers de configuration nécessaires (pi5_mqtt_broker, etc.) sont déjà présents dans flux-nodered/*.json avec des IDs stables.

Résultat après ce fix :
  - 0 doublon après make deploy-nodered
  - Flux uniquement ceux du git
  - Pas besoin de nettoyage manuel

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH