### PR TITLE
feat(et112): position AC configurable + nom ProductName depuis config

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -223,6 +223,7 @@ ring_buffer_size = 720
 address     = "0x03"           # Adresse Modbus RTU de l'ET112
 name        = "Micro Onduleurs"
 mqtt_index  = 3                # → topic santuario/pvinverter/3/venus
+position    = 1                # 0=AC Input, 1=AC Output
 
 # Les ET112 0x01 et 0x02 sont connectés directement sur le Victron (à migrer)
 # [[et112.devices]]

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -84,13 +84,13 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
         // ── ET112 snapshots → topic pvinverter/{mqtt_index}/venus ────────────
         let et112_snaps = state.et112_latest_all().await;
         for snap in &et112_snaps {
-            // Résoudre le mqtt_index depuis la config
-            let idx = state.config.et112.devices
+            // Résoudre le mqtt_index et la position depuis la config
+            let dev_cfg = state.config.et112.devices
                 .iter()
-                .find(|d| d.parsed_address() == snap.address)
-                .and_then(|d| d.mqtt_index)
-                .unwrap_or(snap.address);
-            if let Err(e) = publish_et112_snapshot(&client, &cfg, snap, idx).await {
+                .find(|d| d.parsed_address() == snap.address);
+            let idx      = dev_cfg.and_then(|d| d.mqtt_index).unwrap_or(snap.address);
+            let position = dev_cfg.map(|d| d.position).unwrap_or(1);
+            if let Err(e) = publish_et112_snapshot(&client, &cfg, snap, idx, position).await {
                 error!("MQTT publish ET112 erreur : {:?}", e);
             }
         }
@@ -105,6 +105,7 @@ async fn publish_et112_snapshot(
     cfg: &MqttConfig,
     snap: &Et112Snapshot,
     mqtt_index: u8,
+    position: u8,
 ) -> anyhow::Result<()> {
     // Dériver le topic prefix pvinverter depuis le topic prefix BMS
     // "santuario/bms" → "santuario/pvinverter"
@@ -133,9 +134,9 @@ async fn publish_et112_snapshot(
         },
         "StatusCode":           7,   // Running
         "ErrorCode":            0,   // No Error
-        "Position":             1,   // AC output (micro-inverseurs sur AC output)
+        "Position":             position,  // 0=AC Input, 1=AC Output (configurable)
         "IsGenericEnergyMeter": 1,   // ET112 = generic energy meter
-        "ProductName":          format!("ET112 addr={:#04x}", snap.address),
+        "ProductName":          snap.name,
         "CustomName":           snap.name,
     });
 

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -214,7 +214,12 @@ pub struct Et112DeviceConfig {
     pub mqtt_index: Option<u8>,
     /// Puissance nominale max (W) — pour l'affichage gauge
     pub max_power_w: Option<f32>,
+    /// Position sur le bus AC Victron : 0=AC Input, 1=AC Output (défaut)
+    #[serde(default = "default_et112_position")]
+    pub position: u8,
 }
+
+fn default_et112_position() -> u8 { 1 }
 
 fn default_et112_name() -> String {
     "ET112".to_string()


### PR DESCRIPTION
- Ajout champ `position` dans [[et112.devices]] (0=AC Input, 1=AC Output, défaut=1)
- publish_et112_snapshot() utilise la position de la config au lieu de hardcoder 1
- ProductName = snap.name (nom config) au lieu de "ET112 addr=0x03"
- Config.toml : position=1 pour Micro Onduleurs

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH