### PR TITLE
feat(rs485): bus RS485 unifié — SharedBus, Modbus RTU pur Rust, PRALR…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "rs485-bus",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -733,13 +734,13 @@ dependencies = [
  "influxdb2-structmap",
  "lettre",
  "reqwest 0.12.28",
+ "rs485-bus",
  "rumqttc",
  "rusqlite",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tokio-modbus",
  "tokio-serial",
  "toml",
  "tower 0.4.13",
@@ -2366,6 +2367,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rs485-bus"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-serial",
+ "tracing",
+]
+
+[[package]]
 name = "rumqttc"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,24 +3035,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-modbus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033b1b9843d693c3543e6b9c656a566ea45d2564e72ad5447e83233b9e2f3fe1"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "futures-core",
- "futures-util",
- "log",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/rs485-bus",
     "crates/daly-bms-core",
     "crates/daly-bms-server",
     "crates/daly-bms-cli",
@@ -23,6 +24,9 @@ repository  = "https://github.com/thieryus007-cloud/Daly-BMS-Rust"
 # Shared dependencies (referenced as { workspace = true } in each crate)
 # =============================================================================
 [workspace.dependencies]
+
+# ── Crates internes ────────────────────────────────────────────────────────────
+rs485-bus     = { path = "crates/rs485-bus" }
 
 # ── Async runtime ─────────────────────────────────────────────────────────────
 tokio         = { version = "1",    features = ["full"] }

--- a/Config.toml
+++ b/Config.toml
@@ -196,23 +196,33 @@ device_instance = 40      # DeviceInstance Venus OS / VRM
 
 
 # =============================================================================
-# Compteur énergie ET112 Carlo Gavazzi (RS485 Modbus RTU)
+# Capteur irradiance PRALRAN (RS485 Modbus RTU — bus unifié)
 # =============================================================================
-# Matériel : ET112 sur /dev/ttyUSB1 (FTDI FT232 USB-RS485, Bus 004 Device 003)
-# Adresses : 0x03 = micro-inverseurs Pi5 (0x01 et 0x02 connectés directement sur Victron)
+# Matériel : Solar Radiation Sensor PRALRAN, adresse Modbus RTU 0x05
+# Branché sur le BUS UNIFIÉ /dev/ttyUSB0 (même bus que BMS Daly)
+# Registre 0x0000 → irradiance W/m² (FC04, uint16 big-endian)
+# Publie sur MQTT : santuario/irradiance/raw (retain=true)
+# Même topic que l'ancien irradiance_reader.py → Node-RED inchangé
+
+[irradiance]
+address          = "0x05"          # Adresse Modbus RTU du capteur PRALRAN
+name             = "Irradiance PRALRAN"
+poll_interval_ms = 5000            # 5 secondes (identique à l'ancien script Python)
+
+
+# =============================================================================
+# Compteur énergie ET112 Carlo Gavazzi (RS485 Modbus RTU — bus unifié)
+# =============================================================================
+# ARCHITECTURE UNIFIÉE : tous les ET112 partagent le BUS RS485 /dev/ttyUSB0
+# (même bus que les BMS Daly 0x01-0x04 et irradiance 0x05)
+# Les champs port/baud sont supprimés — bus hérité du SharedBus global.
 #
-# Chemins D-Bus pvinverter exposés (via dbus-mqtt-venus sur NanoPi) :
-#   /Ac/Power, /Ac/Energy/Forward
-#   /Ac/L1/{Voltage, Current, Power, Energy/Forward}
-#   /StatusCode=7, /ErrorCode=0, /Position=1, /IsGenericEnergyMeter=1
+# Adresses RS485 (configurées physiquement sur les compteurs) :
+#   0x07 = Micro-onduleurs → D-Bus pvinverter (mqtt_3, instance 63)
+#   0x08 = PAC Chauffe-eau  → D-Bus pvinverter ou acload
+#   0x09 = PAC Climatisation → D-Bus pvinverter ou acload
 
 [et112]
-# Port série USB-RS485 (partagé ou dédié)
-port = "/dev/ttyUSB1"
-
-# Vitesse de communication (ET112 standard = 9600 baud)
-baud = 9600
-
 # Intervalle de polling en millisecondes (5000 = toutes les 5 secondes)
 poll_interval_ms = 5000
 
@@ -220,20 +230,22 @@ poll_interval_ms = 5000
 ring_buffer_size = 720
 
 [[et112.devices]]
-address     = "0x03"           # Adresse Modbus RTU de l'ET112
+address     = "0x07"           # Adresse Modbus RTU — Micro-onduleurs
 name        = "Micro Onduleurs"
 mqtt_index  = 3                # → topic santuario/pvinverter/3/venus
 position    = 1                # 0=AC Input, 1=AC Output
 
-# Les ET112 0x01 et 0x02 sont connectés directement sur le Victron (à migrer)
-# [[et112.devices]]
-# address     = "0x01"
-# name        = "ET112-PV-1"
-# mqtt_index  = 1
-# [[et112.devices]]
-# address     = "0x02"
-# name        = "ET112-PV-2"
-# mqtt_index  = 2
+[[et112.devices]]
+address     = "0x08"           # Adresse Modbus RTU — PAC Chauffe-eau
+name        = "PAC Chauffe-eau"
+mqtt_index  = 4                # → topic santuario/pvinverter/4/venus
+position    = 1                # 0=AC Input, 1=AC Output
+
+[[et112.devices]]
+address     = "0x09"           # Adresse Modbus RTU — PAC Climatisation
+name        = "PAC Climatisation"
+mqtt_index  = 5                # → topic santuario/pvinverter/5/venus
+position    = 1                # 0=AC Input, 1=AC Output
 
 
 [influxdb]

--- a/crates/daly-bms-core/Cargo.toml
+++ b/crates/daly-bms-core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace   = true
 rust-version.workspace = true
 
 [dependencies]
+rs485-bus     = { workspace = true }
 tokio         = { workspace = true }
 tokio-serial  = { workspace = true }
 tokio-util    = { workspace = true }

--- a/crates/daly-bms-core/src/bus.rs
+++ b/crates/daly-bms-core/src/bus.rs
@@ -1,53 +1,79 @@
 //! Gestion du port série RS485 partagé entre plusieurs BMS.
 //!
-//! Le [`DalyPort`] encapsule le port série avec un Mutex pour garantir
-//! qu'une seule commande est en cours à tout moment (bus RS485 half-duplex).
+//! Le [`DalyPort`] encapsule un [`rs485_bus::SharedBus`] et implémente le
+//! protocole Daly par-dessus (framing, checksum, gestion adresse).
 //!
 //! Le [`DalyBusManager`] coordonne plusieurs [`DalyBms`] sur le même bus.
+//!
+//! ## Bus unifié
+//!
+//! Pour partager le même port série avec d'autres drivers (ET112, PRALRAN…) :
+//! ```rust,ignore
+//! let port = DalyPort::open("/dev/ttyUSB0", 9600, 500)?;
+//! let bus  = port.shared_bus();  // Arc<SharedBus> partageable
+//! // passer bus à run_et112_poll_loop(), run_irradiance_poll_loop()…
+//! ```
 
 use crate::error::{DalyError, Result};
 use crate::protocol::{DataId, RequestFrame, ResponseFrame, FRAME_LEN};
+use rs485_bus::SharedBus;
 use std::sync::Arc;
-use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::Mutex;
-use tokio::time::timeout;
 use tracing::{debug, trace, warn};
 
 /// Timeout par défaut pour une réponse BMS.
 pub const DEFAULT_TIMEOUT_MS: u64 = 500;
 
-/// Délai minimum entre deux commandes sur le bus (50 ms selon doc Daly).
+/// Délai minimum entre deux commandes sur le bus (50 ms selon doc Daly V1.21).
 pub const INTER_FRAME_DELAY_MS: u64 = 50;
 
 // =============================================================================
-// DalyPort — port série avec accès exclusif
+// DalyPort — protocole Daly par-dessus SharedBus
 // =============================================================================
 
-/// Port série RS485 asynchrone, sécurisé par un Mutex.
+/// Port RS485 avec implémentation du protocole Daly.
 ///
-/// Utilise `tokio-serial` (wrapper autour de `tokio::io`).
+/// Wraps un [`SharedBus`] et ajoute le framing Daly, la validation
+/// des réponses (checksum, adresse, DataId) et la logique de fallback
+/// (2ème trame si BMS maître répond en premier).
 pub struct DalyPort {
-    inner: Mutex<tokio_serial::SerialStream>,
+    bus: Arc<SharedBus>,
     timeout_ms: u64,
 }
 
 impl DalyPort {
-    /// Ouvre le port série avec les paramètres spécifiés.
+    /// Ouvre le port série et crée un `SharedBus` sous-jacent (8N1).
+    ///
+    /// Compatible avec le comportement précédent : `DalyPort::open(path, baud, timeout_ms)`.
     pub fn open(port_path: &str, baud: u32, timeout_ms: u64) -> Result<Arc<Self>> {
-        use tokio_serial::SerialPortBuilderExt;
-
-        let stream = tokio_serial::new(port_path, baud)
-            .data_bits(tokio_serial::DataBits::Eight)
-            .stop_bits(tokio_serial::StopBits::One)
-            .parity(tokio_serial::Parity::None)
-            .flow_control(tokio_serial::FlowControl::None)
-            .open_native_async()?;
-
-        Ok(Arc::new(Self {
-            inner: Mutex::new(stream),
+        let bus = SharedBus::open(
+            port_path,
+            baud,
+            tokio_serial::Parity::None,
+            INTER_FRAME_DELAY_MS,
             timeout_ms,
-        }))
+        )
+        .map_err(DalyError::Other)?;
+
+        Ok(Arc::new(Self { bus, timeout_ms }))
+    }
+
+    /// Crée un `DalyPort` à partir d'un `SharedBus` existant.
+    ///
+    /// Utilisé quand le bus est déjà ouvert et partagé avec d'autres drivers.
+    pub fn from_bus(bus: Arc<SharedBus>, timeout_ms: u64) -> Arc<Self> {
+        Arc::new(Self { bus, timeout_ms })
+    }
+
+    /// Retourne le `SharedBus` sous-jacent pour le partager avec d'autres drivers.
+    ///
+    /// ```rust,ignore
+    /// let port = DalyPort::open("/dev/ttyUSB0", 9600, 500)?;
+    /// let bus  = port.shared_bus();
+    /// // Passer bus aux drivers ET112 / PRALRAN
+    /// tokio::spawn(run_et112_poll_loop(bus, ...));
+    /// ```
+    pub fn shared_bus(&self) -> Arc<SharedBus> {
+        self.bus.clone()
     }
 
     /// Envoie une commande et attend la réponse correspondante.
@@ -60,27 +86,18 @@ impl DalyPort {
         cmd: DataId,
         data: [u8; 8],
     ) -> Result<ResponseFrame> {
-        // Protocole Daly V1.21 §2.3.1 : les 8 octets data sont réservés (0x00)
-        // pour les commandes de lecture. L'adressage multi-BMS est assuré
-        // uniquement par byte[1] = 0x3F + bms_address (géré dans RequestFrame::new).
-        // Les commandes d'écriture utilisent data tel quel (payload fourni par l'appelant).
         let request = if cmd.is_write() {
             RequestFrame::new(bms_address, cmd, data)
         } else {
             RequestFrame::read(bms_address, cmd)
         };
+
         trace!(
             bms = format!("{:#04x}", bms_address),
             cmd = format!("{:#04x}", cmd as u8),
             "→ envoi trame"
         );
 
-        let mut port = self.inner.lock().await;
-
-        // Vider le buffer de réception avant l'envoi
-        let _ = Self::flush_input(&mut *port).await;
-
-        // Envoi
         let req_bytes = request.as_bytes();
         trace!(
             bms = format!("{:#04x}", bms_address),
@@ -88,112 +105,93 @@ impl DalyPort {
             raw = format!("{:02X?}", req_bytes),
             "→ envoi trame"
         );
-        port.write_all(req_bytes).await?;
-        port.flush().await?;
 
-        // Délai inter-trame (laisser le temps à l'adaptateur RS485 de basculer en RX)
-        tokio::time::sleep(Duration::from_millis(INTER_FRAME_DELAY_MS)).await;
+        // Acquérir le verrou exclusif pour toute la transaction
+        let mut guard = self.bus.acquire().await;
+
+        guard.flush_rx().await;
+        guard.write_all(req_bytes).await?; // std::io::Error → DalyError::Io via #[from]
+        guard.inter_frame_delay().await;
 
         // Réception avec timeout
-        let mut buf = [0u8; FRAME_LEN];
-        let read_result = timeout(
-            Duration::from_millis(self.timeout_ms),
-            port.read_exact(&mut buf),
-        )
-        .await;
-
-        match read_result {
-            Err(_elapsed) => {
-                // Tenter de lire des octets partiels pour le diagnostic
-                let mut partial = [0u8; 32];
-                let n = timeout(
-                    Duration::from_millis(50),
-                    port.read(&mut partial),
-                )
-                .await
-                .ok()
-                .and_then(|r| r.ok())
-                .unwrap_or(0);
-
-                if n > 0 {
+        let buf = match guard.read_exact_with_timeout(FRAME_LEN, self.timeout_ms).await {
+            None => {
+                // Timeout — tenter lecture partielle pour diagnostic
+                let partial = guard.try_read_partial(32).await;
+                if !partial.is_empty() {
                     warn!(
-                        bms = format!("{:#04x}", bms_address),
-                        cmd = format!("{:#04x}", cmd as u8),
-                        partial = format!("{:02X?}", &partial[..n]),
+                        bms     = format!("{:#04x}", bms_address),
+                        cmd     = format!("{:#04x}", cmd as u8),
+                        partial = format!("{:02X?}", partial),
                         "Timeout — réponse partielle reçue (câblage A/B ?, baud rate ?)"
                     );
                 } else {
                     warn!(
                         bms = format!("{:#04x}", bms_address),
                         cmd = format!("{:#04x}", cmd as u8),
-                        "Timeout — aucun octet reçu (BMS hors tension ? câble débranché ? mauvais port COM ?)"
+                        "Timeout — aucun octet reçu (BMS hors tension ? câble débranché ?)"
                     );
                 }
-                Err(DalyError::Timeout { bms_id: bms_address, cmd: cmd as u8 })
+                return Err(DalyError::Timeout { bms_id: bms_address, cmd: cmd as u8 });
             }
-            Ok(Err(e)) => Err(e.into()),
-            Ok(Ok(_)) => {
+            Some(Err(e)) => return Err(DalyError::Io(e)),
+            Some(Ok(b)) => b,
+        };
+
+        trace!(
+            bms = format!("{:#04x}", bms_address),
+            cmd = format!("{:#04x}", cmd as u8),
+            raw = format!("{:02X?}", &buf),
+            "← réponse reçue"
+        );
+
+        let frame = ResponseFrame::parse(&buf)?;
+
+        // Sur un bus RS485 partagé, BMS 0x01 (master) peut répondre en
+        // premier même si la requête cible BMS 0x02. On tente alors de
+        // lire une deuxième trame : BMS 0x02 peut répondre juste après.
+        // Le verrou est toujours maintenu (même BusGuard).
+        if frame.address() != bms_address {
+            warn!(
+                bms    = format!("{:#04x}", bms_address),
+                actual = format!("{:#04x}", frame.address()),
+                "Adresse inattendue — tentative lecture 2ème trame (bus partagé)"
+            );
+            if let Some(Ok(buf2)) = guard.read_exact_with_timeout(FRAME_LEN, self.timeout_ms).await {
                 trace!(
                     bms = format!("{:#04x}", bms_address),
-                    cmd = format!("{:#04x}", cmd as u8),
-                    raw = format!("{:02X?}", &buf),
-                    "← réponse reçue"
+                    raw = format!("{:02X?}", &buf2),
+                    "← 2ème trame reçue"
                 );
-                let frame = ResponseFrame::parse(&buf)?;
-
-                // Sur un bus RS485 partagé, BMS 0x01 (master) peut répondre en
-                // premier même si la requête cible BMS 0x02. On tente alors de
-                // lire une deuxième trame : BMS 0x02 peut répondre juste après.
-                if frame.address() != bms_address {
-                    warn!(
-                        bms    = format!("{:#04x}", bms_address),
-                        actual = format!("{:#04x}", frame.address()),
-                        "Adresse inattendue — tentative lecture 2ème trame (bus partagé)"
-                    );
-                    let mut buf2 = [0u8; FRAME_LEN];
-                    if let Ok(Ok(_)) = timeout(
-                        Duration::from_millis(self.timeout_ms),
-                        port.read_exact(&mut buf2),
-                    )
-                    .await
-                    {
-                        trace!(
+                if let Ok(frame2) = ResponseFrame::parse(&buf2) {
+                    if frame2.validate_for(bms_address, cmd).is_ok() {
+                        debug!(
                             bms = format!("{:#04x}", bms_address),
-                            raw = format!("{:02X?}", &buf2),
-                            "← 2ème trame reçue"
+                            "← 2ème trame OK (BMS répond après le master)"
                         );
-                        if let Ok(frame2) = ResponseFrame::parse(&buf2) {
-                            if frame2.validate_for(bms_address, cmd).is_ok() {
-                                debug!(
-                                    bms = format!("{:#04x}", bms_address),
-                                    "← 2ème trame OK (BMS répond après le master)"
-                                );
-                                return Ok(frame2);
-                            }
-                        }
+                        return Ok(frame2);
                     }
-                    // Aucune 2ème trame valide — retourner l'erreur d'adresse
-                    return Err(DalyError::UnexpectedAddress {
-                        expected: bms_address,
-                        actual:   frame.address(),
-                    });
                 }
-
-                frame.validate_for(bms_address, cmd)?;
-                debug!(
-                    bms = format!("{:#04x}", bms_address),
-                    cmd = format!("{:#04x}", cmd as u8),
-                    "← réponse OK"
-                );
-                Ok(frame)
             }
+            return Err(DalyError::UnexpectedAddress {
+                expected: bms_address,
+                actual:   frame.address(),
+            });
         }
+
+        frame.validate_for(bms_address, cmd)?;
+        debug!(
+            bms = format!("{:#04x}", bms_address),
+            cmd = format!("{:#04x}", cmd as u8),
+            "← réponse OK"
+        );
+        Ok(frame)
     }
 
-    /// Envoie une commande et lit N trames de réponse successives sans flush entre elles.
+    /// Envoie une commande et lit N trames de réponse successives.
     ///
-    /// Utilisé pour les commandes multi-trames (0x95, 0x96) où le BMS envoie toutes
-    /// les trames d'un coup après une seule requête.
+    /// Utilisé pour les commandes multi-trames (0x95, 0x96) où le BMS envoie
+    /// toutes les trames d'un coup après une seule requête.
     pub async fn send_command_multi(
         &self,
         bms_address: u8,
@@ -204,39 +202,26 @@ impl DalyPort {
             return Ok(Vec::new());
         }
 
-        // Protocole Daly V1.21 : data bytes = 0x00 pour les lectures multi-trames.
         let request = RequestFrame::read(bms_address, cmd);
-        let mut port = self.inner.lock().await;
 
-        // Vider le buffer avant l'envoi
-        let _ = Self::flush_input(&mut *port).await;
+        let mut guard = self.bus.acquire().await;
+        guard.flush_rx().await;
 
         let req_bytes = request.as_bytes();
         trace!(
-            bms = format!("{:#04x}", bms_address),
-            cmd = format!("{:#04x}", cmd as u8),
+            bms     = format!("{:#04x}", bms_address),
+            cmd     = format!("{:#04x}", cmd as u8),
             n_frames,
-            raw = format!("{:02X?}", req_bytes),
+            raw     = format!("{:02X?}", req_bytes),
             "→ envoi trame multi"
         );
-        port.write_all(req_bytes).await?;
-        port.flush().await?;
+        guard.write_all(req_bytes).await?;
+        guard.inter_frame_delay().await;
 
-        // Délai TX→RX une seule fois
-        tokio::time::sleep(Duration::from_millis(INTER_FRAME_DELAY_MS)).await;
-
-        // Lire N trames consécutives sans flush entre elles
         let mut frames = Vec::with_capacity(n_frames);
         for frame_idx in 0..n_frames {
-            let mut buf = [0u8; FRAME_LEN];
-            let read_result = timeout(
-                Duration::from_millis(self.timeout_ms),
-                port.read_exact(&mut buf),
-            )
-            .await;
-
-            match read_result {
-                Err(_elapsed) => {
+            let buf = match guard.read_exact_with_timeout(FRAME_LEN, self.timeout_ms).await {
+                None => {
                     warn!(
                         bms   = format!("{:#04x}", bms_address),
                         cmd   = format!("{:#04x}", cmd as u8),
@@ -245,31 +230,24 @@ impl DalyPort {
                     );
                     return Err(DalyError::Timeout { bms_id: bms_address, cmd: cmd as u8 });
                 }
-                Ok(Err(e)) => return Err(e.into()),
-                Ok(Ok(_)) => {
-                    trace!(
-                        bms   = format!("{:#04x}", bms_address),
-                        cmd   = format!("{:#04x}", cmd as u8),
-                        frame = frame_idx,
-                        raw   = format!("{:02X?}", &buf),
-                        "← trame multi reçue"
-                    );
-                    let frame = ResponseFrame::parse(&buf)?;
-                    // Valider adresse et commande (le numéro de trame est dans data[0])
-                    frame.validate_for(bms_address, cmd)?;
-                    frames.push(frame);
-                }
-            }
+                Some(Err(e)) => return Err(DalyError::Io(e)),
+                Some(Ok(b)) => b,
+            };
+
+            trace!(
+                bms   = format!("{:#04x}", bms_address),
+                cmd   = format!("{:#04x}", cmd as u8),
+                frame = frame_idx,
+                raw   = format!("{:02X?}", &buf),
+                "← trame multi reçue"
+            );
+
+            let frame = ResponseFrame::parse(&buf)?;
+            frame.validate_for(bms_address, cmd)?;
+            frames.push(frame);
         }
 
         Ok(frames)
-    }
-
-    /// Vide le buffer de réception (lecture non-bloquante avec timeout court).
-    async fn flush_input(port: &mut tokio_serial::SerialStream) -> std::io::Result<()> {
-        let mut tmp = [0u8; 256];
-        let _ = timeout(Duration::from_millis(10), port.read(&mut tmp)).await;
-        Ok(())
     }
 }
 
@@ -341,7 +319,7 @@ impl DalyBusManager {
                     tracing::debug!("Découverte {:#04x} : erreur {:?}", addr, e);
                 }
             }
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
         found
     }

--- a/crates/daly-bms-core/src/lib.rs
+++ b/crates/daly-bms-core/src/lib.rs
@@ -27,4 +27,6 @@ pub use types::{
 };
 pub use protocol::{DataId, RequestFrame, ResponseFrame, FRAME_LEN};
 pub use bus::{DalyPort, DalyBusManager};
+// Re-export SharedBus pour les consommateurs du bus unifié
+pub use rs485_bus::SharedBus;
 pub use poll::PollConfig;

--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -12,6 +12,7 @@ name = "daly-bms-server"
 path = "src/main.rs"
 
 [dependencies]
+rs485-bus     = { workspace = true }
 daly-bms-core = { path = "../daly-bms-core" }
 
 tokio          = { workspace = true }
@@ -37,4 +38,4 @@ uuid           = { workspace = true }
 futures        = { workspace = true }
 bytes          = { workspace = true }
 askama         = "0.12"
-tokio-modbus   = { workspace = true }
+# tokio-modbus supprimé — remplacé par rs485_bus::modbus_rtu (pur Rust)

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -94,7 +94,35 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
                 error!("MQTT publish ET112 erreur : {:?}", e);
             }
         }
+
+        // ── Irradiance PRALRAN → santuario/irradiance/raw ────────────────────
+        // Même topic que l'ancien irradiance_reader.py → Node-RED inchangé.
+        if let Some(snap) = state.latest_irradiance().await {
+            if let Err(e) = publish_irradiance(&client, &cfg, snap.irradiance_wm2).await {
+                error!("MQTT publish irradiance erreur : {:?}", e);
+            }
+        }
     }
+}
+
+/// Publie la valeur d'irradiance sur `santuario/irradiance/raw` (retain=true).
+///
+/// Même format que l'ancien `irradiance_reader.py` — entier W/m² en string.
+async fn publish_irradiance(
+    client: &AsyncClient,
+    cfg: &MqttConfig,
+    irradiance_wm2: f32,
+) -> anyhow::Result<()> {
+    let base = cfg.topic_prefix
+        .rsplit_once('/')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or("santuario");
+    let topic = format!("{}/irradiance/raw", base);
+    let payload = format!("{:.0}", irradiance_wm2);
+    client
+        .publish(&topic, QoS::AtLeastOnce, true, payload)
+        .await?;
+    Ok(())
 }
 
 /// Publie un snapshot ET112 sur le topic `santuario/pvinverter/{idx}/venus`.

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -42,6 +42,10 @@ pub struct AppConfig {
     /// Configuration ET112 (compteurs Carlo Gavazzi RS485)
     #[serde(default)]
     pub et112: Et112Config,
+
+    /// Capteur d'irradiance PRALRAN RS485 (sur le bus unifié)
+    /// Remplace le service Python `irradiance-rs485`.
+    pub irradiance: Option<IrradianceConfig>,
 }
 
 // =============================================================================
@@ -163,24 +167,20 @@ pub struct SerialConfig {
 
 /// Configuration globale pour les compteurs Carlo Gavazzi ET112.
 ///
+/// Bus RS485 unifié : port et baud hérités du SharedBus global (ttyUSB0).
+///
 /// ```toml
 /// [et112]
-/// port             = "/dev/ttyUSB1"
-/// baud             = 9600
 /// poll_interval_ms = 5000
 /// ring_buffer_size = 720       # 1 heure à 1 mesure / 5s
 ///
 /// [[et112.devices]]
-/// address          = "0x03"
+/// address          = "0x07"
 /// name             = "Micro-inverseurs"
 /// mqtt_index       = 3         # → topic santuario/pvinverter/3/venus
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Et112Config {
-    /// Port série (ex: /dev/ttyUSB1)
-    pub port: String,
-    /// Vitesse en bauds (9600 par défaut usine)
-    pub baud: u32,
     /// Intervalle de polling en ms
     pub poll_interval_ms: u64,
     /// Taille du ring buffer par appareil
@@ -193,8 +193,6 @@ pub struct Et112Config {
 impl Default for Et112Config {
     fn default() -> Self {
         Self {
-            port:             "/dev/ttyUSB1".into(),
-            baud:             9600,
             poll_interval_ms: 5000,
             ring_buffer_size: 720,
             devices:          Vec::new(),
@@ -392,4 +390,50 @@ impl Default for AlertThresholds {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ReadOnlyConfig {
     pub enabled: bool,
+}
+
+// =============================================================================
+// Configuration capteur irradiance PRALRAN
+// =============================================================================
+
+/// Configuration du capteur d'irradiance solaire PRALRAN RS485.
+///
+/// Le capteur utilise le **bus RS485 unifié** (même port que les BMS Daly).
+/// Aucun `port` / `baud` à configurer ici — ils sont hérités de `[serial]`.
+///
+/// ```toml
+/// [irradiance]
+/// address          = "0x05"
+/// name             = "Irradiance PRALRAN"
+/// poll_interval_ms = 5000
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct IrradianceConfig {
+    /// Adresse Modbus du capteur (ex: "0x05", "5")
+    pub address: String,
+    /// Nom affiché dans les logs et le dashboard
+    #[serde(default = "default_irradiance_name")]
+    pub name: String,
+    /// Intervalle de polling en ms (défaut 5000)
+    #[serde(default = "default_irradiance_interval")]
+    pub poll_interval_ms: u64,
+}
+
+fn default_irradiance_name() -> String {
+    "Irradiance PRALRAN".to_string()
+}
+fn default_irradiance_interval() -> u64 {
+    5000
+}
+
+impl IrradianceConfig {
+    /// Parse l'adresse en u8 (supporte "0x05", "5")
+    pub fn parsed_address(&self) -> u8 {
+        let s = self.address.trim();
+        if s.starts_with("0x") || s.starts_with("0X") {
+            u8::from_str_radix(&s[2..], 16).unwrap_or(5)
+        } else {
+            s.parse::<u8>().unwrap_or(5)
+        }
+    }
 }

--- a/crates/daly-bms-server/src/et112/poll.rs
+++ b/crates/daly-bms-server/src/et112/poll.rs
@@ -16,15 +16,20 @@
 //! | 0x000F      | Fréquence            | Hz    | ×0.1 (INT16 simple) |
 //! | 0x0010      | Énergie import       | kWh   | ×0.1    |
 //! | 0x0020      | Énergie export       | kWh   | ×0.1    |
+//!
+//! ## Refactoring bus unifié
+//!
+//! Cette version utilise `rs485_bus::SharedBus` + `rs485_bus::modbus_rtu`
+//! au lieu de `tokio-modbus`. Le port série est partagé avec les BMS Daly
+//! et le capteur PRALRAN sur un seul `/dev/ttyUSB0`.
 
 use super::types::Et112Snapshot;
 use crate::config::Et112DeviceConfig;
 use chrono::Local;
+use rs485_bus::{modbus_rtu, SharedBus};
+use std::sync::Arc;
 use std::time::Duration;
-use tokio_modbus::client::rtu;
-use tokio_modbus::prelude::*;
-use tokio_serial::SerialStream;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 /// Décode deux registres Modbus ET112 en INT32 signé (little-endian word order).
 ///
@@ -34,17 +39,15 @@ fn regs_to_i32(lo: u16, hi: u16) -> i32 {
     (lo as i32) | ((hi as i32) << 16)
 }
 
-/// Lance la boucle de polling ET112.
+/// Lance la boucle de polling ET112 sur le bus RS485 unifié.
 ///
 /// # Paramètres
-/// - `port_path`     : chemin du port série (ex: `/dev/ttyUSB1`)
-/// - `baud`          : vitesse en bauds (9600 par défaut pour ET112)
+/// - `bus`           : bus RS485 partagé (même instance que le bus Daly BMS)
 /// - `devices`       : liste des ET112 configurés (adresse + nom + ...)
 /// - `poll_interval` : intervalle entre deux cycles complets
 /// - `on_snapshot`   : callback appelé pour chaque snapshot valide
 pub async fn run_et112_poll_loop<F>(
-    port_path: String,
-    baud: u32,
+    bus: Arc<SharedBus>,
     devices: Vec<Et112DeviceConfig>,
     poll_interval: Duration,
     mut on_snapshot: F,
@@ -58,129 +61,113 @@ where
     }
 
     info!(
-        port = %port_path,
-        baud,
         count = devices.len(),
-        "ET112 polling démarré"
+        "ET112 polling démarré (bus RS485 unifié)"
     );
 
-    // Backoff exponentiel en cas d'erreur série
-    let mut backoff_ms: u64 = 500;
-
     loop {
-        match poll_cycle(&port_path, baud, &devices, &mut on_snapshot).await {
-            Ok(()) => {
-                backoff_ms = 500; // reset on success
-            }
-            Err(e) => {
-                error!("ET112 erreur cycle polling : {:#}", e);
-                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-                backoff_ms = (backoff_ms * 2).min(30_000);
-                continue;
+        for dev in &devices {
+            let address = dev.parsed_address();
+            match poll_device(&bus, address, dev).await {
+                Ok(snap) => {
+                    debug!(
+                        addr  = format!("{:#04x}", address),
+                        name  = %dev.name,
+                        power_w = snap.power_w,
+                        "ET112 snapshot OK"
+                    );
+                    on_snapshot(snap);
+                }
+                Err(e) => {
+                    warn!(
+                        addr = format!("{:#04x}", address),
+                        name = %dev.name,
+                        "ET112 erreur lecture : {:#}",
+                        e
+                    );
+                }
             }
         }
+
         tokio::time::sleep(poll_interval).await;
     }
 }
 
-/// Un cycle de polling : lit tous les registres pour chaque ET112 configuré.
-async fn poll_cycle<F>(
-    port_path: &str,
-    baud: u32,
-    devices: &[Et112DeviceConfig],
-    on_snapshot: &mut F,
-) -> anyhow::Result<()>
-where
-    F: FnMut(Et112Snapshot),
-{
-    for dev in devices {
-        let address = dev.parsed_address();
-        match poll_device(port_path, baud, address, dev).await {
-            Ok(snap) => {
-                debug!(
-                    addr = address,
-                    name = %dev.name,
-                    power_w = snap.power_w,
-                    "ET112 snapshot OK"
-                );
-                on_snapshot(snap);
-            }
-            Err(e) => {
-                warn!(
-                    addr = address,
-                    name = %dev.name,
-                    "ET112 erreur lecture : {:#}", e
-                );
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Ouvre le port série, interroge un ET112 et retourne un snapshot.
+/// Interroge un ET112 et retourne un snapshot complet.
 async fn poll_device(
-    port_path: &str,
-    baud: u32,
+    bus: &SharedBus,
     address: u8,
     dev: &Et112DeviceConfig,
 ) -> anyhow::Result<Et112Snapshot> {
-    let builder = tokio_serial::new(port_path, baud)
-        .data_bits(tokio_serial::DataBits::Eight)
-        .parity(tokio_serial::Parity::None)
-        .stop_bits(tokio_serial::StopBits::One)
-        .timeout(Duration::from_millis(1500));
-
-    let port = SerialStream::open(&builder)
-        .map_err(|e| anyhow::anyhow!("Impossible d'ouvrir {} : {}", port_path, e))?;
-
-    let mut ctx = rtu::attach_slave(port, Slave(address));
-
-    // Lecture bloc 1 : 0x0000–0x000F → 16 registres
-    // voltage, current, power_active, power_apparent, power_reactive, pf, (reserved×2), freq(INT16)
-    let regs1: Vec<u16> = ctx
-        .read_input_registers(0x0000, 16)
+    // ── Bloc 1 : 0x0000–0x000F → 16 registres ────────────────────────────────
+    // Tension, courant, puissances (active/apparente/réactive), facteur de puissance,
+    // (2 registres réservés), fréquence (INT16 au registre 0x000F)
+    let req1 = modbus_rtu::build_fc04(address, 0x0000, 16);
+    let resp1 = bus
+        .transact(&req1, modbus_rtu::response_len(16))
         .await
-        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} FC04 read 0x0000: {}", address, e))?
-        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} exception code: {:?}", address, e))?;
+        .map_err(|e| anyhow::anyhow!("ET112 {:#04x} bloc1: {}", address, e))?;
+    let regs1 = modbus_rtu::parse_read_response(address, 0x04, &resp1)
+        .map_err(|e| anyhow::anyhow!("ET112 {:#04x} parse bloc1: {}", address, e))?;
 
     if regs1.len() < 16 {
-        anyhow::bail!("ET112 addr={:#04x} réponse trop courte bloc 1 ({})", address, regs1.len());
+        anyhow::bail!(
+            "ET112 {:#04x} bloc1 trop court ({} registres)",
+            address,
+            regs1.len()
+        );
     }
 
-    // Lecture bloc 2 : 0x0010–0x0011 → 2 registres (énergie import, INT32)
-    let regs2: Vec<u16> = ctx
-        .read_input_registers(0x0010, 2)
+    // ── Bloc 2 : 0x0010–0x0011 → 2 registres (énergie import, INT32) ─────────
+    let req2 = modbus_rtu::build_fc04(address, 0x0010, 2);
+    let resp2 = bus
+        .transact(&req2, modbus_rtu::response_len(2))
         .await
-        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} FC04 read 0x0010: {}", address, e))?
-        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} exception code: {:?}", address, e))?;
+        .map_err(|e| anyhow::anyhow!("ET112 {:#04x} bloc2: {}", address, e))?;
+    let regs2 = modbus_rtu::parse_read_response(address, 0x04, &resp2)
+        .map_err(|e| anyhow::anyhow!("ET112 {:#04x} parse bloc2: {}", address, e))?;
 
     if regs2.len() < 2 {
-        anyhow::bail!("ET112 addr={:#04x} réponse trop courte bloc 2 ({})", address, regs2.len());
+        anyhow::bail!(
+            "ET112 {:#04x} bloc2 trop court ({} registres)",
+            address,
+            regs2.len()
+        );
     }
 
-    // Lecture bloc 3 : 0x0020–0x0021 → 2 registres (énergie export, INT32)
-    let regs3: Vec<u16> = ctx
-        .read_input_registers(0x0020, 2)
+    // ── Bloc 3 : 0x0020–0x0021 → 2 registres (énergie export, INT32) ─────────
+    let req3 = modbus_rtu::build_fc04(address, 0x0020, 2);
+    let resp3 = bus
+        .transact(&req3, modbus_rtu::response_len(2))
         .await
-        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} FC04 read 0x0020: {}", address, e))?
-        .map_err(|e| anyhow::anyhow!("ET112 addr={:#04x} exception code: {:?}", address, e))?;
+        .map_err(|e| anyhow::anyhow!("ET112 {:#04x} bloc3: {}", address, e))?;
+    let regs3 = modbus_rtu::parse_read_response(address, 0x04, &resp3)
+        .map_err(|e| anyhow::anyhow!("ET112 {:#04x} parse bloc3: {}", address, e))?;
 
     if regs3.len() < 2 {
-        anyhow::bail!("ET112 addr={:#04x} réponse trop courte bloc 3 ({})", address, regs3.len());
+        anyhow::bail!(
+            "ET112 {:#04x} bloc3 trop court ({} registres)",
+            address,
+            regs3.len()
+        );
     }
 
-    // Décodage INT32 little-endian (LSW first) avec facteurs d'échelle Victron cgwacs
+    // ── Décodage INT32 little-endian word order ────────────────────────────────
+    // Le ET112 stocke les valeurs 32 bits en « little-endian word order » :
+    // index pair = LSW (poids faible), index impair = MSW (poids fort).
+    // Source : dbus-cgwacs Victron.
     let voltage_v          = regs_to_i32(regs1[0],  regs1[1])  as f32 * 0.1;
     let current_a          = regs_to_i32(regs1[2],  regs1[3])  as f32 * 0.001;
     let power_w            = regs_to_i32(regs1[4],  regs1[5])  as f32 * 0.1;
     let apparent_power_va  = regs_to_i32(regs1[6],  regs1[7])  as f32 * 0.1;
     let reactive_power_var = regs_to_i32(regs1[8],  regs1[9])  as f32 * 0.1;
     let power_factor       = regs_to_i32(regs1[10], regs1[11]) as f32 * 0.001;
-    // regs1[12..13] = phase_angle / reserved (non utilisé)
-    // regs1[15] (0x000F) = fréquence INT16, scale 0.1 → Hz
+    // regs1[12..13] = phase_angle / réservé (non utilisé)
+    // regs1[14] = réservé
+    // regs1[15] (0x000F) = fréquence INT16 simple, facteur 0.1 → Hz
     let frequency_hz       = regs1[15] as i16 as f32 * 0.1;
 
-    // Énergie : INT32 × 0.1 = kWh ; ×100 → Wh pour le champ energy_*_wh
+    // Énergie : INT32 × 0.1 = kWh ; ×100 pour convertir en Wh
     let energy_import_wh   = regs_to_i32(regs2[0], regs2[1]) as f32 * 100.0;
     let energy_export_wh   = regs_to_i32(regs3[0], regs3[1]) as f32 * 100.0;
 

--- a/crates/daly-bms-server/src/irradiance/mod.rs
+++ b/crates/daly-bms-server/src/irradiance/mod.rs
@@ -1,0 +1,7 @@
+//! Module irradiance — capteur PRALRAN RS485 (remplace irradiance_reader.py).
+
+mod poll;
+mod types;
+
+pub use poll::run_irradiance_poll_loop;
+pub use types::IrradianceSnapshot;

--- a/crates/daly-bms-server/src/irradiance/poll.rs
+++ b/crates/daly-bms-server/src/irradiance/poll.rs
@@ -1,0 +1,108 @@
+//! Boucle de polling pour le capteur d'irradiance PRALRAN RS485.
+//!
+//! ## Protocole
+//!
+//! Modbus RTU FC=04, adresse configurable (défaut 0x05).
+//!
+//! | Registre | Grandeur      | Format | Unité |
+//! |----------|--------------|--------|-------|
+//! | 0x0000   | Irradiance   | uint16 | W/m²  |
+//!
+//! ## Intégration
+//!
+//! Le snapshot est transmis via callback puis stocké dans `AppState`.
+//! Le bridge MQTT publie sur `santuario/irradiance/raw` (retain=true)
+//! — même topic que l'ancien `irradiance_reader.py`, Node-RED inchangé.
+
+use super::types::IrradianceSnapshot;
+use crate::config::IrradianceConfig;
+use chrono::Local;
+use rs485_bus::{modbus_rtu, SharedBus};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, error, info, warn};
+
+/// Lance la boucle de polling irradiance.
+///
+/// # Paramètres
+/// - `bus`         : bus RS485 partagé (même instance que le bus Daly BMS)
+/// - `cfg`         : configuration du capteur
+/// - `on_snapshot` : callback appelé à chaque mesure valide
+pub async fn run_irradiance_poll_loop<F>(
+    bus: Arc<SharedBus>,
+    cfg: IrradianceConfig,
+    mut on_snapshot: F,
+)
+where
+    F: FnMut(IrradianceSnapshot) + Send + 'static,
+{
+    let addr = cfg.parsed_address();
+    let poll_interval = Duration::from_millis(cfg.poll_interval_ms);
+
+    info!(
+        addr = format!("{:#04x}", addr),
+        name = %cfg.name,
+        interval_ms = cfg.poll_interval_ms,
+        "Irradiance PRALRAN polling démarré"
+    );
+
+    let mut consecutive_errors: u32 = 0;
+
+    loop {
+        match poll_irradiance(&bus, addr, &cfg.name).await {
+            Ok(snap) => {
+                debug!(
+                    addr = format!("{:#04x}", addr),
+                    wm2  = snap.irradiance_wm2,
+                    "Irradiance OK"
+                );
+                consecutive_errors = 0;
+                on_snapshot(snap);
+            }
+            Err(e) => {
+                consecutive_errors += 1;
+                // Log seulement à la 1ère erreur, puis toutes les 12 (même fréquence que Python)
+                if consecutive_errors == 1 || consecutive_errors % 12 == 0 {
+                    warn!(
+                        addr   = format!("{:#04x}", addr),
+                        errors = consecutive_errors,
+                        "Irradiance erreur lecture : {:#}",
+                        e
+                    );
+                }
+            }
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+/// Interroge le capteur PRALRAN et retourne un snapshot.
+async fn poll_irradiance(
+    bus: &SharedBus,
+    addr: u8,
+    name: &str,
+) -> anyhow::Result<IrradianceSnapshot> {
+    // FC04, registre 0x0000, 1 registre → irradiance W/m² (uint16)
+    let req = modbus_rtu::build_fc04(addr, 0x0000, 1);
+    let resp_len = modbus_rtu::response_len(1); // 7 octets
+
+    let resp = bus.transact(&req, resp_len).await
+        .map_err(|e| anyhow::anyhow!("PRALRAN {:#04x} transact: {}", addr, e))?;
+
+    let regs = modbus_rtu::parse_read_response(addr, 0x04, &resp)
+        .map_err(|e| anyhow::anyhow!("PRALRAN {:#04x} parse: {}", addr, e))?;
+
+    if regs.is_empty() {
+        anyhow::bail!("PRALRAN {:#04x}: réponse vide", addr);
+    }
+
+    let irradiance_wm2 = regs[0] as f32; // uint16 direct, unité W/m²
+
+    Ok(IrradianceSnapshot {
+        address: addr,
+        name: name.to_string(),
+        timestamp: Local::now(),
+        irradiance_wm2,
+    })
+}

--- a/crates/daly-bms-server/src/irradiance/types.rs
+++ b/crates/daly-bms-server/src/irradiance/types.rs
@@ -1,0 +1,20 @@
+//! Types pour le capteur d'irradiance RS485 (PRALRAN Solar Radiation Sensor).
+
+use chrono::{DateTime, Local};
+use serde::{Deserialize, Serialize};
+
+/// Snapshot d'une mesure d'irradiance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IrradianceSnapshot {
+    /// Adresse Modbus du capteur (ex: 5 pour 0x05)
+    pub address: u8,
+
+    /// Nom configuré
+    pub name: String,
+
+    /// Instant de la mesure
+    pub timestamp: DateTime<Local>,
+
+    /// Irradiance solaire (W/m²)
+    pub irradiance_wm2: f32,
+}

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -16,6 +16,7 @@
 mod autodetect;
 mod config;
 mod et112;
+mod irradiance;
 mod state;
 mod api;
 mod bridges;
@@ -144,15 +145,16 @@ async fn main() -> anyhow::Result<()> {
             eprintln!("Config non trouvée ({}) — utilisation des valeurs par défaut", e);
             config_from_file = false;
             AppConfig {
-                serial:    config::SerialConfig::default(),
-                api:       config::ApiConfig::default(),
-                logging:   config::LoggingConfig::default(),
-                mqtt:      config::MqttConfig::default(),
-                influxdb:  config::InfluxConfig::default(),
-                alerts:    config::AlertsConfig::default(),
-                read_only: config::ReadOnlyConfig::default(),
-                bms:       Vec::new(),
-                et112:     config::Et112Config::default(),
+                serial:      config::SerialConfig::default(),
+                api:         config::ApiConfig::default(),
+                logging:     config::LoggingConfig::default(),
+                mqtt:        config::MqttConfig::default(),
+                influxdb:    config::InfluxConfig::default(),
+                alerts:      config::AlertsConfig::default(),
+                read_only:   config::ReadOnlyConfig::default(),
+                bms:         Vec::new(),
+                et112:       config::Et112Config::default(),
+                irradiance:  None,
             }
         }
     };
@@ -224,30 +226,10 @@ async fn main() -> anyhow::Result<()> {
         async move { alerts::run_alert_engine(s, c).await }
     });
 
-    // ── Bridge ET112 polling (tâche indépendante) ──────────────────────────────
-    if !config.et112.devices.is_empty() {
-        info!(
-            port  = %config.et112.port,
-            count = config.et112.devices.len(),
-            "Démarrage polling ET112"
-        );
-        let state_et = state.clone();
-        let et112_cfg = config.et112.clone();
-        tokio::spawn(async move {
-            et112::run_et112_poll_loop(
-                et112_cfg.port,
-                et112_cfg.baud,
-                et112_cfg.devices,
-                std::time::Duration::from_millis(et112_cfg.poll_interval_ms),
-                move |snap| {
-                    let state = state_et.clone();
-                    tokio::spawn(async move {
-                        state.on_et112_snapshot(snap).await;
-                    });
-                },
-            ).await;
-        });
-    }
+    // NOTE : ET112 et PRALRAN utilisent désormais le bus RS485 UNIFIÉ.
+    // Leur lancement est déplacé dans le bloc hardware, après l'ouverture du DalyPort,
+    // afin de partager le même Arc<SharedBus>.
+    // En mode simulation, ET112 et PRALRAN ne sont pas lancés (pas de port réel).
 
     // ── Mode SIMULATION ou HARDWARE ────────────────────────────────────────────
     if args.simulate {
@@ -300,11 +282,58 @@ async fn main() -> anyhow::Result<()> {
             };
             match dal_port {
                 Ok(port) => {
-                    info!("Port série {} ouvert à {} baud", resolved_port, config.serial.baud);
+                    info!("Port série {} ouvert à {} baud — bus RS485 unifié", resolved_port, config.serial.baud);
                     state.polling_active.store(true, Ordering::Relaxed);
 
                     // Rendre le port disponible pour les commandes d'écriture
                     state.set_port(port.clone()).await;
+
+                    // ── Bus RS485 partagé avec ET112 et PRALRAN ────────────────
+                    let shared_bus = port.shared_bus();
+
+                    // ── ET112 sur bus unifié ───────────────────────────────────
+                    if !config.et112.devices.is_empty() {
+                        info!(
+                            count = config.et112.devices.len(),
+                            "Démarrage polling ET112 (bus RS485 unifié)"
+                        );
+                        let state_et  = state.clone();
+                        let bus_et    = shared_bus.clone();
+                        let et112_cfg = config.et112.clone();
+                        tokio::spawn(async move {
+                            et112::run_et112_poll_loop(
+                                bus_et,
+                                et112_cfg.devices,
+                                std::time::Duration::from_millis(et112_cfg.poll_interval_ms),
+                                move |snap| {
+                                    let s = state_et.clone();
+                                    tokio::spawn(async move { s.on_et112_snapshot(snap).await });
+                                },
+                            )
+                            .await;
+                        });
+                    }
+
+                    // ── PRALRAN irradiance sur bus unifié ──────────────────────
+                    if let Some(irrad_cfg) = config.irradiance.clone() {
+                        info!(
+                            addr = %irrad_cfg.address,
+                            "Démarrage polling irradiance PRALRAN (bus RS485 unifié)"
+                        );
+                        let state_irrad = state.clone();
+                        let bus_irrad   = shared_bus.clone();
+                        tokio::spawn(async move {
+                            irradiance::run_irradiance_poll_loop(
+                                bus_irrad,
+                                irrad_cfg,
+                                move |snap| {
+                                    let s = state_irrad.clone();
+                                    tokio::spawn(async move { s.on_irradiance_snapshot(snap).await });
+                                },
+                            )
+                            .await;
+                        });
+                    }
 
                     // ── 2. Résoudre les adresses BMS (auto-découverte ou config) ──
                     let addresses = if auto_discover_addrs {

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -5,6 +5,7 @@
 
 use crate::config::AppConfig;
 use crate::et112::Et112Snapshot;
+use crate::irradiance::IrradianceSnapshot;
 use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
 use serde::Serialize;
@@ -117,6 +118,9 @@ pub struct AppState {
 
     /// Ring buffers ET112 indexés par adresse Modbus.
     pub et112_buffers: Arc<RwLock<BTreeMap<u8, Et112RingBuffer>>>,
+
+    /// Dernière mesure du capteur d'irradiance PRALRAN (None si non configuré).
+    pub irradiance_value: Arc<RwLock<Option<IrradianceSnapshot>>>,
 }
 
 impl AppState {
@@ -145,6 +149,7 @@ impl AppState {
             port: Arc::new(RwLock::new(None)),
             log_buffer,
             et112_buffers: Arc::new(RwLock::new(et112_buffers)),
+            irradiance_value: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -225,5 +230,15 @@ impl AppState {
     pub async fn et112_latest_all(&self) -> Vec<Et112Snapshot> {
         let buffers = self.et112_buffers.read().await;
         buffers.values().filter_map(|b| b.latest().cloned()).collect()
+    }
+
+    /// Enregistre la dernière mesure du capteur d'irradiance.
+    pub async fn on_irradiance_snapshot(&self, snap: IrradianceSnapshot) {
+        *self.irradiance_value.write().await = Some(snap);
+    }
+
+    /// Retourne la dernière mesure d'irradiance (None si jamais reçue).
+    pub async fn latest_irradiance(&self) -> Option<IrradianceSnapshot> {
+        self.irradiance_value.read().await.clone()
     }
 }

--- a/crates/rs485-bus/Cargo.toml
+++ b/crates/rs485-bus/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name        = "rs485-bus"
+description = "Bus RS485 partagé — SharedBus + framing Modbus RTU pur Rust"
+version.workspace    = true
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+rust-version.workspace = true
+
+[dependencies]
+tokio        = { workspace = true }
+tokio-serial = { workspace = true }
+anyhow       = { workspace = true }
+thiserror    = { workspace = true }
+tracing      = { workspace = true }

--- a/crates/rs485-bus/src/lib.rs
+++ b/crates/rs485-bus/src/lib.rs
@@ -1,0 +1,190 @@
+//! # rs485-bus
+//!
+//! Bus RS485 partagé entre plusieurs drivers (Daly BMS, Modbus RTU).
+//!
+//! ## Principe
+//!
+//! Un seul `Arc<SharedBus>` est ouvert pour tout le projet. Chaque driver
+//! (Daly BMS, ET112, PRALRAN…) acquiert le verrou via `SharedBus::acquire()`
+//! ou utilise la méthode de convenance `SharedBus::transact()`.
+//!
+//! Le Mutex interne garantit qu'une seule transaction est en cours à tout
+//! moment sur le bus half-duplex RS485.
+//!
+//! ## Modules
+//! - [`modbus_rtu`] — framing Modbus RTU pur Rust (CRC16, FC03, FC04, FC06)
+
+pub mod modbus_rtu;
+
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+use tracing::trace;
+
+/// Timeout du flush RX (drain des octets résiduels avant émission).
+const FLUSH_TIMEOUT_MS: u64 = 10;
+
+// =============================================================================
+// SharedBus
+// =============================================================================
+
+/// Port série RS485 partagé entre tous les drivers du projet.
+///
+/// Accès exclusif garanti par un `Mutex<SerialStream>`.
+/// Créer une seule instance et la distribuer via `Arc::clone()`.
+pub struct SharedBus {
+    inner: Mutex<tokio_serial::SerialStream>,
+    /// Délai TX→RX après émission (commutation RS485 half-duplex).
+    pub inter_frame_ms: u64,
+    /// Timeout de réception par défaut pour `transact()`.
+    pub timeout_ms: u64,
+}
+
+impl SharedBus {
+    /// Ouvre le port série et crée le bus partagé.
+    ///
+    /// # Paramètres
+    /// - `port_path`      : ex `/dev/ttyUSB0`
+    /// - `baud`           : 9600 pour tous les appareils de ce projet
+    /// - `parity`         : `tokio_serial::Parity::None` pour 8N1
+    /// - `inter_frame_ms` : délai TX→RX en ms (50 ms recommandé pour Daly BMS)
+    /// - `timeout_ms`     : timeout de réception par défaut
+    pub fn open(
+        port_path: &str,
+        baud: u32,
+        parity: tokio_serial::Parity,
+        inter_frame_ms: u64,
+        timeout_ms: u64,
+    ) -> anyhow::Result<Arc<Self>> {
+        use tokio_serial::SerialPortBuilderExt;
+
+        let stream = tokio_serial::new(port_path, baud)
+            .data_bits(tokio_serial::DataBits::Eight)
+            .stop_bits(tokio_serial::StopBits::One)
+            .parity(parity)
+            .flow_control(tokio_serial::FlowControl::None)
+            .open_native_async()
+            .map_err(|e| anyhow::anyhow!("Impossible d'ouvrir {} : {}", port_path, e))?;
+
+        Ok(Arc::new(Self {
+            inner: Mutex::new(stream),
+            inter_frame_ms,
+            timeout_ms,
+        }))
+    }
+
+    /// Acquiert le verrou exclusif et retourne un [`BusGuard`].
+    ///
+    /// Le garde libère le verrou automatiquement à la fin du scope.
+    /// Permet des transactions multi-étapes (ex : Daly 2ème trame de secours).
+    pub async fn acquire(&self) -> BusGuard<'_> {
+        BusGuard {
+            port: self.inner.lock().await,
+            inter_frame_ms: self.inter_frame_ms,
+            timeout_ms: self.timeout_ms,
+        }
+    }
+
+    /// Transaction simple : flush + TX + délai inter-trame + RX exact.
+    ///
+    /// Convient pour tous les appareils Modbus RTU simple (1 requête / 1 réponse).
+    /// Pour des transactions complexes (Daly multi-trame), utiliser [`acquire()`].
+    pub async fn transact(&self, tx: &[u8], resp_len: usize) -> anyhow::Result<Vec<u8>> {
+        let mut guard = self.acquire().await;
+        guard.flush_rx().await;
+        guard.write_all(tx).await
+            .map_err(|e| anyhow::anyhow!("TX erreur : {}", e))?;
+        guard.inter_frame_delay().await;
+        guard
+            .read_exact_timed(resp_len)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("Timeout ({} ms) — aucune réponse", self.timeout_ms))?
+            .map_err(|e| anyhow::anyhow!("RX erreur : {}", e))
+    }
+}
+
+// =============================================================================
+// BusGuard
+// =============================================================================
+
+/// Garde sur le bus RS485 — verrou Mutex maintenu pour la durée de la transaction.
+///
+/// Obtenu via [`SharedBus::acquire()`].
+/// Libère le verrou automatiquement (Drop).
+pub struct BusGuard<'a> {
+    port: tokio::sync::MutexGuard<'a, tokio_serial::SerialStream>,
+    pub inter_frame_ms: u64,
+    pub timeout_ms: u64,
+}
+
+impl<'a> BusGuard<'a> {
+    /// Vide le buffer RX (drain les octets résiduels d'une transaction précédente).
+    pub async fn flush_rx(&mut self) {
+        let mut tmp = [0u8; 256];
+        let _ = tokio::time::timeout(
+            Duration::from_millis(FLUSH_TIMEOUT_MS),
+            self.port.read(&mut tmp),
+        )
+        .await;
+    }
+
+    /// Écrit tous les octets dans le port + flush.
+    pub async fn write_all(&mut self, data: &[u8]) -> std::io::Result<()> {
+        trace!(raw = format!("{:02X?}", data), "→ TX");
+        self.port.write_all(data).await?;
+        self.port.flush().await
+    }
+
+    /// Délai de commutation TX→RX (inter-trame).
+    pub async fn inter_frame_delay(&self) {
+        tokio::time::sleep(Duration::from_millis(self.inter_frame_ms)).await;
+    }
+
+    /// Lit exactement `n` octets avec le timeout par défaut du bus.
+    ///
+    /// Retourne `None` sur timeout, `Some(Err)` sur erreur I/O, `Some(Ok(buf))` sur succès.
+    pub async fn read_exact_timed(&mut self, n: usize) -> Option<std::io::Result<Vec<u8>>> {
+        self.read_exact_with_timeout(n, self.timeout_ms).await
+    }
+
+    /// Lit exactement `n` octets avec un timeout explicite (ms).
+    ///
+    /// Retourne `None` sur timeout, `Some(Err)` sur erreur I/O, `Some(Ok(buf))` sur succès.
+    pub async fn read_exact_with_timeout(
+        &mut self,
+        n: usize,
+        timeout_ms: u64,
+    ) -> Option<std::io::Result<Vec<u8>>> {
+        let mut buf = vec![0u8; n];
+        match tokio::time::timeout(
+            Duration::from_millis(timeout_ms),
+            self.port.read_exact(&mut buf),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {
+                trace!(raw = format!("{:02X?}", buf), "← RX");
+                Some(Ok(buf))
+            }
+            Ok(Err(e)) => Some(Err(e)),
+            Err(_elapsed) => None,
+        }
+    }
+
+    /// Tente de lire jusqu'à `max` octets disponibles (pour diagnostic timeout).
+    ///
+    /// Utilise un timeout court (50 ms). Retourne les octets lus (peut être vide).
+    pub async fn try_read_partial(&mut self, max: usize) -> Vec<u8> {
+        let mut tmp = vec![0u8; max];
+        match tokio::time::timeout(
+            Duration::from_millis(50),
+            self.port.read(&mut tmp),
+        )
+        .await
+        {
+            Ok(Ok(n)) if n > 0 => tmp[..n].to_vec(),
+            _ => vec![],
+        }
+    }
+}

--- a/crates/rs485-bus/src/modbus_rtu.rs
+++ b/crates/rs485-bus/src/modbus_rtu.rs
@@ -1,0 +1,252 @@
+//! Framing Modbus RTU pur Rust — CRC16, FC03, FC04, FC06.
+//!
+//! Implémentation minimale et autonome sans dépendance à `tokio-modbus`.
+//! Couvre les besoins du projet :
+//! - FC04 (Read Input Registers) → ET112, PRALRAN
+//! - FC03 (Read Holding Registers) → CHINT ATS (futur)
+//! - FC06 (Write Single Register) → CHINT ATS (futur)
+
+// =============================================================================
+// CRC-16/Modbus
+// =============================================================================
+
+/// Calcule le CRC-16/Modbus (polynôme 0xA001, init 0xFFFF, LSB first).
+///
+/// La trame Modbus RTU se termine par [CRC_LO, CRC_HI] (little-endian).
+pub fn crc16(data: &[u8]) -> u16 {
+    let mut crc: u16 = 0xFFFF;
+    for &byte in data {
+        crc ^= byte as u16;
+        for _ in 0..8 {
+            if crc & 0x0001 != 0 {
+                crc = (crc >> 1) ^ 0xA001;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    crc
+}
+
+// =============================================================================
+// Constructeurs de requêtes
+// =============================================================================
+
+/// FC04 — Read Input Registers (8 octets).
+///
+/// ```text
+/// [ADDR][0x04][REG_HI][REG_LO][COUNT_HI][COUNT_LO][CRC_LO][CRC_HI]
+/// ```
+pub fn build_fc04(addr: u8, reg_start: u16, count: u16) -> [u8; 8] {
+    let mut frame = [
+        addr,
+        0x04,
+        (reg_start >> 8) as u8,
+        reg_start as u8,
+        (count >> 8) as u8,
+        count as u8,
+        0,
+        0,
+    ];
+    let crc = crc16(&frame[..6]);
+    frame[6] = crc as u8;
+    frame[7] = (crc >> 8) as u8;
+    frame
+}
+
+/// FC03 — Read Holding Registers (8 octets).
+///
+/// ```text
+/// [ADDR][0x03][REG_HI][REG_LO][COUNT_HI][COUNT_LO][CRC_LO][CRC_HI]
+/// ```
+pub fn build_fc03(addr: u8, reg_start: u16, count: u16) -> [u8; 8] {
+    let mut frame = [
+        addr,
+        0x03,
+        (reg_start >> 8) as u8,
+        reg_start as u8,
+        (count >> 8) as u8,
+        count as u8,
+        0,
+        0,
+    ];
+    let crc = crc16(&frame[..6]);
+    frame[6] = crc as u8;
+    frame[7] = (crc >> 8) as u8;
+    frame
+}
+
+/// FC06 — Write Single Register (8 octets).
+///
+/// ```text
+/// [ADDR][0x06][REG_HI][REG_LO][VAL_HI][VAL_LO][CRC_LO][CRC_HI]
+/// ```
+pub fn build_fc06(addr: u8, reg: u16, value: u16) -> [u8; 8] {
+    let mut frame = [
+        addr,
+        0x06,
+        (reg >> 8) as u8,
+        reg as u8,
+        (value >> 8) as u8,
+        value as u8,
+        0,
+        0,
+    ];
+    let crc = crc16(&frame[..6]);
+    frame[6] = crc as u8;
+    frame[7] = (crc >> 8) as u8;
+    frame
+}
+
+// =============================================================================
+// Longueur de réponse
+// =============================================================================
+
+/// Longueur attendue de la réponse FC03/FC04 pour `count` registres.
+///
+/// Format : `addr(1) + fc(1) + byte_count(1) + data(count×2) + crc(2)`
+pub fn response_len(count: u16) -> usize {
+    5 + (count as usize) * 2
+}
+
+// =============================================================================
+// Parseur de réponse
+// =============================================================================
+
+/// Valide et décode la réponse à une requête FC03/FC04.
+///
+/// Vérifie : adresse, function code, byte_count, CRC.
+/// Retourne les registres comme `Vec<u16>` (big-endian dans la trame Modbus,
+/// index 0 = premier registre demandé).
+///
+/// # Paramètres
+/// - `addr` : adresse esclave attendue
+/// - `fc`   : function code attendu (0x03 ou 0x04)
+/// - `buf`  : octets bruts reçus (longueur = `response_len(count)`)
+pub fn parse_read_response(addr: u8, fc: u8, buf: &[u8]) -> anyhow::Result<Vec<u16>> {
+    if buf.len() < 5 {
+        anyhow::bail!(
+            "Réponse Modbus trop courte ({} octets, minimum 5)",
+            buf.len()
+        );
+    }
+
+    // Adresse
+    if buf[0] != addr {
+        anyhow::bail!(
+            "Adresse inattendue : attendu {:#04x}, reçu {:#04x}",
+            addr,
+            buf[0]
+        );
+    }
+
+    // Function code (ou exception)
+    if buf[1] == fc | 0x80 {
+        let exc = buf.get(2).copied().unwrap_or(0);
+        anyhow::bail!("Exception Modbus : FC {:#04x}, code {:#04x}", fc, exc);
+    }
+    if buf[1] != fc {
+        anyhow::bail!(
+            "Function code inattendu : attendu {:#04x}, reçu {:#04x}",
+            fc,
+            buf[1]
+        );
+    }
+
+    // Byte count
+    let byte_count = buf[2] as usize;
+    let expected_data_bytes = buf.len().saturating_sub(5); // addr+fc+bc+crc_lo+crc_hi
+    if byte_count != expected_data_bytes {
+        anyhow::bail!(
+            "byte_count={} incohérent avec longueur buffer={} (attendu {})",
+            byte_count,
+            buf.len(),
+            expected_data_bytes
+        );
+    }
+
+    // CRC
+    let crc_calc = crc16(&buf[..buf.len() - 2]);
+    let crc_recv = (buf[buf.len() - 2] as u16) | ((buf[buf.len() - 1] as u16) << 8);
+    if crc_recv != crc_calc {
+        anyhow::bail!(
+            "CRC invalide : reçu {:#06x}, calculé {:#06x}",
+            crc_recv,
+            crc_calc
+        );
+    }
+
+    // Extraction registres (big-endian u16 dans la trame Modbus)
+    let data = &buf[3..buf.len() - 2];
+    let regs = data
+        .chunks(2)
+        .map(|c| ((c[0] as u16) << 8) | c[1] as u16)
+        .collect();
+
+    Ok(regs)
+}
+
+// =============================================================================
+// Tests unitaires
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_crc16_known_value() {
+        // Exemple Modbus RTU standard : requête FC03 addr=1 reg=0 count=1
+        // Requête : 01 03 00 00 00 01 → CRC = 0x840A (lo=0x0A, hi=0x84)
+        let data = [0x01u8, 0x03, 0x00, 0x00, 0x00, 0x01];
+        let crc = crc16(&data);
+        assert_eq!(crc, 0x840A, "CRC Modbus RTU incorrect");
+    }
+
+    #[test]
+    fn test_build_fc04_pralran() {
+        // FC04 addr=0x05 reg=0x0000 count=1
+        let frame = build_fc04(0x05, 0x0000, 1);
+        assert_eq!(frame[0], 0x05);
+        assert_eq!(frame[1], 0x04);
+        assert_eq!(frame[2], 0x00);
+        assert_eq!(frame[3], 0x00);
+        assert_eq!(frame[4], 0x00);
+        assert_eq!(frame[5], 0x01);
+        // CRC doit être valide
+        let crc = crc16(&frame[..6]);
+        assert_eq!(frame[6], crc as u8);
+        assert_eq!(frame[7], (crc >> 8) as u8);
+    }
+
+    #[test]
+    fn test_response_len() {
+        assert_eq!(response_len(1), 7);   // 5 + 2×1
+        assert_eq!(response_len(2), 9);   // 5 + 2×2
+        assert_eq!(response_len(16), 37); // 5 + 2×16
+    }
+
+    #[test]
+    fn test_parse_read_response_valid() {
+        // Simuler réponse FC04 addr=0x05, 1 registre, valeur=334 (irradiance)
+        let value: u16 = 334;
+        let data_hi = (value >> 8) as u8;
+        let data_lo = value as u8;
+        let raw = [0x05u8, 0x04, 0x02, data_hi, data_lo, 0x00, 0x00];
+        // Calculer et corriger le CRC
+        let mut buf = raw;
+        let crc = crc16(&buf[..5]);
+        buf[5] = crc as u8;
+        buf[6] = (crc >> 8) as u8;
+
+        let regs = parse_read_response(0x05, 0x04, &buf).unwrap();
+        assert_eq!(regs.len(), 1);
+        assert_eq!(regs[0], 334);
+    }
+
+    #[test]
+    fn test_parse_read_response_bad_crc() {
+        let buf = [0x05u8, 0x04, 0x02, 0x01, 0x4E, 0xFF, 0xFF]; // CRC invalide
+        assert!(parse_read_response(0x05, 0x04, &buf).is_err());
+    }
+}


### PR DESCRIPTION
…AN Rust

## Nouvelle crate rs485-bus
- SharedBus : Arc<Mutex<SerialStream>> partagé entre tous les drivers
- BusGuard  : verrou RAII, flush_rx/write_all/inter_frame_delay/read_exact_timed
- modbus_rtu: CRC-16, build_fc03/fc04/fc06, parse_read_response — sans tokio-modbus

## daly-bms-core refactoré
- DalyPort wraps Arc<SharedBus> (plus SerialStream direct)
- DalyPort::shared_bus() → expose le bus aux autres drivers (ET112, PRALRAN)
- DalyPort::from_bus() → constructeur depuis SharedBus existant

## daly-bms-server : irradiance PRALRAN en Rust pur
- Module irradiance/ : run_irradiance_poll_loop, IrradianceSnapshot
- Remplace le service Python irradiance_reader.py (même topic MQTT retain)
- AppState::irradiance_value + on_irradiance_snapshot + latest_irradiance()
- MQTT bridge publie santuario/irradiance/raw (retain=true, format W/m²)

## ET112 sur bus unifié (sans tokio-modbus)
- et112/poll.rs utilise Arc<SharedBus> + modbus_rtu::build_fc04 + transact()
- Plus de port/baud dédiés — bus hérité du SharedBus Daly

## Config.toml : bus unifié + adresses corrigées
- Nouvelles adresses ET112 : 0x07 (micro-onduleurs), 0x08 (PAC chauffe-eau), 0x09 (PAC clim)
- Section [irradiance] : address=0x05, poll_interval_ms=5000
- Et112Config sans champs port/baud (obsolètes)
- main.rs : ET112 et PRALRAN partagent shared_bus après ouverture DalyPort

Compilation vérifiée : rs485-bus ✅ daly-bms-core ✅ daly-bms-server ✅ (0 erreurs)

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH