### PR TITLE
feat(tasmota): add MQTT subscriber, REST API, dashboard and InfluxDB …

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -247,6 +247,35 @@ device_instance  = 31
 position         = 1
 
 
+# =============================================================================
+# Prises connectées Tasmota (MQTT natif Tasmota)
+# =============================================================================
+# Tasmota publie automatiquement via MQTT :
+#   tele/{tasmota_id}/SENSOR  → mesures énergie (puissance, tension, courant, kWh)
+#   stat/{tasmota_id}/POWER   → état relais ON/OFF
+#
+# Prérequis :
+#   - Tasmota configuré pour publier sur le broker MQTT (mqtt.host / mqtt.port)
+#   - Dans l'interface Tasmota : Configuration → MQTT → Host + User + Password
+#   - Option "Full Topic" recommandée : %prefix%/%topic%/ (défaut Tasmota)
+#
+# service_type = "switch" → forward vers Venus OS com.victronenergy.switch (si mqtt_index défini)
+# service_type = "acload" → forward vers Venus OS com.victronenergy.grid (acload)
+
+[tasmota]
+# Taille du ring buffer par prise (720 = 1 heure si SENSOR toutes les 5s)
+ring_buffer_size = 720
+
+# Décommenter et adapter pour chaque prise Tasmota :
+# [[tasmota.devices]]
+# id           = 1           # Identifiant interne unique (clé du ring buffer)
+# tasmota_id   = "tasmota_01" # Nom du device Tasmota dans les topics MQTT
+# name         = "Prise Salon"
+# mqtt_index   = 1            # Optionnel — forward Venus OS switch/1/venus
+# service_type = "switch"     # "switch" (défaut) ou "acload"
+# device_instance = 500       # Optionnel — instance D-Bus Venus OS
+
+
 [influxdb]
 # true  = activer l'écriture InfluxDB (Docker infra doit être démarré)
 # false = désactiver (pas de Docker, ou test sans InfluxDB)

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -5,6 +5,7 @@
 pub mod system;
 pub mod bms;
 pub mod et112;
+pub mod tasmota;
 
 use crate::dashboard;
 use crate::state::AppState;
@@ -62,6 +63,11 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/et112",                   get(et112::list_et112))
         .route("/api/v1/et112/:addr/status",      get(et112::get_et112_status))
         .route("/api/v1/et112/:addr/history",     get(et112::get_et112_history))
+
+        // ── Tasmota ──────────────────────────────────────────────────────────
+        .route("/api/v1/tasmota",                 get(tasmota::list_tasmota))
+        .route("/api/v1/tasmota/:id/status",      get(tasmota::get_tasmota_status))
+        .route("/api/v1/tasmota/:id/history",     get(tasmota::get_tasmota_history))
 
         // ── WebSocket ─────────────────────────────────────────────────────────
         .route("/ws/bms/stream",         get(bms::ws_all))

--- a/crates/daly-bms-server/src/api/tasmota.rs
+++ b/crates/daly-bms-server/src/api/tasmota.rs
@@ -1,0 +1,61 @@
+//! Endpoints REST pour les prises connectées Tasmota.
+//!
+//! Routes :
+//! ```text
+//! GET /api/v1/tasmota                  → liste des prises configurées + dernier snapshot
+//! GET /api/v1/tasmota/:id/status       → dernier snapshot d'une prise
+//! GET /api/v1/tasmota/:id/history      → historique (ring buffer)
+//! ```
+
+use crate::state::AppState;
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use serde::Deserialize;
+
+/// GET /api/v1/tasmota — liste de toutes les prises + dernier snapshot
+pub async fn list_tasmota(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let devices = &state.config.tasmota.devices;
+    let mut result = Vec::new();
+    for dev in devices {
+        let snap = state.tasmota_latest_for(dev.id).await;
+        result.push(serde_json::json!({
+            "id":           dev.id,
+            "name":         dev.name,
+            "tasmota_id":   dev.tasmota_id,
+            "mqtt_index":   dev.mqtt_index,
+            "service_type": dev.service_type,
+            "snapshot":     snap,
+        }));
+    }
+    Json(serde_json::json!({ "tasmota": result }))
+}
+
+/// GET /api/v1/tasmota/:id/status — dernier snapshot
+pub async fn get_tasmota_status(
+    State(state): State<AppState>,
+    Path(id_str): Path<String>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let id   = id_str.trim().parse::<u8>().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let snap = state.tasmota_latest_for(id).await.ok_or(StatusCode::NOT_FOUND)?;
+    Ok(Json(serde_json::to_value(&snap).unwrap_or_default()))
+}
+
+#[derive(Deserialize)]
+pub struct HistoryParams {
+    pub limit: Option<usize>,
+}
+
+/// GET /api/v1/tasmota/:id/history — historique complet
+pub async fn get_tasmota_history(
+    State(state): State<AppState>,
+    Path(id_str): Path<String>,
+    Query(params): Query<HistoryParams>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let id    = id_str.trim().parse::<u8>().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let limit = params.limit.unwrap_or(360).min(1440);
+    let snaps = state.tasmota_history_for(id, limit).await;
+    Ok(Json(serde_json::json!({ "id": id, "count": snaps.len(), "history": snaps })))
+}

--- a/crates/daly-bms-server/src/bridges/influx.rs
+++ b/crates/daly-bms-server/src/bridges/influx.rs
@@ -7,6 +7,7 @@
 use crate::config::InfluxConfig;
 use crate::et112::Et112Snapshot;
 use crate::state::AppState;
+use crate::tasmota::TasmotaSnapshot;
 use daly_bms_core::types::BmsSnapshot;
 use influxdb2::Client;
 use influxdb2::models::DataPoint;
@@ -32,9 +33,11 @@ pub async fn run_influx_bridge(state: AppState, cfg: InfluxConfig) {
     let mut rx = state.subscribe_ws();
     let flush_interval = Duration::from_secs_f64(cfg.batch_flush_interval_sec.max(1.0));
     let mut flush_ticker = tokio::time::interval(flush_interval);
-    // Ticker séparé pour polling ET112 (état est dans state, pas dans channel broadcast)
+    // Ticker séparé pour polling ET112 + Tasmota (état est dans state)
     let et112_interval = Duration::from_secs(10);
     let mut et112_ticker = tokio::time::interval(et112_interval);
+    let tasmota_interval = Duration::from_secs(10);
+    let mut tasmota_ticker = tokio::time::interval(tasmota_interval);
 
     loop {
         tokio::select! {
@@ -59,6 +62,17 @@ pub async fn run_influx_bridge(state: AppState, cfg: InfluxConfig) {
                     flush_batch(&client, &cfg.bucket, &mut batch).await;
                 }
             }
+            _ = tasmota_ticker.tick() => {
+                let tasmota_snaps = state.tasmota_latest_all().await;
+                for snap in tasmota_snaps {
+                    if let Ok(p) = tasmota_snapshot_to_point(&snap) {
+                        batch.push(p);
+                    }
+                }
+                if !batch.is_empty() {
+                    flush_batch(&client, &cfg.bucket, &mut batch).await;
+                }
+            }
             _ = flush_ticker.tick() => {
                 if !batch.is_empty() {
                     flush_batch(&client, &cfg.bucket, &mut batch).await;
@@ -66,6 +80,32 @@ pub async fn run_influx_bridge(state: AppState, cfg: InfluxConfig) {
             }
         }
     }
+}
+
+/// Convertit un [`TasmotaSnapshot`] en un point InfluxDB.
+///
+/// Measurement : `tasmota_status`
+/// Tags : `id`, `name`, `tasmota_id`
+fn tasmota_snapshot_to_point(snap: &TasmotaSnapshot) -> anyhow::Result<DataPoint> {
+    let ts_ns = snap.timestamp.timestamp_nanos_opt().unwrap_or(0);
+
+    let point = DataPoint::builder("tasmota_status")
+        .tag("id",         snap.id.to_string())
+        .tag("name",       snap.name.clone())
+        .tag("tasmota_id", snap.tasmota_id.clone())
+        .field("power_on",            snap.power_on as i64)
+        .field("power_w",             snap.power_w as f64)
+        .field("voltage_v",           snap.voltage_v as f64)
+        .field("current_a",           snap.current_a as f64)
+        .field("apparent_power_va",   snap.apparent_power_va as f64)
+        .field("power_factor",        snap.power_factor as f64)
+        .field("energy_today_kwh",    snap.energy_today_kwh as f64)
+        .field("energy_yesterday_kwh",snap.energy_yesterday_kwh as f64)
+        .field("energy_total_kwh",    snap.energy_total_kwh as f64)
+        .timestamp(ts_ns)
+        .build()?;
+
+    Ok(point)
 }
 
 /// Flush le batch vers InfluxDB et vide le vecteur.

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -16,6 +16,7 @@
 use crate::config::MqttConfig;
 use crate::et112::Et112Snapshot;
 use crate::state::AppState;
+use crate::tasmota::TasmotaSnapshot;
 use daly_bms_core::types::BmsSnapshot;
 use rumqttc::{AsyncClient, MqttOptions, QoS};
 use serde_json::json;
@@ -101,6 +102,22 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
         if let Some(snap) = state.latest_irradiance().await {
             if let Err(e) = publish_irradiance(&client, &cfg, snap.irradiance_wm2).await {
                 error!("MQTT publish irradiance erreur : {:?}", e);
+            }
+        }
+
+        // ── Tasmota → forward Venus OS switch/acload si mqtt_index défini ──
+        let tasmota_snaps = state.tasmota_latest_all().await;
+        for snap in &tasmota_snaps {
+            let dev_cfg = state.config.tasmota.devices
+                .iter()
+                .find(|d| d.id == snap.id);
+            if let Some(dev) = dev_cfg {
+                if let Some(idx) = dev.mqtt_index {
+                    let svc = dev.service_type.as_str();
+                    if let Err(e) = publish_tasmota_snapshot(&client, &cfg, snap, idx, svc).await {
+                        error!("MQTT publish Tasmota erreur : {:?}", e);
+                    }
+                }
             }
         }
     }
@@ -193,6 +210,51 @@ async fn publish_et112_snapshot(
 
     client
         .publish(&topic, QoS::AtLeastOnce, true, serde_json::to_vec(&payload)?)
+        .await?;
+
+    Ok(())
+}
+
+/// Publie un snapshot Tasmota vers Venus OS.
+///
+/// service_type = "switch" → topic `santuario/switch/{idx}/venus`  (SwitchPayload)
+/// service_type = "acload" → topic `santuario/grid/{idx}/venus`    (GridPayload)
+async fn publish_tasmota_snapshot(
+    client: &AsyncClient,
+    cfg: &MqttConfig,
+    snap: &TasmotaSnapshot,
+    mqtt_index: u8,
+    service_type: &str,
+) -> anyhow::Result<()> {
+    let base = cfg.topic_prefix
+        .rsplit_once('/')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or("santuario");
+
+    let (topic_prefix, payload) = if service_type == "acload" {
+        let topic = format!("{}/grid/{}/venus", base, mqtt_index);
+        let p = json!({
+            "Ac/L1/Power":   snap.power_w,
+            "Ac/L1/Voltage": snap.voltage_v,
+            "Ac/L1/Current": snap.current_a,
+            "ProductName":   snap.name,
+            "CustomName":    snap.name,
+        });
+        (topic, p)
+    } else {
+        // switch (défaut)
+        let topic = format!("{}/switch/{}/venus", base, mqtt_index);
+        let p = json!({
+            "State":       if snap.power_on { 1 } else { 0 },
+            "Position":    1,
+            "ProductName": snap.name,
+            "CustomName":  snap.name,
+        });
+        (topic, p)
+    };
+
+    client
+        .publish(&topic_prefix, QoS::AtLeastOnce, true, serde_json::to_vec(&payload)?)
         .await?;
 
     Ok(())

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -46,6 +46,10 @@ pub struct AppConfig {
     /// Capteur d'irradiance PRALRAN RS485 (sur le bus unifié)
     /// Remplace le service Python `irradiance-rs485`.
     pub irradiance: Option<IrradianceConfig>,
+
+    /// Prises connectées Tasmota (MQTT natif Tasmota)
+    #[serde(default)]
+    pub tasmota: TasmotaConfig,
 }
 
 // =============================================================================
@@ -441,3 +445,65 @@ impl IrradianceConfig {
         }
     }
 }
+
+// =============================================================================
+// Configuration prises Tasmota
+// =============================================================================
+
+/// Configuration globale pour les prises connectées Tasmota.
+///
+/// Tasmota publie nativement via MQTT :
+///   tele/{tasmota_id}/SENSOR  → énergie, puissance, tension, courant
+///   stat/{tasmota_id}/POWER   → état relais ON/OFF
+///
+/// ```toml
+/// [tasmota]
+/// ring_buffer_size = 720
+///
+/// [[tasmota.devices]]
+/// id           = 1
+/// tasmota_id   = "tasmota_01"
+/// name         = "Prise Salon"
+/// mqtt_index   = 1
+/// service_type = "switch"
+/// device_instance = 500
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TasmotaConfig {
+    /// Taille du ring buffer par appareil
+    pub ring_buffer_size: usize,
+    /// Liste des prises Tasmota configurées
+    #[serde(default)]
+    pub devices: Vec<TasmotaDeviceConfig>,
+}
+
+impl Default for TasmotaConfig {
+    fn default() -> Self {
+        Self {
+            ring_buffer_size: 720,
+            devices:          Vec::new(),
+        }
+    }
+}
+
+/// Configuration d'une prise Tasmota individuelle.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct TasmotaDeviceConfig {
+    /// Identifiant interne unique (clé du ring buffer, ex: 1)
+    pub id: u8,
+    /// Nom du device Tasmota dans les topics MQTT (ex: "tasmota_01")
+    pub tasmota_id: String,
+    /// Nom affiché dans le dashboard
+    #[serde(default = "default_tasmota_name")]
+    pub name: String,
+    /// Index MQTT → forward vers Venus OS : `santuario/{service_type}/{mqtt_index}/venus`
+    pub mqtt_index: Option<u8>,
+    /// Type de service D-Bus : "switch" (défaut) ou "acload"
+    #[serde(default = "default_tasmota_service_type")]
+    pub service_type: String,
+    /// Instance D-Bus Venus OS (ex: 500)
+    pub device_instance: Option<u16>,
+}
+
+fn default_tasmota_name()         -> String { "Tasmota".to_string() }
+fn default_tasmota_service_type() -> String { "switch".to_string() }

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -22,6 +22,7 @@ use axum::{
 use daly_bms_core::types::BmsSnapshot;
 use std::sync::atomic::Ordering;
 use tracing::error;
+use crate::tasmota::TasmotaSnapshot;
 
 // =============================================================================
 // Filtres Askama pour le formatage des nombres
@@ -522,14 +523,184 @@ pub async fn dashboard_et112_list(State(state): State<AppState>) -> Response {
     render(Et112AllTemplate { devices, device_count })
 }
 
+// =============================================================================
+// Dashboard Tasmota
+// =============================================================================
+
+/// Résumé d'une prise Tasmota pour la page d'ensemble.
+#[derive(Debug, Clone)]
+pub struct TasmotaDeviceSummary {
+    pub id:                   u8,
+    pub name:                 String,
+    pub tasmota_id:           String,
+    pub connected:            bool,
+    pub power_on:             bool,
+    pub power_w:              f32,
+    pub voltage_v:            f32,
+    pub current_a:            f32,
+    pub power_factor:         f32,
+    pub energy_today_kwh:     f32,
+    pub energy_yesterday_kwh: f32,
+    pub energy_total_kwh:     f32,
+    pub rssi:                 Option<i32>,
+    pub last_ts:              String,
+    pub service_type:         String,
+}
+
+#[derive(Template)]
+#[template(path = "tasmota_all.html")]
+struct TasmotaAllTemplate {
+    devices:      Vec<TasmotaDeviceSummary>,
+    device_count: usize,
+}
+
+#[derive(Template)]
+#[template(path = "tasmota.html")]
+struct TasmotaTemplate {
+    id:                   u8,
+    name:                 String,
+    tasmota_id:           String,
+    connected:            bool,
+    last_ts:              String,
+    power_on:             bool,
+    power_w:              f32,
+    voltage_v:            f32,
+    current_a:            f32,
+    apparent_power_va:    f32,
+    power_factor:         f32,
+    energy_today_kwh:     f32,
+    energy_yesterday_kwh: f32,
+    energy_total_kwh:     f32,
+    rssi:                 String,
+    service_type:         String,
+}
+
+fn summary_from_tasmota(cfg: &crate::config::TasmotaDeviceConfig, snap_opt: Option<TasmotaSnapshot>) -> TasmotaDeviceSummary {
+    let connected = snap_opt.is_some();
+    if let Some(s) = snap_opt {
+        TasmotaDeviceSummary {
+            id:                   s.id,
+            name:                 s.name.clone(),
+            tasmota_id:           s.tasmota_id.clone(),
+            connected,
+            power_on:             s.power_on,
+            power_w:              s.power_w,
+            voltage_v:            s.voltage_v,
+            current_a:            s.current_a,
+            power_factor:         s.power_factor,
+            energy_today_kwh:     s.energy_today_kwh,
+            energy_yesterday_kwh: s.energy_yesterday_kwh,
+            energy_total_kwh:     s.energy_total_kwh,
+            rssi:                 s.rssi,
+            last_ts:              s.timestamp.format("%H:%M:%S").to_string(),
+            service_type:         cfg.service_type.clone(),
+        }
+    } else {
+        TasmotaDeviceSummary {
+            id:                   cfg.id,
+            name:                 cfg.name.clone(),
+            tasmota_id:           cfg.tasmota_id.clone(),
+            connected:            false,
+            power_on:             false,
+            power_w:              0.0,
+            voltage_v:            0.0,
+            current_a:            0.0,
+            power_factor:         0.0,
+            energy_today_kwh:     0.0,
+            energy_yesterday_kwh: 0.0,
+            energy_total_kwh:     0.0,
+            rssi:                 None,
+            last_ts:              "—".to_string(),
+            service_type:         cfg.service_type.clone(),
+        }
+    }
+}
+
+/// Page d'ensemble — toutes les prises Tasmota configurées.
+pub async fn dashboard_tasmota_list(State(state): State<AppState>) -> Response {
+    let configs = &state.config.tasmota.devices;
+    if configs.is_empty() {
+        return (StatusCode::NOT_FOUND, "Aucune prise Tasmota configurée").into_response();
+    }
+
+    let mut devices: Vec<TasmotaDeviceSummary> = Vec::new();
+    for cfg in configs {
+        let snap_opt = state.tasmota_latest_for(cfg.id).await;
+        devices.push(summary_from_tasmota(cfg, snap_opt));
+    }
+
+    let device_count = devices.len();
+    render(TasmotaAllTemplate { devices, device_count })
+}
+
+/// Page de détail d'une prise Tasmota.
+pub async fn dashboard_tasmota(
+    State(state): State<AppState>,
+    Path(id_str): Path<String>,
+) -> Response {
+    let id = match id_str.trim().parse::<u8>() {
+        Ok(v)  => v,
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
+    };
+
+    let cfg_opt = state.config.tasmota.devices.iter().find(|d| d.id == id);
+    let name = cfg_opt.map(|d| d.name.clone()).unwrap_or_else(|| format!("Tasmota {}", id));
+    let tasmota_id = cfg_opt.map(|d| d.tasmota_id.clone()).unwrap_or_default();
+    let service_type = cfg_opt.map(|d| d.service_type.clone()).unwrap_or_else(|| "switch".to_string());
+
+    let snap_opt  = state.tasmota_latest_for(id).await;
+    let connected = snap_opt.is_some();
+
+    let (last_ts, power_on, power_w, voltage_v, current_a, apparent_power_va,
+         power_factor, energy_today_kwh, energy_yesterday_kwh, energy_total_kwh, rssi_str) =
+        if let Some(ref s) = snap_opt {
+            (
+                s.timestamp.format("%H:%M:%S").to_string(),
+                s.power_on,
+                s.power_w,
+                s.voltage_v,
+                s.current_a,
+                s.apparent_power_va,
+                s.power_factor,
+                s.energy_today_kwh,
+                s.energy_yesterday_kwh,
+                s.energy_total_kwh,
+                s.rssi.map(|v| format!("{} dBm", v)).unwrap_or_else(|| "—".to_string()),
+            )
+        } else {
+            ("—".to_string(), false, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, "—".to_string())
+        };
+
+    render(TasmotaTemplate {
+        id,
+        name,
+        tasmota_id,
+        connected,
+        last_ts,
+        power_on,
+        power_w,
+        voltage_v,
+        current_a,
+        apparent_power_va,
+        power_factor,
+        energy_today_kwh,
+        energy_yesterday_kwh,
+        energy_total_kwh,
+        rssi: rssi_str,
+        service_type,
+    })
+}
+
 /// Construit le routeur du dashboard (à fusionner dans le routeur principal).
 pub fn build_dashboard_router() -> Router<AppState> {
     Router::new()
-        .route("/",                          get(redirect_root))
-        .route("/dashboard",                 get(dashboard_index))
-        .route("/dashboard/bms/:id",         get(dashboard_bms))
-        .route("/dashboard/logs",            get(dashboard_logs))
-        .route("/dashboard/settings",        get(dashboard_settings))
-        .route("/dashboard/et112",           get(dashboard_et112_list))
-        .route("/dashboard/et112/:addr",     get(dashboard_et112))
+        .route("/",                            get(redirect_root))
+        .route("/dashboard",                   get(dashboard_index))
+        .route("/dashboard/bms/:id",           get(dashboard_bms))
+        .route("/dashboard/logs",              get(dashboard_logs))
+        .route("/dashboard/settings",          get(dashboard_settings))
+        .route("/dashboard/et112",             get(dashboard_et112_list))
+        .route("/dashboard/et112/:addr",       get(dashboard_et112))
+        .route("/dashboard/tasmota",           get(dashboard_tasmota_list))
+        .route("/dashboard/tasmota/:id",       get(dashboard_tasmota))
 }

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -17,6 +17,7 @@ mod autodetect;
 mod config;
 mod et112;
 mod irradiance;
+mod tasmota;
 mod state;
 mod api;
 mod bridges;
@@ -155,6 +156,7 @@ async fn main() -> anyhow::Result<()> {
                 bms:         Vec::new(),
                 et112:       config::Et112Config::default(),
                 irradiance:  None,
+                tasmota:     config::TasmotaConfig::default(),
             }
         }
     };
@@ -225,6 +227,28 @@ async fn main() -> anyhow::Result<()> {
         let (s, c) = (state.clone(), config.alerts.clone());
         async move { alerts::run_alert_engine(s, c).await }
     });
+
+    // ── Tasmota MQTT subscriber ────────────────────────────────────────────────
+    if !config.tasmota.devices.is_empty() {
+        info!(
+            count = config.tasmota.devices.len(),
+            "Démarrage Tasmota MQTT subscriber"
+        );
+        let state_ta = state.clone();
+        let devs_ta  = config.tasmota.devices.clone();
+        let mqtt_ta  = config.mqtt.clone();
+        tokio::spawn(async move {
+            tasmota::run_tasmota_mqtt_loop(
+                devs_ta,
+                mqtt_ta,
+                move |snap| {
+                    let s = state_ta.clone();
+                    tokio::spawn(async move { s.on_tasmota_snapshot(snap).await });
+                },
+            )
+            .await;
+        });
+    }
 
     // NOTE : ET112 et PRALRAN utilisent désormais le bus RS485 UNIFIÉ.
     // Leur lancement est déplacé dans le bloc hardware, après l'ouverture du DalyPort,

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -6,6 +6,7 @@
 use crate::config::AppConfig;
 use crate::et112::Et112Snapshot;
 use crate::irradiance::IrradianceSnapshot;
+use crate::tasmota::TasmotaSnapshot;
 use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
 use serde::Serialize;
@@ -95,6 +96,36 @@ impl Et112RingBuffer {
     }
 }
 
+// =============================================================================
+// Ring buffer Tasmota
+// =============================================================================
+
+/// Ring buffer de snapshots Tasmota pour une prise.
+pub struct TasmotaRingBuffer {
+    pub buffer:   VecDeque<TasmotaSnapshot>,
+    pub capacity: usize,
+}
+
+impl TasmotaRingBuffer {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buffer:   VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    pub fn push(&mut self, snap: TasmotaSnapshot) {
+        if self.buffer.len() >= self.capacity {
+            self.buffer.pop_front();
+        }
+        self.buffer.push_back(snap);
+    }
+
+    pub fn latest(&self) -> Option<&TasmotaSnapshot> {
+        self.buffer.back()
+    }
+}
+
 /// État global partagé de l'application.
 #[derive(Clone)]
 pub struct AppState {
@@ -121,6 +152,9 @@ pub struct AppState {
 
     /// Dernière mesure du capteur d'irradiance PRALRAN (None si non configuré).
     pub irradiance_value: Arc<RwLock<Option<IrradianceSnapshot>>>,
+
+    /// Ring buffers Tasmota indexés par id de device.
+    pub tasmota_buffers: Arc<RwLock<BTreeMap<u8, TasmotaRingBuffer>>>,
 }
 
 impl AppState {
@@ -141,6 +175,13 @@ impl AppState {
             et112_buffers.insert(dev.parsed_address(), Et112RingBuffer::new(et112_ring_size));
         }
 
+        // Pré-allouer les ring buffers Tasmota
+        let tasmota_ring_size = config.tasmota.ring_buffer_size;
+        let mut tasmota_buffers = BTreeMap::new();
+        for dev in &config.tasmota.devices {
+            tasmota_buffers.insert(dev.id, TasmotaRingBuffer::new(tasmota_ring_size));
+        }
+
         Self {
             config: Arc::new(config),
             buffers: Arc::new(RwLock::new(buffers)),
@@ -150,6 +191,7 @@ impl AppState {
             log_buffer,
             et112_buffers: Arc::new(RwLock::new(et112_buffers)),
             irradiance_value: Arc::new(RwLock::new(None)),
+            tasmota_buffers: Arc::new(RwLock::new(tasmota_buffers)),
         }
     }
 
@@ -240,5 +282,36 @@ impl AppState {
     /// Retourne la dernière mesure d'irradiance (None si jamais reçue).
     pub async fn latest_irradiance(&self) -> Option<IrradianceSnapshot> {
         self.irradiance_value.read().await.clone()
+    }
+
+    /// Enregistre un snapshot Tasmota dans le ring buffer correspondant.
+    pub async fn on_tasmota_snapshot(&self, snap: TasmotaSnapshot) {
+        let mut buffers = self.tasmota_buffers.write().await;
+        buffers
+            .entry(snap.id)
+            .or_insert_with(|| TasmotaRingBuffer::new(self.config.tasmota.ring_buffer_size))
+            .push(snap);
+    }
+
+    /// Retourne le dernier snapshot Tasmota pour un id donné.
+    pub async fn tasmota_latest_for(&self, id: u8) -> Option<TasmotaSnapshot> {
+        let buffers = self.tasmota_buffers.read().await;
+        buffers.get(&id)?.latest().cloned()
+    }
+
+    /// Retourne les `n` derniers snapshots Tasmota (pour historique).
+    pub async fn tasmota_history_for(&self, id: u8, limit: usize) -> Vec<TasmotaSnapshot> {
+        let buffers = self.tasmota_buffers.read().await;
+        if let Some(buf) = buffers.get(&id) {
+            buf.buffer.iter().rev().take(limit).cloned().collect()
+        } else {
+            vec![]
+        }
+    }
+
+    /// Retourne tous les derniers snapshots Tasmota.
+    pub async fn tasmota_latest_all(&self) -> Vec<TasmotaSnapshot> {
+        let buffers = self.tasmota_buffers.read().await;
+        buffers.values().filter_map(|b| b.latest().cloned()).collect()
     }
 }

--- a/crates/daly-bms-server/src/tasmota/mod.rs
+++ b/crates/daly-bms-server/src/tasmota/mod.rs
@@ -1,0 +1,10 @@
+//! Module Tasmota — prises connectées WiFi avec mesure d'énergie.
+//!
+//! Reçoit les payloads MQTT natifs Tasmota (tele/.../SENSOR, stat/.../POWER)
+//! et les expose via l'API REST, le dashboard et les bridges InfluxDB/MQTT Venus.
+
+pub mod types;
+pub mod mqtt;
+
+pub use types::TasmotaSnapshot;
+pub use mqtt::run_tasmota_mqtt_loop;

--- a/crates/daly-bms-server/src/tasmota/mqtt.rs
+++ b/crates/daly-bms-server/src/tasmota/mqtt.rs
@@ -1,0 +1,139 @@
+//! Subscriber MQTT Tasmota — réception des topics natifs Tasmota.
+//!
+//! Topics surveillés (wildcards) :
+//!   tele/+/SENSOR  → payload JSON avec bloc ENERGY (puissance, énergie, tension, courant)
+//!   stat/+/POWER   → payload texte "ON" ou "OFF"
+//!
+//! Pour chaque message reçu, le device est identifié par son `tasmota_id`
+//! (deuxième segment du topic), puis le snapshot est mis à jour et le
+//! callback `on_snapshot` est appelé.
+
+use crate::config::{MqttConfig, TasmotaDeviceConfig};
+use super::types::TasmotaSnapshot;
+use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, QoS};
+use std::collections::HashMap;
+use std::time::Duration;
+use tracing::{info, warn};
+use chrono::Local;
+
+/// Boucle principale d'abonnement MQTT Tasmota.
+///
+/// Se reconnecte automatiquement après déconnexion (backoff 10 s).
+/// Appelle `on_snapshot` pour chaque mesure reçue.
+pub async fn run_tasmota_mqtt_loop<F>(
+    devices: Vec<TasmotaDeviceConfig>,
+    mqtt_cfg: MqttConfig,
+    mut on_snapshot: F,
+)
+where
+    F: FnMut(TasmotaSnapshot) + Send + 'static,
+{
+    if devices.is_empty() {
+        return;
+    }
+
+    info!(count = devices.len(), host = %mqtt_cfg.host, "Démarrage Tasmota MQTT subscriber");
+
+    // État inter-messages : état relais (POWER) et dernier snapshot énergie (SENSOR)
+    let mut power_states:    HashMap<u8, bool>             = HashMap::new();
+    let mut energy_cache:    HashMap<u8, TasmotaSnapshot>  = HashMap::new();
+
+    loop {
+        let mut opts = MqttOptions::new(
+            format!("daly-bms-tasmota-{}", uuid::Uuid::new_v4()),
+            &mqtt_cfg.host,
+            mqtt_cfg.port,
+        );
+        opts.set_keep_alive(Duration::from_secs(30));
+
+        if let (Some(user), Some(pass)) = (&mqtt_cfg.username, &mqtt_cfg.password) {
+            opts.set_credentials(user, pass);
+        }
+
+        let (client, mut eventloop) = AsyncClient::new(opts, 128);
+
+        // Abonnement aux deux wildcards Tasmota
+        let _ = client.subscribe("tele/+/SENSOR", QoS::AtMostOnce).await;
+        let _ = client.subscribe("stat/+/POWER",  QoS::AtMostOnce).await;
+
+        loop {
+            match eventloop.poll().await {
+                Ok(Event::Incoming(Incoming::ConnAck(_))) => {
+                    info!("Tasmota MQTT connecté (broker {}:{})", mqtt_cfg.host, mqtt_cfg.port);
+                }
+
+                Ok(Event::Incoming(Incoming::Publish(msg))) => {
+                    let topic   = msg.topic.as_str();
+                    let payload = match std::str::from_utf8(&msg.payload) {
+                        Ok(s) => s,
+                        Err(_) => continue,
+                    };
+
+                    // Découper le topic : tele/{device_name}/SENSOR ou stat/{device_name}/POWER
+                    let parts: Vec<&str> = topic.split('/').collect();
+                    if parts.len() != 3 { continue; }
+                    let device_name = parts[1];
+                    let msg_type    = parts[2];
+
+                    // Trouver la config du device par son tasmota_id
+                    let dev_cfg = match devices.iter().find(|d| d.tasmota_id == device_name) {
+                        Some(d) => d,
+                        None    => continue,
+                    };
+                    let id = dev_cfg.id;
+
+                    match msg_type {
+                        "POWER" => {
+                            let on = payload.trim().eq_ignore_ascii_case("ON");
+                            power_states.insert(id, on);
+                            // Si un snapshot énergie existe déjà, mettre à jour et notifier
+                            if let Some(snap) = energy_cache.get_mut(&id) {
+                                snap.power_on  = on;
+                                snap.timestamp = Local::now();
+                                on_snapshot(snap.clone());
+                            }
+                        }
+
+                        "SENSOR" => {
+                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(payload) {
+                                let energy   = &json["ENERGY"];
+                                let power_on = power_states.get(&id).copied().unwrap_or(true);
+
+                                let snap = TasmotaSnapshot {
+                                    id,
+                                    name:                  dev_cfg.name.clone(),
+                                    tasmota_id:            dev_cfg.tasmota_id.clone(),
+                                    timestamp:             Local::now(),
+                                    power_on,
+                                    power_w:               energy["Power"]        .as_f64().unwrap_or(0.0) as f32,
+                                    voltage_v:             energy["Voltage"]      .as_f64().unwrap_or(0.0) as f32,
+                                    current_a:             energy["Current"]      .as_f64().unwrap_or(0.0) as f32,
+                                    apparent_power_va:     energy["ApparentPower"].as_f64().unwrap_or(0.0) as f32,
+                                    power_factor:          energy["Factor"]       .as_f64().unwrap_or(0.0) as f32,
+                                    energy_today_kwh:      energy["Today"]        .as_f64().unwrap_or(0.0) as f32,
+                                    energy_yesterday_kwh:  energy["Yesterday"]    .as_f64().unwrap_or(0.0) as f32,
+                                    energy_total_kwh:      energy["Total"]        .as_f64().unwrap_or(0.0) as f32,
+                                    rssi:                  json["Wifi"]["RSSI"]   .as_i64().map(|v| v as i32),
+                                };
+                                energy_cache.insert(id, snap.clone());
+                                on_snapshot(snap);
+                            }
+                        }
+
+                        _ => {}
+                    }
+                }
+
+                Ok(_) => {}
+
+                Err(e) => {
+                    warn!("Tasmota MQTT erreur : {:?}", e);
+                    break; // sortir pour reconnecter
+                }
+            }
+        }
+
+        warn!("Tasmota MQTT déconnecté — reconnexion dans 10s");
+        tokio::time::sleep(Duration::from_secs(10)).await;
+    }
+}

--- a/crates/daly-bms-server/src/tasmota/types.rs
+++ b/crates/daly-bms-server/src/tasmota/types.rs
@@ -1,0 +1,58 @@
+//! Types de données pour les prises connectées Tasmota.
+//!
+//! Tasmota publie nativement via MQTT :
+//!   tele/{device}/SENSOR  → mesures énergie (ENERGY block)
+//!   stat/{device}/POWER   → état relais (ON/OFF)
+
+use chrono::{DateTime, Local};
+use serde::{Deserialize, Serialize};
+
+/// Snapshot complet d'une prise Tasmota à un instant donné.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TasmotaSnapshot {
+    /// Identifiant interne (clé du ring buffer)
+    pub id: u8,
+
+    /// Nom configuré (ex: "Prise Salon")
+    pub name: String,
+
+    /// Identifiant Tasmota (nom du device dans les topics MQTT, ex: "tasmota_01")
+    pub tasmota_id: String,
+
+    /// Instant de la mesure
+    pub timestamp: DateTime<Local>,
+
+    // ── État relais ─────────────────────────────────────────────────────────
+    /// true = ON, false = OFF
+    pub power_on: bool,
+
+    // ── Mesures instantanées (ENERGY block) ─────────────────────────────────
+    /// Puissance active (W)
+    pub power_w: f32,
+
+    /// Tension (V)
+    pub voltage_v: f32,
+
+    /// Courant (A)
+    pub current_a: f32,
+
+    /// Puissance apparente (VA)
+    pub apparent_power_va: f32,
+
+    /// Facteur de puissance (0.0 – 1.0)
+    pub power_factor: f32,
+
+    // ── Énergie cumulée ─────────────────────────────────────────────────────
+    /// Énergie consommée aujourd'hui (kWh)
+    pub energy_today_kwh: f32,
+
+    /// Énergie consommée hier (kWh)
+    pub energy_yesterday_kwh: f32,
+
+    /// Énergie totale depuis mise en service (kWh)
+    pub energy_total_kwh: f32,
+
+    // ── Infos réseau ────────────────────────────────────────────────────────
+    /// Signal WiFi (dBm) — None si absent du payload
+    pub rssi: Option<i32>,
+}

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -549,6 +549,7 @@
   <div class="nav-links">
     <a href="/dashboard">🔋 BMS</a>
     <a href="/dashboard/et112">⚡ Compteurs ET112</a>
+    <a href="/dashboard/tasmota">🔌 Tasmota</a>
     <a href="/dashboard/settings">Paramètres</a>
     <a href="/dashboard/logs">Logs</a>
     <a href="/api/v1/system/status" target="_blank">API</a>

--- a/crates/daly-bms-server/templates/tasmota.html
+++ b/crates/daly-bms-server/templates/tasmota.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+
+{% block title %}{{ name }} — Tasmota{% endblock %}
+
+{% block content %}
+
+{# ─── En-tête ────────────────────────────────────────────────────────────── #}
+<div class="info-bar">
+  <strong>🔌 {{ name }}</strong>
+  <span>
+    {% if connected %}
+      {% if power_on %}<span style="color:var(--green);font-weight:600">ON</span>{% else %}<span style="color:var(--red);font-weight:600">OFF</span>{% endif %}
+    {% else %}
+      <span style="color:var(--muted)">Hors ligne</span>
+    {% endif %}
+    — {{ tasmota_id }} — Màj : {{ last_ts }}
+  </span>
+  <a href="/dashboard/tasmota" style="font-size:0.8rem">← Retour liste</a>
+</div>
+
+{% if !connected %}
+<div style="margin:2rem auto;max-width:500px;padding:2rem;background:var(--surface);border-radius:var(--radius);text-align:center;color:var(--muted);box-shadow:var(--shadow);">
+  <div style="font-size:2rem;margin-bottom:1rem">⏳</div>
+  <div>En attente du premier message MQTT…</div>
+  <div style="font-size:0.8rem;margin-top:0.5rem">
+    Vérifier que <code>tele/{{ tasmota_id }}/SENSOR</code> est publié sur le broker.
+  </div>
+</div>
+{% else %}
+
+{# ─── Puissance instantanée ───────────────────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:1rem;margin-bottom:1rem;">
+
+  <div class="bms-card-ng" style="padding:1rem;">
+    <div class="kpi4-lbl">Puissance active</div>
+    <div class="kpi4-val" style="font-size:2rem;color:var(--accent)" id="pw">{{ power_w|f1 }} W</div>
+  </div>
+
+  <div class="bms-card-ng" style="padding:1rem;">
+    <div class="kpi4-lbl">Tension</div>
+    <div class="kpi4-val" style="font-size:2rem;" id="vv">{{ voltage_v|f1 }} V</div>
+  </div>
+
+  <div class="bms-card-ng" style="padding:1rem;">
+    <div class="kpi4-lbl">Courant</div>
+    <div class="kpi4-val" style="font-size:2rem;" id="iv">{{ current_a|f2 }} A</div>
+  </div>
+
+  <div class="bms-card-ng" style="padding:1rem;">
+    <div class="kpi4-lbl">Puissance apparente</div>
+    <div class="kpi4-val" style="font-size:2rem;" id="pva">{{ apparent_power_va|f1 }} VA</div>
+  </div>
+
+  <div class="bms-card-ng" style="padding:1rem;">
+    <div class="kpi4-lbl">Facteur de puissance</div>
+    <div class="kpi4-val" style="font-size:2rem;" id="pf">{{ power_factor|f2 }}</div>
+  </div>
+
+  <div class="bms-card-ng" style="padding:1rem;">
+    <div class="kpi4-lbl">Signal WiFi</div>
+    <div class="kpi4-val" style="font-size:2rem;color:var(--muted)" id="rssi">{{ rssi }}</div>
+  </div>
+
+</div>
+
+{# ─── Énergie ─────────────────────────────────────────────────────────────── #}
+<div class="bms-card-ng" style="margin-bottom:1rem;">
+  <div class="bms-hdr" style="background:#1a5f8a;">
+    <div class="bms-hdr-title">Énergie consommée</div>
+    <div class="bms-hdr-right"><span>{{ service_type }}</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:1fr 1fr 1fr;">
+    <div style="padding:1rem;border-right:1px solid var(--border);">
+      <div class="kpi4-lbl">Aujourd'hui</div>
+      <div class="kpi4-val" style="font-size:1.8rem;color:var(--accent)" id="etd">{{ energy_today_kwh|f3 }} kWh</div>
+    </div>
+    <div style="padding:1rem;border-right:1px solid var(--border);">
+      <div class="kpi4-lbl">Hier</div>
+      <div class="kpi4-val" style="font-size:1.8rem;color:var(--muted)" id="eyd">{{ energy_yesterday_kwh|f3 }} kWh</div>
+    </div>
+    <div style="padding:1rem;">
+      <div class="kpi4-lbl">Total</div>
+      <div class="kpi4-val" style="font-size:1.8rem;" id="etot">{{ energy_total_kwh|f1 }} kWh</div>
+    </div>
+  </div>
+</div>
+
+{% endif %}
+
+{# ─── Mise à jour automatique ─────────────────────────────────────────────── #}
+<script>
+const TASMOTA_ID = {{ id }};
+
+async function update() {
+    try {
+        const resp = await fetch(`/api/v1/tasmota/${TASMOTA_ID}/status`);
+        if (!resp.ok) return;
+        const d = await resp.json();
+        const el = (id) => document.getElementById(id);
+        if (el('pw'))   el('pw').textContent   = d.power_w.toFixed(1) + ' W';
+        if (el('vv'))   el('vv').textContent   = d.voltage_v.toFixed(1) + ' V';
+        if (el('iv'))   el('iv').textContent   = d.current_a.toFixed(2) + ' A';
+        if (el('pva'))  el('pva').textContent  = d.apparent_power_va.toFixed(1) + ' VA';
+        if (el('pf'))   el('pf').textContent   = d.power_factor.toFixed(2);
+        if (el('etd'))  el('etd').textContent  = d.energy_today_kwh.toFixed(3) + ' kWh';
+        if (el('eyd'))  el('eyd').textContent  = d.energy_yesterday_kwh.toFixed(3) + ' kWh';
+        if (el('etot')) el('etot').textContent = d.energy_total_kwh.toFixed(1) + ' kWh';
+        if (el('rssi') && d.rssi != null) el('rssi').textContent = d.rssi + ' dBm';
+    } catch(e) {}
+}
+
+update();
+setInterval(update, 5000);
+</script>
+
+{% endblock %}

--- a/crates/daly-bms-server/templates/tasmota_all.html
+++ b/crates/daly-bms-server/templates/tasmota_all.html
@@ -1,0 +1,139 @@
+{% extends "base.html" %}
+
+{% block title %}Prises Tasmota — Monitoring{% endblock %}
+
+{% block content %}
+
+{# ─── En-tête ────────────────────────────────────────────────────────────── #}
+<div class="info-bar">
+  <strong>Prises connectées Tasmota</strong>
+  <span>{{ device_count }} appareil(s) configuré(s)</span>
+</div>
+
+{# ─── Grille des prises ───────────────────────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(360px,1fr));gap:1rem;">
+
+{% for d in devices %}
+<div class="bms-card-ng" id="tasmota-card-{{ d.id }}" style="{% if !d.connected %}opacity:0.7;{% endif %}">
+
+  {# ── En-tête carte ──── #}
+  <div class="bms-hdr" style="{% if d.connected %}{% if d.power_on %}background:#1a5f1a;{% else %}background:#5f1a1a;{% endif %}{% else %}background:#57606a;{% endif %}">
+    <div class="bms-hdr-title">
+      🔌 {{ d.name }}
+    </div>
+    <div class="bms-hdr-right">
+      {% if d.connected %}
+        <div class="bms-live-dot"></div>
+        {% if d.power_on %}
+          <span style="color:#90ee90;font-weight:600">ON</span>
+        {% else %}
+          <span style="color:#ff9999;font-weight:600">OFF</span>
+        {% endif %}
+      {% else %}
+        <span style="color:rgba(255,255,255,0.5)">Hors ligne</span>
+      {% endif %}
+      <div class="bms-can-badge">{{ d.tasmota_id }}</div>
+      <span class="bms-hdr-ts" id="ts-{{ d.id }}">{{ d.last_ts }}</span>
+    </div>
+  </div>
+
+  {% if d.connected %}
+
+  {# ── KPI 4 colonnes ── #}
+  <div class="kpi4">
+    <div class="kpi4-cell kpi4-p">
+      <div class="kpi4-lbl">Puissance</div>
+      <div class="kpi4-val chg" id="p-{{ d.id }}">{{ d.power_w|f1 }} W</div>
+    </div>
+    <div class="kpi4-cell kpi4-v">
+      <div class="kpi4-lbl">Tension</div>
+      <div class="kpi4-val" id="v-{{ d.id }}">{{ d.voltage_v|f1 }} V</div>
+    </div>
+    <div class="kpi4-cell kpi4-i">
+      <div class="kpi4-lbl">Courant</div>
+      <div class="kpi4-val" id="i-{{ d.id }}">{{ d.current_a|f2 }} A</div>
+    </div>
+    <div class="kpi4-cell">
+      <div class="kpi4-lbl">Cos φ</div>
+      <div class="kpi4-val" id="pf-{{ d.id }}">{{ d.power_factor|f2 }}</div>
+    </div>
+  </div>
+
+  {# ── Énergie ── #}
+  <div style="display:grid;grid-template-columns:1fr 1fr 1fr;border-bottom:1px solid var(--border);">
+    <div style="padding:0.45rem 0.65rem;border-right:1px solid var(--border);">
+      <div class="kpi4-lbl">Aujourd'hui</div>
+      <div class="kpi4-val" style="color:var(--accent)" id="etd-{{ d.id }}">
+        {{ d.energy_today_kwh|f2 }} kWh
+      </div>
+    </div>
+    <div style="padding:0.45rem 0.65rem;border-right:1px solid var(--border);">
+      <div class="kpi4-lbl">Hier</div>
+      <div class="kpi4-val" style="color:var(--muted)" id="eyd-{{ d.id }}">
+        {{ d.energy_yesterday_kwh|f2 }} kWh
+      </div>
+    </div>
+    <div style="padding:0.45rem 0.65rem;">
+      <div class="kpi4-lbl">Total</div>
+      <div class="kpi4-val" id="etot-{{ d.id }}">
+        {{ d.energy_total_kwh|f1 }} kWh
+      </div>
+    </div>
+  </div>
+
+  {% else %}
+
+  {# ── Hors ligne ── #}
+  <div style="padding:1.5rem;text-align:center;color:var(--muted);">
+    <div style="font-size:1.5rem;margin-bottom:0.5rem">⏳</div>
+    <div style="font-size:0.8rem">En attente du premier message MQTT…</div>
+    <div style="font-size:0.7rem;margin-top:0.25rem">Topic : <code>tele/{{ d.tasmota_id }}/SENSOR</code></div>
+  </div>
+
+  {% endif %}
+
+  {# ── Lien détail ── #}
+  <div style="padding:0.4rem 0.75rem;display:flex;justify-content:flex-end;border-top:1px solid var(--border);">
+    <a class="link-detail" href="/dashboard/tasmota/{{ d.id }}">Détails →</a>
+  </div>
+
+</div>
+{% endfor %}
+
+</div>
+
+{# ─── Scripts de mise à jour ─────────────────────────────────────────────── #}
+<script>
+const TASMOTA_IDS = [{% for d in devices %}{{ d.id }}{% if !loop.last %}, {% endif %}{% endfor %}];
+
+async function updateAll() {
+    for (const id of TASMOTA_IDS) {
+        try {
+            const resp = await fetch(`/api/v1/tasmota/${id}/status`);
+            if (!resp.ok) continue;
+            const d = await resp.json();
+            const pw  = document.getElementById(`p-${id}`);
+            const vv  = document.getElementById(`v-${id}`);
+            const iv  = document.getElementById(`i-${id}`);
+            const pf  = document.getElementById(`pf-${id}`);
+            const etd = document.getElementById(`etd-${id}`);
+            const eyd = document.getElementById(`eyd-${id}`);
+            const tot = document.getElementById(`etot-${id}`);
+            const ts  = document.getElementById(`ts-${id}`);
+            if (pw)  pw.textContent  = d.power_w.toFixed(1) + ' W';
+            if (vv)  vv.textContent  = d.voltage_v.toFixed(1) + ' V';
+            if (iv)  iv.textContent  = d.current_a.toFixed(2) + ' A';
+            if (pf)  pf.textContent  = d.power_factor.toFixed(2);
+            if (etd) etd.textContent = d.energy_today_kwh.toFixed(2) + ' kWh';
+            if (eyd) eyd.textContent = d.energy_yesterday_kwh.toFixed(2) + ' kWh';
+            if (tot) tot.textContent = d.energy_total_kwh.toFixed(1) + ' kWh';
+            if (ts)  ts.textContent  = new Date().toLocaleTimeString();
+        } catch(e) {}
+    }
+}
+
+updateAll();
+setInterval(updateAll, 5000);
+</script>
+
+{% endblock %}


### PR DESCRIPTION
…bridge

- tasmota/types.rs    : TasmotaSnapshot (power, energy, voltage, current, WiFi RSSI)
- tasmota/mqtt.rs     : MQTT subscriber tele/+/SENSOR + stat/+/POWER with auto-reconnect
- tasmota/mod.rs      : public module exports
- config.rs           : TasmotaConfig + TasmotaDeviceConfig (id, tasmota_id, service_type, mqtt_index)
- state.rs            : TasmotaRingBuffer + on_tasmota_snapshot/tasmota_latest_for/tasmota_latest_all
- api/tasmota.rs      : GET /api/v1/tasmota, /tasmota/:id/status, /tasmota/:id/history
- api/mod.rs          : register tasmota routes
- bridges/influx.rs   : tasmota_snapshot_to_point() → measurement tasmota_status
- bridges/mqtt.rs     : publish_tasmota_snapshot() → Venus OS switch/acload forward (optional)
- dashboard/mod.rs    : dashboard_tasmota_list + dashboard_tasmota handlers + routes
- templates/tasmota_all.html : device list page (live update every 5s)
- templates/tasmota.html     : device detail page (live update every 5s)
- templates/base.html        : nav link 🔌 Tasmota
- Config.toml         : [tasmota] section with commented example [[tasmota.devices]]
- main.rs             : spawn run_tasmota_mqtt_loop if devices configured

https://claude.ai/code/session_01PqhNgfsHtV3GL8dqAhNYYH