### PR TITLE
fix(dbus-mqtt-venus): ignorer retained MQTT fantômes — garde is_confi…

### DIFF
--- a/crates/dbus-mqtt-venus/src/grid_manager.rs
+++ b/crates/dbus-mqtt-venus/src/grid_manager.rs
@@ -66,6 +66,10 @@ impl GridManager {
 
     async fn handle_event(&mut self, evt: GridMqttEvent) -> Result<()> {
         let idx = evt.mqtt_index;
+        if !self.is_configured(idx) {
+            warn!(index = idx, "Message grid reçu pour index non configuré — ignoré (retained MQTT fantôme ?)");
+            return Ok(());
+        }
         if !self.services.contains_key(&idx) {
             let handle = self.create_service(idx).await?;
             self.services.insert(idx, handle);
@@ -74,6 +78,12 @@ impl GridManager {
             svc.update(&evt.payload).await?;
         }
         Ok(())
+    }
+
+    fn is_configured(&self, idx: u8) -> bool {
+        self.grid_refs.iter().enumerate().any(|(pos, g)| {
+            g.mqtt_index.unwrap_or((pos + 1) as u8) == idx
+        })
     }
 
     async fn create_service(&self, idx: u8) -> Result<GridServiceHandle> {

--- a/crates/dbus-mqtt-venus/src/heatpump_manager.rs
+++ b/crates/dbus-mqtt-venus/src/heatpump_manager.rs
@@ -65,6 +65,10 @@ impl HeatpumpManager {
 
     async fn handle_event(&mut self, evt: HeatpumpMqttEvent) -> Result<()> {
         let idx = evt.mqtt_index;
+        if !self.is_configured(idx) {
+            warn!(index = idx, "Message heatpump reçu pour index non configuré — ignoré (retained MQTT fantôme ?)");
+            return Ok(());
+        }
         if !self.services.contains_key(&idx) {
             let handle = self.create_service(idx).await?;
             self.services.insert(idx, handle);
@@ -73,6 +77,12 @@ impl HeatpumpManager {
             svc.update(&evt.payload).await?;
         }
         Ok(())
+    }
+
+    fn is_configured(&self, idx: u8) -> bool {
+        self.heatpump_refs.iter().enumerate().any(|(pos, h)| {
+            h.mqtt_index.unwrap_or((pos + 1) as u8) == idx
+        })
     }
 
     async fn create_service(&self, idx: u8) -> Result<HeatpumpServiceHandle> {

--- a/crates/dbus-mqtt-venus/src/pvinverter_manager.rs
+++ b/crates/dbus-mqtt-venus/src/pvinverter_manager.rs
@@ -65,6 +65,10 @@ impl PvinverterManager {
 
     async fn handle_event(&mut self, evt: PvinverterMqttEvent) -> Result<()> {
         let idx = evt.mqtt_index;
+        if !self.is_configured(idx) {
+            warn!(index = idx, "Message pvinverter reçu pour index non configuré — ignoré (retained MQTT fantôme ?)");
+            return Ok(());
+        }
         if !self.services.contains_key(&idx) {
             let handle = self.create_service(idx).await?;
             self.services.insert(idx, handle);
@@ -73,6 +77,12 @@ impl PvinverterManager {
             svc.update(&evt.payload).await?;
         }
         Ok(())
+    }
+
+    fn is_configured(&self, idx: u8) -> bool {
+        self.pvinverter_refs.iter().enumerate().any(|(pos, p)| {
+            p.mqtt_index.unwrap_or((pos + 1) as u8) == idx
+        })
     }
 
     async fn create_service(&self, idx: u8) -> Result<PvinverterServiceHandle> {

--- a/crates/dbus-mqtt-venus/src/switch_manager.rs
+++ b/crates/dbus-mqtt-venus/src/switch_manager.rs
@@ -65,6 +65,10 @@ impl SwitchManager {
 
     async fn handle_event(&mut self, evt: SwitchMqttEvent) -> Result<()> {
         let idx = evt.mqtt_index;
+        if !self.is_configured(idx) {
+            warn!(index = idx, "Message switch reçu pour index non configuré — ignoré (retained MQTT fantôme ?)");
+            return Ok(());
+        }
         if !self.services.contains_key(&idx) {
             let handle = self.create_service(idx).await?;
             self.services.insert(idx, handle);
@@ -73,6 +77,12 @@ impl SwitchManager {
             svc.update(&evt.payload).await?;
         }
         Ok(())
+    }
+
+    fn is_configured(&self, idx: u8) -> bool {
+        self.switch_refs.iter().enumerate().any(|(pos, s)| {
+            s.mqtt_index.unwrap_or((pos + 1) as u8) == idx
+        })
     }
 
     async fn create_service(&self, idx: u8) -> Result<SwitchServiceHandle> {

--- a/nanoPi/config-nanopi.toml
+++ b/nanoPi/config-nanopi.toml
@@ -94,11 +94,10 @@ mqtt_index      = 8             # ET112 addr=0x08 (SN: 119215X) — PAC Chauffe-
 name            = "PAC Chauffe-eau"
 device_instance = 30
 
-# PAC Climatisation (ET112 addr=0x09, SN: 061077X) — non connecté pour le moment :
-# [[heatpumps]]
-# mqtt_index      = 9
-# name            = "PAC Climatisation"
-# device_instance = 31
+[[heatpumps]]
+mqtt_index      = 9             # ET112 addr=0x09 (SN: 061077X) — PAC Climatisation branché ✅
+name            = "PAC Climatisation"
+device_instance = 31
 
 # -----------------------------------------------------------------------------
 # Capteur météo / irradiance (singleton — un seul capteur)


### PR DESCRIPTION
…gured() dans tous les managers

Problème : HeatpumpManager (et Pvinverter/Grid/Switch) créaient un service D-Bus pour N'IMPORTE quel mqtt_index reçu, même non configuré dans [[heatpumps]]/etc. Un message retained résiduel sur santuario/heatpump/1/venus créait heatpump.mqtt_1 avec fallback device_instance=1, visible dans VRM comme "Heat Pump 1".

Fix : is_configured(idx) vérifie que l'index est bien dans les refs config avant de créer le service. Message WARN loggé si index inconnu reçu.

Managers corrigés : heatpump_manager, pvinverter_manager, switch_manager, grid_manager.

Config NanoPi : activer [[heatpumps]] mqtt_index=9 "PAC Climatisation" device_instance=31 (était commenté → fallback "Heat Pump 9" [9] dans VRM au lieu de "PAC Climatisation" [31]).

Action manuelle requise sur Pi5 après déploiement :
  mosquitto_pub -h 192.168.1.120 -p 1883 -t 'santuario/heatpump/1/venus' -n -r

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH