### PR TITLE
feat(et112): intégration complète ET112 Carlo Gavazzi + pvinverter D-…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@
 │    ├── com.victronenergy.heatpump.mqtt_1                         │
 │    ├── com.victronenergy.switch.*                                │
 │    ├── com.victronenergy.grid.* / acload.*                       │
+│    ├── com.victronenergy.pvinverter.mqtt_3 (instance 63) ← ET112 │
 │    └── com.victronenergy.meteo (singleton)                       │
 │                                                                  │
 │  dbus-mqtt-battery (legacy, à terme à supprimer)                 │
@@ -890,6 +891,157 @@ ls -la /dev/serial/by-id/
 
 ---
 
+## 16c. INTÉGRATION ET112 CARLO GAVAZZI (2026-03-22) ✅
+
+**Objectif** : Remplacer le capteur irradiance RS485 (déplacé) par un compteur ET112
+connecté sur le même port `/dev/ttyUSB1`, et l'exposer comme `com.victronenergy.pvinverter`
+sur le D-Bus Venus OS (micro-inverseurs, instance 63).
+
+### Matériel
+
+| Composant | Détail |
+|---|---|
+| Compteur | Carlo Gavazzi ET112 |
+| Interface | FTDI FT232 USB-RS485 — Pi5 Bus 004 Device 003 |
+| Port | `/dev/ttyUSB1` |
+| Adresse Modbus | `0x03` (slave address configurée sur le compteur) |
+| Baud | 9600 8N1 |
+| Protocole | Modbus RTU FC=04, FLOAT32 Big-Endian |
+
+### Registres Modbus ET112 (FLOAT32 = 2 words par registre)
+
+| Adresse | Grandeur | Unité |
+|---|---|---|
+| 0x0000 | Tension V | V |
+| 0x0002 | Courant I | A |
+| 0x0004 | Puissance active | W |
+| 0x0006 | Puissance apparente | VA |
+| 0x0008 | Puissance réactive | VAR |
+| 0x000A | Facteur de puissance | — |
+| 0x000C | Angle de phase | ° |
+| 0x000E | Fréquence | Hz |
+| 0x0010 | Énergie importée | Wh |
+| 0x0012 | Énergie exportée | Wh |
+
+### Architecture
+
+```
+ET112 (/dev/ttyUSB1, addr 0x03)
+  ↓ Modbus RTU (tokio-modbus 0.14, FLOAT32 Big-Endian)
+daly-bms-server — et112::run_et112_poll_loop (5s)
+  ├── AppState::on_et112_snapshot() → ring buffer 720 entrées
+  ├── API REST : GET /api/v1/et112, /api/v1/et112/3/status, /api/v1/et112/3/history
+  ├── Dashboard SSR : /dashboard/et112/3 (ECharts temps réel)
+  ├── MQTT : santuario/pvinverter/3/venus (retain=true)
+  └── InfluxDB : measurement et112_status (tags: address, name)
+
+santuario/pvinverter/3/venus → (NanoPi broker)
+  ↓ dbus-mqtt-venus — PvinverterManager → PvinverterServiceHandle
+com.victronenergy.pvinverter.mqtt_3 (device instance 63)
+  ├── /Ac/Power
+  ├── /Ac/Energy/Forward
+  ├── /Ac/L1/{Voltage, Current, Power, Energy/Forward}
+  ├── /StatusCode=7 (Running)
+  ├── /ErrorCode=0
+  ├── /Position=1 (AC Output — micro-inverseurs sur AC output)
+  └── /IsGenericEnergyMeter=1 (ET112 masquerade)
+```
+
+### Fichiers créés/modifiés
+
+| Fichier | Modification |
+|---|---|
+| `crates/daly-bms-server/src/et112/types.rs` | Struct `Et112Snapshot` |
+| `crates/daly-bms-server/src/et112/poll.rs` | Polling Modbus RTU async |
+| `crates/daly-bms-server/src/et112/mod.rs` | Module public |
+| `crates/daly-bms-server/src/api/et112.rs` | Endpoints REST |
+| `crates/daly-bms-server/src/dashboard/mod.rs` | Handler dashboard ET112 |
+| `crates/daly-bms-server/templates/et112.html` | Template Askama |
+| `crates/daly-bms-server/templates/base.html` | Lien nav ET112 |
+| `crates/daly-bms-server/src/bridges/mqtt.rs` | `publish_et112_snapshot()` |
+| `crates/daly-bms-server/src/bridges/influx.rs` | `et112_snapshot_to_point()` |
+| `crates/dbus-mqtt-venus/src/types.rs` | `PvinverterPayload` |
+| `crates/dbus-mqtt-venus/src/config.rs` | `PvinverterConfig`, `PvinverterRef` |
+| `crates/dbus-mqtt-venus/src/mqtt_source.rs` | `start_pvinverter_mqtt_source()` |
+| `crates/dbus-mqtt-venus/src/pvinverter_service.rs` | Service D-Bus pvinverter |
+| `crates/dbus-mqtt-venus/src/pvinverter_manager.rs` | Manager pvinverter |
+| `crates/dbus-mqtt-venus/src/main.rs` | Wire-up PvinverterManager |
+| `Config.toml` | Section `[et112]` + `[[et112.devices]]` |
+| `nanoPi/config-nanopi.toml` | Section `[pvinverter]` + `[[pvinverters]]` |
+
+### ET112 déjà sur Victron (instances 61/62 — à migrer ultérieurement)
+
+Les ET112 aux adresses RS485 0x01 et 0x02 sont connectés directement sur le Victron
+via USB-RS485 et apparaissent en production comme :
+- `com.victronenergy.pvinverter.cgwacs_ttyUSBx_mb1` → instance 61
+- `com.victronenergy.pvinverter.cgwacs_ttyUSBx_mb2` → instance 62
+
+Lors de la migration vers Pi5 :
+1. Débrancher les 2 câbles USB du Victron
+2. Brancher les 2 ET112 sur les ports USB du Pi5 (`/dev/ttyUSB2`, `/dev/ttyUSB3`)
+3. Ajouter `[[et112.devices]]` dans `Config.toml` pour addresses 0x01 et 0x02
+4. Décommenter `[[pvinverters]]` mqtt_index=1 et 2 dans `nanoPi/config-nanopi.toml`
+5. Déployer + redémarrer les services
+
+### Topics MQTT pvinverter
+
+```
+santuario/pvinverter/3/venus  ← ET112 addr=0x03 (Pi5 → NanoPi)
+```
+
+Format JSON (compatible `dbus-mqtt-venus` PvinverterPayload) :
+```json
+{
+  "Ac": {
+    "L1": { "Voltage": 230.1, "Current": 5.43, "Power": 1250.0,
+            "Energy": { "Forward": 587.23, "Reverse": 0.0 } },
+    "Power": 1250.0,
+    "Energy": { "Forward": 587.23, "Reverse": 0.0 }
+  },
+  "StatusCode": 7,
+  "ErrorCode": 0,
+  "Position": 1,
+  "IsGenericEnergyMeter": 1,
+  "ProductName": "ET112 addr=0x03",
+  "CustomName": "Micro-inverseurs"
+}
+```
+
+### Vérification D-Bus (📍 NanoPi)
+
+```bash
+# Vérifier que le service apparaît
+dbus -y | grep pvinverter
+
+# Lire la puissance instantanée
+dbus -y com.victronenergy.pvinverter.mqtt_3 /Ac/Power GetValue
+
+# Lire l'énergie totale
+dbus -y com.victronenergy.pvinverter.mqtt_3 /Ac/Energy/Forward GetValue
+
+# Tous les chemins
+dbus -y com.victronenergy.pvinverter.mqtt_3 / GetItems
+```
+
+### Diagnostic Pi5
+
+```bash
+# Dashboard web
+http://192.168.1.141:8080/dashboard/et112/3
+
+# API REST
+curl http://192.168.1.141:8080/api/v1/et112/3/status
+curl http://192.168.1.141:8080/api/v1/et112/3/history?limit=60
+
+# MQTT publié
+mosquitto_sub -h 192.168.1.120 -p 1883 -t 'santuario/pvinverter/3/venus' -v
+
+# InfluxDB
+# measurement: et112_status, tags: address=0x03, name=Micro-inverseurs
+```
+
+---
+
 ## 17. MAINTENANCE OPÉRATIONNELLE
 
 ### Checklist quotidienne / hebdomadaire
@@ -998,7 +1150,8 @@ git commit -m "chore(nanopi): backup config.toml"
 | `com.victronenergy.temperature.mqtt_1` | Capteur ext. (type 4) | `dbus -y ... /Temperature GetValue` |
 | `com.victronenergy.heatpump.mqtt_1` | PAC / chauffe-eau | `dbus -y ... /State GetValue` |
 | `com.victronenergy.meteo` | Irradiance + TodaysYield | `dbus -y ... /TodaysYield GetValue` |
-| `com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2` | Onduleur PV AC | `dbus -y ... /Ac/Energy/Forward GetValue` |
+| `com.victronenergy.pvinverter.mqtt_3` | ET112 micro-inverseurs Pi5 (instance 63) | `dbus -y ... /Ac/Power GetValue` |
+| `com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2` | Onduleur PV AC (Victron direct) | `dbus -y ... /Ac/Energy/Forward GetValue` |
 
 ### Commandes de diagnostic rapide (📍 NanoPi)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,9 @@ bytes         = "1"
 futures       = "0.3"
 tokio-util    = { version = "0.7",  features = ["codec"] }
 
+# ── Modbus RTU (ET112 et autres compteurs RS485) ───────────────────────────────
+tokio-modbus  = { version = "0.14", features = ["rtu"] }
+
 # =============================================================================
 # Release profile — optimisé taille + vitesse pour le Pi
 # =============================================================================

--- a/Config.toml
+++ b/Config.toml
@@ -195,6 +195,46 @@ product_name    = "Capteur Irradiance"
 device_instance = 40      # DeviceInstance Venus OS / VRM
 
 
+# =============================================================================
+# Compteur énergie ET112 Carlo Gavazzi (RS485 Modbus RTU)
+# =============================================================================
+# Matériel : ET112 sur /dev/ttyUSB1 (FTDI FT232 USB-RS485, Bus 004 Device 003)
+# Adresses : 0x03 = micro-inverseurs Pi5 (0x01 et 0x02 connectés directement sur Victron)
+#
+# Chemins D-Bus pvinverter exposés (via dbus-mqtt-venus sur NanoPi) :
+#   /Ac/Power, /Ac/Energy/Forward
+#   /Ac/L1/{Voltage, Current, Power, Energy/Forward}
+#   /StatusCode=7, /ErrorCode=0, /Position=1, /IsGenericEnergyMeter=1
+
+[et112]
+# Port série USB-RS485 (partagé ou dédié)
+port = "/dev/ttyUSB1"
+
+# Vitesse de communication (ET112 standard = 9600 baud)
+baud = 9600
+
+# Intervalle de polling en millisecondes (5000 = toutes les 5 secondes)
+poll_interval_ms = 5000
+
+# Taille du ring buffer (720 = 1 heure à 1 mesure/5s)
+ring_buffer_size = 720
+
+[[et112.devices]]
+address     = "0x03"           # Adresse Modbus RTU de l'ET112
+name        = "Micro-inverseurs"
+mqtt_index  = 3                # → topic santuario/pvinverter/3/venus
+
+# Les ET112 0x01 et 0x02 sont connectés directement sur le Victron (à migrer)
+# [[et112.devices]]
+# address     = "0x01"
+# name        = "ET112-PV-1"
+# mqtt_index  = 1
+# [[et112.devices]]
+# address     = "0x02"
+# name        = "ET112-PV-2"
+# mqtt_index  = 2
+
+
 [influxdb]
 # true  = activer l'écriture InfluxDB (Docker infra doit être démarré)
 # false = désactiver (pas de Docker, ou test sans InfluxDB)

--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -37,3 +37,4 @@ uuid           = { workspace = true }
 futures        = { workspace = true }
 bytes          = { workspace = true }
 askama         = "0.12"
+tokio-modbus   = { workspace = true }

--- a/crates/daly-bms-server/src/api/et112.rs
+++ b/crates/daly-bms-server/src/api/et112.rs
@@ -1,0 +1,79 @@
+//! Endpoints REST pour les compteurs Carlo Gavazzi ET112.
+//!
+//! Routes :
+//! ```text
+//! GET /api/v1/et112                     → liste des ET112 configurés + dernier snapshot
+//! GET /api/v1/et112/:addr/status        → dernier snapshot d'un ET112
+//! GET /api/v1/et112/:addr/history       → historique (ring buffer)
+//! ```
+
+use crate::state::AppState;
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+/// Parse une adresse Modbus depuis un segment de chemin ("3", "0x03").
+fn parse_addr(s: &str) -> Option<u8> {
+    let s = s.trim();
+    if s.starts_with("0x") || s.starts_with("0X") {
+        u8::from_str_radix(&s[2..], 16).ok()
+    } else {
+        s.parse::<u8>().ok()
+    }
+}
+
+/// Réponse JSON liste des ET112 configurés.
+#[derive(Serialize)]
+pub struct Et112ListItem {
+    pub address: u8,
+    pub name: String,
+    pub mqtt_index: Option<u8>,
+}
+
+/// GET /api/v1/et112 — liste de tous les ET112 + dernier snapshot
+pub async fn list_et112(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let devices = &state.config.et112.devices;
+    let mut result = Vec::new();
+    for dev in devices {
+        let addr = dev.parsed_address();
+        let snap = state.et112_latest_for(addr).await;
+        result.push(serde_json::json!({
+            "address":    addr,
+            "name":       dev.name,
+            "mqtt_index": dev.mqtt_index,
+            "snapshot":   snap,
+        }));
+    }
+    Json(serde_json::json!({ "et112": result }))
+}
+
+/// GET /api/v1/et112/:addr/status — dernier snapshot
+pub async fn get_et112_status(
+    State(state): State<AppState>,
+    Path(addr_str): Path<String>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let addr = parse_addr(&addr_str).ok_or(StatusCode::BAD_REQUEST)?;
+    let snap = state.et112_latest_for(addr).await.ok_or(StatusCode::NOT_FOUND)?;
+    Ok(Json(serde_json::to_value(&snap).unwrap_or_default()))
+}
+
+#[derive(Deserialize)]
+pub struct HistoryParams {
+    /// Nombre de points (défaut 360)
+    pub limit: Option<usize>,
+}
+
+/// GET /api/v1/et112/:addr/history — historique complet
+pub async fn get_et112_history(
+    State(state): State<AppState>,
+    Path(addr_str): Path<String>,
+    Query(params): Query<HistoryParams>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let addr  = parse_addr(&addr_str).ok_or(StatusCode::BAD_REQUEST)?;
+    let limit = params.limit.unwrap_or(360).min(1440);
+    let snaps = state.et112_history_for(addr, limit).await;
+    Ok(Json(serde_json::json!({ "address": addr, "count": snaps.len(), "history": snaps })))
+}

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod system;
 pub mod bms;
+pub mod et112;
 
 use crate::dashboard;
 use crate::state::AppState;
@@ -56,6 +57,11 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/bms/:id/settings/current-alarms",          post(bms::set_current_alarms))
         .route("/api/v1/bms/:id/settings/delta-alarms",            post(bms::set_delta_alarms))
         .route("/api/v1/bms/:id/settings/balancing",               post(bms::set_balancing))
+
+        // ── ET112 ────────────────────────────────────────────────────────────
+        .route("/api/v1/et112",                   get(et112::list_et112))
+        .route("/api/v1/et112/:addr/status",      get(et112::get_et112_status))
+        .route("/api/v1/et112/:addr/history",     get(et112::get_et112_history))
 
         // ── WebSocket ─────────────────────────────────────────────────────────
         .route("/ws/bms/stream",         get(bms::ws_all))

--- a/crates/daly-bms-server/src/bridges/influx.rs
+++ b/crates/daly-bms-server/src/bridges/influx.rs
@@ -5,6 +5,7 @@
 //! `batch_flush_interval_sec` secondes.
 
 use crate::config::InfluxConfig;
+use crate::et112::Et112Snapshot;
 use crate::state::AppState;
 use daly_bms_core::types::BmsSnapshot;
 use influxdb2::Client;
@@ -31,6 +32,9 @@ pub async fn run_influx_bridge(state: AppState, cfg: InfluxConfig) {
     let mut rx = state.subscribe_ws();
     let flush_interval = Duration::from_secs_f64(cfg.batch_flush_interval_sec.max(1.0));
     let mut flush_ticker = tokio::time::interval(flush_interval);
+    // Ticker séparé pour polling ET112 (état est dans state, pas dans channel broadcast)
+    let et112_interval = Duration::from_secs(10);
+    let mut et112_ticker = tokio::time::interval(et112_interval);
 
     loop {
         tokio::select! {
@@ -40,6 +44,18 @@ pub async fn run_influx_bridge(state: AppState, cfg: InfluxConfig) {
                     batch.extend(points);
                 }
                 if batch.len() >= cfg.batch_size {
+                    flush_batch(&client, &cfg.bucket, &mut batch).await;
+                }
+            }
+            _ = et112_ticker.tick() => {
+                // Lire les derniers snapshots ET112 et les écrire dans InfluxDB
+                let et112_snaps = state.et112_latest_all().await;
+                for snap in et112_snaps {
+                    if let Ok(p) = et112_snapshot_to_point(&snap) {
+                        batch.push(p);
+                    }
+                }
+                if !batch.is_empty() {
                     flush_batch(&client, &cfg.bucket, &mut batch).await;
                 }
             }
@@ -109,4 +125,30 @@ fn snapshot_to_points(snap: &BmsSnapshot) -> Vec<DataPoint> {
     }
 
     points
+}
+
+/// Convertit un [`Et112Snapshot`] en un point InfluxDB.
+///
+/// Measurement : `et112_status`
+/// Tags : `address` (hex), `name`
+fn et112_snapshot_to_point(snap: &Et112Snapshot) -> anyhow::Result<DataPoint> {
+    let addr_tag = format!("{:#04x}", snap.address);
+    let ts_ns = snap.timestamp.timestamp_nanos_opt().unwrap_or(0);
+
+    let point = DataPoint::builder("et112_status")
+        .tag("address", addr_tag)
+        .tag("name",    snap.name.clone())
+        .field("voltage_v",          snap.voltage_v as f64)
+        .field("current_a",          snap.current_a as f64)
+        .field("power_w",            snap.power_w as f64)
+        .field("apparent_power_va",  snap.apparent_power_va as f64)
+        .field("reactive_power_var", snap.reactive_power_var as f64)
+        .field("power_factor",       snap.power_factor as f64)
+        .field("frequency_hz",       snap.frequency_hz as f64)
+        .field("energy_import_wh",   snap.energy_import_wh as f64)
+        .field("energy_export_wh",   snap.energy_export_wh as f64)
+        .timestamp(ts_ns)
+        .build()?;
+
+    Ok(point)
 }

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -14,6 +14,7 @@
 //! ```
 
 use crate::config::MqttConfig;
+use crate::et112::Et112Snapshot;
 use crate::state::AppState;
 use daly_bms_core::types::BmsSnapshot;
 use rumqttc::{AsyncClient, MqttOptions, QoS};
@@ -68,18 +69,81 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
     loop {
         ticker.tick().await;
 
+        // ── BMS snapshots ─────────────────────────────────────────────────────
         let snapshots = state.latest_snapshots().await;
         for snap in &snapshots {
-            // Résoudre l'identifiant de topic : "1", "2", … ou adresse décimale brute
             let topic_id = addr_map
                 .get(&snap.address)
                 .cloned()
                 .unwrap_or_else(|| snap.address.to_string());
             if let Err(e) = publish_snapshot(&client, &cfg, snap, &topic_id).await {
-                error!("MQTT publish erreur : {:?}", e);
+                error!("MQTT publish BMS erreur : {:?}", e);
+            }
+        }
+
+        // ── ET112 snapshots → topic pvinverter/{mqtt_index}/venus ────────────
+        let et112_snaps = state.et112_latest_all().await;
+        for snap in &et112_snaps {
+            // Résoudre le mqtt_index depuis la config
+            let idx = state.config.et112.devices
+                .iter()
+                .find(|d| d.parsed_address() == snap.address)
+                .and_then(|d| d.mqtt_index)
+                .unwrap_or(snap.address);
+            if let Err(e) = publish_et112_snapshot(&client, &cfg, snap, idx).await {
+                error!("MQTT publish ET112 erreur : {:?}", e);
             }
         }
     }
+}
+
+/// Publie un snapshot ET112 sur le topic `santuario/pvinverter/{idx}/venus`.
+///
+/// Format compatible `dbus-mqtt-venus` type pvinverter (com.victronenergy.pvinverter).
+async fn publish_et112_snapshot(
+    client: &AsyncClient,
+    cfg: &MqttConfig,
+    snap: &Et112Snapshot,
+    mqtt_index: u8,
+) -> anyhow::Result<()> {
+    // Dériver le topic prefix pvinverter depuis le topic prefix BMS
+    // "santuario/bms" → "santuario/pvinverter"
+    let base = cfg.topic_prefix
+        .rsplit_once('/')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or("santuario");
+    let topic = format!("{}/pvinverter/{}/venus", base, mqtt_index);
+
+    let payload = json!({
+        "Ac": {
+            "L1": {
+                "Voltage": snap.voltage_v,
+                "Current": snap.current_a,
+                "Power":   snap.power_w,
+                "Energy": {
+                    "Forward": snap.energy_import_kwh(),
+                    "Reverse": snap.energy_export_kwh()
+                }
+            },
+            "Power":         snap.power_w,
+            "Energy": {
+                "Forward":   snap.energy_import_kwh(),
+                "Reverse":   snap.energy_export_kwh()
+            }
+        },
+        "StatusCode":           7,   // Running
+        "ErrorCode":            0,   // No Error
+        "Position":             1,   // AC output (micro-inverseurs sur AC output)
+        "IsGenericEnergyMeter": 1,   // ET112 = generic energy meter
+        "ProductName":          format!("ET112 addr={:#04x}", snap.address),
+        "CustomName":           snap.name,
+    });
+
+    client
+        .publish(&topic, QoS::AtLeastOnce, true, serde_json::to_vec(&payload)?)
+        .await?;
+
+    Ok(())
 }
 
 /// Publie un snapshot complet sur tous les topics d'un BMS.

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -38,6 +38,10 @@ pub struct AppConfig {
     /// Configurations individuelles par BMS (optionnel)
     #[serde(default)]
     pub bms: Vec<BmsDeviceConfig>,
+
+    /// Configuration ET112 (compteurs Carlo Gavazzi RS485)
+    #[serde(default)]
+    pub et112: Et112Config,
 }
 
 // =============================================================================
@@ -151,6 +155,81 @@ pub struct SerialConfig {
     /// Liste explicite d'adresses BMS (ex: ["0x01", "0x02"])
     #[serde(default)]
     pub addresses: Vec<String>,
+}
+
+// =============================================================================
+// Configuration ET112
+// =============================================================================
+
+/// Configuration globale pour les compteurs Carlo Gavazzi ET112.
+///
+/// ```toml
+/// [et112]
+/// port             = "/dev/ttyUSB1"
+/// baud             = 9600
+/// poll_interval_ms = 5000
+/// ring_buffer_size = 720       # 1 heure à 1 mesure / 5s
+///
+/// [[et112.devices]]
+/// address          = "0x03"
+/// name             = "Micro-inverseurs"
+/// mqtt_index       = 3         # → topic santuario/pvinverter/3/venus
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Et112Config {
+    /// Port série (ex: /dev/ttyUSB1)
+    pub port: String,
+    /// Vitesse en bauds (9600 par défaut usine)
+    pub baud: u32,
+    /// Intervalle de polling en ms
+    pub poll_interval_ms: u64,
+    /// Taille du ring buffer par appareil
+    pub ring_buffer_size: usize,
+    /// Liste des compteurs ET112 configurés
+    #[serde(default)]
+    pub devices: Vec<Et112DeviceConfig>,
+}
+
+impl Default for Et112Config {
+    fn default() -> Self {
+        Self {
+            port:             "/dev/ttyUSB1".into(),
+            baud:             9600,
+            poll_interval_ms: 5000,
+            ring_buffer_size: 720,
+            devices:          Vec::new(),
+        }
+    }
+}
+
+/// Configuration d'un ET112 individuel.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct Et112DeviceConfig {
+    /// Adresse Modbus (ex: "0x03", "3")
+    pub address: String,
+    /// Nom affiché dans le dashboard
+    #[serde(default = "default_et112_name")]
+    pub name: String,
+    /// Index MQTT → topic `santuario/pvinverter/{mqtt_index}/venus`
+    pub mqtt_index: Option<u8>,
+    /// Puissance nominale max (W) — pour l'affichage gauge
+    pub max_power_w: Option<f32>,
+}
+
+fn default_et112_name() -> String {
+    "ET112".to_string()
+}
+
+impl Et112DeviceConfig {
+    /// Parse l'adresse en u8 (supporte "0x03", "3").
+    pub fn parsed_address(&self) -> u8 {
+        let s = self.address.trim();
+        if s.starts_with("0x") || s.starts_with("0X") {
+            u8::from_str_radix(&s[2..], 16).unwrap_or(3)
+        } else {
+            s.parse::<u8>().unwrap_or(3)
+        }
+    }
 }
 
 impl Default for SerialConfig {

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod charts;
 
+use crate::et112::Et112Snapshot;
 use crate::state::AppState;
 use askama::Template;
 use axum::{
@@ -35,6 +36,10 @@ mod filters {
     /// Formate un f32 sans décimale : 1234
     pub fn f0(v: &f32) -> ::askama::Result<String> {
         Ok(format!("{:.0}", v))
+    }
+    /// Formate un f32 avec 2 décimales : 3.40
+    pub fn f2(v: &f32) -> ::askama::Result<String> {
+        Ok(format!("{:.2}", v))
     }
     /// Formate un f32 avec 3 décimales : 3.405
     pub fn f3(v: &f32) -> ::askama::Result<String> {
@@ -376,12 +381,101 @@ pub async fn dashboard_settings(State(state): State<AppState>) -> Response {
     render(SettingsTemplate { bms_list })
 }
 
+// =============================================================================
+// Dashboard ET112
+// =============================================================================
+
+#[derive(Template)]
+#[template(path = "et112.html")]
+struct Et112Template {
+    name:                String,
+    address:             u8,
+    addr_hex:            String,
+    connected:           bool,
+    last_ts:             String,
+    // Valeurs instantanées
+    power_w:             f32,
+    voltage_v:           f32,
+    current_a:           f32,
+    apparent_power_va:   f32,
+    power_factor:        f32,
+    frequency_hz:        f32,
+    // Énergie
+    energy_import_wh:    f32,
+    energy_export_wh:    f32,
+    energy_import_kwh:   f32,
+    energy_export_kwh:   f32,
+}
+
+/// Page de monitoring ET112.
+pub async fn dashboard_et112(
+    State(state): State<AppState>,
+    Path(addr_str): Path<String>,
+) -> Response {
+    let addr = match parse_addr(&addr_str) {
+        Some(a) => a,
+        None    => return StatusCode::BAD_REQUEST.into_response(),
+    };
+
+    // Trouver le nom depuis la config
+    let name = state.config.et112.devices
+        .iter()
+        .find(|d| d.parsed_address() == addr)
+        .map(|d| d.name.clone())
+        .unwrap_or_else(|| format!("ET112 {:#04x}", addr));
+
+    let snap_opt = state.et112_latest_for(addr).await;
+    let connected = snap_opt.is_some();
+
+    let (last_ts, power_w, voltage_v, current_a, apparent_power_va,
+         power_factor, frequency_hz, energy_import_wh, energy_export_wh) =
+        if let Some(ref s) = snap_opt {
+            (
+                s.timestamp.format("%H:%M:%S").to_string(),
+                s.power_w, s.voltage_v, s.current_a, s.apparent_power_va,
+                s.power_factor, s.frequency_hz, s.energy_import_wh, s.energy_export_wh,
+            )
+        } else {
+            ("—".to_string(), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        };
+
+    render(Et112Template {
+        name,
+        address: addr,
+        addr_hex: format!("{:#04x}", addr),
+        connected,
+        last_ts,
+        power_w,
+        voltage_v,
+        current_a,
+        apparent_power_va,
+        power_factor,
+        frequency_hz,
+        energy_import_wh,
+        energy_export_wh,
+        energy_import_kwh: energy_import_wh / 1000.0,
+        energy_export_kwh: energy_export_wh / 1000.0,
+    })
+}
+
+/// Liste des ET112 configurés (page d'accueil redirige vers premier ET112).
+pub async fn dashboard_et112_list(State(state): State<AppState>) -> Response {
+    let devices = &state.config.et112.devices;
+    if let Some(first) = devices.first() {
+        let addr = first.parsed_address();
+        return Redirect::temporary(&format!("/dashboard/et112/{}", addr)).into_response();
+    }
+    (StatusCode::NOT_FOUND, "Aucun ET112 configuré").into_response()
+}
+
 /// Construit le routeur du dashboard (à fusionner dans le routeur principal).
 pub fn build_dashboard_router() -> Router<AppState> {
     Router::new()
-        .route("/",                      get(redirect_root))
-        .route("/dashboard",             get(dashboard_index))
-        .route("/dashboard/bms/:id",     get(dashboard_bms))
-        .route("/dashboard/logs",        get(dashboard_logs))
-        .route("/dashboard/settings",    get(dashboard_settings))
+        .route("/",                          get(redirect_root))
+        .route("/dashboard",                 get(dashboard_index))
+        .route("/dashboard/bms/:id",         get(dashboard_bms))
+        .route("/dashboard/logs",            get(dashboard_logs))
+        .route("/dashboard/settings",        get(dashboard_settings))
+        .route("/dashboard/et112",           get(dashboard_et112_list))
+        .route("/dashboard/et112/:addr",     get(dashboard_et112))
 }

--- a/crates/daly-bms-server/src/et112/mod.rs
+++ b/crates/daly-bms-server/src/et112/mod.rs
@@ -1,0 +1,7 @@
+//! Module ET112 — Carlo Gavazzi ET112 compteur monophasé RS485/Modbus RTU.
+
+pub mod poll;
+pub mod types;
+
+pub use poll::run_et112_poll_loop;
+pub use types::Et112Snapshot;

--- a/crates/daly-bms-server/src/et112/poll.rs
+++ b/crates/daly-bms-server/src/et112/poll.rs
@@ -1,0 +1,184 @@
+//! Boucle de polling Modbus RTU pour le compteur Carlo Gavazzi ET112.
+//!
+//! ## Registres lus (FC=04, FLOAT32 big-endian)
+//!
+//! | Adresse hex | Description           | Unité |
+//! |-------------|----------------------|-------|
+//! | 0x0000      | Tension L1           | V     |
+//! | 0x0002      | Courant L1           | A     |
+//! | 0x0004      | Puissance active     | W     |
+//! | 0x0006      | Puissance apparente  | VA    |
+//! | 0x0008      | Puissance réactive   | VAr   |
+//! | 0x000A      | Facteur de puissance | —     |
+//! | 0x000C      | Angle de phase       | °     |
+//! | 0x000E      | Fréquence            | Hz    |
+//! | 0x0010      | Énergie import       | Wh    |
+//! | 0x0012      | Énergie export       | Wh    |
+
+use super::types::Et112Snapshot;
+use crate::config::Et112DeviceConfig;
+use chrono::Local;
+use std::time::Duration;
+use tokio_modbus::client::rtu;
+use tokio_modbus::prelude::*;
+use tokio_serial::SerialStream;
+use tracing::{debug, error, info, warn};
+
+/// Convertit deux registres u16 (big-endian) en f32 IEEE 754.
+fn regs_to_f32(hi: u16, lo: u16) -> f32 {
+    f32::from_bits(((hi as u32) << 16) | (lo as u32))
+}
+
+/// Lance la boucle de polling ET112.
+///
+/// # Paramètres
+/// - `port_path`     : chemin du port série (ex: `/dev/ttyUSB1`)
+/// - `baud`          : vitesse en bauds (9600 par défaut pour ET112)
+/// - `devices`       : liste des ET112 configurés (adresse + nom + ...)
+/// - `poll_interval` : intervalle entre deux cycles complets
+/// - `on_snapshot`   : callback appelé pour chaque snapshot valide
+pub async fn run_et112_poll_loop<F>(
+    port_path: String,
+    baud: u32,
+    devices: Vec<Et112DeviceConfig>,
+    poll_interval: Duration,
+    mut on_snapshot: F,
+)
+where
+    F: FnMut(Et112Snapshot) + Send + 'static,
+{
+    if devices.is_empty() {
+        info!("ET112 : aucun appareil configuré, polling désactivé");
+        return;
+    }
+
+    info!(
+        port = %port_path,
+        baud,
+        count = devices.len(),
+        "ET112 polling démarré"
+    );
+
+    // Backoff exponentiel en cas d'erreur série
+    let mut backoff_ms: u64 = 500;
+
+    loop {
+        match poll_cycle(&port_path, baud, &devices, &mut on_snapshot).await {
+            Ok(()) => {
+                backoff_ms = 500; // reset on success
+            }
+            Err(e) => {
+                error!("ET112 erreur cycle polling : {:#}", e);
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                backoff_ms = (backoff_ms * 2).min(30_000);
+                continue;
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+/// Un cycle de polling : lit tous les registres pour chaque ET112 configuré.
+async fn poll_cycle<F>(
+    port_path: &str,
+    baud: u32,
+    devices: &[Et112DeviceConfig],
+    on_snapshot: &mut F,
+) -> anyhow::Result<()>
+where
+    F: FnMut(Et112Snapshot),
+{
+    for dev in devices {
+        let address = dev.parsed_address();
+        match poll_device(port_path, baud, address, dev).await {
+            Ok(snap) => {
+                debug!(
+                    addr = address,
+                    name = %dev.name,
+                    power_w = snap.power_w,
+                    "ET112 snapshot OK"
+                );
+                on_snapshot(snap);
+            }
+            Err(e) => {
+                warn!(
+                    addr = address,
+                    name = %dev.name,
+                    "ET112 erreur lecture : {:#}", e
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Ouvre le port série, interroge un ET112 et retourne un snapshot.
+async fn poll_device(
+    port_path: &str,
+    baud: u32,
+    address: u8,
+    dev: &Et112DeviceConfig,
+) -> anyhow::Result<Et112Snapshot> {
+    let builder = tokio_serial::new(port_path, baud)
+        .data_bits(tokio_serial::DataBits::Eight)
+        .parity(tokio_serial::Parity::None)
+        .stop_bits(tokio_serial::StopBits::One)
+        .timeout(Duration::from_millis(1500));
+
+    let port = SerialStream::open(&builder)
+        .map_err(|e| anyhow::anyhow!("Impossible d'ouvrir {} : {}", port_path, e))?;
+
+    let mut ctx = rtu::attach_slave(port, Slave(address));
+
+    // Lecture bloc 1 : 0x0000–0x000F → 16 registres (8 × FLOAT32)
+    // voltage, current, power_active, power_apparent, power_reactive, pf, phase_angle, freq
+    let regs1: Vec<u16> = ctx
+        .read_input_registers(0x0000, 16)
+        .await
+        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} FC04 read 0x0000: {}", address, e))?
+        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} exception code: {:?}", address, e))?;
+
+    if regs1.len() < 16 {
+        anyhow::bail!("ET112 addr={:#04x} réponse trop courte bloc 1 ({})", address, regs1.len());
+    }
+
+    // Lecture bloc 2 : 0x0010–0x0013 → 4 registres (2 × FLOAT32)
+    // energy_import, energy_export
+    let regs2: Vec<u16> = ctx
+        .read_input_registers(0x0010, 4)
+        .await
+        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} FC04 read 0x0010: {}", address, e))?
+        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} exception code: {:?}", address, e))?;
+
+    if regs2.len() < 4 {
+        anyhow::bail!("ET112 addr={:#04x} réponse trop courte bloc 2 ({})", address, regs2.len());
+    }
+
+    // Décodage FLOAT32 big-endian (2 registres par valeur)
+    let voltage_v          = regs_to_f32(regs1[0],  regs1[1]);
+    let current_a          = regs_to_f32(regs1[2],  regs1[3]);
+    let power_w            = regs_to_f32(regs1[4],  regs1[5]);
+    let apparent_power_va  = regs_to_f32(regs1[6],  regs1[7]);
+    let reactive_power_var = regs_to_f32(regs1[8],  regs1[9]);
+    let power_factor       = regs_to_f32(regs1[10], regs1[11]);
+    // regs1[12..13] = phase_angle (non utilisé pour l'instant)
+    let frequency_hz       = regs_to_f32(regs1[14], regs1[15]);
+
+    let energy_import_wh   = regs_to_f32(regs2[0],  regs2[1]);
+    let energy_export_wh   = regs_to_f32(regs2[2],  regs2[3]);
+
+    Ok(Et112Snapshot {
+        address,
+        name: dev.name.clone(),
+        timestamp: Local::now(),
+        voltage_v,
+        current_a,
+        power_w,
+        apparent_power_va,
+        reactive_power_var,
+        power_factor,
+        frequency_hz,
+        energy_import_wh,
+        energy_export_wh,
+    })
+}

--- a/crates/daly-bms-server/src/et112/types.rs
+++ b/crates/daly-bms-server/src/et112/types.rs
@@ -1,0 +1,61 @@
+//! Types de données pour le compteur Carlo Gavazzi ET112.
+//!
+//! Le ET112 est un compteur monophasé RS485/Modbus RTU.
+//! Registres lus via FC=04 (Read Input Registers), FLOAT32 big-endian.
+
+use chrono::{DateTime, Local};
+use serde::{Deserialize, Serialize};
+
+/// Snapshot complet d'un ET112 à un instant donné.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Et112Snapshot {
+    /// Adresse Modbus (ex: 3 pour 0x03)
+    pub address: u8,
+
+    /// Nom configuré (ex: "Micro-inverseurs")
+    pub name: String,
+
+    /// Instant de la mesure
+    pub timestamp: DateTime<Local>,
+
+    // ── Mesures instantanées ────────────────────────────────────────────────
+    /// Tension L1 (V)
+    pub voltage_v: f32,
+
+    /// Courant L1 (A) — positif = import, négatif = export
+    pub current_a: f32,
+
+    /// Puissance active (W) — positif = import, négatif = export
+    pub power_w: f32,
+
+    /// Puissance apparente (VA)
+    pub apparent_power_va: f32,
+
+    /// Puissance réactive (VAr)
+    pub reactive_power_var: f32,
+
+    /// Facteur de puissance (sans unité, -1.0 à +1.0)
+    pub power_factor: f32,
+
+    /// Fréquence réseau (Hz)
+    pub frequency_hz: f32,
+
+    // ── Énergies cumulées ───────────────────────────────────────────────────
+    /// Énergie importée depuis la mise en service (Wh)
+    pub energy_import_wh: f32,
+
+    /// Énergie exportée depuis la mise en service (Wh)
+    pub energy_export_wh: f32,
+}
+
+impl Et112Snapshot {
+    /// Énergie importée en kWh.
+    pub fn energy_import_kwh(&self) -> f32 {
+        self.energy_import_wh / 1000.0
+    }
+
+    /// Énergie exportée en kWh.
+    pub fn energy_export_kwh(&self) -> f32 {
+        self.energy_export_wh / 1000.0
+    }
+}

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -15,6 +15,7 @@
 
 mod autodetect;
 mod config;
+mod et112;
 mod state;
 mod api;
 mod bridges;
@@ -221,6 +222,31 @@ async fn main() -> anyhow::Result<()> {
         let (s, c) = (state.clone(), config.alerts.clone());
         async move { alerts::run_alert_engine(s, c).await }
     });
+
+    // ── Bridge ET112 polling (tâche indépendante) ──────────────────────────────
+    if !config.et112.devices.is_empty() {
+        info!(
+            port  = %config.et112.port,
+            count = config.et112.devices.len(),
+            "Démarrage polling ET112"
+        );
+        let state_et = state.clone();
+        let et112_cfg = config.et112.clone();
+        tokio::spawn(async move {
+            et112::run_et112_poll_loop(
+                et112_cfg.port,
+                et112_cfg.baud,
+                et112_cfg.devices,
+                std::time::Duration::from_millis(et112_cfg.poll_interval_ms),
+                move |snap| {
+                    let state = state_et.clone();
+                    tokio::spawn(async move {
+                        state.on_et112_snapshot(snap).await;
+                    });
+                },
+            ).await;
+        });
+    }
 
     // ── Mode SIMULATION ou HARDWARE ────────────────────────────────────────────
     if args.simulate {

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -4,6 +4,7 @@
 //! et les handlers Axum.
 
 use crate::config::AppConfig;
+use crate::et112::Et112Snapshot;
 use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
 use serde::Serialize;
@@ -63,6 +64,36 @@ impl BmsRingBuffer {
 // AppState
 // =============================================================================
 
+// =============================================================================
+// Ring buffer ET112
+// =============================================================================
+
+/// Ring buffer de snapshots ET112 pour un compteur.
+pub struct Et112RingBuffer {
+    pub buffer: VecDeque<Et112Snapshot>,
+    pub capacity: usize,
+}
+
+impl Et112RingBuffer {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buffer: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    pub fn push(&mut self, snap: Et112Snapshot) {
+        if self.buffer.len() >= self.capacity {
+            self.buffer.pop_front();
+        }
+        self.buffer.push_back(snap);
+    }
+
+    pub fn latest(&self) -> Option<&Et112Snapshot> {
+        self.buffer.back()
+    }
+}
+
 /// État global partagé de l'application.
 #[derive(Clone)]
 pub struct AppState {
@@ -83,6 +114,9 @@ pub struct AppState {
 
     /// Buffer de logs pour l'interface web.
     pub log_buffer: LogBuffer,
+
+    /// Ring buffers ET112 indexés par adresse Modbus.
+    pub et112_buffers: Arc<RwLock<BTreeMap<u8, Et112RingBuffer>>>,
 }
 
 impl AppState {
@@ -96,6 +130,13 @@ impl AppState {
             buffers.insert(*addr, BmsRingBuffer::new(ring_size));
         }
 
+        // Pré-allouer les ring buffers ET112
+        let et112_ring_size = config.et112.ring_buffer_size;
+        let mut et112_buffers = BTreeMap::new();
+        for dev in &config.et112.devices {
+            et112_buffers.insert(dev.parsed_address(), Et112RingBuffer::new(et112_ring_size));
+        }
+
         Self {
             config: Arc::new(config),
             buffers: Arc::new(RwLock::new(buffers)),
@@ -103,6 +144,7 @@ impl AppState {
             polling_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             port: Arc::new(RwLock::new(None)),
             log_buffer,
+            et112_buffers: Arc::new(RwLock::new(et112_buffers)),
         }
     }
 
@@ -152,5 +194,36 @@ impl AppState {
     /// S'abonne au canal broadcast WebSocket.
     pub fn subscribe_ws(&self) -> broadcast::Receiver<Arc<Vec<BmsSnapshot>>> {
         self.ws_tx.subscribe()
+    }
+
+    /// Enregistre un snapshot ET112 dans le ring buffer correspondant.
+    pub async fn on_et112_snapshot(&self, snap: Et112Snapshot) {
+        let mut buffers = self.et112_buffers.write().await;
+        buffers
+            .entry(snap.address)
+            .or_insert_with(|| Et112RingBuffer::new(self.config.et112.ring_buffer_size))
+            .push(snap);
+    }
+
+    /// Retourne le dernier snapshot ET112 pour une adresse donnée.
+    pub async fn et112_latest_for(&self, addr: u8) -> Option<Et112Snapshot> {
+        let buffers = self.et112_buffers.read().await;
+        buffers.get(&addr)?.latest().cloned()
+    }
+
+    /// Retourne les `n` derniers snapshots ET112 (pour historique).
+    pub async fn et112_history_for(&self, addr: u8, limit: usize) -> Vec<Et112Snapshot> {
+        let buffers = self.et112_buffers.read().await;
+        if let Some(buf) = buffers.get(&addr) {
+            buf.buffer.iter().rev().take(limit).cloned().collect()
+        } else {
+            vec![]
+        }
+    }
+
+    /// Retourne tous les derniers snapshots ET112.
+    pub async fn et112_latest_all(&self) -> Vec<Et112Snapshot> {
+        let buffers = self.et112_buffers.read().await;
+        buffers.values().filter_map(|b| b.latest().cloned()).collect()
     }
 }

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -548,6 +548,7 @@
   <div class="nav-brand">⚡ Daly<span>BMS</span></div>
   <div class="nav-links">
     <a href="/dashboard">Vue d'ensemble</a>
+    <a href="/dashboard/et112">⚡ ET112</a>
     <a href="/dashboard/settings">Paramètres</a>
     <a href="/dashboard/logs">Logs</a>
     <a href="/api/v1/system/status" target="_blank">API</a>

--- a/crates/daly-bms-server/templates/et112.html
+++ b/crates/daly-bms-server/templates/et112.html
@@ -1,0 +1,181 @@
+{% extends "base.html" %}
+
+{% block title %}ET112 — {{ name }} — DalyBMS{% endblock %}
+
+{% block content %}
+
+{# ─── En-tête ────────────────────────────────────────────────────────────── #}
+<div class="info-bar">
+  <div style="display:flex;align-items:center;gap:0.5rem;">
+    <div class="dot {% if connected %}active{% endif %}"></div>
+    {% if connected %}
+      <strong>Connecté</strong>
+    {% else %}
+      <span style="color:var(--muted)">En attente de données…</span>
+    {% endif %}
+  </div>
+  <div>⚡ <strong>ET112</strong> — {{ name }}</div>
+  <div>Adresse Modbus : <code>{{ addr_hex }}</code></div>
+  <div style="margin-left:auto;font-size:0.7rem;color:var(--muted)">
+    Dernière mesure : <span id="last-ts">{{ last_ts }}</span>
+  </div>
+</div>
+
+{% if connected %}
+
+{# ─── Cartes de métriques instantanées ──────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1rem;margin-bottom:1.5rem;">
+
+  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
+    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Puissance</div>
+    <div style="font-size:2rem;font-weight:700;color:{% if power_w >= 0.0 %}var(--green){% else %}var(--accent){% endif %}" id="val-power">
+      {{ power_w|f1 }} W
+    </div>
+    <div style="font-size:0.7rem;color:var(--muted)">{% if power_w >= 0.0 %}Import{% else %}Export{% endif %}</div>
+  </div>
+
+  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
+    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Tension</div>
+    <div style="font-size:2rem;font-weight:700;color:var(--text)" id="val-voltage">
+      {{ voltage_v|f1 }} V
+    </div>
+  </div>
+
+  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
+    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Courant</div>
+    <div style="font-size:2rem;font-weight:700;color:var(--text)" id="val-current">
+      {{ current_a|f2 }} A
+    </div>
+  </div>
+
+  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
+    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Facteur de puissance</div>
+    <div style="font-size:2rem;font-weight:700;color:var(--text)" id="val-pf">
+      {{ power_factor|f3 }}
+    </div>
+  </div>
+
+  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
+    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Fréquence</div>
+    <div style="font-size:2rem;font-weight:700;color:var(--text)" id="val-freq">
+      {{ frequency_hz|f2 }} Hz
+    </div>
+  </div>
+
+  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
+    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Puiss. apparente</div>
+    <div style="font-size:2rem;font-weight:700;color:var(--muted)" id="val-apparent">
+      {{ apparent_power_va|f1 }} VA
+    </div>
+  </div>
+
+</div>
+
+{# ─── Énergie cumulée ─────────────────────────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:1.5rem;">
+
+  <div class="card" style="padding:1.5rem;display:flex;flex-direction:column;gap:0.5rem;">
+    <div style="font-size:0.75rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em">⬇ Énergie importée (depuis MàJ)</div>
+    <div style="font-size:2.2rem;font-weight:700;color:var(--green)" id="val-import">
+      {{ energy_import_kwh|f3 }} kWh
+    </div>
+    <div style="font-size:0.7rem;color:var(--muted)">{{ energy_import_wh|f0 }} Wh brut (cumulé compteur)</div>
+  </div>
+
+  <div class="card" style="padding:1.5rem;display:flex;flex-direction:column;gap:0.5rem;">
+    <div style="font-size:0.75rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em">⬆ Énergie exportée</div>
+    <div style="font-size:2.2rem;font-weight:700;color:var(--accent)" id="val-export">
+      {{ energy_export_kwh|f3 }} kWh
+    </div>
+    <div style="font-size:0.7rem;color:var(--muted)">{{ energy_export_wh|f0 }} Wh brut (cumulé compteur)</div>
+  </div>
+
+</div>
+
+{# ─── Graphique puissance (ECharts) ──────────────────────────────────────── #}
+<div class="card" style="padding:1rem;">
+  <div style="font-size:0.8rem;font-weight:600;margin-bottom:0.75rem;color:var(--muted)">Historique puissance (dernières mesures)</div>
+  <div id="chart-power" style="height:250px;"></div>
+</div>
+
+{% else %}
+
+<div class="card" style="text-align:center;padding:3rem;color:var(--muted)">
+  <div style="font-size:2.5rem;margin-bottom:1rem">⏳</div>
+  <div>En attente du premier snapshot ET112…</div>
+  <div style="font-size:0.8rem;margin-top:0.5rem">
+    Vérifiez que l'ET112 est alimenté sur <code>{{ addr_hex }}</code> @ <code>/dev/ttyUSB1</code>
+  </div>
+</div>
+
+{% endif %}
+
+{# ─── Script ECharts ──────────────────────────────────────────────────────── #}
+<script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
+<script>
+const ADDR = "{{ address }}";
+const API  = `/api/v1/et112/${ADDR}`;
+
+// Initialiser le graphique
+const chartDom = document.getElementById('chart-power');
+let myChart = null;
+if (chartDom) {
+    myChart = echarts.init(chartDom);
+    myChart.setOption({
+        tooltip: { trigger: 'axis', formatter: params => {
+            const t = params[0].name;
+            return `${t}<br/>Puissance: <b>${params[0].value} W</b>`;
+        }},
+        xAxis: { type: 'category', data: [], axisLabel: { fontSize: 11 } },
+        yAxis: { type: 'value', name: 'W', axisLabel: { fontSize: 11 } },
+        series: [{
+            name: 'Puissance',
+            type: 'line',
+            data: [],
+            smooth: true,
+            lineStyle: { color: '#0969da' },
+            areaStyle: { opacity: 0.15 },
+            symbol: 'none',
+        }],
+        grid: { left: 50, right: 20, top: 20, bottom: 30 },
+    });
+    window.addEventListener('resize', () => myChart.resize());
+}
+
+// Mise à jour périodique
+async function update() {
+    try {
+        const resp = await fetch(`${API}/status`);
+        if (!resp.ok) return;
+        const d = await resp.json();
+        document.getElementById('val-power').textContent   = d.power_w.toFixed(1) + ' W';
+        document.getElementById('val-voltage').textContent = d.voltage_v.toFixed(1) + ' V';
+        document.getElementById('val-current').textContent = d.current_a.toFixed(2) + ' A';
+        document.getElementById('val-pf').textContent      = d.power_factor.toFixed(3);
+        document.getElementById('val-freq').textContent    = d.frequency_hz.toFixed(2) + ' Hz';
+        document.getElementById('val-apparent').textContent = d.apparent_power_va.toFixed(1) + ' VA';
+        document.getElementById('val-import').textContent  = (d.energy_import_wh / 1000).toFixed(3) + ' kWh';
+        document.getElementById('val-export').textContent  = (d.energy_export_wh / 1000).toFixed(3) + ' kWh';
+        document.getElementById('last-ts').textContent     = new Date().toLocaleTimeString();
+    } catch(e) {}
+}
+
+async function loadHistory() {
+    if (!myChart) return;
+    try {
+        const resp = await fetch(`${API}/history?limit=120`);
+        if (!resp.ok) return;
+        const d = await resp.json();
+        const xs = d.history.map(s => new Date(s.timestamp).toLocaleTimeString());
+        const ys = d.history.map(s => s.power_w.toFixed(1));
+        myChart.setOption({ xAxis: { data: xs }, series: [{ data: ys }] });
+    } catch(e) {}
+}
+
+update();
+loadHistory();
+setInterval(update, 5000);
+setInterval(loadHistory, 30000);
+</script>
+
+{% endblock %}

--- a/crates/dbus-mqtt-venus/src/config.rs
+++ b/crates/dbus-mqtt-venus/src/config.rs
@@ -64,6 +64,14 @@ pub struct VenusServiceConfig {
     /// Configuration du service platform (backup/restore Pi5)
     #[serde(default)]
     pub platform: PlatformConfig,
+
+    /// Configuration MQTT pvinverter (onduleurs PV / compteurs ET112)
+    #[serde(default)]
+    pub pvinverter: PvinverterConfig,
+
+    /// Configurations par onduleur PV / compteur ET112
+    #[serde(default)]
+    pub pvinverters: Vec<PvinverterRef>,
 }
 
 /// Référence à la config MQTT du serveur principal.
@@ -326,6 +334,41 @@ pub struct GridRef {
     /// "grid"   → `com.victronenergy.grid.{prefix}_{n}`
     /// "acload" → `com.victronenergy.acload.{prefix}_{n}`
     pub service_type: Option<String>,
+}
+
+// =============================================================================
+// Configuration onduleurs PV / compteurs ET112 (pvinverter)
+// =============================================================================
+
+/// Préfixe MQTT pour les onduleurs PV / compteurs d'énergie ET112.
+///
+/// Topic abonné : `{topic_prefix}/{n}/venus`
+/// Exemple : `santuario/pvinverter/3/venus`
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PvinverterConfig {
+    /// Préfixe des topics pvinverter (ex: "santuario/pvinverter")
+    pub topic_prefix: String,
+}
+
+impl Default for PvinverterConfig {
+    fn default() -> Self {
+        Self { topic_prefix: "santuario/pvinverter".to_string() }
+    }
+}
+
+/// Configuration d'un onduleur PV / compteur ET112 individuel.
+///
+/// Une section `[[pvinverters]]` par appareil dans le TOML.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct PvinverterRef {
+    /// Index dans le topic MQTT (ex: 3 → `santuario/pvinverter/3/venus`).
+    pub mqtt_index: Option<u8>,
+
+    /// Nom affiché dans Venus OS (`/ProductName`).
+    pub name: Option<String>,
+
+    /// DeviceInstance Venus OS D-Bus (ex: 63).
+    pub device_instance: Option<u32>,
 }
 
 // =============================================================================

--- a/crates/dbus-mqtt-venus/src/main.rs
+++ b/crates/dbus-mqtt-venus/src/main.rs
@@ -36,6 +36,8 @@ mod meteo_service;
 mod mqtt_source;
 mod platform_manager;
 mod platform_service;
+mod pvinverter_manager;
+mod pvinverter_service;
 mod sensor_manager;
 mod switch_manager;
 mod switch_service;
@@ -51,10 +53,11 @@ use manager::BatteryManager;
 use meteo_manager::MeteoManager;
 use mqtt_source::{
     start_grid_mqtt_source, start_heatpump_mqtt_source, start_meteo_mqtt_source,
-    start_mqtt_source, start_platform_mqtt_source, start_sensor_mqtt_source,
-    start_switch_mqtt_source,
+    start_mqtt_source, start_platform_mqtt_source, start_pvinverter_mqtt_source,
+    start_sensor_mqtt_source, start_switch_mqtt_source,
 };
 use platform_manager::PlatformManager;
+use pvinverter_manager::PvinverterManager;
 use sensor_manager::SensorManager;
 use switch_manager::SwitchManager;
 use std::path::PathBuf;
@@ -111,21 +114,23 @@ async fn main() -> Result<()> {
     }
 
     info!(
-        version          = env!("CARGO_PKG_VERSION"),
-        dbus_bus         = %cfg.venus.dbus_bus,
-        mqtt_host        = %cfg.mqtt.host,
-        bms_prefix       = %cfg.mqtt.topic_prefix,
-        heat_prefix      = %cfg.heat.topic_prefix,
-        heatpump_prefix  = %cfg.heatpump.topic_prefix,
-        meteo_topic      = %cfg.meteo.topic,
-        switch_prefix    = %cfg.switch.topic_prefix,
-        grid_prefix      = %cfg.grid.topic_prefix,
-        platform_topic   = %cfg.platform.topic,
-        bms_count        = cfg.bms.len(),
-        sensor_count     = cfg.sensors.len(),
-        heatpump_count   = cfg.heatpumps.len(),
-        switch_count     = cfg.switches.len(),
-        grid_count       = cfg.grids.len(),
+        version            = env!("CARGO_PKG_VERSION"),
+        dbus_bus           = %cfg.venus.dbus_bus,
+        mqtt_host          = %cfg.mqtt.host,
+        bms_prefix         = %cfg.mqtt.topic_prefix,
+        heat_prefix        = %cfg.heat.topic_prefix,
+        heatpump_prefix    = %cfg.heatpump.topic_prefix,
+        meteo_topic        = %cfg.meteo.topic,
+        switch_prefix      = %cfg.switch.topic_prefix,
+        grid_prefix        = %cfg.grid.topic_prefix,
+        pvinverter_prefix  = %cfg.pvinverter.topic_prefix,
+        platform_topic     = %cfg.platform.topic,
+        bms_count          = cfg.bms.len(),
+        sensor_count       = cfg.sensors.len(),
+        heatpump_count     = cfg.heatpumps.len(),
+        switch_count       = cfg.switches.len(),
+        grid_count         = cfg.grids.len(),
+        pvinverter_count   = cfg.pvinverters.len(),
         "dbus-mqtt-venus démarrage"
     );
 
@@ -236,14 +241,31 @@ async fn main() -> Result<()> {
     });
 
     // -------------------------------------------------------------------------
+    // Bridge pvinverter/ET112 : MQTT santuario/pvinverter/{n}/venus → D-Bus com.victronenergy.pvinverter.{n}
+    // -------------------------------------------------------------------------
+    let (pvinverter_tx, pvinverter_rx) = mpsc::channel(32);
+    let mqtt_cfg7          = cfg.mqtt.clone();
+    let pvinverter_prefix  = cfg.pvinverter.topic_prefix.clone();
+    tokio::spawn(async move {
+        start_pvinverter_mqtt_source(mqtt_cfg7, pvinverter_prefix, pvinverter_tx).await;
+    });
+
+    let pvinverter_manager = PvinverterManager::new(cfg.venus.clone(), cfg.pvinverters, pvinverter_rx);
+    tokio::spawn(async move {
+        if let Err(e) = pvinverter_manager.run().await {
+            error!("PvinverterManager terminé avec erreur : {:#}", e);
+        }
+    });
+
+    // -------------------------------------------------------------------------
     // Bridge platform : MQTT santuario/platform/venus → D-Bus com.victronenergy.platform
     // Le PlatformManager est le dernier et bloque le thread principal
     // -------------------------------------------------------------------------
     let (platform_tx, platform_rx) = mpsc::channel(16);
-    let mqtt_cfg7      = cfg.mqtt.clone();
+    let mqtt_cfg8      = cfg.mqtt.clone();
     let platform_topic = cfg.platform.topic.clone();
     tokio::spawn(async move {
-        start_platform_mqtt_source(mqtt_cfg7, platform_topic, platform_tx).await;
+        start_platform_mqtt_source(mqtt_cfg8, platform_topic, platform_tx).await;
     });
 
     let platform_manager = PlatformManager::new(cfg.venus, cfg.platform, platform_rx);

--- a/crates/dbus-mqtt-venus/src/mqtt_source.rs
+++ b/crates/dbus-mqtt-venus/src/mqtt_source.rs
@@ -6,7 +6,7 @@
 //! - `{heat_prefix}/+/venus` → capteurs température → `SensorMqttEvent`
 
 use crate::config::MqttRef;
-use crate::types::{GridPayload, HeatPayload, HeatpumpPayload, MeteoPayload, PlatformPayload, SwitchPayload, VenusPayload};
+use crate::types::{GridPayload, HeatPayload, HeatpumpPayload, MeteoPayload, PlatformPayload, PvinverterPayload, SwitchPayload, VenusPayload};
 use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -73,6 +73,15 @@ pub struct GridMqttEvent {
 pub struct PlatformMqttEvent {
     /// Payload platform parsé
     pub payload: PlatformPayload,
+}
+
+/// Événement onduleur PV / compteur ET112 reçu depuis MQTT (topic pvinverter).
+#[derive(Debug)]
+pub struct PvinverterMqttEvent {
+    /// Index (ex: `santuario/pvinverter/3/venus` → `3`)
+    pub mqtt_index: u8,
+    /// Payload pvinverter parsé
+    pub payload: PvinverterPayload,
 }
 
 // =============================================================================
@@ -596,6 +605,74 @@ async fn platform_connect_and_run(
                 }
             }
             Ok(Event::Incoming(Packet::ConnAck(_))) => info!("MQTT platform ConnAck reçu"),
+            Ok(_) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+// =============================================================================
+// Source MQTT pour onduleurs PV / compteurs ET112 (santuario/pvinverter/{n}/venus)
+// =============================================================================
+
+/// Démarre la source MQTT pour les onduleurs PV / compteurs ET112.
+///
+/// S'abonne sur `{pvinverter_prefix}/+/venus`, parse le `PvinverterPayload`
+/// et émet des `PvinverterMqttEvent` vers le `PvinverterManager`.
+pub async fn start_pvinverter_mqtt_source(
+    cfg:               MqttRef,
+    pvinverter_prefix: String,
+    tx:                mpsc::Sender<PvinverterMqttEvent>,
+) {
+    let subscribe_topic = format!("{}/+/venus", pvinverter_prefix);
+
+    info!(
+        broker = %format!("{}:{}", cfg.host, cfg.port),
+        topic  = %subscribe_topic,
+        "Démarrage source MQTT pvinverter/ET112"
+    );
+
+    loop {
+        match pvinverter_connect_and_run(&cfg, &subscribe_topic, &pvinverter_prefix, &tx).await {
+            Ok(())  => warn!("MQTT source pvinverter terminée de façon inattendue, reconnexion dans 5s"),
+            Err(e)  => error!("MQTT source pvinverter erreur : {:#}, reconnexion dans 5s", e),
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn pvinverter_connect_and_run(
+    cfg:               &MqttRef,
+    subscribe_topic:   &str,
+    pvinverter_prefix: &str,
+    tx:                &mpsc::Sender<PvinverterMqttEvent>,
+) -> anyhow::Result<()> {
+    let client_id = format!("dbus-mqtt-venus-pvinverter-{}", uuid_short());
+    let mut opts = MqttOptions::new(client_id, &cfg.host, cfg.port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_clean_session(true);
+    if let (Some(u), Some(p)) = (&cfg.username, &cfg.password) { opts.set_credentials(u, p); }
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 64);
+    client.subscribe(subscribe_topic, QoS::AtLeastOnce).await?;
+    info!("MQTT pvinverter connecté, abonnement sur '{}'", subscribe_topic);
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Packet::Publish(msg))) => {
+                let topic = &msg.topic;
+                debug!(topic = %topic, "MQTT pvinverter message reçu");
+                if let Some(idx) = extract_mqtt_index(topic, pvinverter_prefix) {
+                    match serde_json::from_slice::<PvinverterPayload>(&msg.payload) {
+                        Ok(payload) => {
+                            let evt = PvinverterMqttEvent { mqtt_index: idx, payload };
+                            if tx.send(evt).await.is_err() { return Ok(()); }
+                        }
+                        Err(e) => warn!(topic = %topic, "Échec parsing payload pvinverter: {}", e),
+                    }
+                }
+            }
+            Ok(Event::Incoming(Packet::ConnAck(_))) => info!("MQTT pvinverter ConnAck reçu"),
             Ok(_) => {}
             Err(e) => return Err(e.into()),
         }

--- a/crates/dbus-mqtt-venus/src/pvinverter_manager.rs
+++ b/crates/dbus-mqtt-venus/src/pvinverter_manager.rs
@@ -1,0 +1,119 @@
+//! Manager des services D-Bus pvinverter — orchestre N onduleurs PV / compteurs ET112.
+//!
+//! Reçoit les `PvinverterMqttEvent` depuis `mqtt_source` et les route vers
+//! le `PvinverterServiceHandle` correspondant.
+//! Topic MQTT : `santuario/pvinverter/{n}/venus`
+//! Service D-Bus : `com.victronenergy.pvinverter.{prefix}_{n}`
+
+use crate::config::{PvinverterRef, VenusConfig};
+use crate::mqtt_source::PvinverterMqttEvent;
+use crate::pvinverter_service::{PvinverterServiceHandle, create_pvinverter_service};
+use anyhow::Result;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::time::interval;
+use tracing::{error, info, warn};
+
+pub struct PvinverterManager {
+    cfg:              VenusConfig,
+    pvinverter_refs:  Vec<PvinverterRef>,
+    services:         HashMap<u8, PvinverterServiceHandle>,
+    rx:               mpsc::Receiver<PvinverterMqttEvent>,
+}
+
+impl PvinverterManager {
+    pub fn new(
+        cfg:             VenusConfig,
+        pvinverter_refs: Vec<PvinverterRef>,
+        rx:              mpsc::Receiver<PvinverterMqttEvent>,
+    ) -> Self {
+        Self { cfg, pvinverter_refs, services: HashMap::new(), rx }
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        if !self.cfg.enabled {
+            info!("Service pvinverter D-Bus désactivé (enabled = false)");
+            while self.rx.recv().await.is_some() {}
+            return Ok(());
+        }
+
+        let watchdog_dur  = Duration::from_secs(self.cfg.watchdog_sec);
+        let republish_dur = Duration::from_secs(self.cfg.republish_sec);
+        let mut tick      = interval(republish_dur);
+
+        info!(
+            dbus_bus      = %self.cfg.dbus_bus,
+            pvinverters   = self.pvinverter_refs.len(),
+            watchdog_sec  = self.cfg.watchdog_sec,
+            "PvinverterManager démarré"
+        );
+
+        loop {
+            tokio::select! {
+                Some(evt) = self.rx.recv() => {
+                    if let Err(e) = self.handle_event(evt).await {
+                        error!("Erreur événement pvinverter MQTT : {:#}", e);
+                    }
+                }
+                _ = tick.tick() => {
+                    self.republish_and_watchdog(watchdog_dur).await;
+                }
+            }
+        }
+    }
+
+    async fn handle_event(&mut self, evt: PvinverterMqttEvent) -> Result<()> {
+        let idx = evt.mqtt_index;
+        if !self.services.contains_key(&idx) {
+            let handle = self.create_service(idx).await?;
+            self.services.insert(idx, handle);
+        }
+        if let Some(svc) = self.services.get(&idx) {
+            svc.update(&evt.payload).await?;
+        }
+        Ok(())
+    }
+
+    async fn create_service(&self, idx: u8) -> Result<PvinverterServiceHandle> {
+        let suffix          = format!("{}_{}", self.cfg.service_prefix, idx);
+        let device_instance = self.device_instance_for(idx);
+        let product_name    = self.product_name_for(idx);
+        create_pvinverter_service(
+            &self.cfg.dbus_bus,
+            &suffix,
+            device_instance,
+            product_name,
+        ).await
+    }
+
+    fn device_instance_for(&self, idx: u8) -> u32 {
+        for (pos, p) in self.pvinverter_refs.iter().enumerate() {
+            let pi = p.mqtt_index.unwrap_or((pos + 1) as u8);
+            if pi == idx { return p.device_instance.unwrap_or(pi as u32); }
+        }
+        idx as u32
+    }
+
+    fn product_name_for(&self, idx: u8) -> String {
+        for (pos, p) in self.pvinverter_refs.iter().enumerate() {
+            let pi = p.mqtt_index.unwrap_or((pos + 1) as u8);
+            if pi == idx { if let Some(n) = &p.name { return n.clone(); } }
+        }
+        format!("PV Inverter {}", idx)
+    }
+
+    async fn republish_and_watchdog(&self, watchdog_dur: Duration) {
+        let now = Instant::now();
+        for (idx, svc) in &self.services {
+            let last = { svc.values.lock().unwrap().last_update };
+            if now.duration_since(last) > watchdog_dur {
+                if let Err(e) = svc.set_disconnected().await {
+                    warn!(index = idx, "Erreur watchdog pvinverter : {:#}", e);
+                }
+            } else if let Err(e) = svc.republish().await {
+                warn!(index = idx, "Erreur republication pvinverter : {:#}", e);
+            }
+        }
+    }
+}

--- a/crates/dbus-mqtt-venus/src/pvinverter_service.rs
+++ b/crates/dbus-mqtt-venus/src/pvinverter_service.rs
@@ -1,0 +1,373 @@
+//! Service D-Bus `com.victronenergy.pvinverter.{name}`
+//! pour onduleurs PV et compteurs d'énergie AC (ET112 micro-inverseurs).
+//!
+//! Conforme au wiki Victron Venus OS — section PV Inverter :
+//! <https://github.com/victronenergy/venus/wiki/dbus#pv-inverters>
+//!
+//! ## Chemins D-Bus exposés
+//!
+//! ```text
+//! /Ac/Power              — W puissance AC totale
+//! /Ac/Energy/Forward     — kWh énergie produite totale
+//! /Ac/L1/Voltage         — V tension L1
+//! /Ac/L1/Current         — A courant L1
+//! /Ac/L1/Power           — W puissance L1
+//! /Ac/L1/Energy/Forward  — kWh énergie L1
+//! /StatusCode            — 7=Running
+//! /ErrorCode             — 0=No Error
+//! /Position              — 1=AC Output
+//! /IsGenericEnergyMeter  — 1 (ET112 masquerade)
+//! /Connected
+//! /ProductName
+//! /ProductId
+//! /DeviceInstance
+//! /Mgmt/ProcessName
+//! /Mgmt/ProcessVersion
+//! /Mgmt/Connection
+//! ```
+
+use crate::types::PvinverterPayload;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tracing::{debug, info, warn};
+use zbus::{connection, object_server::SignalContext, Connection};
+use zvariant::{OwnedValue, Str};
+
+// =============================================================================
+// Constantes
+// =============================================================================
+
+const VICTRON_PVINVERTER_PREFIX: &str = "com.victronenergy.pvinverter";
+
+// =============================================================================
+// Item D-Bus
+// =============================================================================
+
+#[derive(Debug, Clone)]
+pub struct DbusItem {
+    pub value: serde_json::Value,
+    pub text:  String,
+}
+
+impl DbusItem {
+    pub fn f64(v: f64, unit: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: format!("{:.2} {}", v, unit) }
+    }
+    pub fn i32(v: i32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn str(v: &str) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+    pub fn u32(v: u32) -> Self {
+        Self { value: serde_json::Value::from(v), text: v.to_string() }
+    }
+}
+
+fn json_to_owned(v: &serde_json::Value) -> OwnedValue {
+    match v {
+        serde_json::Value::Number(n) => {
+            if n.is_f64() {
+                OwnedValue::from(n.as_f64().unwrap_or(0.0))
+            } else if n.is_u64() {
+                OwnedValue::from(n.as_u64().unwrap_or(0) as u32)
+            } else {
+                let i = n.as_i64().unwrap_or(0);
+                if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                    OwnedValue::from(i as i32)
+                } else {
+                    OwnedValue::from(i)
+                }
+            }
+        }
+        serde_json::Value::String(s) => OwnedValue::from(Str::from(s.clone())),
+        _ => OwnedValue::from(0i32),
+    }
+}
+
+fn item_to_inner(item: &DbusItem) -> HashMap<String, OwnedValue> {
+    let mut d = HashMap::new();
+    d.insert("Value".to_string(), json_to_owned(&item.value));
+    d.insert("Text".to_string(), OwnedValue::from(Str::from(item.text.clone())));
+    d
+}
+
+type ItemsDict = HashMap<String, HashMap<String, OwnedValue>>;
+
+// =============================================================================
+// Valeurs courantes
+// =============================================================================
+
+/// État courant d'un service pvinverter exposé sur D-Bus.
+#[derive(Debug, Clone)]
+pub struct PvinverterValues {
+    pub connected:              i32,
+    pub power:                  f64,
+    pub energy_forward:         f64,
+    pub l1_voltage:             f64,
+    pub l1_current:             f64,
+    pub l1_power:               f64,
+    pub l1_energy_forward:      f64,
+    pub status_code:            i32,
+    pub error_code:             i32,
+    pub position:               i32,
+    pub is_generic_energy_meter: i32,
+    pub product_name:           String,
+    pub device_instance:        u32,
+    pub last_update:            Instant,
+}
+
+impl PvinverterValues {
+    pub fn disconnected(device_instance: u32, product_name: String) -> Self {
+        Self {
+            connected:               0,
+            power:                   0.0,
+            energy_forward:          0.0,
+            l1_voltage:              0.0,
+            l1_current:              0.0,
+            l1_power:                0.0,
+            l1_energy_forward:       0.0,
+            status_code:             7,
+            error_code:              0,
+            position:                1,
+            is_generic_energy_meter: 1,
+            product_name,
+            device_instance,
+            last_update:             Instant::now(),
+        }
+    }
+
+    pub fn from_payload(
+        payload:         &PvinverterPayload,
+        device_instance: u32,
+        product_name:    String,
+    ) -> Self {
+        let l1 = payload.ac.l1.as_ref();
+        Self {
+            connected:               1,
+            power:                   payload.ac.power,
+            energy_forward:          payload.ac.energy.as_ref().map(|e| e.forward).unwrap_or(0.0),
+            l1_voltage:              l1.map(|p| p.voltage).unwrap_or(0.0),
+            l1_current:              l1.map(|p| p.current).unwrap_or(0.0),
+            l1_power:                l1.map(|p| p.power).unwrap_or(payload.ac.power),
+            l1_energy_forward:       l1.and_then(|p| p.energy.as_ref()).map(|e| e.forward).unwrap_or(0.0),
+            status_code:             payload.status_code,
+            error_code:              payload.error_code,
+            position:                payload.position,
+            is_generic_energy_meter: payload.is_generic_energy_meter,
+            product_name,
+            device_instance,
+            last_update:             Instant::now(),
+        }
+    }
+
+    pub fn to_items(&self) -> HashMap<String, DbusItem> {
+        let mut m = HashMap::new();
+
+        // Identification
+        m.insert("/Mgmt/ProcessName".into(),    DbusItem::str("dbus-mqtt-venus"));
+        m.insert("/Mgmt/ProcessVersion".into(), DbusItem::str(env!("CARGO_PKG_VERSION")));
+        m.insert("/Mgmt/Connection".into(),     DbusItem::str("MQTT"));
+        m.insert("/ProductId".into(),           DbusItem::u32(0));
+        m.insert("/ProductName".into(),         DbusItem::str(&self.product_name));
+        m.insert("/DeviceInstance".into(),      DbusItem::u32(self.device_instance));
+        m.insert("/Connected".into(),           DbusItem::i32(self.connected));
+
+        // Metadata pvinverter
+        m.insert("/StatusCode".into(),            DbusItem::i32(self.status_code));
+        m.insert("/ErrorCode".into(),             DbusItem::i32(self.error_code));
+        m.insert("/Position".into(),              DbusItem::i32(self.position));
+        m.insert("/IsGenericEnergyMeter".into(),  DbusItem::i32(self.is_generic_energy_meter));
+
+        // Totaux AC
+        m.insert("/Ac/Power".into(),           DbusItem::f64(self.power,          "W"));
+        m.insert("/Ac/Energy/Forward".into(),  DbusItem::f64(self.energy_forward, "kWh"));
+
+        // Phase L1
+        m.insert("/Ac/L1/Voltage".into(),        DbusItem::f64(self.l1_voltage,        "V"));
+        m.insert("/Ac/L1/Current".into(),        DbusItem::f64(self.l1_current,        "A"));
+        m.insert("/Ac/L1/Power".into(),          DbusItem::f64(self.l1_power,          "W"));
+        m.insert("/Ac/L1/Energy/Forward".into(), DbusItem::f64(self.l1_energy_forward, "kWh"));
+
+        m
+    }
+}
+
+// =============================================================================
+// Interface D-Bus — objet racine `/`
+// =============================================================================
+
+struct PvinverterRootIface {
+    values: Arc<Mutex<PvinverterValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl PvinverterRootIface {
+    fn get_items(&self) -> ItemsDict {
+        let guard = self.values.lock().unwrap();
+        guard
+            .to_items()
+            .iter()
+            .map(|(path, item)| (path.clone(), item_to_inner(item)))
+            .collect()
+    }
+
+    fn get_value(&self) -> OwnedValue { OwnedValue::from(0i32) }
+    fn get_text(&self) -> String { String::new() }
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+
+    #[zbus(signal)]
+    async fn items_changed(
+        ctx:   &SignalContext<'_>,
+        items: ItemsDict,
+    ) -> zbus::Result<()>;
+}
+
+// =============================================================================
+// Interface D-Bus — objet feuille
+// =============================================================================
+
+struct BusItemLeaf {
+    path:   String,
+    values: Arc<Mutex<PvinverterValues>>,
+}
+
+#[zbus::interface(name = "com.victronenergy.BusItem")]
+impl BusItemLeaf {
+    fn get_value(&self) -> OwnedValue {
+        let guard = self.values.lock().unwrap();
+        match guard.to_items().get(&self.path) {
+            Some(item) => json_to_owned(&item.value),
+            None       => OwnedValue::from(0i32),
+        }
+    }
+
+    fn get_text(&self) -> String {
+        let guard = self.values.lock().unwrap();
+        guard.to_items().get(&self.path).map(|i| i.text.clone()).unwrap_or_default()
+    }
+
+    fn set_value(&self, _val: zvariant::Value<'_>) -> i32 { 1 }
+}
+
+// =============================================================================
+// Handle
+// =============================================================================
+
+pub struct PvinverterServiceHandle {
+    pub service_name:    String,
+    pub device_instance: u32,
+    pub values:          Arc<Mutex<PvinverterValues>>,
+    connection:          Connection,
+    pub product_name:    String,
+}
+
+impl PvinverterServiceHandle {
+    pub async fn update(&self, payload: &PvinverterPayload) -> Result<()> {
+        let new_values = PvinverterValues::from_payload(
+            payload,
+            self.device_instance,
+            self.product_name.clone(),
+        );
+        let items = new_values.to_items();
+        { *self.values.lock().unwrap() = new_values; }
+        self.emit_items_changed(&items).await?;
+        debug!(
+            service = %self.service_name,
+            power   = payload.ac.power,
+            "D-Bus ItemsChanged pvinverter émis"
+        );
+        Ok(())
+    }
+
+    pub async fn set_disconnected(&self) -> Result<()> {
+        let items = {
+            let mut g = self.values.lock().unwrap();
+            g.connected = 0;
+            g.to_items()
+        };
+        warn!(service = %self.service_name, "PV Inverter déconnecté — watchdog timeout");
+        self.emit_items_changed(&items).await
+    }
+
+    pub async fn republish(&self) -> Result<()> {
+        let items = { self.values.lock().unwrap().to_items() };
+        self.emit_items_changed(&items).await
+    }
+
+    async fn emit_items_changed(&self, items: &HashMap<String, DbusItem>) -> Result<()> {
+        let dict: ItemsDict = items
+            .iter()
+            .map(|(p, i)| (p.clone(), item_to_inner(i)))
+            .collect();
+        let ctx = SignalContext::new(&self.connection, "/")?;
+        match PvinverterRootIface::items_changed(&ctx, dict).await {
+            Ok(_)  => { debug!(service = %self.service_name, "ItemsChanged pvinverter émis"); Ok(()) }
+            Err(e) => { warn!(service = %self.service_name, "ItemsChanged warning : {}", e); Ok(()) }
+        }
+    }
+}
+
+// =============================================================================
+// Création du service
+// =============================================================================
+
+/// Crée un service `com.victronenergy.pvinverter.{service_suffix}`.
+pub async fn create_pvinverter_service(
+    dbus_bus:        &str,
+    service_suffix:  &str,
+    device_instance: u32,
+    product_name:    String,
+) -> Result<PvinverterServiceHandle> {
+    let service_name = format!("{}.{}", VICTRON_PVINVERTER_PREFIX, service_suffix);
+
+    info!(
+        service         = %service_name,
+        device_instance = device_instance,
+        "Enregistrement service D-Bus pvinverter Venus OS"
+    );
+
+    let initial_values = Arc::new(Mutex::new(
+        PvinverterValues::disconnected(device_instance, product_name.clone())
+    ));
+
+    let root = PvinverterRootIface { values: initial_values.clone() };
+
+    let builder = match dbus_bus {
+        "session" => connection::Builder::session()?,
+        _         => connection::Builder::system()?,
+    };
+
+    let conn = builder
+        .name(service_name.as_str())?
+        .serve_at("/", root)?
+        .build()
+        .await?;
+
+    let leaf_paths: Vec<String> = {
+        initial_values.lock().unwrap().to_items().into_keys().collect()
+    };
+
+    for path in &leaf_paths {
+        conn.object_server()
+            .at(path.as_str(), BusItemLeaf { path: path.clone(), values: initial_values.clone() })
+            .await?;
+    }
+
+    info!(
+        service = %service_name,
+        paths   = leaf_paths.len(),
+        "Service D-Bus pvinverter enregistré ({} chemins + racine /)",
+        leaf_paths.len()
+    );
+
+    Ok(PvinverterServiceHandle {
+        service_name,
+        device_instance,
+        values: initial_values,
+        connection: conn,
+        product_name,
+    })
+}

--- a/crates/dbus-mqtt-venus/src/types.rs
+++ b/crates/dbus-mqtt-venus/src/types.rs
@@ -297,6 +297,106 @@ pub struct PlatformRestorePayload {
 }
 
 // =============================================================================
+// Payload onduleur PV / compteur énergie AC (santuario/pvinverter/{n}/venus)
+// =============================================================================
+
+/// Payload pour onduleurs PV et compteurs énergie AC (ET112 micro-inverseurs).
+///
+/// Publié par `daly-bms-server` sur `santuario/pvinverter/{n}/venus`.
+/// Cible D-Bus : `com.victronenergy.pvinverter.{n}`
+///
+/// Chemins D-Bus exposés (wiki Victron — PV Inverter) :
+///   /Ac/Power              — W puissance AC totale
+///   /Ac/Energy/Forward     — kWh énergie produite totale
+///   /Ac/L1/Voltage         — V tension L1
+///   /Ac/L1/Current         — A courant L1
+///   /Ac/L1/Power           — W puissance L1
+///   /Ac/L1/Energy/Forward  — kWh énergie L1
+///   /StatusCode            — 0=Startup…7=Running
+///   /ErrorCode             — 0=No Error
+///   /Position              — 0=AC Input, 1=AC Output
+///   /IsGenericEnergyMeter  — 1 si compteur générique (ET112)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PvinverterPayload {
+    /// Données AC (L1 + totaux).
+    #[serde(rename = "Ac")]
+    pub ac: PvinverterAcPayload,
+
+    /// Code d'état : 0=Startup, 1=Fault, 2=Bulk, 3=Absorption,
+    /// 4=Float, 5=Inverted, 6=Off, 7=Running.
+    #[serde(rename = "StatusCode", default)]
+    pub status_code: i32,
+
+    /// Code d'erreur : 0=No Error.
+    #[serde(rename = "ErrorCode", default)]
+    pub error_code: i32,
+
+    /// Position : 0=AC Input, 1=AC Output.
+    #[serde(rename = "Position", default)]
+    pub position: i32,
+
+    /// 1 si compteur générique masquerade en pvinverter (ET112).
+    #[serde(rename = "IsGenericEnergyMeter", default)]
+    pub is_generic_energy_meter: i32,
+
+    /// Nom produit (ex: "ET112 addr=0x03").
+    #[serde(rename = "ProductName", default)]
+    pub product_name: Option<String>,
+
+    /// Nom personnalisé affiché dans Venus OS.
+    #[serde(rename = "CustomName", default)]
+    pub custom_name: Option<String>,
+}
+
+/// Données AC du payload pvinverter (totaux + phase L1).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PvinverterAcPayload {
+    /// Phase L1.
+    #[serde(rename = "L1", default)]
+    pub l1: Option<PvinverterL1Payload>,
+
+    /// Puissance AC totale en W.
+    #[serde(rename = "Power", default)]
+    pub power: f64,
+
+    /// Énergie AC totale.
+    #[serde(rename = "Energy", default)]
+    pub energy: Option<PvinverterEnergyPayload>,
+}
+
+/// Données de la phase L1 pour pvinverter.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PvinverterL1Payload {
+    /// Tension en V AC.
+    #[serde(rename = "Voltage", default)]
+    pub voltage: f64,
+
+    /// Courant en A.
+    #[serde(rename = "Current", default)]
+    pub current: f64,
+
+    /// Puissance en W.
+    #[serde(rename = "Power", default)]
+    pub power: f64,
+
+    /// Énergie L1.
+    #[serde(rename = "Energy", default)]
+    pub energy: Option<PvinverterEnergyPayload>,
+}
+
+/// Sous-payload énergie pour pvinverter.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PvinverterEnergyPayload {
+    /// Énergie produite / importée en kWh.
+    #[serde(rename = "Forward", default)]
+    pub forward: f64,
+
+    /// Énergie consommée / exportée en kWh (optionnel).
+    #[serde(rename = "Reverse", default)]
+    pub reverse: f64,
+}
+
+// =============================================================================
 // Payload batteries (santuario/bms/{n}/venus)
 // =============================================================================
 

--- a/nanoPi/config-nanopi.toml
+++ b/nanoPi/config-nanopi.toml
@@ -143,6 +143,38 @@ topic_prefix = "santuario/grid"
 # service_type    = "grid"     # "grid" ou "acload"
 
 # -----------------------------------------------------------------------------
+# Onduleurs PV / compteurs énergie ET112 (Carlo Gavazzi)
+# Topics : santuario/pvinverter/{mqtt_index}/venus
+# D-Bus  : com.victronenergy.pvinverter.mqtt_{mqtt_index}
+#
+# ET112 sur Pi5 (adresse RS485 0x03 → mqtt_index=3, device_instance=63)
+# Les ET112 0x01/0x02 restent connectés directement sur le Victron
+# (instances 61/62 déjà enregistrées côté Victron).
+#
+# /Ac/Power, /Ac/Energy/Forward, /Ac/L1/{Voltage,Current,Power,Energy/Forward}
+# /StatusCode=7 (Running), /ErrorCode=0, /Position=1 (AC Output)
+# /IsGenericEnergyMeter=1 (ET112 masquerade en pvinverter)
+# -----------------------------------------------------------------------------
+[pvinverter]
+topic_prefix = "santuario/pvinverter"
+
+[[pvinverters]]
+mqtt_index      = 3
+name            = "Micro-inverseurs"
+device_instance = 63          # 61/62 = ET112 Victron direct, 63 = ET112 Pi5
+
+# Décommenter lors de la migration des ET112 depuis le Victron vers le Pi5 :
+# [[pvinverters]]
+# mqtt_index      = 1
+# name            = "ET112-PV-1"
+# device_instance = 61
+#
+# [[pvinverters]]
+# mqtt_index      = 2
+# name            = "ET112-PV-2"
+# device_instance = 62
+
+# -----------------------------------------------------------------------------
 # Platform Pi5 — état backup/restore (singleton)
 # Topic fixe : santuario/platform/venus
 # D-Bus      : com.victronenergy.platform


### PR DESCRIPTION
…Bus Venus OS

## daly-bms-server (Pi5)
- Nouveau module `et112/` : polling Modbus RTU async (tokio-modbus 0.14)
  - `types.rs` : struct `Et112Snapshot` (V, I, P, PF, freq, énergie import/export)
  - `poll.rs` : boucle polling avec backoff exponentiel, FLOAT32 Big-Endian decode
- `config.rs` : section `[et112]` + `Et112DeviceConfig` (port, baud, devices)
- `state.rs` : `Et112RingBuffer` + méthodes `on_et112_snapshot`, `et112_latest_all`, etc.
- `api/et112.rs` : GET /api/v1/et112, /et112/:addr/status, /et112/:addr/history
- `dashboard/mod.rs` : handler `dashboard_et112()` + filtre `f2`
- `templates/et112.html` : dashboard SSR (6 métriques + 2 énergies + ECharts)
- `templates/base.html` : lien nav "⚡ ET112"
- `bridges/mqtt.rs` : `publish_et112_snapshot()` → santuario/pvinverter/{idx}/venus
- `bridges/influx.rs` : `et112_snapshot_to_point()` → measurement et112_status

## dbus-mqtt-venus (NanoPi)
- `types.rs` : `PvinverterPayload` + sous-structs Ac/L1/Energy
- `config.rs` : `PvinverterConfig` (topic_prefix) + `PvinverterRef` (mqtt_index, device_instance)
- `mqtt_source.rs` : `PvinverterMqttEvent` + `start_pvinverter_mqtt_source()`
- `pvinverter_service.rs` : service D-Bus com.victronenergy.pvinverter.{n}
  - Chemins : /Ac/Power, /Ac/Energy/Forward, /Ac/L1/{V,I,P,E}, /StatusCode, /Position, etc.
- `pvinverter_manager.rs` : orchestre N pvinverter, watchdog + republication
- `main.rs` : wire PvinverterManager (spawn + tokio::select)

## Configuration
- `Config.toml` : section [et112] + [[et112.devices]] addr=0x03 (mqtt_index=3)
- `nanoPi/config-nanopi.toml` : section [pvinverter] + [[pvinverters]] mqtt_index=3, instance=63
- `CLAUDE.md` : §16c ET112 documentation complète + mise à jour §19 inventaire D-Bus

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH