### PR TITLE
chore(config): desactiver irradiance et ET112 jusqu'au branchement ph…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -204,10 +204,10 @@ device_instance = 40      # DeviceInstance Venus OS / VRM
 # Publie sur MQTT : santuario/irradiance/raw (retain=true)
 # Même topic que l'ancien irradiance_reader.py → Node-RED inchangé
 
-[irradiance]
-address          = "0x05"          # Adresse Modbus RTU du capteur PRALRAN
-name             = "Irradiance PRALRAN"
-poll_interval_ms = 5000            # 5 secondes (identique à l'ancien script Python)
+# [irradiance]                       # Décommenter quand le capteur PRALRAN sera branché sur le bus
+# address          = "0x05"
+# name             = "Irradiance PRALRAN"
+# poll_interval_ms = 5000
 
 
 # =============================================================================
@@ -229,23 +229,25 @@ poll_interval_ms = 5000
 # Taille du ring buffer (720 = 1 heure à 1 mesure/5s)
 ring_buffer_size = 720
 
-[[et112.devices]]
-address     = "0x07"           # Adresse Modbus RTU — Micro-onduleurs
-name        = "Micro Onduleurs"
-mqtt_index  = 3                # → topic santuario/pvinverter/3/venus
-position    = 1                # 0=AC Input, 1=AC Output
-
-[[et112.devices]]
-address     = "0x08"           # Adresse Modbus RTU — PAC Chauffe-eau
-name        = "PAC Chauffe-eau"
-mqtt_index  = 4                # → topic santuario/pvinverter/4/venus
-position    = 1                # 0=AC Input, 1=AC Output
-
-[[et112.devices]]
-address     = "0x09"           # Adresse Modbus RTU — PAC Climatisation
-name        = "PAC Climatisation"
-mqtt_index  = 5                # → topic santuario/pvinverter/5/venus
-position    = 1                # 0=AC Input, 1=AC Output
+# Décommenter au fur et à mesure du branchement physique sur le bus RS485 :
+#
+# [[et112.devices]]
+# address     = "0x07"           # Micro-onduleurs
+# name        = "Micro Onduleurs"
+# mqtt_index  = 3                # → santuario/pvinverter/3/venus
+# position    = 1
+#
+# [[et112.devices]]
+# address     = "0x08"           # PAC Chauffe-eau
+# name        = "PAC Chauffe-eau"
+# mqtt_index  = 4                # → santuario/pvinverter/4/venus
+# position    = 1
+#
+# [[et112.devices]]
+# address     = "0x09"           # PAC Climatisation
+# name        = "PAC Climatisation"
+# mqtt_index  = 5                # → santuario/pvinverter/5/venus
+# position    = 1
 
 
 [influxdb]


### PR DESCRIPTION
…ysique

Seuls les BMS (0x01, 0x02) sont connectes sur le bus RS485 pour l'instant. Sections [irradiance] et [[et112.devices]] commentees pour eviter les timeouts en boucle dans les logs. A decommentern au fur et a mesure du branchement.

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH