### PR TITLE
docs(et112): plan migration 3 ET112 sur Pi5 — pvinverter + 2 acload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -969,19 +969,42 @@ com.victronenergy.pvinverter.mqtt_3 (device instance 63)
 | `Config.toml` | Section `[et112]` + `[[et112.devices]]` |
 | `nanoPi/config-nanopi.toml` | Section `[pvinverter]` + `[[pvinverters]]` |
 
-### ET112 déjà sur Victron (instances 61/62 — à migrer ultérieurement)
+### Architecture cible : 3 ET112 sur Pi5 (migration depuis Victron)
 
-Les ET112 aux adresses RS485 0x01 et 0x02 sont connectés directement sur le Victron
-via USB-RS485 et apparaissent en production comme :
-- `com.victronenergy.pvinverter.cgwacs_ttyUSBx_mb1` → instance 61
-- `com.victronenergy.pvinverter.cgwacs_ttyUSBx_mb2` → instance 62
+**Rôle de chaque ET112 (décision 2026-03-22)** :
 
-Lors de la migration vers Pi5 :
-1. Débrancher les 2 câbles USB du Victron
-2. Brancher les 2 ET112 sur les ports USB du Pi5 (`/dev/ttyUSB2`, `/dev/ttyUSB3`)
-3. Ajouter `[[et112.devices]]` dans `Config.toml` pour addresses 0x01 et 0x02
-4. Décommenter `[[pvinverters]]` mqtt_index=1 et 2 dans `nanoPi/config-nanopi.toml`
-5. Déployer + redémarrer les services
+| ET112 | Usage | Type D-Bus | Topic MQTT | Device instance |
+|---|---|---|---|---|
+| addr 0x03 (actuel Pi5) | **Micro-inverseurs** | `pvinverter` | `santuario/pvinverter/3/venus` | 63 |
+| addr à définir | **PAC Climatisation** (AC Out 1) | `acload` | `santuario/grid/4/venus` | 501 |
+| addr à définir | **Chauffe-eau** (AC Out 1) | `acload` | `santuario/grid/5/venus` | 502 |
+
+**État actuel** :
+- `com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2` = ET112 micro-inverseurs connecté directement sur le Victron (Modbus addr 0x02)
+- Les 2 ET112 acload (PAC + chauffe-eau) ne sont **pas encore installés**
+- Le ET112 Pi5 (addr 0x03, mqtt_index=3) est **déjà actif** mais pvinverter config pas encore dans config.toml NanoPi
+
+**Procédure de migration (quand prêt)** :
+1. Brancher les 3 ET112 sur Pi5 (`/dev/ttyUSB1`, `/dev/ttyUSB2`, `/dev/ttyUSB3`)
+2. Configurer adresses RS485 sur les ET112 : 0x03=micro-inv, 0x04=PAC, 0x05=chauffe-eau (ou selon dispo)
+3. Dans `Config.toml` Pi5 : ajouter `[[et112.devices]]` pour chaque ET112, avec un champ `service_type` ("pvinverter" ou "acload")
+4. Adapter `et112/poll.rs` pour publier sur `santuario/pvinverter/{n}/venus` ou `santuario/grid/{n}/venus` selon `service_type`
+5. Dans `nanoPi/config-nanopi.toml` : décommenter les entrées `[[grids]]` mqtt_index=4 et 5
+6. Débrancher l'ancien câble USB Victron → `cgwacs_ttyUSB0_mb2` disparaît du D-Bus
+7. Déployer `daly-bms-server` (Pi5) + `dbus-mqtt-venus` (NanoPi) + redémarrer
+
+**Format JSON pour acload ET112** (compatible `GridPayload`) :
+```json
+{
+  "Ac": {
+    "L1": { "Voltage": 230.1, "Current": 8.2, "Power": 1886.0,
+            "Energy": { "Forward": 142.5, "Reverse": 0.0 } }
+  },
+  "DeviceType": 340,
+  "IsGenericEnergyMeter": 1
+}
+```
+Publié sur `santuario/grid/4/venus` (PAC) et `santuario/grid/5/venus` (chauffe-eau).
 
 ### Topics MQTT pvinverter
 

--- a/nanoPi/config-nanopi.toml
+++ b/nanoPi/config-nanopi.toml
@@ -131,25 +131,52 @@ device_instance = 60
 # Topics : santuario/grid/{mqtt_index}/venus
 # D-Bus  : com.victronenergy.grid.mqtt_{mqtt_index}
 #          com.victronenergy.acload.mqtt_{mqtt_index} (si service_type="acload")
+#
+# PLAN MIGRATION 3 ET112 (quand tous sur Pi5) :
+#   mqtt_index=3 → pvinverter (ci-dessous, section [pvinverter])
+#   mqtt_index=4 → acload PAC climatisation (AC Out 1)
+#   mqtt_index=5 → acload chauffe-eau (AC Out 1)
+#
+# Le daly-bms-server publie les ET112 acload sur santuario/grid/{n}/venus
+# avec un payload GridPayload (même format que grid, service_type="acload").
 # -----------------------------------------------------------------------------
 [grid]
 topic_prefix = "santuario/grid"
 
-# Décommenter quand un compteur sera connecté :
+# Décommenter quand un compteur réseau sera connecté :
 # [[grids]]
 # mqtt_index      = 1
 # name            = "Compteur réseau"
 # device_instance = 401
 # service_type    = "grid"     # "grid" ou "acload"
 
+# Décommenter lors de la migration des ET112 acload depuis le Victron vers Pi5 :
+# [[grids]]
+# mqtt_index      = 4
+# name            = "PAC Climatisation"
+# device_instance = 501
+# service_type    = "acload"   # AC Out 1 — consommation PAC climatisation
+#
+# [[grids]]
+# mqtt_index      = 5
+# name            = "Chauffe-eau"
+# device_instance = 502
+# service_type    = "acload"   # AC Out 1 — consommation chauffe-eau
+
 # -----------------------------------------------------------------------------
 # Onduleurs PV / compteurs énergie ET112 (Carlo Gavazzi)
 # Topics : santuario/pvinverter/{mqtt_index}/venus
 # D-Bus  : com.victronenergy.pvinverter.mqtt_{mqtt_index}
 #
-# ET112 sur Pi5 (adresse RS485 0x03 → mqtt_index=3, device_instance=63)
-# Les ET112 0x01/0x02 restent connectés directement sur le Victron
-# (instances 61/62 déjà enregistrées côté Victron).
+# ARCHITECTURE 3 ET112 SUR PI5 (migration depuis Victron) :
+#
+#   ET112 #1 — Micro-inverseurs (mqtt_index=3, device_instance=63)
+#     → Remplace com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2 (Victron direct)
+#     → Adresse RS485 actuelle : 0x03 (Pi5 /dev/ttyUSB1)
+#     → Publié par daly-bms-server → santuario/pvinverter/3/venus
+#
+#   ET112 #2 — PAC Climatisation (acload) → section [[grids]] mqtt_index=4
+#   ET112 #3 — Chauffe-eau (acload)       → section [[grids]] mqtt_index=5
 #
 # /Ac/Power, /Ac/Energy/Forward, /Ac/L1/{Voltage,Current,Power,Energy/Forward}
 # /StatusCode=7 (Running), /ErrorCode=0, /Position=1 (AC Output)
@@ -161,18 +188,7 @@ topic_prefix = "santuario/pvinverter"
 [[pvinverters]]
 mqtt_index      = 3
 name            = "Micro-inverseurs"
-device_instance = 63          # 61/62 = ET112 Victron direct, 63 = ET112 Pi5
-
-# Décommenter lors de la migration des ET112 depuis le Victron vers le Pi5 :
-# [[pvinverters]]
-# mqtt_index      = 1
-# name            = "ET112-PV-1"
-# device_instance = 61
-#
-# [[pvinverters]]
-# mqtt_index      = 2
-# name            = "ET112-PV-2"
-# device_instance = 62
+device_instance = 63          # remplace cgwacs_ttyUSB0_mb2 après migration
 
 # -----------------------------------------------------------------------------
 # Platform Pi5 — état backup/restore (singleton)


### PR DESCRIPTION
Architecture cible clarifiée :
- ET112 addr 0x03 → micro-inverseurs (pvinverter, mqtt_index=3, instance 63)
- ET112 #2 → PAC climatisation (acload, mqtt_index=4, instance 501, AC Out 1)
- ET112 #3 → chauffe-eau (acload, mqtt_index=5, instance 502, AC Out 1)

Modifications :
- nanoPi/config-nanopi.toml : entrées [[grids]] mqtt_index=4/5 commentées (acload)
  + section [[pvinverters]] clarifiée (remplace cgwacs_ttyUSB0_mb2)
- CLAUDE.md §16c : tableau rôles ET112, procédure migration, format JSON acload

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH