### PR TITLE
feat(et112): activer 0x07 pvinverter + 0x08 heatpump, corriger adress…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1096,45 +1096,31 @@ com.victronenergy.pvinverter.mqtt_3 (device instance 63)
 | `Config.toml` | Section `[et112]` + `[[et112.devices]]` |
 | `nanoPi/config-nanopi.toml` | Section `[pvinverter]` + `[[pvinverters]]` |
 
-### Architecture RS485 unifiée — Bus `/dev/ttyUSB0` (état 2026-03-23) ✅
+### Architecture RS485 unifiée — Bus `/dev/ttyUSB0` (état 2026-03-23 → mis à jour) ✅
 
 **Tous les appareils RS485 sont sur le même bus `/dev/ttyUSB0`** :
 
 | Adresse | Appareil | SN | Usage | Type D-Bus | Topic MQTT | Device instance |
 |---|---|---|---|---|---|---|
-| 0x01 | BMS-360Ah | — | Batterie 1 | `battery` | `santuario/bms/1/venus` | 141 |
-| 0x02 | BMS-320Ah | — | Batterie 2 | `battery` | `santuario/bms/2/venus` | 142 |
-| 0x09 | ET112 PAC Climatisation | 061077X | AC Load | `acload` | `santuario/grid/9/venus` | 31 |
+| 0x01 | BMS-360Ah | — | Batterie 1 | `battery` | `santuario/bms/1/venus` | 151 |
+| 0x02 | BMS-320Ah | — | Batterie 2 | `battery` | `santuario/bms/2/venus` | 152 |
+| 0x05 | PRALRAN irradiance | — | Capteur solaire | `meteo` | `santuario/irradiance/raw` | 40 |
+| 0x07 | ET112 Micro-Onduleurs | 119253X | PVInverter AC Out 1 | `pvinverter` | `santuario/pvinverter/7/venus` | 32 ✅ |
+| 0x08 | ET112 PAC Chauffe-eau | 119215X | Heatpump AC Out 1 | `heatpump` | `santuario/heatpump/8/venus` | 30 ✅ |
+| 0x09 | ET112 PAC Climatisation | 061077X | Heatpump AC Out 1 | `heatpump` | `santuario/heatpump/9/venus` | 31 ⏳ non connecté |
 
-**État actuel (✅ OPÉRATIONNEL 2026-03-23)** :
-- ET112 addr `0x09` activé dans `Config.toml` (commit `cf4b99a`) — PAC Climatisation
-- `daly-bms-server` poll le bus unifié `/dev/ttyUSB0` pour BMS + ET112
-- Topic `santuario/grid/9/venus` publié → `com.victronenergy.acload.mqtt_9` sur D-Bus NanoPi
+> **NOTE** : Tous les appareils RS485 sont câblés sur le même bus `/dev/ttyUSB0`.
+> `service_type="heatpump"` → topic `santuario/heatpump/{n}/venus` (ajouté commit 2026-03-23).
 
-> **NOTE** : L'architecture initiale prévoyait un port `/dev/ttyUSB1` séparé pour ET112.
-> La réalité terrain : ET112 addr 0x09 est câblé **sur le même bus** que les BMS (`/dev/ttyUSB0`).
-> Le champ `port` dans `[et112]` doit donc pointer vers `/dev/ttyUSB0`.
-
-**Format JSON pour acload ET112** (compatible `GridPayload`) :
-```json
-{
-  "Ac": {
-    "L1": { "Voltage": 230.1, "Current": 8.2, "Power": 1886.0,
-            "Energy": { "Forward": 142.5, "Reverse": 0.0 } }
-  },
-  "DeviceType": 340,
-  "IsGenericEnergyMeter": 1
-}
-```
-Publié sur `santuario/grid/4/venus` (PAC) et `santuario/grid/5/venus` (chauffe-eau).
-
-### Topics MQTT pvinverter
+### Topics MQTT ET112
 
 ```
-santuario/pvinverter/3/venus  ← ET112 addr=0x03 (Pi5 → NanoPi)
+santuario/pvinverter/7/venus  ← ET112 addr=0x07 Micro-Onduleurs
+santuario/heatpump/8/venus    ← ET112 addr=0x08 PAC Chauffe-eau
+santuario/heatpump/9/venus    ← ET112 addr=0x09 PAC Climatisation (futur)
 ```
 
-Format JSON (compatible `dbus-mqtt-venus` PvinverterPayload) :
+Format JSON pvinverter (compatible `PvinverterPayload`) :
 ```json
 {
   "Ac": {
@@ -1143,46 +1129,46 @@ Format JSON (compatible `dbus-mqtt-venus` PvinverterPayload) :
     "Power": 1250.0,
     "Energy": { "Forward": 587.23, "Reverse": 0.0 }
   },
-  "StatusCode": 7,
-  "ErrorCode": 0,
+  "StatusCode": 7, "ErrorCode": 0, "Position": 1,
+  "IsGenericEnergyMeter": 1, "ProductName": "Micro Onduleurs"
+}
+```
+
+Format JSON heatpump (compatible `HeatpumpPayload`) :
+```json
+{
+  "Ac": { "Power": 1886.0, "Energy": { "Forward": 142.5 } },
   "Position": 1,
-  "IsGenericEnergyMeter": 1,
-  "ProductName": "ET112 addr=0x03",
-  "CustomName": "Micro-inverseurs"
+  "State": 0,
+  "ProductName": "PAC Chauffe-eau"
 }
 ```
 
 ### Vérification D-Bus (📍 NanoPi)
 
 ```bash
-# Vérifier que le service apparaît
-dbus -y | grep pvinverter
+# Vérifier que les services apparaissent
+dbus -y | grep -E "pvinverter|heatpump"
 
-# Lire la puissance instantanée
-dbus -y com.victronenergy.pvinverter.mqtt_3 /Ac/Power GetValue
+# Micro-Onduleurs (instance 32)
+dbus -y com.victronenergy.pvinverter.mqtt_7 /Ac/Power GetValue
+dbus -y com.victronenergy.pvinverter.mqtt_7 / GetItems
 
-# Lire l'énergie totale
-dbus -y com.victronenergy.pvinverter.mqtt_3 /Ac/Energy/Forward GetValue
-
-# Tous les chemins
-dbus -y com.victronenergy.pvinverter.mqtt_3 / GetItems
+# PAC Chauffe-eau (instance 30)
+dbus -y com.victronenergy.heatpump.mqtt_8 /Ac/Power GetValue
+dbus -y com.victronenergy.heatpump.mqtt_8 / GetItems
 ```
 
 ### Diagnostic Pi5
 
 ```bash
-# Dashboard web
-http://192.168.1.141:8080/dashboard/et112/3
-
 # API REST
-curl http://192.168.1.141:8080/api/v1/et112/3/status
-curl http://192.168.1.141:8080/api/v1/et112/3/history?limit=60
+curl http://192.168.1.141:8080/api/v1/et112/7/status    # Micro-Onduleurs
+curl http://192.168.1.141:8080/api/v1/et112/8/status    # PAC Chauffe-eau
 
 # MQTT publié
-mosquitto_sub -h 192.168.1.120 -p 1883 -t 'santuario/pvinverter/3/venus' -v
-
-# InfluxDB
-# measurement: et112_status, tags: address=0x03, name=Micro-inverseurs
+mosquitto_sub -h 192.168.1.120 -p 1883 -t 'santuario/pvinverter/7/venus' -v
+mosquitto_sub -h 192.168.1.120 -p 1883 -t 'santuario/heatpump/8/venus' -v
 ```
 
 ---
@@ -1241,20 +1227,24 @@ ssh root@192.168.1.120 "svc -t /service/dbus-mqtt-venus"  # Venus bridge
 ### Services D-Bus présents en production (état nominal)
 
 ```
-com.victronenergy.battery.mqtt_1                    ← BMS-360Ah (instance 141)
-com.victronenergy.battery.mqtt_2                    ← BMS-320Ah (instance 142)
-com.victronenergy.acload.mqtt_9                     ← ET112 PAC Climatisation (addr 0x09, instance 31) ← ✅ 2026-03-23
-com.victronenergy.temperature.mqtt_1                ← capteur température extérieure (type 4=Outdoor)
-com.victronenergy.heatpump.mqtt_1                   ← PAC / chauffe-eau
-com.victronenergy.switch.*                          ← ATS / relais (si configuré)
-com.victronenergy.grid.*                            ← compteur réseau (si configuré)
-com.victronenergy.meteo                             ← capteur irradiance + TodaysYield
+com.victronenergy.battery.mqtt_1                    ← BMS-360Ah (instance 151)
+com.victronenergy.battery.mqtt_2                    ← BMS-320Ah (instance 152)
+com.victronenergy.pvinverter.mqtt_7                 ← ET112 Micro-Onduleurs (addr 0x07, SN 119253X, instance 32) ✅
+com.victronenergy.heatpump.mqtt_8                   ← ET112 PAC Chauffe-eau (addr 0x08, SN 119215X, instance 30) ✅
+com.victronenergy.temperature.mqtt_1                ← capteur température extérieure (type 4=Outdoor, instance 20)
+com.victronenergy.switch.mqtt_1                     ← ATS CHINT (si configuré, instance 60)
+com.victronenergy.meteo                             ← capteur irradiance PRALRAN + TodaysYield (instance 40)
 com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2     ← onduleur PV (cgwacs Modbus ttyUSB0 addr 2)
+```
+
+Services futurs (quand 0x09 connecté) :
+```
+com.victronenergy.heatpump.mqtt_9                   ← ET112 PAC Climatisation (addr 0x09, SN 061077X, instance 31)
 ```
 
 Si un service manque : vérifier logs `dbus-mqtt-venus` ET que le topic MQTT est bien publié.
 
-> **IMPORTANT** : Le nom exact du PV inverter est `cgwacs_ttyUSB0_mb2` — NE PAS utiliser `rs485`.
+> **IMPORTANT** : Le nom exact du PV inverter cgwacs est `cgwacs_ttyUSB0_mb2` — NE PAS utiliser `rs485`.
 > Toujours vérifier avec `dbus -y | grep pvinverter` avant toute commande.
 
 ### Sauvegarde config NanoPi
@@ -1291,14 +1281,15 @@ git commit -m "chore(nanopi): backup config.toml"
 
 | Service D-Bus | Description | Commande vérification |
 |---|---|---|
-| `com.victronenergy.battery.mqtt_1` | BMS-360Ah | `dbus -y ... /Soc GetValue` |
-| `com.victronenergy.battery.mqtt_2` | BMS-320Ah | `dbus -y ... /Soc GetValue` |
-| `com.victronenergy.acload.mqtt_9` | ET112 PAC Climatisation (addr 0x09, SN: 061077X) ✅ | `dbus -y ... /Ac/Power GetValue` |
-| `com.victronenergy.temperature.mqtt_1` | Capteur ext. (type 4) | `dbus -y ... /Temperature GetValue` |
-| `com.victronenergy.heatpump.mqtt_1` | PAC / chauffe-eau | `dbus -y ... /State GetValue` |
-| `com.victronenergy.meteo` | Irradiance + TodaysYield | `dbus -y ... /TodaysYield GetValue` |
-| `com.victronenergy.pvinverter.mqtt_3` | ET112 micro-inverseurs Pi5 (instance 63) | `dbus -y ... /Ac/Power GetValue` |
+| `com.victronenergy.battery.mqtt_1` | BMS-360Ah (instance 151) | `dbus -y ... /Soc GetValue` |
+| `com.victronenergy.battery.mqtt_2` | BMS-320Ah (instance 152) | `dbus -y ... /Soc GetValue` |
+| `com.victronenergy.pvinverter.mqtt_7` | ET112 Micro-Onduleurs (addr 0x07, SN: 119253X, instance 32) ✅ | `dbus -y ... /Ac/Power GetValue` |
+| `com.victronenergy.heatpump.mqtt_8` | ET112 PAC Chauffe-eau (addr 0x08, SN: 119215X, instance 30) ✅ | `dbus -y ... /Ac/Power GetValue` |
+| `com.victronenergy.temperature.mqtt_1` | Capteur ext. (type 4, instance 20) | `dbus -y ... /Temperature GetValue` |
+| `com.victronenergy.switch.mqtt_1` | ATS CHINT (instance 60) | `dbus -y ... /State GetValue` |
+| `com.victronenergy.meteo` | Irradiance PRALRAN + TodaysYield (instance 40) | `dbus -y ... /TodaysYield GetValue` |
 | `com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2` | Onduleur PV AC (Victron direct) | `dbus -y ... /Ac/Energy/Forward GetValue` |
+| `com.victronenergy.heatpump.mqtt_9` | ET112 PAC Climatisation (addr 0x09, SN: 061077X, instance 31) ⏳ futur | `dbus -y ... /Ac/Power GetValue` |
 
 ### Commandes de diagnostic rapide (📍 NanoPi)
 
@@ -1311,6 +1302,8 @@ dbus -y com.victronenergy.meteo /TodaysYield GetValue
 dbus -y com.victronenergy.temperature.mqtt_1 /Temperature GetValue
 dbus -y com.victronenergy.temperature.mqtt_1 /Connected GetValue
 dbus -y com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2 /Ac/Energy/Forward GetValue
+dbus -y com.victronenergy.pvinverter.mqtt_7 /Ac/Power GetValue
+dbus -y com.victronenergy.heatpump.mqtt_8 /Ac/Power GetValue
 dbus -y com.victronenergy.battery.mqtt_1 /Soc GetValue
 dbus -y com.victronenergy.battery.mqtt_2 /Soc GetValue
 ```

--- a/Config.toml
+++ b/Config.toml
@@ -229,31 +229,29 @@ poll_interval_ms = 5000
 # Taille du ring buffer (720 = 1 heure à 1 mesure/5s)
 ring_buffer_size = 720
 
-# Décommenter au fur et à mesure du branchement physique sur le bus RS485 :
-#
-# [[et112.devices]]              # ← décommenter quand branché (SN: 119253X)
-# address          = "0x07"
-# name             = "Micro Onduleurs"
-# mqtt_index       = 3          # → santuario/pvinverter/3/venus
-# service_type     = "pvinverter"
-# device_instance  = 32
-# position         = 1
-#
-# [[et112.devices]]              # ← décommenter quand branché (SN: 119215X)
-# address          = "0x08"
-# name             = "PAC Chauffe-eau"
-# mqtt_index       = 8          # → santuario/grid/8/venus
-# service_type     = "acload"
-# device_instance  = 30
-# position         = 1
-#
-[[et112.devices]]               # SN: 061077X
-address          = "0x09"
-name             = "PAC Climatisation"
-mqtt_index       = 9
-service_type     = "acload"
-device_instance  = 31
+[[et112.devices]]               # SN: 119253X — branché ✅
+address          = "0x07"
+name             = "Micro Onduleurs"
+mqtt_index       = 7           # → santuario/pvinverter/7/venus
+service_type     = "pvinverter"
+device_instance  = 32
 position         = 1
+
+[[et112.devices]]               # SN: 119215X — branché ✅
+address          = "0x08"
+name             = "PAC Chauffe-eau"
+mqtt_index       = 8           # → santuario/heatpump/8/venus
+service_type     = "heatpump"
+device_instance  = 30
+position         = 1
+
+# [[et112.devices]]              # SN: 061077X — non connecté pour le moment
+# address          = "0x09"
+# name             = "PAC Climatisation"
+# mqtt_index       = 9          # → santuario/heatpump/9/venus
+# service_type     = "heatpump"
+# device_instance  = 31
+# position         = 1
 
 
 [influxdb]

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -128,8 +128,9 @@ async fn publish_irradiance(
 
 /// Publie un snapshot ET112 sur le topic `santuario/{service_type}/{idx}/venus`.
 ///
-/// service_type = "pvinverter" → topic pvinverter/{idx}/venus
-/// service_type = "acload"     → topic grid/{idx}/venus
+/// service_type = "pvinverter" → topic pvinverter/{idx}/venus  (PvinverterPayload)
+/// service_type = "acload"     → topic grid/{idx}/venus        (GridPayload)
+/// service_type = "heatpump"   → topic heatpump/{idx}/venus    (HeatpumpPayload)
 async fn publish_et112_snapshot(
     client: &AsyncClient,
     cfg: &MqttConfig,
@@ -142,33 +143,53 @@ async fn publish_et112_snapshot(
         .rsplit_once('/')
         .map(|(prefix, _)| prefix)
         .unwrap_or("santuario");
-    let topic_prefix = if service_type == "acload" { "grid" } else { "pvinverter" };
+
+    let topic_prefix = match service_type {
+        "acload"   => "grid",
+        "heatpump" => "heatpump",
+        _          => "pvinverter",
+    };
     let topic = format!("{}/{}/{}/venus", base, topic_prefix, mqtt_index);
 
-    let payload = json!({
-        "Ac": {
-            "L1": {
-                "Voltage": snap.voltage_v,
-                "Current": snap.current_a,
-                "Power":   snap.power_w,
+    let payload = if service_type == "heatpump" {
+        // HeatpumpPayload — l'ET112 mesure la consommation AC de la PAC
+        json!({
+            "Ac": {
+                "Power":  snap.power_w,
+                "Energy": { "Forward": snap.energy_import_kwh() }
+            },
+            "Position":    position,   // 1=AC Output
+            "State":       0,          // 0=Off/unknown (l'ET112 ne connaît pas l'état)
+            "ProductName": snap.name,
+            "CustomName":  snap.name,
+        })
+    } else {
+        // PvinverterPayload / GridPayload — format complet L1
+        json!({
+            "Ac": {
+                "L1": {
+                    "Voltage": snap.voltage_v,
+                    "Current": snap.current_a,
+                    "Power":   snap.power_w,
+                    "Energy": {
+                        "Forward": snap.energy_import_kwh(),
+                        "Reverse": snap.energy_export_kwh()
+                    }
+                },
+                "Power":  snap.power_w,
                 "Energy": {
                     "Forward": snap.energy_import_kwh(),
                     "Reverse": snap.energy_export_kwh()
                 }
             },
-            "Power":         snap.power_w,
-            "Energy": {
-                "Forward":   snap.energy_import_kwh(),
-                "Reverse":   snap.energy_export_kwh()
-            }
-        },
-        "StatusCode":           7,   // Running
-        "ErrorCode":            0,   // No Error
-        "Position":             position,  // 0=AC Input, 1=AC Output (configurable)
-        "IsGenericEnergyMeter": 1,   // ET112 = generic energy meter
-        "ProductName":          snap.name,
-        "CustomName":           snap.name,
-    });
+            "StatusCode":           7,   // Running
+            "ErrorCode":            0,   // No Error
+            "Position":             position,
+            "IsGenericEnergyMeter": 1,
+            "ProductName":          snap.name,
+            "CustomName":           snap.name,
+        })
+    };
 
     client
         .publish(&topic, QoS::AtLeastOnce, true, serde_json::to_vec(&payload)?)

--- a/nanoPi/config-nanopi.toml
+++ b/nanoPi/config-nanopi.toml
@@ -90,14 +90,14 @@ device_instance  = 20
 topic_prefix = "santuario/heatpump"
 
 [[heatpumps]]
-mqtt_index      = 1
-name            = "Chauffe-eau"
+mqtt_index      = 8             # ET112 addr=0x08 (SN: 119215X) — PAC Chauffe-eau branché ✅
+name            = "PAC Chauffe-eau"
 device_instance = 30
 
-# PAC LG (future intégration) :
+# PAC Climatisation (ET112 addr=0x09, SN: 061077X) — non connecté pour le moment :
 # [[heatpumps]]
-# mqtt_index      = 2
-# name            = "PAC LG Climatisation"
+# mqtt_index      = 9
+# name            = "PAC Climatisation"
 # device_instance = 31
 
 # -----------------------------------------------------------------------------
@@ -150,12 +150,6 @@ topic_prefix = "santuario/grid"
 # device_instance = 401
 # service_type    = "grid"     # "grid" ou "acload"
 
-[[grids]]
-mqtt_index      = 9
-name            = "PAC Climatisation"
-device_instance = 31
-service_type    = "acload"   # ET112 addr=0x09 sur bus RS485 ttyUSB0
-
 # Décommenter lors de la migration des ET112 acload depuis le Victron vers Pi5 :
 # [[grids]]
 # mqtt_index      = 4
@@ -192,9 +186,9 @@ service_type    = "acload"   # ET112 addr=0x09 sur bus RS485 ttyUSB0
 topic_prefix = "santuario/pvinverter"
 
 [[pvinverters]]
-mqtt_index      = 3
+mqtt_index      = 7             # ET112 addr=0x07 (SN: 119253X) — Micro-Onduleurs branché ✅
 name            = "Micro Onduleurs"
-device_instance = 63          # remplace cgwacs_ttyUSB0_mb2 après migration
+device_instance = 32
 
 # -----------------------------------------------------------------------------
 # Platform Pi5 — état backup/restore (singleton)


### PR DESCRIPTION
…es MQTT et instances VRM

- bridges/mqtt.rs : ajout service_type heatpump → topic santuario/heatpump/{n}/venus
- Config.toml : activer ET112 0x07 (pvinverter/7/32) et 0x08 (heatpump/8/30), commenter 0x09
- config-nanopi.toml : pvinverter mqtt_7/instance 32, heatpump mqtt_8/instance 30
- CLAUDE.md : inventaire RS485 complet + services D-Bus nominaux mis à jour