### PR TITLE
feat(makefile): add sync target for Pi5 deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,15 @@ uninstall:
 
 PI_HOST ?= pi5compute@192.168.1.141
 PI_BIN_PATH ?= /usr/local/bin/daly-bms-server
+BRANCH ?= claude/review-venus-integration-35qN7
+
+# sync : utiliser sur Pi5 à la place de git pull
+# Écrase les fichiers locaux sans créer de commits
+.PHONY: sync
+sync:
+	git fetch origin $(BRANCH)
+	git reset --hard origin/$(BRANCH)
+	@echo "✓ Synchronisé sur origin/$(BRANCH) (aucun commit local)"
 
 .PHONY: deploy
 


### PR DESCRIPTION
Replace 'git pull --rebase' with 'make sync' on Pi5. Uses fetch + reset --hard to avoid local commits.

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH