### PR TITLE
fix(config): supprimer [[heatpumps]] mqtt_index=1 inutilisé dans Conf…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -168,16 +168,9 @@ device_instance  = 20      # DeviceInstance Venus OS / VRM
 # Préfixe des topics heatpump
 topic_prefix = "santuario/heatpump"
 
-[[heatpumps]]
-mqtt_index      = 1       # Topic : santuario/heatpump/1/venus
-name            = "Chauffe-eau"
-device_instance = 30      # DeviceInstance Venus OS / VRM
-
-# Pompe à chaleur LG (future intégration — même service D-Bus)
-# [[heatpumps]]
-# mqtt_index      = 2     # Topic : santuario/heatpump/2/venus
-# name            = "PAC LG Climatisation"
-# device_instance = 31
+# Les PAC/chauffe-eau sont déclarés via [[et112.devices]] (service_type="heatpump")
+# et configurés dans nanoPi/config-nanopi.toml côté dbus-mqtt-venus.
+# Aucun [[heatpumps]] ici — daly-bms-server ne lit pas cette section.
 
 # =============================================================================
 # Capteur météo / irradiance RS485 (com.victronenergy.meteo)


### PR DESCRIPTION
…ig.toml Pi5

daly-bms-server ne lit pas [[heatpumps]] — les PAC sont déclarés via [[et112.devices]] service_type="heatpump". Cette entrée spurieuse (mqtt_index=1, device_instance=30) créait la confusion et conflictait avec mqtt_8 (instance 30).

Source du service fantôme heatpump.mqtt_1 sur NanoPi : retained MQTT sur santuario/heatpump/1/venus — à effacer manuellement sur Pi5 :
  mosquitto_pub -h 192.168.1.120 -p 1883 -t 'santuario/heatpump/1/venus' -n -r

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH