### PR TITLE
feat(dashboard): rebrand 'DalyBMS' → 'Monitoring' + page ET112 unique…

### DIFF
--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -382,6 +382,29 @@ pub async fn dashboard_settings(State(state): State<AppState>) -> Response {
 // Dashboard ET112
 // =============================================================================
 
+/// Résumé d'un ET112 pour la page d'ensemble.
+#[derive(Debug, Clone)]
+pub struct Et112DeviceSummary {
+    pub name:              String,
+    pub address:           u8,
+    pub addr_hex:          String,
+    pub connected:         bool,
+    pub power_w:           f32,
+    pub voltage_v:         f32,
+    pub current_a:         f32,
+    pub energy_import_kwh: f32,
+    pub energy_export_kwh: f32,
+    pub last_ts:           String,
+    pub service_type:      String,
+}
+
+#[derive(Template)]
+#[template(path = "et112_all.html")]
+struct Et112AllTemplate {
+    devices:      Vec<Et112DeviceSummary>,
+    device_count: usize,
+}
+
 #[derive(Template)]
 #[template(path = "et112.html")]
 struct Et112Template {
@@ -455,14 +478,48 @@ pub async fn dashboard_et112(
     })
 }
 
-/// Liste des ET112 configurés (page d'accueil redirige vers premier ET112).
+/// Page d'ensemble — tous les ET112 configurés.
 pub async fn dashboard_et112_list(State(state): State<AppState>) -> Response {
-    let devices = &state.config.et112.devices;
-    if let Some(first) = devices.first() {
-        let addr = first.parsed_address();
-        return Redirect::temporary(&format!("/dashboard/et112/{}", addr)).into_response();
+    let configs = &state.config.et112.devices;
+    if configs.is_empty() {
+        return (StatusCode::NOT_FOUND, "Aucun ET112 configuré").into_response();
     }
-    (StatusCode::NOT_FOUND, "Aucun ET112 configuré").into_response()
+
+    let mut devices: Vec<Et112DeviceSummary> = Vec::new();
+    for cfg in configs {
+        let addr = cfg.parsed_address();
+        let snap_opt = state.et112_latest_for(addr).await;
+        let connected = snap_opt.is_some();
+        let (power_w, voltage_v, current_a, energy_import_kwh, energy_export_kwh, last_ts) =
+            if let Some(ref s) = snap_opt {
+                (
+                    s.power_w,
+                    s.voltage_v,
+                    s.current_a,
+                    s.energy_import_kwh(),
+                    s.energy_export_kwh(),
+                    s.timestamp.format("%H:%M:%S").to_string(),
+                )
+            } else {
+                (0.0, 0.0, 0.0, 0.0, 0.0, "—".to_string())
+            };
+        devices.push(Et112DeviceSummary {
+            name:              cfg.name.clone(),
+            address:           addr,
+            addr_hex:          format!("{:#04x}", addr),
+            connected,
+            power_w,
+            voltage_v,
+            current_a,
+            energy_import_kwh,
+            energy_export_kwh,
+            last_ts,
+            service_type:      cfg.service_type.clone(),
+        });
+    }
+
+    let device_count = devices.len();
+    render(Et112AllTemplate { devices, device_count })
 }
 
 /// Construit le routeur du dashboard (à fusionner dans le routeur principal).

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}DalyBMS{% endblock %}</title>
+  <title>{% block title %}Monitoring{% endblock %}</title>
   <style>
     /* ─── Variables ───────────────────────────────────────────────────── */
     :root {
@@ -545,10 +545,10 @@
 <body>
 
 <nav class="nav">
-  <div class="nav-brand">⚡ Daly<span>BMS</span></div>
+  <div class="nav-brand">⚡ <span>Monitoring</span></div>
   <div class="nav-links">
-    <a href="/dashboard">Vue d'ensemble</a>
-    <a href="/dashboard/et112">⚡ ET112</a>
+    <a href="/dashboard">🔋 BMS</a>
+    <a href="/dashboard/et112">⚡ Compteurs ET112</a>
     <a href="/dashboard/settings">Paramètres</a>
     <a href="/dashboard/logs">Logs</a>
     <a href="/api/v1/system/status" target="_blank">API</a>
@@ -564,7 +564,7 @@
 </main>
 
 <footer>
-  DalyBMS Rust Edition &nbsp;·&nbsp;
+  Monitoring &nbsp;·&nbsp;
   <a href="/api/v1/system/status">API status</a> &nbsp;·&nbsp;
   <a href="/ws/bms/stream">WebSocket</a>
 </footer>

--- a/crates/daly-bms-server/templates/bms_detail.html
+++ b/crates/daly-bms-server/templates/bms_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}BMS {{ detail.summary.address_hex }} — DalyBMS{% endblock %}
+{% block title %}BMS {{ detail.summary.address_hex }} — Monitoring{% endblock %}
 
 {% block content %}
 

--- a/crates/daly-bms-server/templates/et112.html
+++ b/crates/daly-bms-server/templates/et112.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}ET112 — {{ name }} — DalyBMS{% endblock %}
+{% block title %}ET112 — {{ name }} — Monitoring{% endblock %}
 
 {% block content %}
 

--- a/crates/daly-bms-server/templates/et112_all.html
+++ b/crates/daly-bms-server/templates/et112_all.html
@@ -1,0 +1,130 @@
+{% extends "base.html" %}
+
+{% block title %}Compteurs ET112 — Monitoring{% endblock %}
+
+{% block content %}
+
+{# ─── En-tête ────────────────────────────────────────────────────────────── #}
+<div class="info-bar">
+  <strong>Compteurs ET112</strong>
+  <span>{{ device_count }} appareil(s) configuré(s)</span>
+</div>
+
+{# ─── Grille des compteurs ───────────────────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(360px,1fr));gap:1rem;">
+
+{% for d in devices %}
+<div class="bms-card-ng {% if !d.connected %}{% endif %}" id="et112-card-{{ d.address }}" style="{% if !d.connected %}opacity:0.7;{% endif %}">
+
+  {# ── En-tête carte ──── #}
+  <div class="bms-hdr" style="{% if d.connected %}background:#1a5f8a;{% else %}background:#57606a;{% endif %}">
+    <div class="bms-hdr-title">
+      ⚡ {{ d.name }}
+    </div>
+    <div class="bms-hdr-right">
+      {% if d.connected %}
+        <div class="bms-live-dot"></div>
+        <span>LIVE</span>
+      {% else %}
+        <span style="color:rgba(255,255,255,0.5)">Hors ligne</span>
+      {% endif %}
+      <div class="bms-can-badge">{{ d.addr_hex }}</div>
+      <span class="bms-hdr-ts" id="ts-{{ d.address }}">{{ d.last_ts }}</span>
+    </div>
+  </div>
+
+  {% if d.connected %}
+
+  {# ── KPI 4 colonnes ── #}
+  <div class="kpi4">
+    <div class="kpi4-cell kpi4-p">
+      <div class="kpi4-lbl">Puissance</div>
+      <div class="kpi4-val {% if d.power_w >= 0.0 %}chg{% else %}dch{% endif %}" id="p-{{ d.address }}">
+        {{ d.power_w|f1 }} W
+      </div>
+    </div>
+    <div class="kpi4-cell kpi4-v">
+      <div class="kpi4-lbl">Tension</div>
+      <div class="kpi4-val" id="v-{{ d.address }}">{{ d.voltage_v|f1 }} V</div>
+    </div>
+    <div class="kpi4-cell kpi4-i">
+      <div class="kpi4-lbl">Courant</div>
+      <div class="kpi4-val" id="i-{{ d.address }}">{{ d.current_a|f2 }} A</div>
+    </div>
+    <div class="kpi4-cell">
+      <div class="kpi4-lbl">Type</div>
+      <div class="kpi4-val" style="font-size:0.78rem;">{{ d.service_type }}</div>
+    </div>
+  </div>
+
+  {# ── Énergie ── #}
+  <div style="display:grid;grid-template-columns:1fr 1fr;border-bottom:1px solid var(--border);">
+    <div style="padding:0.45rem 0.65rem;border-right:1px solid var(--border);">
+      <div class="kpi4-lbl">⬇ Énergie importée</div>
+      <div class="kpi4-val" style="color:var(--green)" id="imp-{{ d.address }}">
+        {{ d.energy_import_kwh|f1 }} kWh
+      </div>
+    </div>
+    <div style="padding:0.45rem 0.65rem;">
+      <div class="kpi4-lbl">⬆ Énergie exportée</div>
+      <div class="kpi4-val" style="color:var(--accent)" id="exp-{{ d.address }}">
+        {{ d.energy_export_kwh|f1 }} kWh
+      </div>
+    </div>
+  </div>
+
+  {% else %}
+
+  {# ── Hors ligne ── #}
+  <div style="padding:1.5rem;text-align:center;color:var(--muted);">
+    <div style="font-size:1.5rem;margin-bottom:0.5rem">⏳</div>
+    <div style="font-size:0.8rem">En attente du premier snapshot…</div>
+    <div style="font-size:0.7rem;margin-top:0.25rem">Adresse Modbus : <code>{{ d.addr_hex }}</code></div>
+  </div>
+
+  {% endif %}
+
+  {# ── Lien détail ── #}
+  <div style="padding:0.4rem 0.75rem;display:flex;justify-content:flex-end;border-top:1px solid var(--border);">
+    <a class="link-detail" href="/dashboard/et112/{{ d.address }}">Détails →</a>
+  </div>
+
+</div>
+{% endfor %}
+
+</div>
+
+{# ─── Scripts de mise à jour ─────────────────────────────────────────────── #}
+<script>
+const ET112_ADDRS = [{% for d in devices %}{{ d.address }}{% if !loop.last %}, {% endif %}{% endfor %}];
+
+async function updateAll() {
+    for (const addr of ET112_ADDRS) {
+        try {
+            const resp = await fetch(`/api/v1/et112/${addr}/status`);
+            if (!resp.ok) continue;
+            const d = await resp.json();
+            const pw = document.getElementById(`p-${addr}`);
+            const vv = document.getElementById(`v-${addr}`);
+            const iv = document.getElementById(`i-${addr}`);
+            const im = document.getElementById(`imp-${addr}`);
+            const ex = document.getElementById(`exp-${addr}`);
+            const ts = document.getElementById(`ts-${addr}`);
+            if (pw) {
+                pw.textContent = d.power_w.toFixed(1) + ' W';
+                pw.className = 'kpi4-val ' + (d.power_w >= 0 ? 'chg' : 'dch');
+            }
+            if (vv) vv.textContent = d.voltage_v.toFixed(1) + ' V';
+            if (iv) iv.textContent = d.current_a.toFixed(2) + ' A';
+            if (im) im.textContent = (d.energy_import_wh / 1000).toFixed(1) + ' kWh';
+            if (ex) ex.textContent = (d.energy_export_wh / 1000).toFixed(1) + ' kWh';
+            if (ts) ts.textContent = new Date().toLocaleTimeString();
+        } catch(e) {}
+    }
+}
+
+updateAll();
+setInterval(updateAll, 5000);
+</script>
+
+{% endblock %}

--- a/crates/daly-bms-server/templates/index.html
+++ b/crates/daly-bms-server/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Vue d'ensemble — DalyBMS{% endblock %}
+{% block title %}Vue d'ensemble — Monitoring{% endblock %}
 
 {% block content %}
 

--- a/crates/daly-bms-server/templates/logs.html
+++ b/crates/daly-bms-server/templates/logs.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Logs — DalyBMS{% endblock %}
+{% block title %}Logs — Monitoring{% endblock %}
 
 {% block content %}
 <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">

--- a/crates/daly-bms-server/templates/settings.html
+++ b/crates/daly-bms-server/templates/settings.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Paramètres BMS — DalyBMS{% endblock %}
+{% block title %}Paramètres BMS — Monitoring{% endblock %}
 
 {% block content %}
 <style>

--- a/flux-nodered/meteo.json
+++ b/flux-nodered/meteo.json
@@ -535,12 +535,14 @@
     "type": "function",
     "z": "e6e3a16384301f83",
     "name": "Restaurer yield_yesterday",
-    "func": "const raw = msg.payload;\nif (raw === '' || raw === null || raw === undefined) {\n    global.set('yield_yesterday', 0);\n    node.status({fill:'grey', shape:'ring', text:'Pas de yield_yesterday (1er jour)'});\n    return null;\n}\nconst val = parseFloat(raw);\nif (!isNaN(val) && val >= 0) {\n    global.set('yield_yesterday', val);\n    node.status({fill:'yellow', shape:'dot', text:'Hier: ' + val.toFixed(2) + ' kWh'});\n}\nreturn null;",
+    "func": "const raw = msg.payload;\nif (raw === '' || raw === null || raw === undefined) {\n    global.set('yield_yesterday', 0);\n    node.status({fill:'grey', shape:'ring', text:'Pas de yield_yesterday (1er jour)'});\n    return null;\n}\nconst val = parseFloat(raw);\n// Seuil raisonnable : production max journalière ~50 kWh sur cette installation\nconst MAX_DAILY_KWH = 50;\nif (!isNaN(val) && val >= 0 && val <= MAX_DAILY_KWH) {\n    global.set('yield_yesterday', val);\n    node.status({fill:'yellow', shape:'dot', text:'Hier: ' + val.toFixed(2) + ' kWh'});\n} else if (!isNaN(val) && val > MAX_DAILY_KWH) {\n    // Valeur aberrante (cumul brut) — réinitialiser et nettoyer le retained\n    global.set('yield_yesterday', 0);\n    node.status({fill:'orange', shape:'ring', text:'Valeur aberrante ignorée: ' + val.toFixed(1) + ' kWh → reset'});\n    // Publier 0 pour écraser le retained incorrect\n    return {payload: '0', topic: 'santuario/persist/yield_yesterday', retain: true};\n}\nreturn null;",
     "outputs": 1,
     "x": 480,
     "y": 680,
     "wires": [
-      []
+      [
+        "yield_yesterday_persist_out"
+      ]
     ]
   }
 ]


### PR DESCRIPTION
… + fix yield_yesterday

- Renommage site : 'DalyBMS' → 'Monitoring' (tous les templates)
- Navigation : '🔋 BMS' + '⚡ Compteurs ET112' (liens clairs)
- Nouvelle page /dashboard/et112 : vue d'ensemble des 3 ET112 en grid (plus de redirection vers le 1er appareil)
- Chaque carte ET112 : puissance, tension, courant, énergie, type de service Mise à jour automatique toutes les 5s via fetch /api/v1/et112/{addr}/status
- meteo.json : sanity check yield_yesterday (max 50 kWh/j) Valeurs aberrantes (ex: 615.9 kWh cumul brut) ignorées + retained corrigé automatiquement via output → yield_yesterday_persist_out

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH