### PR TITLE
fix(heatpump,switch): add /CustomName and /FirmwareVersion to D-Bus s…

### DIFF
--- a/crates/dbus-mqtt-venus/src/config.rs
+++ b/crates/dbus-mqtt-venus/src/config.rs
@@ -206,6 +206,10 @@ pub struct HeatpumpRef {
     /// Nom affiché dans Venus OS (`/ProductName`).
     pub name: Option<String>,
 
+    /// Nom personnalisé affiché dans Venus OS (`/CustomName`).
+    /// Si absent, utilise `name` comme fallback.
+    pub custom_name: Option<String>,
+
     /// DeviceInstance Venus OS D-Bus.
     pub device_instance: Option<u32>,
 }
@@ -291,6 +295,10 @@ pub struct SwitchRef {
 
     /// Nom affiché dans Venus OS (`/ProductName`).
     pub name: Option<String>,
+
+    /// Nom personnalisé affiché dans Venus OS (`/CustomName`).
+    /// Si absent, utilise `name` comme fallback.
+    pub custom_name: Option<String>,
 
     /// DeviceInstance Venus OS D-Bus.
     pub device_instance: Option<u32>,

--- a/crates/dbus-mqtt-venus/src/heatpump_manager.rs
+++ b/crates/dbus-mqtt-venus/src/heatpump_manager.rs
@@ -79,7 +79,8 @@ impl HeatpumpManager {
         let suffix          = format!("{}_{}", self.cfg.service_prefix, idx);
         let device_instance = self.device_instance_for(idx);
         let product_name    = self.product_name_for(idx);
-        create_heatpump_service(&self.cfg.dbus_bus, &suffix, device_instance, product_name).await
+        let custom_name     = self.custom_name_for(idx);
+        create_heatpump_service(&self.cfg.dbus_bus, &suffix, device_instance, product_name, custom_name).await
     }
 
     fn device_instance_for(&self, idx: u8) -> u32 {
@@ -94,6 +95,17 @@ impl HeatpumpManager {
         for (pos, h) in self.heatpump_refs.iter().enumerate() {
             let hi = h.mqtt_index.unwrap_or((pos + 1) as u8);
             if hi == idx { if let Some(n) = &h.name { return n.clone(); } }
+        }
+        format!("Heat Pump {}", idx)
+    }
+
+    fn custom_name_for(&self, idx: u8) -> String {
+        for (pos, h) in self.heatpump_refs.iter().enumerate() {
+            let hi = h.mqtt_index.unwrap_or((pos + 1) as u8);
+            if hi == idx {
+                if let Some(cn) = &h.custom_name { return cn.clone(); }
+                if let Some(n)  = &h.name        { return n.clone(); }
+            }
         }
         format!("Heat Pump {}", idx)
     }

--- a/crates/dbus-mqtt-venus/src/heatpump_service.rs
+++ b/crates/dbus-mqtt-venus/src/heatpump_service.rs
@@ -111,12 +111,13 @@ pub struct HeatpumpValues {
     pub ac_energy_forward:  f64,
     pub position:           i32,
     pub product_name:       String,
+    pub custom_name:        String,
     pub device_instance:    u32,
     pub last_update:        Instant,
 }
 
 impl HeatpumpValues {
-    pub fn disconnected(device_instance: u32, product_name: String) -> Self {
+    pub fn disconnected(device_instance: u32, product_name: String, custom_name: String) -> Self {
         Self {
             connected:          0,
             state:              0,
@@ -126,6 +127,7 @@ impl HeatpumpValues {
             ac_energy_forward:  0.0,
             position:           0,
             product_name,
+            custom_name,
             device_instance,
             last_update:        Instant::now(),
         }
@@ -135,6 +137,7 @@ impl HeatpumpValues {
         payload:         &HeatpumpPayload,
         device_instance: u32,
         product_name:    String,
+        custom_name:     String,
     ) -> Self {
         let ac_power         = payload.ac.as_ref().map(|a| a.power).unwrap_or(0.0);
         let ac_energy_forward = payload.ac.as_ref()
@@ -151,6 +154,7 @@ impl HeatpumpValues {
             ac_energy_forward,
             position: payload.position,
             product_name,
+            custom_name,
             device_instance,
             last_update: Instant::now(),
         }
@@ -167,6 +171,8 @@ impl HeatpumpValues {
         m.insert("/ProductName".into(),         DbusItem::str(&self.product_name));
         m.insert("/DeviceInstance".into(),      DbusItem::u32(self.device_instance));
         m.insert("/Connected".into(),           DbusItem::i32(self.connected));
+        m.insert("/CustomName".into(),          DbusItem::str(&self.custom_name));
+        m.insert("/FirmwareVersion".into(),     DbusItem::str("1"));
 
         // Heatpump (chemins officiels wiki Victron)
         m.insert("/State".into(),    DbusItem::i32(self.state));
@@ -251,6 +257,7 @@ pub struct HeatpumpServiceHandle {
     pub values:          Arc<Mutex<HeatpumpValues>>,
     connection:          Connection,
     pub product_name:    String,
+    pub custom_name:     String,
 }
 
 impl HeatpumpServiceHandle {
@@ -259,6 +266,7 @@ impl HeatpumpServiceHandle {
             payload,
             self.device_instance,
             self.product_name.clone(),
+            self.custom_name.clone(),
         );
         let items = new_values.to_items();
         { *self.values.lock().unwrap() = new_values; }
@@ -304,6 +312,7 @@ pub async fn create_heatpump_service(
     service_suffix:  &str,
     device_instance: u32,
     product_name:    String,
+    custom_name:     String,
 ) -> Result<HeatpumpServiceHandle> {
     let service_name = format!("{}.{}", VICTRON_HEATPUMP_PREFIX, service_suffix);
 
@@ -314,7 +323,7 @@ pub async fn create_heatpump_service(
     );
 
     let initial_values = Arc::new(Mutex::new(
-        HeatpumpValues::disconnected(device_instance, product_name.clone())
+        HeatpumpValues::disconnected(device_instance, product_name.clone(), custom_name.clone())
     ));
 
     let root = HeatpumpRootIface { values: initial_values.clone() };
@@ -353,5 +362,6 @@ pub async fn create_heatpump_service(
         values: initial_values,
         connection: conn,
         product_name,
+        custom_name,
     })
 }

--- a/crates/dbus-mqtt-venus/src/switch_manager.rs
+++ b/crates/dbus-mqtt-venus/src/switch_manager.rs
@@ -79,7 +79,8 @@ impl SwitchManager {
         let suffix          = format!("{}_{}", self.cfg.service_prefix, idx);
         let device_instance = self.device_instance_for(idx);
         let product_name    = self.product_name_for(idx);
-        create_switch_service(&self.cfg.dbus_bus, &suffix, device_instance, product_name).await
+        let custom_name     = self.custom_name_for(idx);
+        create_switch_service(&self.cfg.dbus_bus, &suffix, device_instance, product_name, custom_name).await
     }
 
     fn device_instance_for(&self, idx: u8) -> u32 {
@@ -94,6 +95,17 @@ impl SwitchManager {
         for (pos, s) in self.switch_refs.iter().enumerate() {
             let si = s.mqtt_index.unwrap_or((pos + 1) as u8);
             if si == idx { if let Some(n) = &s.name { return n.clone(); } }
+        }
+        format!("Switch {}", idx)
+    }
+
+    fn custom_name_for(&self, idx: u8) -> String {
+        for (pos, s) in self.switch_refs.iter().enumerate() {
+            let si = s.mqtt_index.unwrap_or((pos + 1) as u8);
+            if si == idx {
+                if let Some(cn) = &s.custom_name { return cn.clone(); }
+                if let Some(n)  = &s.name        { return n.clone(); }
+            }
         }
         format!("Switch {}", idx)
     }

--- a/crates/dbus-mqtt-venus/src/switch_service.rs
+++ b/crates/dbus-mqtt-venus/src/switch_service.rs
@@ -99,17 +99,19 @@ pub struct SwitchValues {
     pub position:        i32,
     pub state:           i32,
     pub product_name:    String,
+    pub custom_name:     String,
     pub device_instance: u32,
     pub last_update:     Instant,
 }
 
 impl SwitchValues {
-    pub fn disconnected(device_instance: u32, product_name: String) -> Self {
+    pub fn disconnected(device_instance: u32, product_name: String, custom_name: String) -> Self {
         Self {
             connected:       0,
             position:        0,
             state:           0,
             product_name,
+            custom_name,
             device_instance,
             last_update:     Instant::now(),
         }
@@ -119,12 +121,14 @@ impl SwitchValues {
         payload:         &SwitchPayload,
         device_instance: u32,
         product_name:    String,
+        custom_name:     String,
     ) -> Self {
         Self {
             connected:       1,
             position:        payload.position,
             state:           payload.state,
             product_name,
+            custom_name,
             device_instance,
             last_update:     Instant::now(),
         }
@@ -141,6 +145,8 @@ impl SwitchValues {
         m.insert("/ProductName".into(),         DbusItem::str(&self.product_name));
         m.insert("/DeviceInstance".into(),      DbusItem::u32(self.device_instance));
         m.insert("/Connected".into(),           DbusItem::i32(self.connected));
+        m.insert("/CustomName".into(),          DbusItem::str(&self.custom_name));
+        m.insert("/FirmwareVersion".into(),     DbusItem::str("1"));
 
         // Switch (chemins officiels wiki Victron)
         m.insert("/Position".into(), DbusItem::i32(self.position));
@@ -217,6 +223,7 @@ pub struct SwitchServiceHandle {
     pub values:          Arc<Mutex<SwitchValues>>,
     connection:          Connection,
     pub product_name:    String,
+    pub custom_name:     String,
 }
 
 impl SwitchServiceHandle {
@@ -225,6 +232,7 @@ impl SwitchServiceHandle {
             payload,
             self.device_instance,
             self.product_name.clone(),
+            self.custom_name.clone(),
         );
         let items = new_values.to_items();
         { *self.values.lock().unwrap() = new_values; }
@@ -270,6 +278,7 @@ pub async fn create_switch_service(
     service_suffix:  &str,
     device_instance: u32,
     product_name:    String,
+    custom_name:     String,
 ) -> Result<SwitchServiceHandle> {
     let service_name = format!("{}.{}", VICTRON_SWITCH_PREFIX, service_suffix);
 
@@ -280,7 +289,7 @@ pub async fn create_switch_service(
     );
 
     let initial_values = Arc::new(Mutex::new(
-        SwitchValues::disconnected(device_instance, product_name.clone())
+        SwitchValues::disconnected(device_instance, product_name.clone(), custom_name.clone())
     ));
 
     let root = SwitchRootIface { values: initial_values.clone() };
@@ -319,5 +328,6 @@ pub async fn create_switch_service(
         values: initial_values,
         connection: conn,
         product_name,
+        custom_name,
     })
 }


### PR DESCRIPTION
…ervices

Both services were missing /CustomName (user-friendly label in VRM/GUI) and /FirmwareVersion (expected by Venus OS for native device consistency).

Also adds custom_name field to HeatpumpRef and SwitchRef in config.toml so each device can have an independent custom name (falls back to name).

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH