### PR TITLE
feat(dashboard): complete dark theme redesign — modern ESS monitor UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,95 @@
 
 ---
 
+## 0. RÉFÉRENCE COMMANDES — QUI / OÙ / QUAND / QUOI
+
+> Cette section est la seule référence à consulter pour savoir quelle commande lancer.
+> Chaque commande indique : **qui** l'exécute, **où**, **quand**, et **ce qu'elle fait**.
+
+---
+
+### 0A. COMMANDES PI5 — USAGE QUOTIDIEN
+
+| Quand | Commande (sur Pi5, dans ~/Daly-BMS-Rust) | Ce que ça fait |
+|-------|------------------------------------------|----------------|
+| Récupérer le code depuis GitHub | `make sync` | git fetch + sudo chown + git reset --hard → Pi5 à jour |
+| Appliquer une modif de Config.toml | `sudo cp Config.toml /etc/daly-bms/config.toml` | Copie la config repo → config production lue par systemd |
+| Redémarrer le serveur BMS | `sudo systemctl restart daly-bms` | Redémarre daly-bms-server avec la config en cours |
+| Voir les logs BMS en direct | `journalctl -u daly-bms -f` | Logs temps réel du serveur |
+| Compiler daly-bms-server (Pi5) | `make build-arm` | Cross-compile aarch64 (~5-10 min) |
+| Déployer le nouveau binaire BMS | `sudo systemctl stop daly-bms && sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/ && sudo systemctl start daly-bms` | Remplace le binaire et redémarre |
+| Compiler dbus-mqtt-venus (NanoPi) | `make build-venus-v7` | Cross-compile armv7 (~5 min) |
+| Déployer dbus-mqtt-venus sur NanoPi | `make install-venus-v7` | SSH → arrêt service → copie binaire → redémarrage |
+| Démarrer Docker (Mosquitto/InfluxDB/Grafana/Node-RED) | `make up` | Lance la stack Docker complète |
+| Arrêter Docker | `make down` | Arrête la stack, **volumes préservés** |
+| Tout supprimer Docker (⚠ destructif) | `make reset` | Arrête + supprime volumes (retained MQTT perdu) |
+| Voir logs Docker | `make logs` | Logs de tous les conteneurs |
+
+---
+
+### 0B. COMMANDES PI5 — RÉCUPÉRATION ERREURS
+
+| Erreur | Commandes exactes (sur Pi5, dans ~/Daly-BMS-Rust) | Explication |
+|--------|---------------------------------------------------|-------------|
+| `make sync` → **"Permission denied" sur mosquitto.conf** | `sudo chown -R pi5compute:pi5compute ~/Daly-BMS-Rust/`<br>`git reset --hard origin/claude/review-dashboard-plan-JEvFY` | Docker a créé des fichiers root. chown les rend accessibles, puis reset force la mise à jour. |
+| Service BMS ne démarre pas | `journalctl -u daly-bms -n 50` | Voir les 50 dernières lignes de log pour identifier l'erreur |
+| Config modifiée mais ignorée par le service | `sudo cp Config.toml /etc/daly-bms/config.toml && sudo systemctl restart daly-bms` | Le service lit /etc/daly-bms/, pas ~/Daly-BMS-Rust/ |
+
+---
+
+### 0C. COMMANDES NANOPI — USAGE QUOTIDIEN
+
+| Quand | Commande (sur NanoPi via SSH) | Ce que ça fait |
+|-------|-------------------------------|----------------|
+| Vérifier que le bridge Venus tourne | `svstat /service/dbus-mqtt-venus` | Affiche "up (pid X) Xs" si OK |
+| Redémarrer le bridge Venus | `svc -t /service/dbus-mqtt-venus` | Redémarre proprement via runit |
+| Arrêter le bridge Venus | `svc -d /service/dbus-mqtt-venus` | Arrêt (nécessaire avant de copier le binaire manuellement) |
+| Voir les logs Venus en direct | `tail -f /var/log/dbus-mqtt-venus/current` | Logs temps réel |
+| Lister tous les services Victron actifs | `dbus -y \| grep victronenergy` | Tous les services D-Bus enregistrés |
+| Appliquer une modif config NanoPi | `scp nanoPi/config-nanopi.toml root@192.168.1.120:/data/daly-bms/config.toml && ssh root@192.168.1.120 "svc -t /service/dbus-mqtt-venus"` | Copie config + redémarre (depuis Pi5) |
+
+---
+
+### 0D. COMMANDES CLAUDE CODE — DÉVELOPPEMENT
+
+| Quand | Commande (Claude Code, dans ~/Daly-BMS-Rust) | Ce que ça fait |
+|-------|----------------------------------------------|----------------|
+| Après toute modification de code | `git add <fichiers> && git commit -m "type(scope): description" && git push -u origin claude/review-dashboard-plan-JEvFY` | Commit + push vers GitHub |
+| Vérifier la branche courante | `git branch` | Confirme qu'on est sur la bonne branche |
+
+---
+
+### 0E. WORKFLOW COMPLET — MODIFIER LE CODE ET DÉPLOYER
+
+```
+1. Claude Code modifie le code
+   git add ... && git commit -m "..." && git push
+
+2. Pi5 récupère
+   make sync
+
+3a. Si seulement Config.toml a changé :
+    sudo cp Config.toml /etc/daly-bms/config.toml
+    sudo systemctl restart daly-bms
+
+3b. Si le code Rust ou les templates HTML ont changé :
+    make build-arm
+    sudo systemctl stop daly-bms
+    sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
+    sudo cp Config.toml /etc/daly-bms/config.toml   ← seulement si config aussi modifiée
+    sudo systemctl start daly-bms
+
+3c. Si dbus-mqtt-venus a changé (code NanoPi) :
+    make build-venus-v7
+    make install-venus-v7
+
+3d. Si nanoPi/config-nanopi.toml a changé :
+    scp nanoPi/config-nanopi.toml root@192.168.1.120:/data/daly-bms/config.toml
+    ssh root@192.168.1.120 "svc -t /service/dbus-mqtt-venus"
+```
+
+---
+
 ## 1. ARCHITECTURE GLOBALE
 
 ```

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -3,615 +3,798 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}Monitoring{% endblock %}</title>
+  <title>{% block title %}ESS Monitor{% endblock %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    /* ─── Variables ───────────────────────────────────────────────────── */
+    /* ═══════════════════════════════════════════════════════════
+       DESIGN SYSTEM — ESS Monitor
+       ═══════════════════════════════════════════════════════════ */
     :root {
-      --bg:       #f0f4f8;
-      --surface:  #ffffff;
-      --surface2: #f0f4f8;
-      --border:   #d0d7de;
-      --text:     #1f2328;
-      --muted:    #57606a;
-      --accent:   #0969da;
-      --green:    #1a7f37;
-      --yellow:   #9a6700;
-      --orange:   #bc4c00;
-      --red:      #cf222e;
-      --radius:   8px;
-      --shadow:   0 1px 3px rgba(0,0,0,0.1), 0 4px 12px rgba(0,0,0,0.06);
+      --bg:        #0d1117;
+      --bg2:       #0a0d12;
+      --surface:   #161b22;
+      --surface2:  #21262d;
+      --surface3:  #2d333b;
+      --border:    #30363d;
+      --border2:   #444c56;
+      --text:      #e6edf3;
+      --text2:     #c9d1d9;
+      --muted:     #8b949e;
+      --muted2:    #6e7681;
+      --accent:    #58a6ff;
+      --accent2:   #388bfd;
+      --green:     #3fb950;
+      --green2:    #238636;
+      --yellow:    #d29922;
+      --orange:    #f0883e;
+      --red:       #f85149;
+      --purple:    #bc8cff;
+      --cyan:      #39d3f2;
+      --radius:    10px;
+      --radius-sm: 6px;
+      --sidebar-w: 220px;
+      --topbar-h:  56px;
+      --shadow:    0 1px 3px rgba(0,0,0,.5), 0 4px 16px rgba(0,0,0,.3);
+      --shadow-lg: 0 8px 32px rgba(0,0,0,.6);
     }
 
-    /* ─── Reset & Base ────────────────────────────────────────────────── */
+    /* ─── Reset ─────────────────────────────────────────────── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    html { font-size: 14px; }
+    html { font-size: 14px; scroll-behavior: smooth; }
     body {
       background: var(--bg);
       color: var(--text);
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
       min-height: 100vh;
       display: flex;
-      flex-direction: column;
+      overflow-x: hidden;
     }
     a { color: var(--accent); text-decoration: none; }
     a:hover { text-decoration: underline; }
+    code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85em;
+      background: var(--surface2);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+      color: var(--text2);
+    }
 
-    /* ─── Nav ─────────────────────────────────────────────────────────── */
-    .nav {
-      display: flex;
-      align-items: center;
-      gap: 1.5rem;
-      padding: 0.75rem 1.5rem;
+    /* ─── Sidebar ────────────────────────────────────────────── */
+    .sidebar {
+      width: var(--sidebar-w);
+      height: 100vh;
+      position: fixed;
+      top: 0; left: 0;
       background: var(--surface);
-      border-bottom: 1px solid var(--border);
-      position: sticky;
-      top: 0;
-      z-index: 100;
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      z-index: 200;
+      transition: transform 0.25s ease;
     }
-    .nav-brand {
-      font-size: 1.05rem;
-      font-weight: 700;
-      color: var(--text);
+    .sidebar-brand {
+      padding: 1rem 1.1rem;
+      border-bottom: 1px solid var(--border);
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      letter-spacing: -0.3px;
+      gap: 0.65rem;
+      flex-shrink: 0;
     }
-    .nav-brand span { color: var(--accent); }
-    .nav-links { display: flex; gap: 1rem; flex: 1; }
-    .nav-links a {
+    .sidebar-logo {
+      width: 34px; height: 34px;
+      background: linear-gradient(135deg, #1a6fd4 0%, #0a3060 100%);
+      border-radius: 9px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 1.1rem;
+      flex-shrink: 0;
+      box-shadow: 0 2px 12px rgba(26,111,212,0.5);
+    }
+    .sidebar-brand-text { display: flex; flex-direction: column; }
+    .sidebar-brand-title {
+      font-size: 0.88rem; font-weight: 700; color: var(--text); line-height: 1.2;
+    }
+    .sidebar-brand-sub {
+      font-size: 0.6rem; color: var(--muted); font-weight: 500;
+      letter-spacing: 0.06em; text-transform: uppercase;
+    }
+
+    .sidebar-nav {
+      flex: 1;
+      padding: 0.6rem 0.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.1rem;
+      overflow-y: auto;
+    }
+    .nav-sep {
+      font-size: 0.58rem;
+      color: var(--muted2);
+      text-transform: uppercase;
+      letter-spacing: 0.09em;
+      font-weight: 700;
+      padding: 0.65rem 0.6rem 0.2rem;
+    }
+    .nav-link {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.52rem 0.7rem;
+      border-radius: var(--radius-sm);
       color: var(--muted);
-      font-size: 0.875rem;
-      padding: 0.25rem 0.5rem;
-      border-radius: 4px;
-      transition: background 0.15s, color 0.15s;
+      font-size: 0.82rem;
+      font-weight: 500;
+      transition: all 0.12s;
+      text-decoration: none;
+      border: 1px solid transparent;
     }
-    .nav-links a:hover, .nav-links a.active {
+    .nav-link:hover {
       color: var(--text);
       background: var(--surface2);
       text-decoration: none;
     }
-    .nav-status {
+    .nav-link.active {
+      color: var(--accent);
+      background: rgba(88,166,255,0.1);
+      border-color: rgba(88,166,255,0.18);
+      font-weight: 600;
+    }
+    .nav-icon { width: 18px; text-align: center; flex-shrink: 0; }
+
+    .sidebar-footer {
+      padding: 0.75rem 1rem;
+      border-top: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .ws-status {
       display: flex;
       align-items: center;
       gap: 0.5rem;
+      font-size: 0.7rem;
+      color: var(--muted);
+      margin-bottom: 0.3rem;
+    }
+    .ws-dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      background: var(--muted2);
+      flex-shrink: 0;
+      transition: background 0.3s;
+    }
+    .ws-dot.live {
+      background: var(--green);
+      box-shadow: 0 0 8px rgba(63,185,80,0.5);
+      animation: pulse-dot 2s infinite;
+    }
+    .ws-dot.alarm {
+      background: var(--red);
+      box-shadow: 0 0 8px rgba(248,81,73,0.5);
+      animation: pulse-dot 1s infinite;
+    }
+    @keyframes pulse-dot {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: 0.4; }
+    }
+    .sidebar-clock {
+      font-size: 0.62rem;
+      color: var(--muted2);
+      font-family: 'JetBrains Mono', monospace;
+    }
+
+    /* ─── Overlay mobile ─────────────────────────────────────── */
+    #sb-overlay {
+      display: none;
+      position: fixed; inset: 0;
+      z-index: 199;
+      background: rgba(0,0,0,0.6);
+      backdrop-filter: blur(2px);
+    }
+
+    /* ─── Layout ─────────────────────────────────────────────── */
+    .layout {
+      margin-left: var(--sidebar-w);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    /* ─── Topbar ─────────────────────────────────────────────── */
+    .topbar {
+      height: var(--topbar-h);
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      padding: 0 1.5rem 0 1rem;
+      gap: 0.75rem;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+    .topbar-burger {
+      display: none;
+      background: none;
+      border: none;
+      color: var(--muted);
+      cursor: pointer;
+      font-size: 1.15rem;
+      padding: 0.3rem;
+      line-height: 1;
+    }
+    .topbar-title {
+      font-size: 0.95rem;
+      font-weight: 700;
+      color: var(--text);
+      flex: 1;
+    }
+    .topbar-clock {
+      font-family: 'JetBrains Mono', monospace;
       font-size: 0.75rem;
       color: var(--muted);
     }
-    .dot {
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: var(--muted);
-    }
-    .dot.active { background: var(--green); animation: pulse 2s infinite; }
-    .dot.alarm  { background: var(--red);   animation: pulse 1s infinite; }
-    @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50%       { opacity: 0.3; }
-    }
 
-    /* ─── Main ────────────────────────────────────────────────────────── */
+    /* ─── Main ───────────────────────────────────────────────── */
     main {
       flex: 1;
       padding: 1.5rem;
-      max-width: 1600px;
+      max-width: 1800px;
       width: 100%;
-      margin: 0 auto;
     }
 
-    /* ─── Cards ───────────────────────────────────────────────────────── */
+    /* ─── Section headers ────────────────────────────────────── */
+    .section-hdr {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+    .section-hdr h2 {
+      font-size: 0.9rem;
+      font-weight: 700;
+      color: var(--text);
+      white-space: nowrap;
+    }
+    .section-count {
+      font-size: 0.65rem;
+      font-weight: 600;
+      padding: 0.12rem 0.5rem;
+      border-radius: 10px;
+      background: var(--surface2);
+      color: var(--muted);
+      border: 1px solid var(--border);
+    }
+    .section-rule {
+      flex: 1;
+      height: 1px;
+      background: var(--border);
+    }
+
+    /* ─── Cards ──────────────────────────────────────────────── */
     .card {
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: var(--radius);
-      padding: 1rem;
       box-shadow: var(--shadow);
     }
+    .card-p { padding: 1.2rem; }
     .card-title {
-      font-size: 0.75rem;
-      font-weight: 600;
+      font-size: 0.65rem;
+      font-weight: 700;
       text-transform: uppercase;
-      letter-spacing: 0.05em;
+      letter-spacing: 0.08em;
       color: var(--muted);
-      margin-bottom: 0.75rem;
+      margin-bottom: 0.85rem;
     }
 
-    /* ─── Grille BMS (overview) ───────────────────────────────────────── */
-    .bms-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-      gap: 1rem;
+    /* ─── KPI boxes ──────────────────────────────────────────── */
+    .kpi-box {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 0.8rem 1rem;
     }
+    .kpi-lbl {
+      font-size: 0.58rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: var(--muted);
+      margin-bottom: 0.3rem;
+    }
+    .kpi-val {
+      font-size: 1.3rem;
+      font-weight: 700;
+      font-family: 'JetBrains Mono', monospace;
+      color: var(--text);
+      line-height: 1;
+    }
+    .kpi-val.blue   { color: var(--accent); }
+    .kpi-val.green  { color: var(--green); }
+    .kpi-val.yellow { color: var(--yellow); }
+    .kpi-val.orange { color: var(--orange); }
+    .kpi-val.red    { color: var(--red); }
+    .kpi-val.muted  { color: var(--muted); }
 
-    /* ─── Carte BMS ───────────────────────────────────────────────────── */
+    /* ─── BMS card ───────────────────────────────────────────── */
     .bms-card {
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: var(--radius);
-      padding: 1rem;
-      box-shadow: var(--shadow);
-      transition: border-color 0.2s;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-    .bms-card:hover { border-color: var(--accent); }
-    .bms-card.alarm { border-color: var(--red); }
-
-    .bms-card-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-    .bms-addr {
-      font-size: 1rem;
-      font-weight: 700;
-      font-family: monospace;
-      color: var(--accent);
-    }
-    .bms-time {
-      font-size: 0.7rem;
-      color: var(--muted);
-    }
-
-    /* ─── Layout gauge + stats ────────────────────────────────────────── */
-    .bms-body {
-      display: grid;
-      grid-template-columns: 140px 1fr;
-      gap: 0.75rem;
-      align-items: center;
-    }
-    .gauge-wrap { height: 130px; }
-
-    /* ─── Stats horizontaux ───────────────────────────────────────────── */
-    .stats-grid {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 0.4rem 0.75rem;
-    }
-    .stat { display: flex; flex-direction: column; }
-    .stat-label { font-size: 0.65rem; color: var(--muted); text-transform: uppercase; }
-    .stat-value { font-size: 0.95rem; font-weight: 600; font-family: monospace; }
-    .stat-value.pos { color: var(--green); }
-    .stat-value.neg { color: var(--accent); }
-    .stat-value.warn{ color: var(--yellow); }
-    .stat-value.err { color: var(--red); }
-
-    /* ─── Badges ──────────────────────────────────────────────────────── */
-    .badge {
-      display: inline-block;
-      padding: 0.15rem 0.5rem;
-      border-radius: 20px;
-      font-size: 0.7rem;
-      font-weight: 600;
-      letter-spacing: 0.03em;
-    }
-    .badge.ok     { background: rgba(63,185,80,0.15);  color: var(--green); }
-    .badge.warn   { background: rgba(210,153,34,0.15); color: var(--yellow); }
-    .badge.alarm  { background: rgba(248,81,73,0.2);   color: var(--red); }
-    .badge.off    { background: rgba(139,148,158,0.15); color: var(--muted); }
-
-    .bms-footer {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 0.5rem;
-    }
-    .mos-badges { display: flex; gap: 0.35rem; }
-    .link-detail {
-      font-size: 0.75rem;
-      color: var(--accent);
-      padding: 0.25rem 0.75rem;
-      border: 1px solid var(--accent);
-      border-radius: 4px;
-      transition: background 0.15s;
-    }
-    .link-detail:hover { background: rgba(88,166,255,0.1); text-decoration: none; }
-
-    /* ─── Page Détail ─────────────────────────────────────────────────── */
-    .detail-header {
-      display: flex;
-      align-items: center;
-      gap: 1rem;
-      margin-bottom: 1.25rem;
-    }
-    .detail-header h1 {
-      font-size: 1.5rem;
-      font-weight: 700;
-      font-family: monospace;
-    }
-    .back-link {
-      font-size: 0.8rem;
-      color: var(--muted);
-      padding: 0.3rem 0.75rem;
-      border: 1px solid var(--border);
-      border-radius: 4px;
-    }
-    .back-link:hover { color: var(--text); text-decoration: none; background: var(--surface2); }
-
-    .detail-grid {
-      display: grid;
-      grid-template-columns: 220px 1fr;
-      gap: 1rem;
-      margin-bottom: 1rem;
-    }
-    .detail-gauge { height: 200px; }
-
-    .kpi-row {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-      gap: 0.75rem;
-    }
-    .kpi {
-      background: var(--surface2);
-      border-radius: var(--radius);
-      padding: 0.75rem 1rem;
-      display: flex;
-      flex-direction: column;
-      gap: 0.2rem;
-    }
-    .kpi-label { font-size: 0.65rem; text-transform: uppercase; color: var(--muted); }
-    .kpi-value {
-      font-size: 1.25rem;
-      font-weight: 700;
-      font-family: monospace;
-    }
-    .kpi-value.green  { color: var(--green); }
-    .kpi-value.blue   { color: var(--accent); }
-    .kpi-value.yellow { color: var(--yellow); }
-    .kpi-value.red    { color: var(--red); }
-    .kpi-value.orange { color: var(--orange); }
-
-    /* ─── Charts ──────────────────────────────────────────────────────── */
-    .chart-section { margin-bottom: 1rem; }
-    .chart-section h3 {
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--muted);
-      margin-bottom: 0.5rem;
-      padding-left: 0.25rem;
-    }
-    .chart-box {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      overflow: hidden;
-    }
-    .chart-row {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 1rem;
-      margin-bottom: 1rem;
-    }
-
-    /* ─── Tableau alarmes ─────────────────────────────────────────────── */
-    table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
-    thead th {
-      text-align: left;
-      padding: 0.5rem 0.75rem;
-      color: var(--muted);
-      border-bottom: 1px solid var(--border);
-      font-weight: 600;
-      font-size: 0.7rem;
-      text-transform: uppercase;
-    }
-    tbody td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--surface2); }
-    tbody tr:last-child td { border-bottom: none; }
-    tbody tr:hover { background: var(--surface2); }
-
-    /* ─── Info-bar accueil ────────────────────────────────────────────── */
-    .info-bar {
-      display: flex;
-      align-items: center;
-      gap: 1.5rem;
-      margin-bottom: 1.25rem;
-      color: var(--muted);
-      font-size: 0.8rem;
-    }
-    .info-bar strong { color: var(--text); }
-
-    /* ─── Footer ──────────────────────────────────────────────────────── */
-    footer {
-      padding: 0.75rem 1.5rem;
-      text-align: center;
-      font-size: 0.7rem;
-      color: var(--muted);
-      border-top: 1px solid var(--border);
-    }
-
-    /* ─── Responsive ──────────────────────────────────────────────────── */
-    @media (max-width: 680px) {
-      main { padding: 0.75rem; }
-      .bms-grid { grid-template-columns: 1fr; }
-      .detail-grid { grid-template-columns: 1fr; }
-      .chart-row { grid-template-columns: 1fr; }
-      .kpi-row { grid-template-columns: repeat(2, 1fr); }
-      .bms-body { grid-template-columns: 120px 1fr; }
-      .gauge-wrap { height: 110px; }
-    }
-
-    /* ═══════════════════════════════════════════════════════════════
-       Nouvelle carte BMS — style Node-RED (vue d'ensemble)
-       ═══════════════════════════════════════════════════════════════ */
-
-    /* Grille : 2 colonnes sur grand écran */
-    .bms-grid { grid-template-columns: repeat(auto-fill, minmax(560px, 1fr)); }
-
-    .bms-card-ng {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
       overflow: hidden;
       box-shadow: var(--shadow);
       display: flex;
       flex-direction: column;
-      transition: border-color 0.2s;
+      transition: border-color 0.2s, box-shadow 0.2s;
+      text-decoration: none;
+      color: inherit;
     }
-    .bms-card-ng:hover { border-color: #4a9bd4; }
-    .bms-card-ng.alarm { border-color: var(--red); }
+    .bms-card:hover {
+      border-color: var(--border2);
+      box-shadow: var(--shadow-lg);
+      text-decoration: none;
+    }
+    .bms-card.alarm {
+      border-color: rgba(248,81,73,0.45);
+      box-shadow: 0 0 0 1px rgba(248,81,73,0.15), var(--shadow);
+    }
 
-    /* ── En-tête ─────────────────────────────────────────────────── */
     .bms-hdr {
-      background: #1a5f8a;
-      padding: 0.55rem 0.9rem;
+      padding: 0.75rem 0.9rem;
       display: flex;
       align-items: center;
       justify-content: space-between;
+      background: linear-gradient(135deg, #163952 0%, #0d2535 100%);
+      border-bottom: 1px solid rgba(255,255,255,0.05);
+      flex-shrink: 0;
     }
-    .bms-hdr-title {
-      font-size: 0.95rem;
-      font-weight: 700;
-      color: #fff;
-      display: flex;
-      align-items: center;
-      gap: 0.4rem;
+    .bms-hdr.alarm-hdr {
+      background: linear-gradient(135deg, #4a1515 0%, #2c0d0d 100%);
     }
-    .bms-hdr-right {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.72rem;
-      color: rgba(255,255,255,0.85);
+    .bms-hdr-left  { display: flex; align-items: center; gap: 0.55rem; }
+    .bms-hdr-name  { font-size: 0.92rem; font-weight: 700; color: #fff; }
+    .bms-live      { display: flex; align-items: center; gap: 0.3rem; font-size: 0.62rem; color: rgba(255,255,255,0.6); }
+    .live-dot      { width: 6px; height: 6px; border-radius: 50%; background: var(--green); animation: pulse-dot 2s infinite; }
+    .bms-hdr-right { display: flex; align-items: center; gap: 0.45rem; }
+    .bms-badge {
+      background: rgba(255,255,255,0.08);
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: 4px;
+      padding: 0.08rem 0.4rem;
+      font-size: 0.62rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-weight: 600;
+      color: rgba(255,255,255,0.75);
     }
-    .bms-live-dot {
-      width: 7px; height: 7px;
-      border-radius: 50%;
-      background: #4ade80;
-      animation: pulse 2s infinite;
-    }
-    .bms-can-badge {
-      background: rgba(255,255,255,0.18);
-      border: 1px solid rgba(255,255,255,0.25);
-      padding: 0.1rem 0.45rem;
-      border-radius: 3px;
-      font-weight: 700;
-      font-size: 0.7rem;
-      font-family: monospace;
-    }
-    .bms-hdr-ts {
-      font-size: 0.65rem;
-      color: rgba(255,255,255,0.6);
-    }
+    .bms-ts { font-size: 0.6rem; color: rgba(255,255,255,0.38); font-family: 'JetBrains Mono', monospace; }
 
-    /* ── Grille KPI 4 colonnes ─────────────────────────────────── */
+    /* KPI strip 4 colonnes */
     .kpi4 {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
       border-bottom: 1px solid var(--border);
     }
     .kpi4-cell {
-      padding: 0.45rem 0.65rem;
+      padding: 0.65rem 0.75rem;
       border-right: 1px solid var(--border);
-      border-top: 3px solid transparent;
+      border-top: 2px solid transparent;
     }
     .kpi4-cell:last-child { border-right: none; }
+    .kpi4-cell.t-blue   { border-top-color: var(--accent); }
+    .kpi4-cell.t-green  { border-top-color: var(--green); }
+    .kpi4-cell.t-orange { border-top-color: var(--orange); }
+    .kpi4-cell.t-yellow { border-top-color: var(--yellow); }
+    .kpi4-cell.t-red    { border-top-color: var(--red); }
     .kpi4-lbl {
-      font-size: 0.58rem;
-      color: var(--muted);
+      font-size: 0.56rem;
+      font-weight: 700;
       text-transform: uppercase;
-      letter-spacing: 0.04em;
-      margin-bottom: 0.12rem;
+      letter-spacing: 0.07em;
+      color: var(--muted);
+      margin-bottom: 0.18rem;
     }
     .kpi4-val {
       font-size: 1rem;
       font-weight: 700;
-      font-family: monospace;
+      font-family: 'JetBrains Mono', monospace;
       color: var(--text);
     }
-    .kpi4-v   { border-top-color: var(--accent); }
-    .kpi4-soc { border-top-color: var(--green); }
-    .kpi4-i   { border-top-color: var(--orange); }
-    .kpi4-p   { border-top-color: var(--yellow); }
-    .kpi4-val.chg { color: var(--green); }
-    .kpi4-val.dch { color: var(--accent); }
-    .kpi4-val.mos-on  { color: var(--green);  font-size: 0.88rem; }
-    .kpi4-val.mos-off { color: var(--red);    font-size: 0.88rem; }
+    .kpi4-val.chg    { color: var(--green); }
+    .kpi4-val.dch    { color: var(--accent); }
+    .kpi4-val.mos-on { color: var(--green);  font-size: 0.82rem; }
+    .kpi4-val.mos-off{ color: var(--red);    font-size: 0.82rem; }
+    .kpi4-val.muted  { color: var(--muted);  font-size: 0.8rem; }
 
-    /* ── Barre SOC ──────────────────────────────────────────────── */
-    .soc-bar-row {
+    /* SOC bar */
+    .soc-row {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      padding: 0.35rem 0.75rem;
-      font-size: 0.65rem;
-      color: var(--muted);
+      gap: 0.55rem;
+      padding: 0.45rem 0.75rem;
       border-bottom: 1px solid var(--border);
+      font-size: 0.6rem;
+      color: var(--muted);
     }
-    .soc-bar-wrap {
+    .soc-track {
       flex: 1;
-      height: 7px;
+      height: 5px;
       background: var(--surface2);
-      border-radius: 4px;
+      border-radius: 3px;
       overflow: hidden;
     }
-    .soc-bar-fill {
+    .soc-fill {
       height: 100%;
-      border-radius: 4px;
-      transition: width 0.4s, background 0.4s;
+      border-radius: 3px;
+      transition: width 0.6s ease, background 0.6s ease;
     }
 
-    /* ── Grille de cellules ─────────────────────────────────────── */
+    /* Cells grid */
     .cells-section {
-      padding: 0.45rem 0.65rem;
+      padding: 0.5rem 0.75rem;
       border-bottom: 1px solid var(--border);
     }
-    .cells-hdr {
-      font-size: 0.62rem;
+    .cells-meta {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      font-size: 0.58rem;
       color: var(--muted);
-      margin-bottom: 0.35rem;
-      line-height: 1.5;
+      margin-bottom: 0.3rem;
     }
-    .cells-hdr .c-min  { color: var(--red); }
-    .cells-hdr .c-max  { color: var(--yellow); }
-    .cells-hdr .c-dlt  { font-weight: 600; }
-    .cells-hdr .c-dlt.ok   { color: var(--green); }
-    .cells-hdr .c-dlt.warn { color: var(--yellow); }
-    .cells-hdr .c-dlt.crit { color: var(--red); }
+    .cells-meta .c-min { color: var(--red); font-weight: 700; }
+    .cells-meta .c-max { color: var(--yellow); font-weight: 700; }
+    .c-dlt.ok   { color: var(--green); font-weight: 700; }
+    .c-dlt.warn { color: var(--yellow); font-weight: 700; }
+    .c-dlt.crit { color: var(--red); font-weight: 700; }
     .cells-grid {
       display: grid;
       grid-template-columns: repeat(8, 1fr);
       gap: 3px;
     }
     .cell-box {
-      background: rgba(26,127,55,0.07);
-      border: 1px solid rgba(26,127,55,0.35);
+      background: rgba(63,185,80,0.05);
+      border: 1px solid rgba(63,185,80,0.18);
       border-radius: 3px;
-      padding: 0.22rem 0.1rem;
+      padding: 0.16rem 0.05rem;
       text-align: center;
     }
-    .cell-box .c-n { font-size: 0.55rem; color: var(--muted); display: block; }
-    .cell-box .c-v { font-size: 0.62rem; font-weight: 600; font-family: monospace; color: var(--text); display: block; }
-    .cell-box.cell-min { background: rgba(207,34,46,0.08); border-color: rgba(207,34,46,0.45); }
-    .cell-box.cell-min .c-v { color: var(--red); }
-    .cell-box.cell-max { background: rgba(154,103,0,0.08); border-color: rgba(154,103,0,0.45); }
-    .cell-box.cell-max .c-v { color: var(--yellow); }
-    .cell-box.cell-bal .c-n::after { content: "⚡"; font-size: 0.5rem; }
+    .cell-box .cn { font-size: 0.48rem; color: var(--muted2); display: block; }
+    .cell-box .cv {
+      font-size: 0.59rem; font-weight: 600;
+      font-family: 'JetBrains Mono', monospace;
+      color: var(--text2); display: block;
+    }
+    .cell-box.cell-min { background: rgba(248,81,73,0.1); border-color: rgba(248,81,73,0.4); }
+    .cell-box.cell-min .cv { color: var(--red); }
+    .cell-box.cell-max { background: rgba(210,153,34,0.1); border-color: rgba(210,153,34,0.4); }
+    .cell-box.cell-max .cv { color: var(--yellow); }
+    .cell-box.cell-bal .cn::after { content: "⚡"; font-size: 0.42rem; }
 
-    /* ── Températures ───────────────────────────────────────────── */
-    .temp4 {
+    /* Info strip générique */
+    .istrip {
       display: grid;
-      grid-template-columns: repeat(4, 1fr);
       border-bottom: 1px solid var(--border);
     }
-    .temp4-cell {
-      padding: 0.3rem 0.65rem;
+    .istrip.c4 { grid-template-columns: repeat(4, 1fr); }
+    .istrip.c2 { grid-template-columns: repeat(2, 1fr); }
+    .istrip.c3 { grid-template-columns: repeat(3, 1fr); }
+    .icell {
+      padding: 0.38rem 0.7rem;
       border-right: 1px solid var(--border);
     }
-    .temp4-cell:last-child { border-right: none; }
-    .temp4-lbl { font-size: 0.58rem; color: var(--muted); display: block; }
-    .temp4-val { font-size: 0.78rem; font-family: monospace; font-weight: 600; }
+    .icell:last-child { border-right: none; }
+    .i-lbl {
+      font-size: 0.54rem; color: var(--muted);
+      text-transform: uppercase; letter-spacing: 0.05em;
+      display: block; margin-bottom: 0.08rem; font-weight: 600;
+    }
+    .i-val {
+      font-size: 0.7rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-weight: 600;
+      color: var(--text2);
+    }
+    .i-val.ok   { color: var(--green); }
+    .i-val.bad  { color: var(--red); }
+    .i-val.warn { color: var(--yellow); }
+    .i-val.blue { color: var(--accent); }
+    .i-val.muted{ color: var(--muted); }
 
-    /* ── Alarmes ────────────────────────────────────────────────── */
-    .alarm4 {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
+    /* ─── Badges ──────────────────────────────────────────────── */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.18rem 0.55rem;
+      border-radius: 20px;
+      font-size: 0.66rem;
+      font-weight: 600;
+    }
+    .badge.ok    { background: rgba(63,185,80,0.12);  color: var(--green);  border: 1px solid rgba(63,185,80,0.25); }
+    .badge.warn  { background: rgba(210,153,34,0.12); color: var(--yellow); border: 1px solid rgba(210,153,34,0.25); }
+    .badge.alarm { background: rgba(248,81,73,0.14);  color: var(--red);    border: 1px solid rgba(248,81,73,0.3); }
+    .badge.muted { background: var(--surface2);        color: var(--muted);  border: 1px solid var(--border); }
+    .badge.blue  { background: rgba(88,166,255,0.12); color: var(--accent); border: 1px solid rgba(88,166,255,0.25); }
+
+    /* ─── Tables ──────────────────────────────────────────────── */
+    table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+    thead th {
+      text-align: left;
+      padding: 0.6rem 0.85rem;
+      color: var(--muted);
       border-bottom: 1px solid var(--border);
+      font-weight: 700;
+      font-size: 0.62rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
     }
-    .alarm4-cell {
-      padding: 0.3rem 0.65rem;
-      border-right: 1px solid var(--border);
-    }
-    .alarm4-cell:last-child { border-right: none; }
-    .alarm4-name { font-size: 0.58rem; color: var(--muted); display: block; margin-bottom: 0.1rem; }
-    .a-ok  { color: var(--green); font-weight: 600; font-size: 0.72rem; }
-    .a-bad { color: var(--red); font-weight: 700; font-size: 0.72rem;
-             background: rgba(248,81,73,0.12); border-radius: 3px; padding: 0.05rem 0.3rem; }
+    tbody td { padding: 0.5rem 0.85rem; border-bottom: 1px solid rgba(48,54,61,0.6); }
+    tbody tr:last-child td { border-bottom: none; }
+    tbody tr:hover { background: rgba(33,38,45,0.8); }
 
-    /* ── Infos du bas ───────────────────────────────────────────── */
-    .info4 {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
+    /* ─── Chart cards ─────────────────────────────────────────── */
+    .chart-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
     }
-    .info4-cell {
-      padding: 0.3rem 0.65rem;
-      border-right: 1px solid var(--border);
+    .chart-hdr {
+      padding: 0.7rem 1rem;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
     }
-    .info4-cell:last-child { border-right: none; }
-    .info4-lbl { font-size: 0.58rem; color: var(--muted); display: block; margin-bottom: 0.1rem; }
-    .info4-val { font-size: 0.72rem; font-family: monospace; font-weight: 600; }
-    .info4-val.a-ok  { color: var(--green); font-size: 0.72rem; }
-    .info4-val.a-bad { color: var(--red); font-size: 0.72rem; }
+    .chart-hdr-title { font-size: 0.72rem; font-weight: 600; color: var(--text2); }
+    .chart-hdr-meta  { font-size: 0.62rem; color: var(--muted); }
 
+    /* ─── Modals ──────────────────────────────────────────────── */
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.75);
+      backdrop-filter: blur(4px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+    .modal-box {
+      background: var(--surface);
+      border: 1px solid var(--border2);
+      border-radius: 12px;
+      box-shadow: 0 24px 64px rgba(0,0,0,0.6);
+      width: min(440px, 92vw);
+      padding: 1.5rem;
+    }
+    .modal-title { font-size: 1rem; font-weight: 700; margin-bottom: 1.25rem; }
+    .modal-body  { display: flex; flex-direction: column; gap: 0.6rem; }
+    .modal-label {
+      font-size: 0.67rem; text-transform: uppercase;
+      letter-spacing: 0.05em; color: var(--muted);
+      font-weight: 700; display: block; margin-bottom: 0.2rem;
+    }
+    .modal-input {
+      width: 100%;
+      padding: 0.5rem 0.75rem;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      color: var(--text);
+      font-size: 0.875rem;
+      font-family: inherit;
+    }
+    .modal-input:focus { outline: 2px solid var(--accent); border-color: transparent; }
+    .modal-footer { display: flex; justify-content: flex-end; gap: 0.5rem; margin-top: 1.25rem; }
+
+    /* ─── Buttons ─────────────────────────────────────────────── */
+    .btn {
+      display: inline-flex; align-items: center; gap: 0.4rem;
+      padding: 0.45rem 1rem;
+      border-radius: var(--radius-sm);
+      font-size: 0.8rem; font-weight: 600;
+      cursor: pointer; transition: all 0.15s;
+      border: 1px solid transparent; font-family: inherit;
+    }
+    .btn-primary  { background: var(--accent2); color: #fff; }
+    .btn-primary:hover  { opacity: 0.88; text-decoration: none; color: #fff; }
+    .btn-outline  { background: transparent; border-color: var(--border2); color: var(--text2); }
+    .btn-outline:hover  { background: var(--surface2); text-decoration: none; color: var(--text); }
+    .btn-danger   { background: transparent; border-color: rgba(248,81,73,0.4); color: var(--red); }
+    .btn-danger:hover   { background: rgba(248,81,73,0.1); text-decoration: none; }
+    .btn-cancel   { background: var(--surface2); border-color: var(--border2); color: var(--text2); }
+    .btn-cancel:hover   { background: var(--surface3); }
+    .btn-confirm  { background: var(--accent2); border-color: transparent; color: #fff; }
+    .btn-confirm:hover  { opacity: 0.88; }
+    .btn-confirm.red    { background: var(--red); }
+
+    /* ─── Empty state ─────────────────────────────────────────── */
+    .empty-state {
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      padding: 4rem 2rem; color: var(--muted);
+      text-align: center; gap: 0.75rem;
+    }
+    .empty-icon  { font-size: 2.5rem; }
+    .empty-title { font-size: 1rem; font-weight: 600; color: var(--text2); }
+    .empty-sub   { font-size: 0.8rem; line-height: 1.6; max-width: 360px; }
+
+    /* ─── Info bar top (page) ─────────────────────────────────── */
+    .page-hdr {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .page-hdr h1 {
+      font-size: 1.15rem;
+      font-weight: 800;
+      color: var(--text);
+    }
+    .page-hdr-meta {
+      font-size: 0.75rem;
+      color: var(--muted);
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .page-hdr-meta .sep { color: var(--border2); }
+
+    /* ─── Responsive ──────────────────────────────────────────── */
+    @media (max-width: 920px) {
+      .sidebar {
+        transform: translateX(-100%);
+        width: 260px;
+        box-shadow: none;
+      }
+      .sidebar.open {
+        transform: translateX(0);
+        box-shadow: 0 0 0 100vw rgba(0,0,0,0.5);
+      }
+      .layout { margin-left: 0; }
+      .topbar-burger { display: flex; align-items: center; }
+    }
     @media (max-width: 700px) {
-      .bms-grid { grid-template-columns: 1fr; }
+      main { padding: 0.75rem; }
       .kpi4 { grid-template-columns: repeat(2, 1fr); }
-      .alarm4, .info4 { grid-template-columns: repeat(2, 1fr); }
+      .istrip.c4 { grid-template-columns: repeat(2, 1fr); }
       .cells-grid { grid-template-columns: repeat(4, 1fr); }
     }
+    @media (max-width: 480px) {
+      .istrip.c4 .icell:nth-child(2n) { border-right: none; }
+      .istrip.c4 .icell:nth-child(n+3) { border-top: 1px solid var(--border); }
+    }
   </style>
+  {% block head %}{% endblock %}
 </head>
 <body>
 
-<nav class="nav">
-  <div class="nav-brand">⚡ <span>Monitoring</span></div>
-  <div class="nav-links">
-    <a href="/dashboard/overview">🏠 Vue d'ensemble</a>
-    <a href="/dashboard">🔋 BMS</a>
-    <a href="/dashboard/et112">⚡ Compteurs ET112</a>
-    <a href="/dashboard/tasmota">🔌 Tasmota</a>
-    <a href="/dashboard/settings">Paramètres</a>
-    <a href="/dashboard/logs">Logs</a>
-    <a href="/api/v1/system/status" target="_blank">API</a>
+<!-- ─── Sidebar ─────────────────────────────────────────────────────── -->
+<aside class="sidebar" id="sidebar">
+  <div class="sidebar-brand">
+    <div class="sidebar-logo">⚡</div>
+    <div class="sidebar-brand-text">
+      <span class="sidebar-brand-title">ESS Monitor</span>
+      <span class="sidebar-brand-sub">Santuario · Pi5</span>
+    </div>
   </div>
-  <div class="nav-status" id="ws-status">
-    <div class="dot" id="ws-dot"></div>
-    <span id="ws-label">Connexion…</span>
+
+  <nav class="sidebar-nav">
+    <span class="nav-sep">Principal</span>
+    <a href="/dashboard/overview" class="nav-link {% block nav_overview %}{% endblock %}">
+      <span class="nav-icon">🏠</span> Vue d'ensemble
+    </a>
+    <a href="/dashboard" class="nav-link {% block nav_bms %}{% endblock %}">
+      <span class="nav-icon">🔋</span> Batteries BMS
+    </a>
+    <a href="/dashboard/et112" class="nav-link {% block nav_et112 %}{% endblock %}">
+      <span class="nav-icon">⚡</span> Compteurs ET112
+    </a>
+    <a href="/dashboard/tasmota" class="nav-link {% block nav_tasmota %}{% endblock %}">
+      <span class="nav-icon">🔌</span> Tasmota
+    </a>
+
+    <span class="nav-sep">Système</span>
+    <a href="/dashboard/settings" class="nav-link {% block nav_settings %}{% endblock %}">
+      <span class="nav-icon">⚙</span> Paramètres
+    </a>
+    <a href="/dashboard/logs" class="nav-link {% block nav_logs %}{% endblock %}">
+      <span class="nav-icon">📋</span> Logs
+    </a>
+    <a href="/api/v1/system/status" target="_blank" class="nav-link">
+      <span class="nav-icon">🔗</span> API JSON
+    </a>
+  </nav>
+
+  <div class="sidebar-footer">
+    <div class="ws-status">
+      <div class="ws-dot" id="ws-dot"></div>
+      <span id="ws-label">Connexion…</span>
+    </div>
+    <div class="sidebar-clock" id="sb-clock"></div>
   </div>
-</nav>
+</aside>
 
-<main>
-  {% block content %}{% endblock %}
-</main>
+<div id="sb-overlay" onclick="closeSidebar()"></div>
 
-<footer>
-  Monitoring &nbsp;·&nbsp;
-  <a href="/api/v1/system/status">API status</a> &nbsp;·&nbsp;
-  <a href="/ws/bms/stream">WebSocket</a>
-</footer>
+<!-- ─── Layout principal ──────────────────────────────────────────── -->
+<div class="layout">
+  <header class="topbar">
+    <button class="topbar-burger" onclick="toggleSidebar()">☰</button>
+    <div class="topbar-title">{% block page_title %}Monitoring{% endblock %}</div>
+    <div class="topbar-clock" id="tb-clock"></div>
+  </header>
 
-<!-- Apache ECharts 5.5 (CDN — remplacer par /static/echarts.min.js pour usage hors-ligne) -->
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</div>
+
+<!-- ─── ECharts ───────────────────────────────────────────────────── -->
 <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
 
 <script>
-// ─── Client WebSocket temps réel ───────────────────────────────────────────
-(function() {
+// ── Horloge ────────────────────────────────────────────────────────────
+(function clock() {
+  function tick() {
+    const now = new Date();
+    const t = now.toLocaleTimeString('fr-FR', {hour:'2-digit',minute:'2-digit',second:'2-digit'});
+    const d = now.toLocaleDateString('fr-FR', {weekday:'short', day:'numeric', month:'short'});
+    const tb = document.getElementById('tb-clock');
+    const sb = document.getElementById('sb-clock');
+    if (tb) tb.textContent = t;
+    if (sb) sb.textContent = d + ' · ' + t;
+  }
+  tick();
+  setInterval(tick, 1000);
+})();
+
+// ── Sidebar mobile ─────────────────────────────────────────────────────
+function toggleSidebar() {
+  const s = document.getElementById('sidebar');
+  const o = document.getElementById('sb-overlay');
+  const open = s.classList.toggle('open');
+  o.style.display = open ? 'block' : 'none';
+}
+function closeSidebar() {
+  document.getElementById('sidebar').classList.remove('open');
+  document.getElementById('sb-overlay').style.display = 'none';
+}
+
+// ── WebSocket ──────────────────────────────────────────────────────────
+(function ws() {
   const dot   = document.getElementById('ws-dot');
   const label = document.getElementById('ws-label');
-
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   const url   = `${proto}://${location.host}/ws/bms/stream`;
-
-  let ws, retryDelay = 2000;
+  let sock, retryDelay = 2000;
 
   function connect() {
-    ws = new WebSocket(url);
-
-    ws.onopen = () => {
-      dot.className   = 'dot active';
-      label.textContent = 'Connecté';
+    sock = new WebSocket(url);
+    sock.onopen = () => {
+      dot.className   = 'ws-dot live';
+      label.textContent = 'Temps réel';
       retryDelay = 2000;
     };
-
-    ws.onmessage = (ev) => {
+    sock.onmessage = (ev) => {
       let snaps;
       try { snaps = JSON.parse(ev.data); } catch { return; }
       if (!Array.isArray(snaps)) return;
-      // Dispatcher aux handlers de la page courante
       if (typeof window.onBmsUpdate === 'function') window.onBmsUpdate(snaps);
     };
-
-    ws.onclose = () => {
-      dot.className   = 'dot';
-      label.textContent = `Reconnexion dans ${retryDelay/1000}s…`;
+    sock.onclose = () => {
+      dot.className   = 'ws-dot';
+      label.textContent = 'Reconnexion…';
       setTimeout(connect, retryDelay);
       retryDelay = Math.min(retryDelay * 2, 30000);
     };
-
-    ws.onerror = () => ws.close();
+    sock.onerror = () => sock.close();
   }
-
   connect();
 })();
 </script>

--- a/crates/daly-bms-server/templates/bms_detail.html
+++ b/crates/daly-bms-server/templates/bms_detail.html
@@ -1,153 +1,175 @@
 {% extends "base.html" %}
 
-{% block title %}BMS {{ detail.summary.address_hex }} — Monitoring{% endblock %}
+{% block title %}BMS {{ detail.summary.address_hex }} — {{ detail.summary.name }}{% endblock %}
+{% block page_title %}{{ detail.summary.name }}{% endblock %}
+{% block nav_bms %}active{% endblock %}
+
+{% block head %}
+<style>
+  .detail-kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+  .kpi-box-lg {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.9rem 1rem;
+  }
+  .kpi-box-lg .kpi-lbl { font-size: 0.58rem; margin-bottom: 0.3rem; }
+  .kpi-box-lg .kpi-val { font-size: 1.2rem; }
+</style>
+{% endblock %}
 
 {% block content %}
 
-{# ─── En-tête ─────────────────────────────────────────────────────────────── #}
-<div class="detail-header">
-  <a href="/dashboard" class="back-link">← Retour</a>
-  <h1>BMS {{ detail.summary.address_hex }}</h1>
-  <span class="badge {% if detail.summary.any_alarm %}alarm{% else %}ok{% endif %}" style="font-size:0.85rem">
+{# ─── Back + header ────────────────────────────────────────────────────── #}
+<div class="page-hdr" style="margin-bottom:1.25rem">
+  <a href="/dashboard" class="btn btn-outline" style="font-size:0.75rem;padding:0.3rem 0.7rem;">← Retour</a>
+  <h1>🔋 {{ detail.summary.name }}</h1>
+  <span class="badge {% if detail.summary.any_alarm %}alarm{% else %}ok{% endif %}">
     {% if detail.summary.any_alarm %}⚠ ALARME{% else %}✓ Normal{% endif %}
   </span>
-  <span style="margin-left:auto;font-size:0.75rem;color:var(--muted)">
-    Dernier snapshot : <span id="last-ts">{{ detail.summary.last_update }}</span>
-  </span>
-</div>
-
-{# ─── KPIs ────────────────────────────────────────────────────────────────── #}
-<div class="card" style="margin-bottom:1rem;padding:1rem">
-  <div style="display:flex;flex-direction:column;gap:0.75rem">
-    <div class="kpi-row">
-      <div class="kpi">
-        <span class="kpi-label">Tension pack</span>
-        <span class="kpi-value blue" id="kpi-v">{{ detail.summary.voltage|f1 }} V</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">Courant</span>
-        <span class="kpi-value {% if detail.summary.current > 0.0 %}green{% else if detail.summary.current < -0.1 %}blue{% endif %}"
-              id="kpi-i">{{ detail.summary.current|sign }} A</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">Puissance</span>
-        <span class="kpi-value" id="kpi-p">{{ detail.summary.power|f0 }} W</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">Temp. max</span>
-        <span class="kpi-value {% if detail.summary.temp_max > 45.0 %}red{% else if detail.summary.temp_max > 35.0 %}yellow{% endif %}"
-              id="kpi-t">{{ detail.summary.temp_max|f1 }} °C</span>
-      </div>
-    </div>
-
-    <div class="kpi-row">
-      <div class="kpi">
-        <span class="kpi-label">SOC</span>
-        <span class="kpi-value {% if detail.summary.soc < 15.0 %}red{% else if detail.summary.soc < 25.0 %}orange{% else if detail.summary.soc < 40.0 %}yellow{% else %}green{% endif %}"
-              id="kpi-soc">{{ detail.summary.soc|f1 }} %</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">SOH</span>
-        <span class="kpi-value {% if detail.soh < 70.0 %}red{% else if detail.soh < 85.0 %}yellow{% else %}green{% endif %}">
-          {{ detail.soh|f1 }} %</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">Δ cellules</span>
-        <span class="kpi-value {% if detail.summary.cell_delta_mv > 100.0 %}red{% else if detail.summary.cell_delta_mv > 50.0 %}yellow{% endif %}"
-              id="kpi-d">{{ detail.summary.cell_delta_mv|mv }} mV</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">Restant (SOC)</span>
-        <span class="kpi-value" id="kpi-c">{{ detail.summary.capacity_ah|f1 }} Ah</span>
-      </div>
-    </div>
-
-    <div class="kpi-row">
-      <div class="kpi">
-        <span class="kpi-label">Cap. BMS</span>
-        <span class="kpi-value" id="kpi-bms-c">{{ detail.summary.bms_capacity_ah|f1 }} Ah</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">Cycles</span>
-        <span class="kpi-value">{{ detail.cycles }}</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">Autonomie</span>
-        <span class="kpi-value" id="kpi-ttg">
-          {% if detail.time_to_go_h > 0.0 %}{{ detail.time_to_go_h|f1 }} h{% else %}—{% endif %}
-        </span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">Cellules</span>
-        <span class="kpi-value">{{ detail.cell_count }}</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">MOS CHG/DCH</span>
-        <span class="kpi-value" style="font-size:0.9rem">
-          {% if detail.summary.charge_ok %}<span style="color:var(--green)">C✓</span>{% else %}<span style="color:var(--red)">C✗</span>{% endif %}
-          &nbsp;
-          {% if detail.summary.discharge_ok %}<span style="color:var(--green)">D✓</span>{% else %}<span style="color:var(--red)">D✗</span>{% endif %}
-        </span>
-      </div>
-    </div>
-
-    {# Min/Max cellules #}
-    <div style="display:flex;gap:0.75rem;font-size:0.8rem;color:var(--muted);padding:0 0.25rem">
-      <span>Min : <strong style="color:var(--text)">{{ detail.min_cell_id }}</strong> = <span id="kpi-vmin">{{ detail.min_cell_v|f3 }}</span> V</span>
-      <span>Max : <strong style="color:var(--text)">{{ detail.max_cell_id }}</strong> = <span id="kpi-vmax">{{ detail.max_cell_v|f3 }}</span> V</span>
-    </div>
+  <div class="page-hdr-meta" style="margin-left:auto">
+    <span>{{ detail.summary.address_hex }}</span>
+    <span class="sep">·</span>
+    <span>{{ detail.summary.can_id }}</span>
+    <span class="sep">·</span>
+    <span>Dernier snapshot : <span id="last-ts">{{ detail.summary.last_update }}</span></span>
   </div>
 </div>
 
-{# ─── Tensions des cellules (pleine largeur) ──────────────────────────────── #}
-<div class="chart-section">
-  <h3>Tensions cellules
-    <span style="font-size:0.7rem;color:var(--muted);font-weight:400;margin-left:0.5rem">
-      MIN <span style="color:var(--red)">&#9632;</span>
-      &nbsp;MAX <span style="color:var(--green)">&#9632;</span>
-      &nbsp;autres <span style="color:var(--accent)">&#9632;</span>
+{# ─── KPIs principaux ─────────────────────────────────────────────────── #}
+<div class="detail-kpi-grid" style="margin-bottom:1rem">
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">Tension pack</div>
+    <div class="kpi-val blue" id="kpi-v">{{ detail.summary.voltage|f1 }} V</div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">Courant</div>
+    <div class="kpi-val {% if detail.summary.current > 0.0 %}green{% else if detail.summary.current < -0.1 %}blue{% endif %}" id="kpi-i">
+      {{ detail.summary.current|sign }} A
+    </div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">Puissance</div>
+    <div class="kpi-val" id="kpi-p">{{ detail.summary.power|f0 }} W</div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">SOC</div>
+    <div class="kpi-val {% if detail.summary.soc < 15.0 %}red{% else if detail.summary.soc < 25.0 %}orange{% else if detail.summary.soc < 40.0 %}yellow{% else %}green{% endif %}" id="kpi-soc">
+      {{ detail.summary.soc|f1 }}%
+    </div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">SOH</div>
+    <div class="kpi-val {% if detail.soh < 70.0 %}red{% else if detail.soh < 85.0 %}yellow{% else %}green{% endif %}">
+      {{ detail.soh|f1 }}%
+    </div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">T° max</div>
+    <div class="kpi-val {% if detail.summary.temp_max > 45.0 %}red{% else if detail.summary.temp_max > 35.0 %}yellow{% endif %}" id="kpi-t">
+      {{ detail.summary.temp_max|f1 }} °C
+    </div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">Δ cellules</div>
+    <div class="kpi-val {% if detail.summary.cell_delta_mv > 100.0 %}red{% else if detail.summary.cell_delta_mv > 50.0 %}yellow{% endif %}" id="kpi-d">
+      {{ detail.summary.cell_delta_mv|mv }} mV
+    </div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">Capacité SOC</div>
+    <div class="kpi-val" id="kpi-c">{{ detail.summary.capacity_ah|f1 }} Ah</div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">Cap. BMS</div>
+    <div class="kpi-val muted" id="kpi-bms-c">{{ detail.summary.bms_capacity_ah|f1 }} Ah</div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">Autonomie</div>
+    <div class="kpi-val" id="kpi-ttg">
+      {% if detail.time_to_go_h > 0.0 %}{{ detail.time_to_go_h|f1 }} h{% else %}—{% endif %}
+    </div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">Cycles</div>
+    <div class="kpi-val muted">{{ detail.cycles }}</div>
+  </div>
+  <div class="kpi-box-lg">
+    <div class="kpi-lbl">Cellules</div>
+    <div class="kpi-val muted">{{ detail.cell_count }}S</div>
+  </div>
+</div>
+
+{# MOS + min/max #}
+<div class="card" style="padding:0.75rem 1rem;margin-bottom:1rem;display:flex;align-items:center;gap:1.5rem;flex-wrap:wrap">
+  <div style="display:flex;align-items:center;gap:0.5rem;">
+    <span style="font-size:0.65rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;font-weight:700">MOS</span>
+    <span style="font-size:0.82rem;font-weight:700;color:{% if detail.summary.charge_ok %}var(--green){% else %}var(--red){% endif %}">
+      CHG {% if detail.summary.charge_ok %}✓{% else %}✗{% endif %}
     </span>
-  </h3>
-  <div class="chart-box">
-    <div id="chart-cells" style="height:240px"></div>
-  </div>
-</div>
-
-{# ─── Boxplot distribution historique par cellule ────────────────────────── #}
-<div class="chart-section">
-  <h3>Boxplot cellules — distribution historique
-    <span style="font-size:0.7rem;color:var(--muted);font-weight:400;margin-left:0.5rem">
-      ┤min · Q1 · médiane · Q3 · max├ &nbsp;
-      MIN <span style="color:var(--red)">&#9632;</span>
-      &nbsp;MAX <span style="color:var(--green)">&#9632;</span>
-      &nbsp;autres <span style="color:var(--accent)">&#9632;</span>
-      &nbsp;&#9670; balancing
+    <span style="font-size:0.82rem;font-weight:700;color:{% if detail.summary.discharge_ok %}var(--green){% else %}var(--red){% endif %}">
+      DCH {% if detail.summary.discharge_ok %}✓{% else %}✗{% endif %}
     </span>
-  </h3>
-  <div class="chart-box">
-    <div id="chart-boxplot" style="height:240px"></div>
+  </div>
+  <div style="font-size:0.75rem;color:var(--muted);">
+    Min : <strong style="color:var(--text);font-family:'JetBrains Mono',monospace">{{ detail.min_cell_id }}</strong>
+    = <span id="kpi-vmin" style="font-family:'JetBrains Mono',monospace;color:var(--red)">{{ detail.min_cell_v|f3 }}</span> V
+  </div>
+  <div style="font-size:0.75rem;color:var(--muted);">
+    Max : <strong style="color:var(--text);font-family:'JetBrains Mono',monospace">{{ detail.max_cell_id }}</strong>
+    = <span id="kpi-vmax" style="font-family:'JetBrains Mono',monospace;color:var(--yellow)">{{ detail.max_cell_v|f3 }}</span> V
   </div>
 </div>
 
-{# ─── Tableau des alarmes ─────────────────────────────────────────────────── #}
-<div class="card chart-section">
-  <div class="card-title">État des alarmes</div>
+{# ─── Graphique tensions cellules ─────────────────────────────────────── #}
+<div class="chart-card" style="margin-bottom:1rem">
+  <div class="chart-hdr">
+    <span class="chart-hdr-title">Tensions cellules</span>
+    <span class="chart-hdr-meta">
+      MIN <span style="color:var(--red)">█</span>&nbsp;
+      MAX <span style="color:var(--green)">█</span>&nbsp;
+      Autres <span style="color:var(--accent)">█</span>
+    </span>
+  </div>
+  <div id="chart-cells" style="height:240px"></div>
+</div>
+
+{# ─── Boxplot ─────────────────────────────────────────────────────────── #}
+<div class="chart-card" style="margin-bottom:1rem">
+  <div class="chart-hdr">
+    <span class="chart-hdr-title">Distribution historique par cellule</span>
+    <span class="chart-hdr-meta">min · Q1 · médiane · Q3 · max — 30 dernières secondes</span>
+  </div>
+  <div id="chart-boxplot" style="height:240px"></div>
+</div>
+
+{# ─── Alarmes ─────────────────────────────────────────────────────────── #}
+<div class="chart-card" style="margin-bottom:1rem">
+  <div class="chart-hdr">
+    <span class="chart-hdr-title">État des alarmes</span>
+    <span class="chart-hdr-meta">{{ detail.alarms|length }} alarmes surveillées</span>
+  </div>
   <table>
     <thead>
       <tr>
         <th>Alarme</th>
-        <th style="text-align:center">État</th>
+        <th style="text-align:center;width:120px">État</th>
       </tr>
     </thead>
     <tbody>
     {% for alarm in detail.alarms %}
       <tr>
-        <td>{{ alarm.name }}</td>
+        <td style="color:var(--text2)">{{ alarm.name }}</td>
         <td style="text-align:center">
           {% if alarm.active %}
             <span class="badge alarm">⚠ ACTIF</span>
           {% else %}
-            <span class="badge ok">OK</span>
+            <span class="badge ok">✓ OK</span>
           {% endif %}
         </td>
       </tr>
@@ -156,148 +178,65 @@
   </table>
 </div>
 
-{# ─── Actions BMS ─────────────────────────────────────────────────────────── #}
-<div class="card chart-section" style="margin-bottom:1rem">
+{# ─── Actions BMS ─────────────────────────────────────────────────────── #}
+<div class="card card-p" style="margin-bottom:1rem">
   <div class="card-title">Actions BMS</div>
   <div style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center">
-    <button onclick="openSocModal()" class="btn-action">⚡ Calibrer SOC</button>
-    <button onclick="openResetModal()" class="btn-action btn-danger">⚠ Reset BMS</button>
-    <span style="font-size:0.7rem;color:var(--muted)">
-      Mot de passe Daly requis &nbsp;·&nbsp; Inopérant en mode simulateur
-    </span>
+    <button onclick="openSocModal()" class="btn btn-outline">⚡ Calibrer SOC</button>
+    <button onclick="openResetModal()" class="btn btn-danger">⚠ Reset BMS</button>
+    <span style="font-size:0.7rem;color:var(--muted)">Mot de passe Daly requis · Inopérant en mode simulateur</span>
   </div>
 </div>
 
-{# ─── Modal Calibration SOC ───────────────────────────────────────────────── #}
+{# ─── Modal SOC ───────────────────────────────────────────────────────── #}
 <div id="modal-soc" class="modal-overlay" style="display:none" onclick="if(event.target===this)closeSocModal()">
   <div class="modal-box">
     <div class="modal-title">⚡ Calibration SOC</div>
     <div class="modal-body">
-      <label class="modal-label">Nouvelle valeur SOC (%)</label>
-      <input type="number" id="soc-value" min="0" max="100" step="0.1" value="100" class="modal-input">
-      <label class="modal-label" style="margin-top:0.75rem">Mot de passe Daly</label>
-      <input type="password" id="soc-password" value="12345678" class="modal-input" autocomplete="off">
-      <div id="soc-result" style="margin-top:0.6rem;min-height:1.2em;font-size:0.75rem"></div>
+      <div>
+        <label class="modal-label">Nouvelle valeur SOC (%)</label>
+        <input type="number" id="soc-value" min="0" max="100" step="0.1" value="100" class="modal-input">
+      </div>
+      <div>
+        <label class="modal-label">Mot de passe Daly</label>
+        <input type="password" id="soc-password" value="12345678" class="modal-input" autocomplete="off">
+      </div>
+      <div id="soc-result" style="min-height:1.2em;font-size:0.75rem"></div>
     </div>
     <div class="modal-footer">
-      <button onclick="closeSocModal()" class="btn-modal-cancel">Annuler</button>
-      <button onclick="submitSoc()" class="btn-modal-confirm">Envoyer</button>
+      <button onclick="closeSocModal()" class="btn btn-cancel">Annuler</button>
+      <button onclick="submitSoc()" class="btn btn-confirm">Envoyer</button>
     </div>
   </div>
 </div>
 
-{# ─── Modal Reset BMS ─────────────────────────────────────────────────────── #}
+{# ─── Modal Reset ─────────────────────────────────────────────────────── #}
 <div id="modal-reset" class="modal-overlay" style="display:none" onclick="if(event.target===this)closeResetModal()">
   <div class="modal-box">
     <div class="modal-title" style="color:var(--red)">⚠ Reset BMS {{ detail.summary.address_hex }}</div>
     <div class="modal-body">
-      <p style="color:var(--red);font-size:0.8rem;background:rgba(207,34,46,0.07);border:1px solid rgba(207,34,46,0.25);border-radius:4px;padding:0.6rem 0.75rem;margin-bottom:0.75rem">
-        Cette opération réinitialise le BMS. Les paramètres de fonctionnement sont conservés par le BMS mais la communication sera interrompue quelques secondes.
+      <p style="color:var(--red);font-size:0.78rem;background:rgba(248,81,73,0.08);border:1px solid rgba(248,81,73,0.2);border-radius:6px;padding:0.6rem 0.75rem;">
+        Cette opération réinitialise le BMS. La communication sera interrompue quelques secondes.
       </p>
-      <label class="modal-label">Mot de passe Daly</label>
-      <input type="password" id="reset-password" value="12345678" class="modal-input" autocomplete="off">
-      <label class="modal-label" style="margin-top:0.75rem;display:flex;align-items:center;gap:0.5rem;cursor:pointer">
+      <div>
+        <label class="modal-label">Mot de passe Daly</label>
+        <input type="password" id="reset-password" value="12345678" class="modal-input" autocomplete="off">
+      </div>
+      <label style="display:flex;align-items:center;gap:0.5rem;font-size:0.78rem;color:var(--text2);cursor:pointer">
         <input type="checkbox" id="reset-confirm" style="width:auto">
         Je confirme le reset du BMS {{ detail.summary.address_hex }}
       </label>
-      <div id="reset-result" style="margin-top:0.6rem;min-height:1.2em;font-size:0.75rem"></div>
+      <div id="reset-result" style="min-height:1.2em;font-size:0.75rem"></div>
     </div>
     <div class="modal-footer">
-      <button onclick="closeResetModal()" class="btn-modal-cancel">Annuler</button>
-      <button onclick="submitReset()" class="btn-modal-confirm" style="background:var(--red)">Reset</button>
+      <button onclick="closeResetModal()" class="btn btn-cancel">Annuler</button>
+      <button onclick="submitReset()" class="btn btn-confirm red">Reset</button>
     </div>
   </div>
 </div>
 
-{# JSON ECharts (cachés) #}
 <script type="application/json" id="opt-cells">{{ detail.cells_bar_json|safe }}</script>
 <script type="application/json" id="opt-boxplot">{{ detail.cells_boxplot_json|safe }}</script>
-
-<style>
-  .btn-action {
-    padding: 0.45rem 1rem;
-    border: 1px solid var(--accent);
-    background: var(--surface);
-    color: var(--accent);
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.8rem;
-    font-weight: 600;
-    transition: background 0.15s;
-  }
-  .btn-action:hover { background: rgba(9,105,218,0.08); }
-  .btn-danger { border-color: var(--red); color: var(--red); }
-  .btn-danger:hover { background: rgba(207,34,46,0.08); }
-
-  .modal-overlay {
-    position: fixed;
-    inset: 0;
-    background: rgba(0,0,0,0.45);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-  }
-  .modal-box {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    box-shadow: 0 8px 32px rgba(0,0,0,0.18);
-    width: min(440px, 92vw);
-    padding: 1.5rem;
-  }
-  .modal-title {
-    font-size: 1rem;
-    font-weight: 700;
-    margin-bottom: 1rem;
-  }
-  .modal-body { display: flex; flex-direction: column; }
-  .modal-label {
-    display: block;
-    font-size: 0.72rem;
-    color: var(--muted);
-    margin-bottom: 0.25rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-  .modal-input {
-    width: 100%;
-    padding: 0.45rem 0.75rem;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 0.875rem;
-    background: var(--surface2);
-    color: var(--text);
-  }
-  .modal-input:focus { outline: 2px solid var(--accent); border-color: transparent; }
-  .modal-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    margin-top: 1.25rem;
-  }
-  .btn-modal-cancel {
-    padding: 0.4rem 1rem;
-    border: 1px solid var(--border);
-    background: var(--surface2);
-    color: var(--text);
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.8rem;
-  }
-  .btn-modal-confirm {
-    padding: 0.4rem 1rem;
-    border: none;
-    background: var(--accent);
-    color: #fff;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.8rem;
-    font-weight: 600;
-  }
-  .btn-modal-confirm:hover { opacity: 0.88; }
-  .btn-modal-cancel:hover  { background: var(--border); }
-</style>
 
 {% endblock %}
 
@@ -305,79 +244,78 @@
 <script>
 (function() {
   const BMS_ADDR = {{ detail.summary.address }};
-  window._bmsAddr = BMS_ADDR;  // exposé pour les fonctions globales (modals)
+  window._bmsAddr = BMS_ADDR;
 
-  // ─── Initialisation des graphiques ────────────────────────────────────────
+  // ── ECharts dark theme ─────────────────────────────────────────────
+  echarts.registerTheme('dark-ess', {
+    backgroundColor: 'transparent',
+    textStyle: { color: '#8b949e' },
+    axisLine:  { lineStyle: { color: '#30363d' } },
+    splitLine: { lineStyle: { color: '#21262d' } },
+  });
+
   function initChart(domId, optId) {
     const dom = document.getElementById(domId);
     const opt = document.getElementById(optId);
     if (!dom || !opt) return null;
-    const c = echarts.init(dom, null, { renderer: 'svg' });
-    c.setOption(JSON.parse(opt.textContent));
+    const c = echarts.init(dom, 'dark-ess', { renderer: 'svg' });
+    const parsed = JSON.parse(opt.textContent);
+    // Injecter les couleurs dark dans les options de base
+    if (parsed.xAxis) { parsed.xAxis.axisLabel = Object.assign({ color: '#6e7681', fontSize: 10 }, parsed.xAxis.axisLabel); }
+    if (parsed.yAxis) { parsed.yAxis.axisLabel = Object.assign({ color: '#6e7681', fontSize: 10 }, parsed.yAxis.axisLabel); }
+    if (parsed.title) { parsed.title.textStyle = Object.assign({ color: '#c9d1d9', fontSize: 11 }, parsed.title.textStyle); }
+    c.setOption(parsed);
     return c;
   }
 
   const cCells   = initChart('chart-cells',   'opt-cells');
   const cBoxplot = initChart('chart-boxplot', 'opt-boxplot');
 
-  // ─── Resize automatique ────────────────────────────────────────────────────
   window.addEventListener('resize', function() {
     [cCells, cBoxplot].forEach(function(c) { if (c) c.resize(); });
   });
 
-  // ─── Helpers ───────────────────────────────────────────────────────────────
-  function set(id, val) {
-    const el = document.getElementById(id);
-    if (el) el.textContent = val;
-  }
-  function fmt1(n) { return (+n).toFixed(1); }
-  function fmt0(n) { return (+n).toFixed(0); }
-  function fmt3(n) { return (+n).toFixed(3); }
+  function set(id, val) { const el = document.getElementById(id); if (el) el.textContent = val; }
+  function f1(n) { return (+n).toFixed(1); }
+  function f0(n) { return (+n).toFixed(0); }
+  function f3(n) { return (+n).toFixed(3); }
 
-  // ─── État courant MIN/MAX/balance (mis à jour par WS, utilisé par boxplot) ─
   var currentMinCell  = '';
   var currentMaxCell  = '';
   var currentBalances = {};
 
-  // ─── Mise à jour en temps-réel (WebSocket) ─────────────────────────────────
+  // ── WebSocket update ───────────────────────────────────────────────
   window.onBmsUpdate = function(snaps) {
     const s = snaps.find(function(x) { return x.address === BMS_ADDR; });
     if (!s) return;
 
-    // Mémoriser pour le boxplot dynamique
     currentMinCell  = (s.System && s.System.MinVoltageCellId) || '';
     currentMaxCell  = (s.System && s.System.MaxVoltageCellId) || '';
     currentBalances = s.Balances || {};
 
-    // KPIs texte
-    set('kpi-v',   fmt1(s.Dc.Voltage)  + ' V');
-    set('kpi-i',   (s.Dc.Current >= 0 ? '+' : '') + fmt1(s.Dc.Current) + ' A');
-    set('kpi-p',   fmt0(s.Dc.Power)    + ' W');
-    set('kpi-t',   fmt1(s.System.MaxCellTemperature) + ' °C');
-    set('kpi-soc',   fmt1(s.Soc) + ' %');
-    set('kpi-c',     fmt1(s.Capacity) + ' Ah');
-    set('kpi-bms-c', s.BmsCapacity > 0.1 ? fmt1(s.BmsCapacity) + ' Ah' : '—');
+    set('kpi-v',     f1(s.Dc.Voltage)  + ' V');
+    set('kpi-i',     (s.Dc.Current >= 0 ? '+' : '') + f1(s.Dc.Current) + ' A');
+    set('kpi-p',     f0(s.Dc.Power)    + ' W');
+    set('kpi-t',     f1(s.System.MaxCellTemperature) + ' °C');
+    set('kpi-soc',   f1(s.Soc) + '%');
+    set('kpi-c',     f1(s.Capacity) + ' Ah');
+    set('kpi-bms-c', s.BmsCapacity > 0.1 ? f1(s.BmsCapacity) + ' Ah' : '—');
 
     const delta = (s.System.MaxCellVoltage - s.System.MinCellVoltage) * 1000;
-    set('kpi-d', fmt0(delta) + ' mV');
-    set('kpi-vmin', fmt3(s.System.MinCellVoltage));
-    set('kpi-vmax', fmt3(s.System.MaxCellVoltage));
+    set('kpi-d',    f0(delta) + ' mV');
+    set('kpi-vmin', f3(s.System.MinCellVoltage));
+    set('kpi-vmax', f3(s.System.MaxCellVoltage));
 
-    // Horodatage
     const d = new Date(s.timestamp);
-    set('last-ts', isNaN(d) ? '—' : d.toLocaleTimeString());
+    set('last-ts', isNaN(d) ? '—' : d.toLocaleTimeString('fr-FR'));
 
-    // Bar chart cellules avec coloration MIN/MAX temps réel
+    // Bar chart cellules
     if (cCells && s.Voltages) {
       const entries = Object.entries(s.Voltages).sort(function(a, b) {
         return parseInt(a[0].replace(/\D/g,'')) - parseInt(b[0].replace(/\D/g,''));
       });
       var minV = Infinity, maxV = -Infinity;
-      entries.forEach(function(e) {
-        var v = +e[1];
-        if (v < minV) minV = v;
-        if (v > maxV) maxV = v;
-      });
+      entries.forEach(function(e) { var v = +e[1]; if (v < minV) minV = v; if (v > maxV) maxV = v; });
       var avg = entries.reduce(function(s,e){return s+(+e[1]);},0) / entries.length;
       var yMin = +(minV - 0.030).toFixed(3);
       var yMax = +(maxV + 0.030).toFixed(3);
@@ -394,26 +332,24 @@
           label: { show: !!lbl, formatter: lbl, position: 'top', fontSize: 8, fontWeight: 'bold', color: color }
         };
       });
-      var deltaColor = ((maxV-minV)*1000 > 100) ? '#f85149' : (((maxV-minV)*1000 > 50) ? '#d29922' : '#3fb950');
+      var deltaColor = delta > 100 ? '#f85149' : delta > 50 ? '#d29922' : '#3fb950';
       cCells.setOption({
-        title: { text: '\u0394 = ' + ((maxV-minV)*1000).toFixed(0) + ' mV', textStyle: { color: deltaColor } },
-        yAxis: { min: yMin, max: yMax },
+        title: { text: 'Δ = ' + delta.toFixed(0) + ' mV', textStyle: { color: deltaColor, fontSize: 11 } },
+        yAxis: { min: yMin, max: yMax, axisLabel: { fontSize: 9 } },
         series: [{
           data: data,
-          markLine: { data: [{ yAxis: avg, label: { formatter: 'moy '+avg.toFixed(3)+'V' } }] }
+          markLine: { data: [{ yAxis: avg, label: { formatter: 'moy ' + avg.toFixed(3) + 'V', color: '#6e7681', fontSize: 9 }, lineStyle: { color: '#444c56', type: 'dashed' } }] }
         }]
       });
     }
   };
 
-  // ─── Rafraîchissement du boxplot (toutes les 30 s) ────────────────────────
+  // ── Refresh boxplot (30s) ──────────────────────────────────────────
   function refreshHistory() {
     fetch('/api/v1/bms/' + BMS_ADDR + '/history')
       .then(function(r) { return r.json(); })
       .then(function(data) {
         if (!Array.isArray(data) || data.length < 4) return;
-
-        // Boxplot : regrouper les tensions par cellule et recalculer les statistiques
         if (cBoxplot) {
           var cellMap = {};
           data.forEach(function(s) {
@@ -427,33 +363,31 @@
             return parseInt(a.replace(/\D/g,'')) - parseInt(b.replace(/\D/g,''));
           });
           var bpLabels = cellKeys.map(function(k) { return 'C' + k.replace(/\D/g,''); });
-
           var bpData = cellKeys.map(function(k) {
             var v = cellMap[k].slice().sort(function(a,b){return a-b;});
             var n = v.length;
-            var boxVals = [v[0], v[Math.floor(n/4)], v[Math.floor(n/2)], v[Math.floor(3*n/4)], v[n-1]];
-            var cShort  = 'C' + k.replace(/\D/g,'');
-            var isMin   = cShort === currentMinCell;
-            var isMax   = cShort === currentMaxCell;
-            var color   = isMin ? 'rgba(248,81,73,0.25)'  : (isMax ? 'rgba(63,185,80,0.25)'  : 'rgba(88,166,255,0.15)');
-            var border  = isMin ? '#f85149'                : (isMax ? '#3fb950'                : '#58a6ff');
-            return { value: boxVals, itemStyle: { color: color, borderColor: border, borderWidth: 2 } };
+            var cShort = 'C' + k.replace(/\D/g,'');
+            var isMin  = cShort === currentMinCell;
+            var isMax  = cShort === currentMaxCell;
+            var color  = isMin ? 'rgba(248,81,73,0.2)'  : (isMax ? 'rgba(63,185,80,0.2)'  : 'rgba(88,166,255,0.12)');
+            var border = isMin ? '#f85149'               : (isMax ? '#3fb950'               : '#58a6ff');
+            return {
+              value: [v[0], v[Math.floor(n/4)], v[Math.floor(n/2)], v[Math.floor(3*n/4)], v[n-1]],
+              itemStyle: { color: color, borderColor: border, borderWidth: 2 }
+            };
           });
-
           var balData = [];
           cellKeys.forEach(function(k) {
             if (currentBalances[k]) {
               var v  = cellMap[k].slice().sort(function(a,b){return a-b;});
               var mx = v[v.length - 1];
               var mn = v[0];
-              var y  = mx + (mx - mn) * 0.08 + 0.001;
-              balData.push(['C' + k.replace(/\D/g,''), y]);
+              balData.push(['C' + k.replace(/\D/g,''), mx + (mx - mn) * 0.08 + 0.001]);
             }
           });
-
           cBoxplot.setOption({
-            title: { text: 'Distribution par cellule (' + data.length + ' snapshots)' },
-            xAxis: { data: bpLabels },
+            title: { text: 'Distribution (' + data.length + ' snapshots)', textStyle: { color: '#8b949e', fontSize: 11 } },
+            xAxis: { data: bpLabels, axisLabel: { fontSize: 9, color: '#6e7681' } },
             series: [{ data: bpData }, { data: balData }]
           });
         }
@@ -461,17 +395,17 @@
       .catch(function() {});
   }
 
-  setTimeout(refreshHistory, 5000);
+  setTimeout(refreshHistory, 3000);
   setInterval(refreshHistory, 30000);
 })();
 
-// ─── Actions BMS — fonctions globales (appelées depuis onclick="") ───────────
-function openSocModal()   { document.getElementById('modal-soc').style.display   = 'flex'; }
-function closeSocModal()  { document.getElementById('modal-soc').style.display   = 'none'; document.getElementById('soc-result').textContent = ''; }
-function openResetModal() { document.getElementById('modal-reset').style.display = 'flex'; }
-function closeResetModal(){ document.getElementById('modal-reset').style.display = 'none'; document.getElementById('reset-result').textContent = ''; document.getElementById('reset-confirm').checked = false; }
+// ── Modals ─────────────────────────────────────────────────────────────
+function openSocModal()    { document.getElementById('modal-soc').style.display   = 'flex'; }
+function closeSocModal()   { document.getElementById('modal-soc').style.display   = 'none'; document.getElementById('soc-result').textContent = ''; }
+function openResetModal()  { document.getElementById('modal-reset').style.display = 'flex'; }
+function closeResetModal() { document.getElementById('modal-reset').style.display = 'none'; document.getElementById('reset-result').textContent = ''; document.getElementById('reset-confirm').checked = false; }
 
-function _bmsActionResult(id, ok, msg) {
+function _result(id, ok, msg) {
   var el = document.getElementById(id);
   el.style.color = ok ? 'var(--green)' : 'var(--red)';
   el.textContent = msg;
@@ -480,57 +414,32 @@ function _bmsActionResult(id, ok, msg) {
 function submitSoc() {
   var soc = parseFloat(document.getElementById('soc-value').value);
   var pwd = document.getElementById('soc-password').value;
-  if (isNaN(soc) || soc < 0 || soc > 100) {
-    _bmsActionResult('soc-result', false, 'SOC invalide — valeur entre 0 et 100 %');
-    return;
-  }
+  if (isNaN(soc) || soc < 0 || soc > 100) { _result('soc-result', false, 'SOC invalide — valeur entre 0 et 100 %'); return; }
+  _result('soc-result', null, 'Envoi en cours…');
   document.getElementById('soc-result').style.color = 'var(--muted)';
-  document.getElementById('soc-result').textContent = 'Envoi en cours…';
   fetch('/api/v1/bms/' + window._bmsAddr + '/soc', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ soc: soc, password: pwd })
-  })
-  .then(function(r) { return r.json(); })
-  .then(function(data) {
-    if (data.ok) {
-      var msg = '✓ SOC calibré à ' + soc.toFixed(1) + ' %';
-      if (data.warning) msg += '  (' + data.warning + ')';
-      _bmsActionResult('soc-result', true, msg);
-      setTimeout(closeSocModal, 2500);
-    } else {
-      _bmsActionResult('soc-result', false, '✗ ' + (data.error || 'Erreur inconnue'));
-    }
-  })
-  .catch(function(e) { _bmsActionResult('soc-result', false, '✗ Erreur réseau : ' + e); });
+  }).then(r => r.json()).then(d => {
+    if (d.ok) { _result('soc-result', true, '✓ SOC calibré à ' + soc.toFixed(1) + ' %' + (d.warning ? '  (' + d.warning + ')' : '')); setTimeout(closeSocModal, 2500); }
+    else       { _result('soc-result', false, '✗ ' + (d.error || 'Erreur inconnue')); }
+  }).catch(e => _result('soc-result', false, '✗ Erreur réseau : ' + e));
 }
 
 function submitReset() {
-  var pwd     = document.getElementById('reset-password').value;
-  var confirm = document.getElementById('reset-confirm').checked;
-  if (!confirm) {
-    _bmsActionResult('reset-result', false, 'Cocher la case de confirmation');
-    return;
-  }
+  if (!document.getElementById('reset-confirm').checked) { _result('reset-result', false, 'Cocher la case de confirmation'); return; }
+  var pwd = document.getElementById('reset-password').value;
   document.getElementById('reset-result').style.color = 'var(--muted)';
   document.getElementById('reset-result').textContent = 'Envoi du reset…';
   fetch('/api/v1/bms/' + window._bmsAddr + '/reset', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ confirm: true, password: pwd })
-  })
-  .then(function(r) { return r.json(); })
-  .then(function(data) {
-    if (data.ok) {
-      var msg = '✓ Reset envoyé — BMS redémarre (quelques secondes d\'interruption)';
-      if (data.warning) msg += '  (' + data.warning + ')';
-      _bmsActionResult('reset-result', true, msg);
-      setTimeout(closeResetModal, 3000);
-    } else {
-      _bmsActionResult('reset-result', false, '✗ ' + (data.error || 'Erreur inconnue'));
-    }
-  })
-  .catch(function(e) { _bmsActionResult('reset-result', false, '✗ Erreur réseau : ' + e); });
+  }).then(r => r.json()).then(d => {
+    if (d.ok) { _result('reset-result', true, '✓ Reset envoyé — quelques secondes d\'interruption'); setTimeout(closeResetModal, 3000); }
+    else       { _result('reset-result', false, '✗ ' + (d.error || 'Erreur inconnue')); }
+  }).catch(e => _result('reset-result', false, '✗ Erreur réseau : ' + e));
 }
 </script>
 {% endblock %}

--- a/crates/daly-bms-server/templates/et112.html
+++ b/crates/daly-bms-server/templates/et112.html
@@ -1,176 +1,195 @@
 {% extends "base.html" %}
 
-{% block title %}ET112 — {{ name }} — Monitoring{% endblock %}
+{% block title %}ET112 {{ name }} — ESS Monitor{% endblock %}
+{% block page_title %}ET112 — {{ name }}{% endblock %}
+{% block nav_et112 %}active{% endblock %}
 
 {% block content %}
 
-{# ─── En-tête ────────────────────────────────────────────────────────────── #}
-<div class="info-bar">
-  <div style="display:flex;align-items:center;gap:0.5rem;">
-    <div class="dot {% if connected %}active{% endif %}"></div>
-    {% if connected %}
-      <strong>Connecté</strong>
-    {% else %}
-      <span style="color:var(--muted)">En attente de données…</span>
-    {% endif %}
-  </div>
-  <div>⚡ <strong>ET112</strong> — {{ name }}</div>
-  <div>Adresse Modbus : <code>{{ addr_hex }}</code></div>
-  <div style="margin-left:auto;font-size:0.7rem;color:var(--muted)">
-    Dernière mesure : <span id="last-ts">{{ last_ts }}</span>
+<div class="page-hdr">
+  <a href="/dashboard/et112" class="btn btn-outline" style="font-size:0.75rem;padding:0.3rem 0.7rem;">← Retour</a>
+  <h1>⚡ {{ name }}</h1>
+  <span class="badge {% if connected %}ok{% else %}muted{% endif %}">
+    {% if connected %}● Connecté{% else %}○ Hors ligne{% endif %}
+  </span>
+  <div class="page-hdr-meta" style="margin-left:auto">
+    <span>{{ addr_hex }}</span>
+    <span class="sep">·</span>
+    <span>Dernière mesure : <span id="last-ts">{{ last_ts }}</span></span>
   </div>
 </div>
 
 {% if connected %}
 
-{# ─── Cartes de métriques instantanées ──────────────────────────────────── #}
-<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1rem;margin-bottom:1.5rem;">
+{# ─── Métriques instantanées ──────────────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:0.85rem;margin-bottom:1.25rem;">
 
-  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
-    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Puissance</div>
-    <div style="font-size:2rem;font-weight:700;color:{% if power_w >= 0.0 %}var(--green){% else %}var(--accent){% endif %}" id="val-power">
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Puissance</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;
+                color:{% if power_w >= 0.0 %}var(--green){% else %}var(--accent){% endif %}" id="val-power">
       {{ power_w|f1 }} W
     </div>
-    <div style="font-size:0.7rem;color:var(--muted)">{% if power_w >= 0.0 %}Import{% else %}Export{% endif %}</div>
+    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.2rem">
+      {% if power_w >= 0.0 %}Import{% else %}Export{% endif %}
+    </div>
   </div>
 
-  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
-    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Tension</div>
-    <div style="font-size:2rem;font-weight:700;color:var(--text)" id="val-voltage">
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Tension</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--accent)" id="val-voltage">
       {{ voltage_v|f1 }} V
     </div>
   </div>
 
-  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
-    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Courant</div>
-    <div style="font-size:2rem;font-weight:700;color:var(--text)" id="val-current">
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Courant</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--orange)" id="val-current">
       {{ current_a|f2 }} A
     </div>
   </div>
 
-  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
-    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Facteur de puissance</div>
-    <div style="font-size:2rem;font-weight:700;color:var(--text)" id="val-pf">
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Facteur puissance</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--text2)" id="val-pf">
       {{ power_factor|f3 }}
     </div>
   </div>
 
-  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
-    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Fréquence</div>
-    <div style="font-size:2rem;font-weight:700;color:var(--text)" id="val-freq">
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Fréquence</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--text)" id="val-freq">
       {{ frequency_hz|f2 }} Hz
     </div>
   </div>
 
-  <div class="card" style="text-align:center;padding:1.5rem 1rem;">
-    <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;text-transform:uppercase;letter-spacing:.05em">Puiss. apparente</div>
-    <div style="font-size:2rem;font-weight:700;color:var(--muted)" id="val-apparent">
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Puiss. apparente</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--muted)" id="val-apparent">
       {{ apparent_power_va|f1 }} VA
     </div>
   </div>
 
 </div>
 
-{# ─── Énergie cumulée ─────────────────────────────────────────────────────── #}
-<div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:1.5rem;">
-
-  <div class="card" style="padding:1.5rem;display:flex;flex-direction:column;gap:0.5rem;">
-    <div style="font-size:0.75rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em">⬇ Énergie importée (depuis MàJ)</div>
-    <div style="font-size:2.2rem;font-weight:700;color:var(--green)" id="val-import">
+{# ─── Énergie cumulée ─────────────────────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:1.25rem;">
+  <div class="card card-p">
+    <div class="card-title">⬇ Énergie importée</div>
+    <div style="font-size:2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--green)" id="val-import">
       {{ energy_import_kwh|f3 }} kWh
     </div>
-    <div style="font-size:0.7rem;color:var(--muted)">{{ energy_import_wh|f0 }} Wh brut (cumulé compteur)</div>
+    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.4rem">{{ energy_import_wh|f0 }} Wh brut cumulé</div>
   </div>
-
-  <div class="card" style="padding:1.5rem;display:flex;flex-direction:column;gap:0.5rem;">
-    <div style="font-size:0.75rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em">⬆ Énergie exportée</div>
-    <div style="font-size:2.2rem;font-weight:700;color:var(--accent)" id="val-export">
+  <div class="card card-p">
+    <div class="card-title">⬆ Énergie exportée</div>
+    <div style="font-size:2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--accent)" id="val-export">
       {{ energy_export_kwh|f3 }} kWh
     </div>
-    <div style="font-size:0.7rem;color:var(--muted)">{{ energy_export_wh|f0 }} Wh brut (cumulé compteur)</div>
+    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.4rem">{{ energy_export_wh|f0 }} Wh brut cumulé</div>
   </div>
-
 </div>
 
-{# ─── Graphique puissance (ECharts) ──────────────────────────────────────── #}
-<div class="card" style="padding:1rem;">
-  <div style="font-size:0.8rem;font-weight:600;margin-bottom:0.75rem;color:var(--muted)">Historique puissance (dernières mesures)</div>
-  <div id="chart-power" style="height:250px;"></div>
+{# ─── Historique puissance ─────────────────────────────────────────────── #}
+<div class="chart-card">
+  <div class="chart-hdr">
+    <span class="chart-hdr-title">Historique puissance</span>
+    <span class="chart-hdr-meta">Dernières mesures — rafraîchi toutes les 5s</span>
+  </div>
+  <div id="chart-power" style="height:260px;"></div>
 </div>
 
 {% else %}
 
-<div class="card" style="text-align:center;padding:3rem;color:var(--muted)">
-  <div style="font-size:2.5rem;margin-bottom:1rem">⏳</div>
-  <div>En attente du premier snapshot ET112…</div>
-  <div style="font-size:0.8rem;margin-top:0.5rem">
-    Vérifiez que l'ET112 est alimenté sur <code>{{ addr_hex }}</code> @ <code>/dev/ttyUSB1</code>
+<div class="card">
+  <div class="empty-state">
+    <div class="empty-icon">⏳</div>
+    <div class="empty-title">En attente du premier snapshot ET112</div>
+    <div class="empty-sub">
+      Vérifiez que l'ET112 est alimenté sur <code>{{ addr_hex }}</code><br>
+      et que le bus RS485 est connecté sur <code>/dev/ttyUSB0</code>.
+    </div>
   </div>
 </div>
 
 {% endif %}
 
-{# ─── Script ECharts ──────────────────────────────────────────────────────── #}
-<script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
+{% endblock %}
+
+{% block scripts %}
 <script>
 const ADDR = "{{ address }}";
-const API  = `/api/v1/et112/${ADDR}`;
 
-// Initialiser le graphique
+// ── ECharts power chart ────────────────────────────────────────────────
 const chartDom = document.getElementById('chart-power');
 let myChart = null;
 if (chartDom) {
-    myChart = echarts.init(chartDom);
-    myChart.setOption({
-        tooltip: { trigger: 'axis', formatter: params => {
-            const t = params[0].name;
-            return `${t}<br/>Puissance: <b>${params[0].value} W</b>`;
-        }},
-        xAxis: { type: 'category', data: [], axisLabel: { fontSize: 11 } },
-        yAxis: { type: 'value', name: 'W', axisLabel: { fontSize: 11 } },
-        series: [{
-            name: 'Puissance',
-            type: 'line',
-            data: [],
-            smooth: true,
-            lineStyle: { color: '#0969da' },
-            areaStyle: { opacity: 0.15 },
-            symbol: 'none',
-        }],
-        grid: { left: 50, right: 20, top: 20, bottom: 30 },
-    });
-    window.addEventListener('resize', () => myChart.resize());
+  myChart = echarts.init(chartDom);
+  myChart.setOption({
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: '#21262d',
+      borderColor: '#30363d',
+      textStyle: { color: '#e6edf3', fontSize: 11 },
+      formatter: p => p[0].name + '<br/>Puissance : <b>' + p[0].value + ' W</b>'
+    },
+    xAxis: {
+      type: 'category', data: [],
+      axisLine: { lineStyle: { color: '#30363d' } },
+      axisLabel: { color: '#6e7681', fontSize: 10 },
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: 'value',
+      axisLine: { show: false },
+      axisLabel: { color: '#6e7681', fontSize: 10 },
+      splitLine: { lineStyle: { color: '#21262d' } },
+    },
+    series: [{
+      name: 'Puissance', type: 'line', data: [],
+      smooth: true, symbol: 'none',
+      lineStyle: { color: '#58a6ff', width: 2 },
+      areaStyle: { color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
+        colorStops: [{ offset: 0, color: 'rgba(88,166,255,0.25)' }, { offset: 1, color: 'rgba(88,166,255,0.02)' }]
+      }},
+    }],
+    grid: { left: 50, right: 16, top: 16, bottom: 30 },
+  });
+  window.addEventListener('resize', () => myChart && myChart.resize());
 }
 
-// Mise à jour périodique
 async function update() {
-    try {
-        const resp = await fetch(`${API}/status`);
-        if (!resp.ok) return;
-        const d = await resp.json();
-        document.getElementById('val-power').textContent   = d.power_w.toFixed(1) + ' W';
-        document.getElementById('val-voltage').textContent = d.voltage_v.toFixed(1) + ' V';
-        document.getElementById('val-current').textContent = d.current_a.toFixed(2) + ' A';
-        document.getElementById('val-pf').textContent      = d.power_factor.toFixed(3);
-        document.getElementById('val-freq').textContent    = d.frequency_hz.toFixed(2) + ' Hz';
-        document.getElementById('val-apparent').textContent = d.apparent_power_va.toFixed(1) + ' VA';
-        document.getElementById('val-import').textContent  = (d.energy_import_wh / 1000).toFixed(3) + ' kWh';
-        document.getElementById('val-export').textContent  = (d.energy_export_wh / 1000).toFixed(3) + ' kWh';
-        document.getElementById('last-ts').textContent     = new Date().toLocaleTimeString();
-    } catch(e) {}
+  try {
+    const resp = await fetch(`/api/v1/et112/${ADDR}/status`);
+    if (!resp.ok) return;
+    const d = await resp.json();
+    const set = (id, txt) => { const el = document.getElementById(id); if (el) el.textContent = txt; };
+    set('val-power',    d.power_w.toFixed(1) + ' W');
+    set('val-voltage',  d.voltage_v.toFixed(1) + ' V');
+    set('val-current',  d.current_a.toFixed(2) + ' A');
+    set('val-pf',       d.power_factor.toFixed(3));
+    set('val-freq',     d.frequency_hz.toFixed(2) + ' Hz');
+    set('val-apparent', d.apparent_power_va.toFixed(1) + ' VA');
+    set('val-import',   (d.energy_import_wh / 1000).toFixed(3) + ' kWh');
+    set('val-export',   (d.energy_export_wh / 1000).toFixed(3) + ' kWh');
+    set('last-ts',      new Date().toLocaleTimeString('fr-FR'));
+    const powEl = document.getElementById('val-power');
+    if (powEl) powEl.style.color = d.power_w >= 0 ? 'var(--green)' : 'var(--accent)';
+  } catch(e) {}
 }
 
 async function loadHistory() {
-    if (!myChart) return;
-    try {
-        const resp = await fetch(`${API}/history?limit=120`);
-        if (!resp.ok) return;
-        const d = await resp.json();
-        const hist = d.history.slice().reverse();
-        const xs = hist.map(s => new Date(s.timestamp).toLocaleTimeString());
-        const ys = hist.map(s => s.power_w.toFixed(1));
-        myChart.setOption({ xAxis: { data: xs }, series: [{ data: ys }] });
-    } catch(e) {}
+  if (!myChart) return;
+  try {
+    const resp = await fetch(`/api/v1/et112/${ADDR}/history?limit=120`);
+    if (!resp.ok) return;
+    const d = await resp.json();
+    const hist = d.history.slice().reverse();
+    const xs = hist.map(s => new Date(s.timestamp).toLocaleTimeString('fr-FR'));
+    const ys = hist.map(s => s.power_w.toFixed(1));
+    myChart.setOption({ xAxis: { data: xs }, series: [{ data: ys }] });
+  } catch(e) {}
 }
 
 update();
@@ -178,5 +197,4 @@ loadHistory();
 setInterval(update, 5000);
 setInterval(loadHistory, 30000);
 </script>
-
 {% endblock %}

--- a/crates/daly-bms-server/templates/et112_all.html
+++ b/crates/daly-bms-server/templates/et112_all.html
@@ -1,92 +1,92 @@
 {% extends "base.html" %}
 
-{% block title %}Compteurs ET112 — Monitoring{% endblock %}
+{% block title %}Compteurs ET112 — ESS Monitor{% endblock %}
+{% block page_title %}Compteurs ET112{% endblock %}
+{% block nav_et112 %}active{% endblock %}
 
 {% block content %}
 
-{# ─── En-tête ────────────────────────────────────────────────────────────── #}
-<div class="info-bar">
-  <strong>Compteurs ET112</strong>
-  <span>{{ device_count }} appareil(s) configuré(s)</span>
+<div class="page-hdr">
+  <h1>⚡ Compteurs ET112</h1>
+  <div class="page-hdr-meta">
+    <span><strong style="color:var(--text)">{{ device_count }}</strong> appareil(s) configuré(s)</span>
+    <span class="sep">·</span>
+    <span>Màj : <span id="et112-ts">—</span></span>
+  </div>
 </div>
 
-{# ─── Grille des compteurs ───────────────────────────────────────────────── #}
-<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(360px,1fr));gap:1rem;">
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1.25rem;">
 
 {% for d in devices %}
-<div class="bms-card-ng {% if !d.connected %}{% endif %}" id="et112-card-{{ d.address }}" style="{% if !d.connected %}opacity:0.7;{% endif %}">
+<div class="bms-card {% if !d.connected %}" style="opacity:0.7{% endif %}" id="et112-card-{{ d.address }}">
 
-  {# ── En-tête carte ──── #}
-  <div class="bms-hdr" style="{% if d.connected %}background:#1a5f8a;{% else %}background:#57606a;{% endif %}">
-    <div class="bms-hdr-title">
-      ⚡ {{ d.name }}
+  {# Header #}
+  <div class="bms-hdr" style="{% if d.connected %}{% if d.service_type == "pvinverter" %}background:linear-gradient(135deg,#0e3320 0%,#081a10 100%){% else if d.service_type == "heatpump" %}background:linear-gradient(135deg,#2a1b40 0%,#180e2a 100%){% else %}background:linear-gradient(135deg,#1a2a40 0%,#0d1a28 100%){% endif %}{% else %}background:linear-gradient(135deg,#2d333b 0%,#1c2128 100%){% endif %}">
+    <div class="bms-hdr-left">
+      {% if d.connected %}
+        <div class="bms-live"><div class="live-dot"></div>LIVE</div>
+      {% else %}
+        <span style="font-size:0.62rem;color:rgba(255,255,255,0.35)">Hors ligne</span>
+      {% endif %}
+      <span class="bms-hdr-name">
+        {% if d.service_type == "pvinverter" %}☀{% else if d.service_type == "heatpump" %}🌡{% else %}⚡{% endif %}
+        {{ d.name }}
+      </span>
     </div>
     <div class="bms-hdr-right">
-      {% if d.connected %}
-        <div class="bms-live-dot"></div>
-        <span>LIVE</span>
-      {% else %}
-        <span style="color:rgba(255,255,255,0.5)">Hors ligne</span>
-      {% endif %}
-      <div class="bms-can-badge">{{ d.addr_hex }}</div>
-      <span class="bms-hdr-ts" id="ts-{{ d.address }}">{{ d.last_ts }}</span>
+      <span class="bms-badge">{{ d.addr_hex }}</span>
+      <span class="bms-ts" id="ts-{{ d.address }}">{{ d.last_ts }}</span>
     </div>
   </div>
 
   {% if d.connected %}
 
-  {# ── KPI 4 colonnes ── #}
+  {# KPI 4 col #}
   <div class="kpi4">
-    <div class="kpi4-cell kpi4-p">
+    <div class="kpi4-cell t-yellow">
       <div class="kpi4-lbl">Puissance</div>
       <div class="kpi4-val {% if d.power_w >= 0.0 %}chg{% else %}dch{% endif %}" id="p-{{ d.address }}">
         {{ d.power_w|f1 }} W
       </div>
     </div>
-    <div class="kpi4-cell kpi4-v">
+    <div class="kpi4-cell t-blue">
       <div class="kpi4-lbl">Tension</div>
       <div class="kpi4-val" id="v-{{ d.address }}">{{ d.voltage_v|f1 }} V</div>
     </div>
-    <div class="kpi4-cell kpi4-i">
+    <div class="kpi4-cell t-orange">
       <div class="kpi4-lbl">Courant</div>
       <div class="kpi4-val" id="i-{{ d.address }}">{{ d.current_a|f2 }} A</div>
     </div>
     <div class="kpi4-cell">
       <div class="kpi4-lbl">Type</div>
-      <div class="kpi4-val" style="font-size:0.78rem;">{{ d.service_type }}</div>
+      <div class="kpi4-val muted">{{ d.service_type }}</div>
     </div>
   </div>
 
-  {# ── Énergie ── #}
-  <div style="display:grid;grid-template-columns:1fr 1fr;border-bottom:1px solid var(--border);">
-    <div style="padding:0.45rem 0.65rem;border-right:1px solid var(--border);">
-      <div class="kpi4-lbl">⬇ Énergie importée</div>
-      <div class="kpi4-val" style="color:var(--green)" id="imp-{{ d.address }}">
-        {{ d.energy_import_kwh|f1 }} kWh
-      </div>
+  {# Énergie #}
+  <div class="istrip c2">
+    <div class="icell">
+      <span class="i-lbl">⬇ Importée</span>
+      <span class="i-val ok" id="imp-{{ d.address }}">{{ d.energy_import_kwh|f2 }} kWh</span>
     </div>
-    <div style="padding:0.45rem 0.65rem;">
-      <div class="kpi4-lbl">⬆ Énergie exportée</div>
-      <div class="kpi4-val" style="color:var(--accent)" id="exp-{{ d.address }}">
-        {{ d.energy_export_kwh|f1 }} kWh
-      </div>
+    <div class="icell">
+      <span class="i-lbl">⬆ Exportée</span>
+      <span class="i-val blue" id="exp-{{ d.address }}">{{ d.energy_export_kwh|f2 }} kWh</span>
     </div>
   </div>
 
   {% else %}
 
-  {# ── Hors ligne ── #}
-  <div style="padding:1.5rem;text-align:center;color:var(--muted);">
-    <div style="font-size:1.5rem;margin-bottom:0.5rem">⏳</div>
-    <div style="font-size:0.8rem">En attente du premier snapshot…</div>
-    <div style="font-size:0.7rem;margin-top:0.25rem">Adresse Modbus : <code>{{ d.addr_hex }}</code></div>
+  <div class="empty-state" style="padding:2rem 1rem;">
+    <div class="empty-icon" style="font-size:1.5rem">⏳</div>
+    <div class="empty-title">En attente de données</div>
+    <div class="empty-sub">Adresse Modbus : <code>{{ d.addr_hex }}</code></div>
   </div>
 
   {% endif %}
 
-  {# ── Lien détail ── #}
-  <div style="padding:0.4rem 0.75rem;display:flex;justify-content:flex-end;border-top:1px solid var(--border);">
-    <a class="link-detail" href="/dashboard/et112/{{ d.address }}">Détails →</a>
+  <div style="padding:0.5rem 0.75rem;display:flex;justify-content:flex-end;border-top:1px solid var(--border);">
+    <a href="/dashboard/et112/{{ d.address }}" class="btn btn-outline" style="font-size:0.72rem;padding:0.3rem 0.7rem;">Détails →</a>
   </div>
 
 </div>
@@ -94,37 +94,41 @@
 
 </div>
 
-{# ─── Scripts de mise à jour ─────────────────────────────────────────────── #}
+{% endblock %}
+
+{% block scripts %}
 <script>
 const ET112_ADDRS = [{% for d in devices %}{{ d.address }}{% if !loop.last %}, {% endif %}{% endfor %}];
 
 async function updateAll() {
-    for (const addr of ET112_ADDRS) {
-        try {
-            const resp = await fetch(`/api/v1/et112/${addr}/status`);
-            if (!resp.ok) continue;
-            const d = await resp.json();
-            const pw = document.getElementById(`p-${addr}`);
-            const vv = document.getElementById(`v-${addr}`);
-            const iv = document.getElementById(`i-${addr}`);
-            const im = document.getElementById(`imp-${addr}`);
-            const ex = document.getElementById(`exp-${addr}`);
-            const ts = document.getElementById(`ts-${addr}`);
-            if (pw) {
-                pw.textContent = d.power_w.toFixed(1) + ' W';
-                pw.className = 'kpi4-val ' + (d.power_w >= 0 ? 'chg' : 'dch');
-            }
-            if (vv) vv.textContent = d.voltage_v.toFixed(1) + ' V';
-            if (iv) iv.textContent = d.current_a.toFixed(2) + ' A';
-            if (im) im.textContent = (d.energy_import_wh / 1000).toFixed(1) + ' kWh';
-            if (ex) ex.textContent = (d.energy_export_wh / 1000).toFixed(1) + ' kWh';
-            if (ts) ts.textContent = new Date().toLocaleTimeString();
-        } catch(e) {}
-    }
+  const ts = new Date().toLocaleTimeString('fr-FR');
+  const tsEl = document.getElementById('et112-ts');
+  if (tsEl) tsEl.textContent = ts;
+
+  for (const addr of ET112_ADDRS) {
+    try {
+      const resp = await fetch(`/api/v1/et112/${addr}/status`);
+      if (!resp.ok) continue;
+      const d = await resp.json();
+
+      const pw = document.getElementById(`p-${addr}`);
+      const vv = document.getElementById(`v-${addr}`);
+      const iv = document.getElementById(`i-${addr}`);
+      const im = document.getElementById(`imp-${addr}`);
+      const ex = document.getElementById(`exp-${addr}`);
+      const tsEl2 = document.getElementById(`ts-${addr}`);
+
+      if (pw) { pw.textContent = d.power_w.toFixed(1) + ' W'; pw.className = 'kpi4-val ' + (d.power_w >= 0 ? 'chg' : 'dch'); }
+      if (vv) vv.textContent = d.voltage_v.toFixed(1) + ' V';
+      if (iv) iv.textContent = d.current_a.toFixed(2) + ' A';
+      if (im) im.textContent = (d.energy_import_wh / 1000).toFixed(2) + ' kWh';
+      if (ex) ex.textContent = (d.energy_export_wh / 1000).toFixed(2) + ' kWh';
+      if (tsEl2) tsEl2.textContent = ts;
+    } catch(e) {}
+  }
 }
 
 updateAll();
 setInterval(updateAll, 5000);
 </script>
-
 {% endblock %}

--- a/crates/daly-bms-server/templates/index.html
+++ b/crates/daly-bms-server/templates/index.html
@@ -1,209 +1,198 @@
 {% extends "base.html" %}
 
-{% block title %}Vue d'ensemble — Monitoring{% endblock %}
+{% block title %}Batteries BMS — ESS Monitor{% endblock %}
+{% block page_title %}Batteries BMS{% endblock %}
+{% block nav_bms %}active{% endblock %}
 
 {% block content %}
 
-{# ─── Barre d'info ───────────────────────────────────────────────────────── #}
-<div class="info-bar">
-  <div style="display:flex;align-items:center;gap:0.5rem;">
-    <div class="dot {% if polling %}active{% else %}{% endif %}"></div>
-    {% if polling %}
-      <strong>Polling actif</strong>
-    {% else %}
-      <span style="color:var(--muted)">Polling arrêté</span>
-    {% endif %}
-  </div>
-  <div><strong>{{ bms_count }}</strong> BMS détecté{{ bms_count|pluralize }}</div>
-  <div style="margin-left:auto;font-size:0.7rem;color:var(--muted)">
-    Dernière maj : <span id="refresh-ts">—</span>
+{# ─── Header ────────────────────────────────────────────────────────── #}
+<div class="page-hdr">
+  <h1>🔋 Batteries BMS</h1>
+  <div class="page-hdr-meta">
+    <div>
+      <span class="dot-inline {% if polling %}live{% endif %}"></span>
+      {% if polling %}<span>Polling actif</span>{% else %}<span style="color:var(--red)">Polling arrêté</span>{% endif %}
+    </div>
+    <span class="sep">·</span>
+    <span><strong style="color:var(--text)">{{ bms_count }}</strong> BMS détecté{{ bms_count|pluralize }}</span>
+    <span class="sep">·</span>
+    <span>Màj : <span id="last-refresh">—</span></span>
   </div>
 </div>
 
-{# ─── Grille de cartes BMS ──────────────────────────────────────────────── #}
+<style>
+.dot-inline {
+  display: inline-block; width: 7px; height: 7px;
+  border-radius: 50%; background: var(--muted2);
+  vertical-align: middle; margin-right: 0.3rem;
+}
+.dot-inline.live { background: var(--green); box-shadow: 0 0 6px rgba(63,185,80,0.5); animation: pulse-dot 2s infinite; }
+</style>
+
 {% if bms_count == 0 %}
-<div class="card" style="text-align:center;padding:3rem;color:var(--muted)">
-  <div style="font-size:2.5rem;margin-bottom:1rem">🔌</div>
-  <div style="font-size:1rem;margin-bottom:0.5rem">Aucun BMS détecté</div>
-  <div style="font-size:0.8rem">Démarrez le serveur avec <code>--simulate</code> pour tester,<br>
-  ou vérifiez le câblage RS485.</div>
+<div class="card">
+  <div class="empty-state">
+    <div class="empty-icon">🔌</div>
+    <div class="empty-title">Aucun BMS détecté</div>
+    <div class="empty-sub">
+      Démarrez le serveur avec <code>--simulate</code> pour tester,<br>
+      ou vérifiez le câblage RS485 sur <code>/dev/ttyUSB0</code>.
+    </div>
+  </div>
 </div>
 {% else %}
-<div class="bms-grid" id="bms-grid">
+
+{# ─── Grille de cartes BMS ──────────────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(540px,1fr));gap:1.25rem;" id="bms-grid">
+
 {% for bms in bms_list %}
+<a href="/dashboard/bms/{{ bms.address }}" class="bms-card {% if bms.any_alarm %}alarm{% endif %}" data-addr="{{ bms.address }}">
 
-  <a href="/dashboard/bms/{{ bms.address }}" style="text-decoration:none;color:inherit;display:block;">
-  <div class="bms-card-ng {% if bms.any_alarm %}alarm{% endif %}" data-addr="{{ bms.address }}">
-
-    {# ── En-tête ──────────────────────────────────────────────────────────── #}
-    <div class="bms-hdr">
-      <div class="bms-hdr-title">
-        🔋 {{ bms.name }}
-      </div>
-      <div class="bms-hdr-right">
-        <span class="bms-live-dot" id="live-dot-{{ bms.address }}"></span>
-        <span>LIVE</span>
-        {% if !bms.firmware_sw.is_empty() %}
-          <span style="color:rgba(255,255,255,0.55);font-size:0.62rem;font-family:monospace">v{{ bms.firmware_sw }}</span>
-        {% endif %}
-        <span class="bms-can-badge">{{ bms.can_id }}</span>
-        <span class="bms-hdr-ts" id="ts-{{ bms.address }}">{{ bms.last_update }}</span>
-      </div>
+  {# ── Header ── #}
+  <div class="bms-hdr {% if bms.any_alarm %}alarm-hdr{% endif %}">
+    <div class="bms-hdr-left">
+      <div class="bms-live"><div class="live-dot"></div>LIVE</div>
+      <span class="bms-hdr-name">{{ bms.name }}</span>
     </div>
-
-    {# ── KPI ligne 1 : Tension · SOC · Courant · Puissance ──────────────── #}
-    <div class="kpi4">
-      <div class="kpi4-cell kpi4-v">
-        <div class="kpi4-lbl">TENSION</div>
-        <div class="kpi4-val" id="v-{{ bms.address }}">{{ bms.voltage|f1 }} V</div>
-      </div>
-      <div class="kpi4-cell kpi4-soc">
-        <div class="kpi4-lbl">SOC</div>
-        <div class="kpi4-val" id="soc-{{ bms.address }}">{{ bms.soc|f1 }}%</div>
-      </div>
-      <div class="kpi4-cell kpi4-i">
-        <div class="kpi4-lbl">COURANT</div>
-        <div class="kpi4-val {% if bms.current > 0.1 %}chg{% else if bms.current < -0.1 %}dch{% endif %}"
-             id="i-{{ bms.address }}">{{ bms.current|sign }} A</div>
-      </div>
-      <div class="kpi4-cell kpi4-p">
-        <div class="kpi4-lbl">PUISSANCE</div>
-        <div class="kpi4-val" id="p-{{ bms.address }}">{{ bms.power|f0 }} W</div>
-      </div>
+    <div class="bms-hdr-right">
+      {% if !bms.firmware_sw.is_empty() %}
+        <span style="color:rgba(255,255,255,0.4);font-size:0.58rem;font-family:'JetBrains Mono',monospace">v{{ bms.firmware_sw }}</span>
+      {% endif %}
+      <span class="bms-badge">{{ bms.can_id }}</span>
+      <span class="bms-ts" id="ts-{{ bms.address }}">{{ bms.last_update }}</span>
     </div>
-
-    {# ── KPI ligne 2 : MOS CHG · MOS DSG · Cycles · Capacité ────────────── #}
-    <div class="kpi4">
-      <div class="kpi4-cell">
-        <div class="kpi4-lbl">CHG MOS</div>
-        <div class="kpi4-val {% if bms.charge_ok %}mos-on{% else %}mos-off{% endif %}"
-             id="chg-{{ bms.address }}">{% if bms.charge_ok %}ON{% else %}OFF{% endif %}</div>
-      </div>
-      <div class="kpi4-cell">
-        <div class="kpi4-lbl">DSG MOS</div>
-        <div class="kpi4-val {% if bms.discharge_ok %}mos-on{% else %}mos-off{% endif %}"
-             id="dsg-{{ bms.address }}">{% if bms.discharge_ok %}ON{% else %}OFF{% endif %}</div>
-      </div>
-      <div class="kpi4-cell">
-        <div class="kpi4-lbl">CYCLES</div>
-        <div class="kpi4-val" id="cyc-{{ bms.address }}">{{ bms.cycles }}</div>
-      </div>
-      <div class="kpi4-cell">
-        <div class="kpi4-lbl">CAPACITÉ</div>
-        <div class="kpi4-val" id="cap-{{ bms.address }}">{{ bms.capacity_ah|f1 }} Ah</div>
-      </div>
-    </div>
-
-    {# ── Barre SOC ───────────────────────────────────────────────────────── #}
-    <div class="soc-bar-row">
-      <span>SOC</span>
-      <div class="soc-bar-wrap">
-        <div class="soc-bar-fill" id="soc-bar-{{ bms.address }}"
-             style="width:{{ bms.soc|f0 }}%;background:{% if bms.soc < 15.0 %}#f85149{% else if bms.soc < 25.0 %}#fb8500{% else if bms.soc < 40.0 %}#d29922{% else %}#3fb950{% endif %}"></div>
-      </div>
-      <span id="soc-pct-{{ bms.address }}">{{ bms.soc|f0 }}%</span>
-      <span style="color:var(--muted)">100%</span>
-    </div>
-
-    {# ── Grille de cellules ──────────────────────────────────────────────── #}
-    <div class="cells-section">
-      <div class="cells-hdr">
-        CELLULES ({{ bms.cell_count }}S LiFePO4) —
-        MIN : <span class="c-min">{{ bms.min_cell_v|f3 }} V {{ bms.min_cell_id }}</span> |
-        MAX : <span class="c-max">{{ bms.max_cell_v|f3 }} V {{ bms.max_cell_id }}</span> |
-        Δ : <span class="c-dlt {% if bms.cell_delta_mv > 100.0 %}crit{% else if bms.cell_delta_mv > 50.0 %}warn{% else %}ok{% endif %}">{{ bms.cell_delta_mv|mv }} mV</span>
-      </div>
-      <div class="cells-grid" id="cells-{{ bms.address }}">
-        {% for cell in bms.cells %}
-          <div class="cell-box{% if cell.is_min %} cell-min{% else if cell.is_max %} cell-max{% endif %}{% if cell.is_bal %} cell-bal{% endif %}">
-            <span class="c-n">{{ cell.num }}</span>
-            <span class="c-v">{{ cell.v|f3 }}</span>
-          </div>
-        {% endfor %}
-      </div>
-    </div>
-
-    {# ── Températures ────────────────────────────────────────────────────── #}
-    <div class="temp4">
-      <div class="temp4-cell">
-        <span class="temp4-lbl">T1 (min)</span>
-        <span class="temp4-val" id="tmin-{{ bms.address }}">{{ bms.temp_min|f1 }} °C</span>
-      </div>
-      <div class="temp4-cell">
-        <span class="temp4-lbl">T2 (max)</span>
-        <span class="temp4-val {% if bms.temp_max > 45.0 %}a-bad{% else if bms.temp_max > 35.0 %}warn{% endif %}"
-              id="tmax-{{ bms.address }}">{{ bms.temp_max|f1 }} °C</span>
-      </div>
-      <div class="temp4-cell">
-        <span class="temp4-lbl">T3</span>
-        <span class="temp4-val" style="color:var(--muted)">—</span>
-      </div>
-      <div class="temp4-cell">
-        <span class="temp4-lbl">T4</span>
-        <span class="temp4-val" style="color:var(--muted)">—</span>
-      </div>
-    </div>
-
-    {# ── Alarmes ──────────────────────────────────────────────────────────── #}
-    <div class="alarm4">
-      <div class="alarm4-cell">
-        <span class="alarm4-name">Sur-tension</span>
-        <span class="{% if bms.alarm_high_voltage %}a-bad{% else %}a-ok{% endif %}">
-          {% if bms.alarm_high_voltage %}ALARM{% else %}OK{% endif %}
-        </span>
-      </div>
-      <div class="alarm4-cell">
-        <span class="alarm4-name">Sous-tension</span>
-        <span class="{% if bms.alarm_low_voltage %}a-bad{% else %}a-ok{% endif %}">
-          {% if bms.alarm_low_voltage %}ALARM{% else %}OK{% endif %}
-        </span>
-      </div>
-      <div class="alarm4-cell">
-        <span class="alarm4-name">Temp. haute</span>
-        <span class="{% if bms.alarm_high_temp %}a-bad{% else %}a-ok{% endif %}">
-          {% if bms.alarm_high_temp %}ALARM{% else %}OK{% endif %}
-        </span>
-      </div>
-      <div class="alarm4-cell">
-        <span class="alarm4-name">Imbalance</span>
-        <span class="{% if bms.alarm_imbalance %}a-bad{% else %}a-ok{% endif %}">
-          {% if bms.alarm_imbalance %}ALARM{% else %}OK{% endif %}
-        </span>
-      </div>
-    </div>
-
-    {# ── Informations du bas ───────────────────────────────────────────────── #}
-    <div class="info4">
-      <div class="info4-cell">
-        <span class="info4-lbl">SOC bas</span>
-        <span class="info4-val {% if bms.alarm_low_soc %}a-bad{% else %}a-ok{% endif %}">
-          {% if bms.alarm_low_soc %}ALARM{% else %}OK{% endif %}
-        </span>
-      </div>
-      <div class="info4-cell">
-        <span class="info4-lbl">Max CHG</span>
-        <span class="info4-val">
-          {% if bms.max_charge_current > 0.1 %}{{ bms.max_charge_current|f0 }} A{% else %}—{% endif %}
-        </span>
-      </div>
-      <div class="info4-cell">
-        <span class="info4-lbl">Max DCH</span>
-        <span class="info4-val">
-          {% if bms.max_discharge_current > 0.1 %}{{ bms.max_discharge_current|f0 }} A{% else %}—{% endif %}
-        </span>
-      </div>
-      <div class="info4-cell">
-        <span class="info4-lbl">Cap. BMS</span>
-        <span class="info4-val" id="bms-cap-{{ bms.address }}">
-          {% if bms.bms_capacity_ah > 0.1 %}{{ bms.bms_capacity_ah|f1 }} Ah{% else %}—{% endif %}
-        </span>
-      </div>
-    </div>
-
   </div>
-  </a>
 
+  {# ── KPI ligne 1 : Tension · SOC · Courant · Puissance ── #}
+  <div class="kpi4">
+    <div class="kpi4-cell t-blue">
+      <div class="kpi4-lbl">Tension</div>
+      <div class="kpi4-val" id="v-{{ bms.address }}">{{ bms.voltage|f1 }} V</div>
+    </div>
+    <div class="kpi4-cell t-green">
+      <div class="kpi4-lbl">SOC</div>
+      <div class="kpi4-val" id="soc-{{ bms.address }}">{{ bms.soc|f1 }}%</div>
+    </div>
+    <div class="kpi4-cell t-orange">
+      <div class="kpi4-lbl">Courant</div>
+      <div class="kpi4-val {% if bms.current > 0.1 %}chg{% else if bms.current < -0.1 %}dch{% endif %}"
+           id="i-{{ bms.address }}">{{ bms.current|sign }} A</div>
+    </div>
+    <div class="kpi4-cell t-yellow">
+      <div class="kpi4-lbl">Puissance</div>
+      <div class="kpi4-val {% if bms.power > 0.1 %}chg{% else if bms.power < -0.1 %}dch{% endif %}"
+           id="p-{{ bms.address }}">{{ bms.power|f0 }} W</div>
+    </div>
+  </div>
+
+  {# ── KPI ligne 2 : MOS CHG · MOS DSG · Cycles · Capacité ── #}
+  <div class="kpi4">
+    <div class="kpi4-cell">
+      <div class="kpi4-lbl">MOS Charge</div>
+      <div class="kpi4-val {% if bms.charge_ok %}mos-on{% else %}mos-off{% endif %}"
+           id="chg-{{ bms.address }}">{% if bms.charge_ok %}ON{% else %}OFF{% endif %}</div>
+    </div>
+    <div class="kpi4-cell">
+      <div class="kpi4-lbl">MOS Décharge</div>
+      <div class="kpi4-val {% if bms.discharge_ok %}mos-on{% else %}mos-off{% endif %}"
+           id="dsg-{{ bms.address }}">{% if bms.discharge_ok %}ON{% else %}OFF{% endif %}</div>
+    </div>
+    <div class="kpi4-cell">
+      <div class="kpi4-lbl">Cycles</div>
+      <div class="kpi4-val muted" id="cyc-{{ bms.address }}">{{ bms.cycles }}</div>
+    </div>
+    <div class="kpi4-cell">
+      <div class="kpi4-lbl">Capacité SOC</div>
+      <div class="kpi4-val muted" id="cap-{{ bms.address }}">{{ bms.capacity_ah|f1 }} Ah</div>
+    </div>
+  </div>
+
+  {# ── Barre SOC ── #}
+  <div class="soc-row">
+    <span style="font-family:'JetBrains Mono',monospace;color:var(--muted2);min-width:28px">0%</span>
+    <div class="soc-track">
+      <div class="soc-fill" id="socbar-{{ bms.address }}"
+           style="width:{{ bms.soc|f0 }}%;background:{% if bms.soc < 15.0 %}var(--red){% else if bms.soc < 25.0 %}var(--orange){% else if bms.soc < 40.0 %}var(--yellow){% else %}var(--green){% endif %}"></div>
+    </div>
+    <span style="font-family:'JetBrains Mono',monospace;min-width:34px;text-align:right" id="soc-pct-{{ bms.address }}">{{ bms.soc|f0 }}%</span>
+    <span style="color:var(--muted2)">/ 100%</span>
+  </div>
+
+  {# ── Cellules ── #}
+  <div class="cells-section">
+    <div class="cells-meta">
+      <span>{{ bms.cell_count }}S LiFePO₄</span>
+      <span>MIN <span class="c-min">{{ bms.min_cell_v|f3 }} V ({{ bms.min_cell_id }})</span></span>
+      <span>MAX <span class="c-max">{{ bms.max_cell_v|f3 }} V ({{ bms.max_cell_id }})</span></span>
+      <span>Δ <span class="c-dlt {% if bms.cell_delta_mv > 100.0 %}crit{% else if bms.cell_delta_mv > 50.0 %}warn{% else %}ok{% endif %}">{{ bms.cell_delta_mv|mv }} mV</span></span>
+    </div>
+    <div class="cells-grid" id="cells-{{ bms.address }}">
+      {% for cell in bms.cells %}
+        <div class="cell-box{% if cell.is_min %} cell-min{% else if cell.is_max %} cell-max{% endif %}{% if cell.is_bal %} cell-bal{% endif %}">
+          <span class="cn">{{ cell.num }}</span>
+          <span class="cv">{{ cell.v|f3 }}</span>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+
+  {# ── Températures ── #}
+  <div class="istrip c4">
+    <div class="icell">
+      <span class="i-lbl">T° min</span>
+      <span class="i-val" id="tmin-{{ bms.address }}">{{ bms.temp_min|f1 }} °C</span>
+    </div>
+    <div class="icell">
+      <span class="i-lbl">T° max</span>
+      <span class="i-val {% if bms.temp_max > 45.0 %}bad{% else if bms.temp_max > 35.0 %}warn{% endif %}"
+            id="tmax-{{ bms.address }}">{{ bms.temp_max|f1 }} °C</span>
+    </div>
+    <div class="icell">
+      <span class="i-lbl">Cap. BMS</span>
+      <span class="i-val" id="bmscap-{{ bms.address }}">
+        {% if bms.bms_capacity_ah > 0.1 %}{{ bms.bms_capacity_ah|f1 }} Ah{% else %}—{% endif %}
+      </span>
+    </div>
+    <div class="icell">
+      <span class="i-lbl">Statut</span>
+      <span class="i-val {% if bms.any_alarm %}bad{% else %}ok{% endif %}">
+        {% if bms.any_alarm %}⚠ ALARME{% else %}✓ Normal{% endif %}
+      </span>
+    </div>
+  </div>
+
+  {# ── Alarmes ── #}
+  <div class="istrip c4">
+    <div class="icell">
+      <span class="i-lbl">Sur-tension</span>
+      <span class="i-val {% if bms.alarm_high_voltage %}bad{% else %}ok{% endif %}">
+        {% if bms.alarm_high_voltage %}ALARM{% else %}OK{% endif %}
+      </span>
+    </div>
+    <div class="icell">
+      <span class="i-lbl">Sous-tension</span>
+      <span class="i-val {% if bms.alarm_low_voltage %}bad{% else %}ok{% endif %}">
+        {% if bms.alarm_low_voltage %}ALARM{% else %}OK{% endif %}
+      </span>
+    </div>
+    <div class="icell">
+      <span class="i-lbl">Temp. haute</span>
+      <span class="i-val {% if bms.alarm_high_temp %}bad{% else %}ok{% endif %}">
+        {% if bms.alarm_high_temp %}ALARM{% else %}OK{% endif %}
+      </span>
+    </div>
+    <div class="icell" style="border-bottom:none">
+      <span class="i-lbl">Déséquilibre</span>
+      <span class="i-val {% if bms.alarm_imbalance %}bad{% else %}ok{% endif %}">
+        {% if bms.alarm_imbalance %}ALARM{% else %}OK{% endif %}
+      </span>
+    </div>
+  </div>
+
+</a>
 {% endfor %}
+
 </div>
 {% endif %}
 
@@ -211,66 +200,72 @@
 
 {% block scripts %}
 <script>
-// ─── Mise à jour temps-réel via WebSocket ────────────────────────────────────
 window.onBmsUpdate = function(snaps) {
-  const now = new Date().toLocaleTimeString();
-  const tsEl = document.getElementById('refresh-ts');
-  if (tsEl) tsEl.textContent = now;
+  const now = new Date().toLocaleTimeString('fr-FR');
+  const rEl = document.getElementById('last-refresh');
+  if (rEl) rEl.textContent = now;
 
   snaps.forEach(function(s) {
     const a = s.address;
-
     function el(id) { return document.getElementById(id + '-' + a); }
     function set(id, txt) { const e = el(id); if (e) e.textContent = txt; }
-    function fmt1(n) { return (+n).toFixed(1); }
-    function fmt0(n) { return (+n).toFixed(0); }
-    function fmt3(n) { return (+n).toFixed(3); }
+    function f1(n) { return (+n).toFixed(1); }
+    function f0(n) { return (+n).toFixed(0); }
+    function f3(n) { return (+n).toFixed(3); }
 
-    // Horodatage
-    const tsE = el('ts');
-    if (tsE) {
+    // Timestamp
+    const tsEl = el('ts');
+    if (tsEl) {
       const d = new Date(s.timestamp);
-      tsE.textContent = isNaN(d) ? '—' : d.toLocaleTimeString();
+      tsEl.textContent = isNaN(d) ? '—' : d.toLocaleTimeString('fr-FR');
     }
 
     // KPI ligne 1
-    set('v',   fmt1(s.Dc.Voltage) + ' V');
-    set('soc', fmt1(s.Soc) + '%');
-    set('soc-pct', fmt0(s.Soc) + '%');
+    set('v',   f1(s.Dc.Voltage) + ' V');
+    set('soc', f1(s.Soc) + '%');
+    set('soc-pct', f0(s.Soc) + '%');
+
     const cur = s.Dc.Current;
     const curEl = el('i');
     if (curEl) {
-      curEl.textContent = (cur >= 0 ? '+' : '') + fmt1(cur) + ' A';
-      curEl.className = 'kpi4-val' + (cur > 0.1 ? ' chg' : (cur < -0.1 ? ' dch' : ''));
+      curEl.textContent = (cur >= 0 ? '+' : '') + f1(cur) + ' A';
+      curEl.className = 'kpi4-val' + (cur > 0.1 ? ' chg' : cur < -0.1 ? ' dch' : '');
     }
-    set('p', fmt0(s.Dc.Power) + ' W');
+    const pow = s.Dc.Power;
+    const powEl = el('p');
+    if (powEl) {
+      powEl.textContent = f0(pow) + ' W';
+      powEl.className = 'kpi4-val' + (pow > 0.1 ? ' chg' : pow < -0.1 ? ' dch' : '');
+    }
 
     // KPI ligne 2
-    const chgE = el('chg'); if (chgE) { const on = s.Io.AllowToCharge; chgE.textContent = on ? 'ON' : 'OFF'; chgE.className = 'kpi4-val ' + (on ? 'mos-on' : 'mos-off'); }
-    const dsgE = el('dsg'); if (dsgE) { const on = s.Io.AllowToDischarge; dsgE.textContent = on ? 'ON' : 'OFF'; dsgE.className = 'kpi4-val ' + (on ? 'mos-on' : 'mos-off'); }
-    set('cap', fmt1(s.Capacity) + ' Ah');
-    // Cap. BMS (coulométrie 0x93)
-    var bmsCap = document.getElementById('bms-cap-' + a);
-    if (bmsCap) bmsCap.textContent = s.BmsCapacity > 0.1 ? fmt1(s.BmsCapacity) + ' Ah' : '—';
+    const chgE = el('chg');
+    if (chgE) { const on = s.Io.AllowToCharge; chgE.textContent = on ? 'ON' : 'OFF'; chgE.className = 'kpi4-val ' + (on ? 'mos-on' : 'mos-off'); }
+    const dsgE = el('dsg');
+    if (dsgE) { const on = s.Io.AllowToDischarge; dsgE.textContent = on ? 'ON' : 'OFF'; dsgE.className = 'kpi4-val ' + (on ? 'mos-on' : 'mos-off'); }
+    set('cap', f1(s.Capacity) + ' Ah');
+    const bc = document.getElementById('bmscap-' + a);
+    if (bc) bc.textContent = s.BmsCapacity > 0.1 ? f1(s.BmsCapacity) + ' Ah' : '—';
 
     // Barre SOC
-    const bar = el('soc-bar');
+    const bar = el('socbar');
     if (bar) {
-      const soc = +s.Soc;
-      const pct = Math.max(0, Math.min(100, soc));
-      bar.style.width = pct + '%';
-      bar.style.background = soc < 15 ? '#f85149' : soc < 25 ? '#fb8500' : soc < 40 ? '#d29922' : '#3fb950';
+      const soc = Math.max(0, Math.min(100, +s.Soc));
+      bar.style.width = soc + '%';
+      bar.style.background = soc < 15 ? 'var(--red)' : soc < 25 ? 'var(--orange)' : soc < 40 ? 'var(--yellow)' : 'var(--green)';
     }
 
     // Températures
-    set('tmin', fmt1(s.System.MinCellTemperature) + ' °C');
-    set('tmax', fmt1(s.System.MaxCellTemperature) + ' °C');
+    set('tmin', f1(s.System.MinCellTemperature) + ' °C');
+    set('tmax', f1(s.System.MaxCellTemperature) + ' °C');
 
-    // Alarme : contour carte
-    const card = document.querySelector('.bms-card-ng[data-addr="' + a + '"]');
+    // Alarme carte
+    const card = document.querySelector('.bms-card[data-addr="' + a + '"]');
     if (card) {
       const hasAlarm = s.Alarms && Object.values(s.Alarms).some(function(v) { return v !== 0; });
       card.classList.toggle('alarm', !!hasAlarm);
+      const hdr = card.querySelector('.bms-hdr');
+      if (hdr) hdr.classList.toggle('alarm-hdr', !!hasAlarm);
     }
 
     // Grille cellules
@@ -293,24 +288,22 @@ window.onBmsUpdate = function(snaps) {
         if (short === minId) cls += ' cell-min';
         else if (short === maxId) cls += ' cell-max';
         if (isBal) cls += ' cell-bal';
-        html += '<div class="' + cls + '">'
-              + '<span class="c-n">' + num + '</span>'
-              + '<span class="c-v">' + v.toFixed(3) + '</span>'
-              + '</div>';
+        html += '<div class="' + cls + '"><span class="cn">' + num + '</span><span class="cv">' + v.toFixed(3) + '</span></div>';
       });
       cellsDiv.innerHTML = html;
 
-      // Mise à jour en-tête Δ cellules
+      // Mise à jour cells-meta
       var minV = Infinity, maxV = -Infinity;
       entries.forEach(function(e) { var v = +e[1]; if (v < minV) minV = v; if (v > maxV) maxV = v; });
       var delta = (maxV - minV) * 1000;
-      var hdr = document.querySelector('.bms-card-ng[data-addr="' + a + '"] .cells-hdr');
-      if (hdr) {
+      var metaEl = card && card.querySelector('.cells-meta');
+      if (metaEl) {
         var dCls = delta > 100 ? 'crit' : delta > 50 ? 'warn' : 'ok';
-        hdr.innerHTML = 'CELLULES (' + entries.length + 'S LiFePO4) — '
-          + 'MIN : <span class="c-min">' + minV.toFixed(3) + ' V ' + minId + '</span> | '
-          + 'MAX : <span class="c-max">' + maxV.toFixed(3) + ' V ' + maxId + '</span> | '
-          + 'Δ : <span class="c-dlt ' + dCls + '">' + delta.toFixed(0) + ' mV</span>';
+        metaEl.innerHTML =
+          '<span>' + entries.length + 'S LiFePO₄</span>' +
+          '<span>MIN <span class="c-min">' + minV.toFixed(3) + ' V (' + minId + ')</span></span>' +
+          '<span>MAX <span class="c-max">' + maxV.toFixed(3) + ' V (' + maxId + ')</span></span>' +
+          '<span>Δ <span class="c-dlt ' + dCls + '">' + delta.toFixed(0) + ' mV</span></span>';
       }
     }
   });

--- a/crates/daly-bms-server/templates/logs.html
+++ b/crates/daly-bms-server/templates/logs.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
-{% block title %}Logs — Monitoring{% endblock %}
+{% block title %}Logs Serveur — ESS Monitor{% endblock %}
+{% block page_title %}Logs Serveur{% endblock %}
+{% block nav_logs %}active{% endblock %}
 
 {% block content %}
 <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">

--- a/crates/daly-bms-server/templates/overview.html
+++ b/crates/daly-bms-server/templates/overview.html
@@ -1,108 +1,186 @@
 {% extends "base.html" %}
 
-{% block title %}Vue d'ensemble — Système ESS{% endblock %}
+{% block title %}Vue d'ensemble — ESS Monitor{% endblock %}
+{% block page_title %}Vue d'ensemble{% endblock %}
+{% block nav_overview %}active{% endblock %}
+
+{% block head %}
+<style>
+  /* ─── Overview-specific ─── */
+  .ov-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(460px, 1fr));
+    gap: 1.25rem;
+    margin-bottom: 1.75rem;
+  }
+  .ov-et112-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.75rem;
+  }
+  .ov-irr-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.75rem;
+  }
+
+  /* ET112 card dans overview */
+  .et112-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: var(--shadow);
+    transition: border-color 0.2s;
+  }
+  .et112-card:hover { border-color: var(--border2); }
+  .et112-hdr {
+    padding: 0.7rem 0.9rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--border);
+  }
+  .et112-hdr.pv  { background: linear-gradient(135deg, #0e3320 0%, #081a10 100%); }
+  .et112-hdr.hp  { background: linear-gradient(135deg, #2a1b40 0%, #180e2a 100%); }
+  .et112-hdr.grd { background: linear-gradient(135deg, #1a2a40 0%, #0d1a28 100%); }
+  .et112-hdr-name { font-size: 0.88rem; font-weight: 700; color: #fff; }
+  .et112-hdr-right { display: flex; align-items: center; gap: 0.4rem; }
+
+  /* Irradiance card */
+  .irr-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: var(--shadow);
+  }
+  .irr-hdr {
+    padding: 0.7rem 0.9rem;
+    background: linear-gradient(135deg, #2a1e00 0%, #160f00 100%);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .irr-hdr-name { font-size: 0.88rem; font-weight: 700; color: #fff; }
+  .irr-ts { font-size: 0.6rem; color: rgba(255,255,255,0.45); font-family: 'JetBrains Mono', monospace; }
+
+  /* Power value large */
+  .power-hero {
+    text-align: center;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .power-hero-val {
+    font-size: 2rem;
+    font-weight: 800;
+    font-family: 'JetBrains Mono', monospace;
+    line-height: 1;
+  }
+  .power-hero-lbl {
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--muted);
+    margin-top: 0.2rem;
+  }
+</style>
+{% endblock %}
 
 {% block content %}
 
-{# ─── En-tête ────────────────────────────────────────────────────────────── #}
-<div class="info-bar" style="margin-bottom:1.25rem;">
-  <strong style="font-size:1rem;">Vue d'ensemble — Système ESS</strong>
-  <div id="ov-ts" style="margin-left:auto;font-size:0.72rem;color:var(--muted)">Mise à jour : —</div>
+{# ─── Header ── #}
+<div class="page-hdr">
+  <h1>🏠 Vue d'ensemble</h1>
+  <div class="page-hdr-meta">
+    <span>Mise à jour : <span id="ov-ts">—</span></span>
+  </div>
 </div>
 
-{# ═══════════════════════════════════════════════════════════════════════════
+{# ═══════════════════════════════════════════════════
    SECTION 1 — BATTERIES
-   ═══════════════════════════════════════════════════════════════════════════ #}
-<div class="card-title" style="margin-bottom:0.6rem;">🔋 Batteries</div>
-<div id="bms-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(480px,1fr));gap:1rem;margin-bottom:1.5rem;">
+   ═══════════════════════════════════════════════════ #}
+<div class="section-hdr">
+  <h2>🔋 Batteries</h2>
+  <span class="section-count">{{ bms_list|length }} BMS</span>
+  <div class="section-rule"></div>
+  <a href="/dashboard" style="font-size:0.72rem;color:var(--muted);white-space:nowrap">Tout voir →</a>
+</div>
 
+<div class="ov-grid" id="ov-bms-grid">
 {% for bms in bms_list %}
-<div class="bms-card-ng {% if bms.any_alarm %}alarm{% endif %}" id="bms-card-{{ bms.address }}">
+<div class="bms-card {% if bms.any_alarm %}alarm{% endif %}" id="ov-bms-{{ bms.address }}">
 
-  {# En-tête bleu #}
-  <div class="bms-hdr">
-    <div class="bms-hdr-title">
-      <div class="bms-live-dot"></div>
-      {{ bms.name }}
+  {# Header #}
+  <div class="bms-hdr {% if bms.any_alarm %}alarm-hdr{% endif %}">
+    <div class="bms-hdr-left">
+      <div class="bms-live"><div class="live-dot"></div>LIVE</div>
+      <span class="bms-hdr-name">{{ bms.name }}</span>
     </div>
     <div class="bms-hdr-right">
-      <span class="bms-can-badge">{{ bms.can_id }}</span>
-      <span class="bms-hdr-ts" id="ts-{{ bms.address }}">{{ bms.last_update }}</span>
+      <span class="bms-badge">{{ bms.can_id }}</span>
+      <span class="bms-ts" id="ov-ts-{{ bms.address }}">{{ bms.last_update }}</span>
     </div>
   </div>
 
-  {# KPI 4 colonnes #}
+  {# KPI 4 col #}
   <div class="kpi4">
-    <div class="kpi4-cell kpi4-v">
+    <div class="kpi4-cell t-blue">
       <div class="kpi4-lbl">Tension</div>
-      <div class="kpi4-val" id="v-{{ bms.address }}">{{ bms.voltage|f2 }} V</div>
+      <div class="kpi4-val" id="ov-v-{{ bms.address }}">{{ bms.voltage|f2 }} V</div>
     </div>
-    <div class="kpi4-cell kpi4-soc">
+    <div class="kpi4-cell t-green">
       <div class="kpi4-lbl">SOC</div>
-      <div class="kpi4-val {% if bms.soc > 60.0 %}chg{% else if bms.soc > 20.0 %}{% else %}dch{% endif %}" id="soc-{{ bms.address }}">{{ bms.soc|f1 }} %</div>
+      <div class="kpi4-val {% if bms.soc > 60.0 %}chg{% else if bms.soc < 20.0 %}dch{% endif %}"
+           id="ov-soc-{{ bms.address }}">{{ bms.soc|f1 }}%</div>
     </div>
-    <div class="kpi4-cell kpi4-i">
+    <div class="kpi4-cell t-orange">
       <div class="kpi4-lbl">Courant</div>
-      <div class="kpi4-val {% if bms.current > 0.0 %}chg{% else %}dch{% endif %}" id="i-{{ bms.address }}">{{ bms.current|sign }} A</div>
+      <div class="kpi4-val {% if bms.current > 0.0 %}chg{% else if bms.current < -0.1 %}dch{% endif %}"
+           id="ov-i-{{ bms.address }}">{{ bms.current|sign }} A</div>
     </div>
-    <div class="kpi4-cell kpi4-p">
+    <div class="kpi4-cell t-yellow">
       <div class="kpi4-lbl">Puissance</div>
-      <div class="kpi4-val {% if bms.power > 0.0 %}chg{% else %}dch{% endif %}" id="p-{{ bms.address }}">{{ bms.power|f0 }} W</div>
+      <div class="kpi4-val {% if bms.power > 0.0 %}chg{% else if bms.power < -0.1 %}dch{% endif %}"
+           id="ov-p-{{ bms.address }}">{{ bms.power|f0 }} W</div>
     </div>
   </div>
 
-  {# Barre SOC #}
-  <div class="soc-bar-row">
+  {# SOC bar #}
+  <div class="soc-row">
     <span>0%</span>
-    <div class="soc-bar-wrap">
-      <div class="soc-bar-fill" id="bar-{{ bms.address }}"
+    <div class="soc-track">
+      <div class="soc-fill" id="ov-bar-{{ bms.address }}"
            style="width:{{ bms.soc|f0 }}%;background:{% if bms.soc > 60.0 %}var(--green){% else if bms.soc > 25.0 %}var(--yellow){% else %}var(--red){% endif %}"></div>
     </div>
-    <span>100%</span>
+    <span id="ov-socpct-{{ bms.address }}">{{ bms.soc|f0 }}%</span>
+    <span style="color:var(--muted2)">100%</span>
   </div>
 
-  {# Températures + Cycles #}
-  <div class="temp4">
-    <div class="temp4-cell">
-      <span class="temp4-lbl">T° Max</span>
-      <span class="temp4-val" id="tmax-{{ bms.address }}">{{ bms.temp_max|f1 }} °C</span>
+  {# Infos bas #}
+  <div class="istrip c4">
+    <div class="icell">
+      <span class="i-lbl">T° max</span>
+      <span class="i-val {% if bms.temp_max > 45.0 %}bad{% else if bms.temp_max > 35.0 %}warn{% endif %}"
+            id="ov-tmax-{{ bms.address }}">{{ bms.temp_max|f1 }} °C</span>
     </div>
-    <div class="temp4-cell">
-      <span class="temp4-lbl">T° Min</span>
-      <span class="temp4-val" id="tmin-{{ bms.address }}">{{ bms.temp_min|f1 }} °C</span>
+    <div class="icell">
+      <span class="i-lbl">Δ cellules</span>
+      <span class="i-val {% if bms.cell_delta_mv > 100.0 %}bad{% else if bms.cell_delta_mv > 50.0 %}warn{% else %}ok{% endif %}"
+            id="ov-dlt-{{ bms.address }}">{{ bms.cell_delta_mv|mv }} mV</span>
     </div>
-    <div class="temp4-cell">
-      <span class="temp4-lbl">Delta</span>
-      <span class="temp4-val" id="dlt-{{ bms.address }}">{{ bms.cell_delta_mv|f1 }} mV</span>
-    </div>
-    <div class="temp4-cell">
-      <span class="temp4-lbl">Cycles</span>
-      <span class="temp4-val">{{ bms.cycles }}</span>
-    </div>
-  </div>
-
-  {# MOS + lien détail #}
-  <div class="info4">
-    <div class="info4-cell">
-      <span class="info4-lbl">MOS Charge</span>
-      <span class="info4-val {% if bms.charge_ok %}a-ok{% else %}a-bad{% endif %}">
-        {% if bms.charge_ok %}ON{% else %}OFF{% endif %}
+    <div class="icell">
+      <span class="i-lbl">Alarmes</span>
+      <span class="i-val {% if bms.any_alarm %}bad{% else %}ok{% endif %}">
+        {% if bms.any_alarm %}⚠ Actives{% else %}✓ Aucune{% endif %}
       </span>
     </div>
-    <div class="info4-cell">
-      <span class="info4-lbl">MOS Décharge</span>
-      <span class="info4-val {% if bms.discharge_ok %}a-ok{% else %}a-bad{% endif %}">
-        {% if bms.discharge_ok %}ON{% else %}OFF{% endif %}
-      </span>
-    </div>
-    <div class="info4-cell">
-      <span class="info4-lbl">Alarmes</span>
-      <span class="info4-val {% if bms.any_alarm %}a-bad{% else %}a-ok{% endif %}">
-        {% if bms.any_alarm %}ALARME{% else %}OK{% endif %}
-      </span>
-    </div>
-    <div class="info4-cell" style="display:flex;align-items:center;justify-content:flex-end;padding-right:0.75rem;">
-      <a href="/dashboard/bms/{{ bms.address }}" class="link-detail">Détail →</a>
+    <div class="icell" style="display:flex;align-items:center;justify-content:flex-end;padding-right:0.85rem;">
+      <a href="/dashboard/bms/{{ bms.address }}" class="btn btn-outline" style="font-size:0.7rem;padding:0.25rem 0.65rem;"
+         onclick="event.stopPropagation()">Détail →</a>
     </div>
   </div>
 
@@ -110,94 +188,111 @@
 {% endfor %}
 
 {% if bms_list.is_empty() %}
-<div class="card" style="text-align:center;padding:2rem;color:var(--muted)">
-  <div>⏳ En attente des données BMS…</div>
+<div class="card">
+  <div class="empty-state">
+    <div class="empty-icon">⏳</div>
+    <div class="empty-title">En attente des données BMS</div>
+  </div>
 </div>
 {% endif %}
-
 </div>
 
-{# ═══════════════════════════════════════════════════════════════════════════
-   SECTION 2 — COMPTEURS ÉNERGIE (ET112)
-   ═══════════════════════════════════════════════════════════════════════════ #}
-<div class="card-title" style="margin-bottom:0.6rem;">⚡ Compteurs énergie</div>
-<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1rem;margin-bottom:1.5rem;">
+{# ═══════════════════════════════════════════════════
+   SECTION 2 — COMPTEURS ÉNERGIE
+   ═══════════════════════════════════════════════════ #}
+<div class="section-hdr">
+  <h2>⚡ Compteurs énergie</h2>
+  <span class="section-count">{{ et112_list|length }} ET112</span>
+  <div class="section-rule"></div>
+  <a href="/dashboard/et112" style="font-size:0.72rem;color:var(--muted);white-space:nowrap">Tout voir →</a>
+</div>
 
+<div class="ov-et112-grid">
 {% for dev in et112_list %}
-<div class="card" style="padding:0;">
+<div class="et112-card" id="ov-et112-{{ dev.address }}">
 
-  {# En-tête par type #}
-  <div style="background:{% if dev.service_type == "pvinverter" %}#1a5f2a{% else %}#5a3a8a{% endif %};padding:0.55rem 0.9rem;border-radius:8px 8px 0 0;display:flex;align-items:center;justify-content:space-between;">
-    <span style="font-weight:700;color:#fff;font-size:0.9rem;">{% if dev.service_type == "pvinverter" %}☀{% else %}🌡{% endif %} {{ dev.name }}</span>
-    <span style="font-size:0.65rem;color:rgba(255,255,255,0.7);font-family:monospace;">{{ dev.addr_hex }}</span>
+  <div class="et112-hdr {% if dev.service_type == "pvinverter" %}pv{% else if dev.service_type == "heatpump" %}hp{% else %}grd{% endif %}">
+    <span class="et112-hdr-name">
+      {% if dev.service_type == "pvinverter" %}☀{% else if dev.service_type == "heatpump" %}🌡{% else %}⚡{% endif %}
+      {{ dev.name }}
+    </span>
+    <div class="et112-hdr-right">
+      {% if dev.connected %}
+        <div class="live-dot"></div>
+        <span style="font-size:0.62rem;color:rgba(255,255,255,0.6)">LIVE</span>
+      {% else %}
+        <span style="font-size:0.62rem;color:rgba(255,255,255,0.35)">Hors ligne</span>
+      {% endif %}
+      <span class="bms-badge">{{ dev.addr_hex }}</span>
+    </div>
   </div>
 
-  <div style="padding:0.75rem;">
-    {% if dev.connected %}
-
-    {# Puissance instantanée — grand chiffre #}
-    <div style="text-align:center;margin-bottom:0.75rem;">
-      <div id="et112-chart-{{ dev.address }}" style="height:130px;"></div>
-    </div>
-
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.5rem;">
-      <div class="kpi">
-        <span class="kpi-label">Puissance</span>
-        <span class="kpi-value blue" id="et112-pow-{{ dev.address }}">{{ dev.power_w|f0 }} W</span>
-      </div>
-      <div class="kpi">
-        <span class="kpi-label">Énergie cumulée</span>
-        <span class="kpi-value green" id="et112-energy-{{ dev.address }}">{{ dev.energy_kwh|f2 }} kWh</span>
-      </div>
-    </div>
-
-    <div style="margin-top:0.5rem;text-align:right;">
-      <a href="/dashboard/et112/{{ dev.address }}" style="font-size:0.72rem;color:var(--accent);">Détail →</a>
-    </div>
-
-    {% else %}
-    <div style="text-align:center;padding:1.5rem;color:var(--muted);font-size:0.8rem;">
-      ⏳ En attente de données…
-    </div>
-    {% endif %}
+  {% if dev.connected %}
+  <div class="power-hero">
+    <div class="power-hero-val {% if dev.service_type == "pvinverter" %}green{% else %}orange{% endif %}"
+         id="ov-et-pow-{{ dev.address }}">{{ dev.power_w|f0 }} W</div>
+    <div class="power-hero-lbl">Puissance instantanée</div>
   </div>
+
+  <div class="istrip c2" style="border-bottom:none">
+    <div class="icell">
+      <span class="i-lbl">⬇ Importée</span>
+      <span class="i-val green" id="ov-et-imp-{{ dev.address }}">{{ dev.energy_kwh|f2 }} kWh</span>
+    </div>
+    <div class="icell" style="display:flex;align-items:flex-end;justify-content:flex-end;padding-right:0.85rem;">
+      <a href="/dashboard/et112/{{ dev.address }}" class="btn btn-outline" style="font-size:0.7rem;padding:0.25rem 0.65rem;">Détail →</a>
+    </div>
+  </div>
+
+  {% else %}
+  <div class="empty-state" style="padding:2rem 1rem;">
+    <div class="empty-icon" style="font-size:1.5rem">⏳</div>
+    <div class="empty-sub">En attente de données…</div>
+  </div>
+  {% endif %}
 
 </div>
 {% endfor %}
 
 {% if et112_list.is_empty() %}
-<div class="card" style="text-align:center;padding:2rem;color:var(--muted)">
-  <div>Aucun ET112 configuré.</div>
-</div>
+<div class="card card-p" style="color:var(--muted);font-size:0.8rem;">Aucun ET112 configuré.</div>
 {% endif %}
-
 </div>
 
-{# ═══════════════════════════════════════════════════════════════════════════
+{# ═══════════════════════════════════════════════════
    SECTION 3 — IRRADIANCE
-   ═══════════════════════════════════════════════════════════════════════════ #}
-<div class="card-title" style="margin-bottom:0.6rem;">🌤 Irradiance solaire</div>
-<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1rem;margin-bottom:1.5rem;">
+   ═══════════════════════════════════════════════════ #}
+<div class="section-hdr">
+  <h2>🌤 Irradiance solaire</h2>
+  <div class="section-rule"></div>
+</div>
 
-  <div class="card" style="padding:0;">
-    <div style="background:#7a5c00;padding:0.55rem 0.9rem;border-radius:8px 8px 0 0;display:flex;align-items:center;justify-content:space-between;">
-      <span style="font-weight:700;color:#fff;font-size:0.9rem;">☀ Capteur PRALRAN</span>
-      <span style="font-size:0.65rem;color:rgba(255,255,255,0.7);">Dernière : <span id="irr-ts">{{ irradiance_ts }}</span></span>
+<div class="ov-irr-grid">
+
+  <div class="irr-card">
+    <div class="irr-hdr">
+      <span class="irr-hdr-name">☀ Capteur PRALRAN</span>
+      <span class="irr-ts">Màj : <span id="irr-ts">{{ irradiance_ts }}</span></span>
     </div>
-    <div style="padding:1rem;text-align:center;">
+    <div style="padding:1rem;">
       {% if let Some(wm2) = irradiance_wm2 %}
-      <div id="irr-gauge" style="height:160px;"></div>
-      <div style="font-size:0.75rem;color:var(--muted);margin-top:0.5rem;">W/m²</div>
+        <div id="irr-gauge" style="height:170px;"></div>
+        <div style="text-align:center;font-size:0.62rem;color:var(--muted);margin-top:0.3rem;">W/m²</div>
       {% else %}
-      <div style="padding:2rem;color:var(--muted);font-size:0.8rem;">⏳ En attente de données…</div>
+        <div class="empty-state" style="padding:2rem 1rem;">
+          <div class="empty-icon" style="font-size:1.5rem">⏳</div>
+          <div class="empty-sub">En attente du capteur RS485…</div>
+        </div>
       {% endif %}
     </div>
   </div>
 
-  {# Courbe historique irradiance #}
-  <div class="card" style="padding:1rem;">
-    <div style="font-size:0.75rem;font-weight:600;color:var(--muted);margin-bottom:0.5rem;">Irradiance (W/m²) — temps réel</div>
-    <div id="irr-history-chart" style="height:160px;"></div>
+  <div class="irr-card">
+    <div class="chart-hdr">
+      <span class="chart-hdr-title">Irradiance W/m² — temps réel</span>
+      <span class="chart-hdr-meta" id="irr-val-label">—</span>
+    </div>
+    <div id="irr-hist" style="height:200px;"></div>
   </div>
 
 </div>
@@ -206,117 +301,74 @@
 
 {% block scripts %}
 <script>
-// ═══════════════════════════════════════════════════════════════════════════
-// Vue d'ensemble — mise à jour temps réel
-// ═══════════════════════════════════════════════════════════════════════════
-
-// ── BMS via WebSocket ──────────────────────────────────────────────────────
+// ── WebSocket BMS ──────────────────────────────────────────────────────
 window.onBmsUpdate = function(snaps) {
-  const now = new Date().toLocaleTimeString();
-  document.getElementById('ov-ts').textContent = 'Mise à jour : ' + now;
+  const now = new Date().toLocaleTimeString('fr-FR');
+  const ovTs = document.getElementById('ov-ts');
+  if (ovTs) ovTs.textContent = now;
 
   snaps.forEach(function(s) {
-    const addr = s.address;
+    const a = s.address;
     function set(id, val) {
-      const el = document.getElementById(id + '-' + addr);
+      const el = document.getElementById(id + '-' + a);
       if (el) el.textContent = val;
     }
 
-    const v    = s.dc ? s.dc.voltage   : (s.voltage  || 0);
-    const i    = s.dc ? s.dc.current   : (s.current  || 0);
-    const p    = s.dc ? s.dc.power     : (s.power    || 0);
-    const soc  = s.soc || 0;
-    const tmax = s.system ? s.system.max_cell_temperature : (s.temp_max || 0);
-    const tmin = s.system ? s.system.min_cell_temperature : (s.temp_min || 0);
-    const dlt  = s.system ? ((s.system.max_cell_voltage - s.system.min_cell_voltage) * 1000) : 0;
+    const v   = s.Dc ? s.Dc.Voltage  : (s.voltage  || 0);
+    const i   = s.Dc ? s.Dc.Current  : (s.current  || 0);
+    const p   = s.Dc ? s.Dc.Power    : (s.power    || 0);
+    const soc = s.Soc || 0;
+    const tmax = s.System ? s.System.MaxCellTemperature : (s.temp_max || 0);
+    const dlt  = s.System ? ((s.System.MaxCellVoltage - s.System.MinCellVoltage) * 1000) : 0;
 
-    set('v',   v.toFixed(2) + ' V');
-    set('soc', soc.toFixed(1) + ' %');
-    set('i',   (i >= 0 ? '+' : '') + i.toFixed(1) + ' A');
-    set('p',   p.toFixed(0) + ' W');
-    set('tmax',tmax.toFixed(1) + ' °C');
-    set('tmin',tmin.toFixed(1) + ' °C');
-    set('dlt', dlt.toFixed(1) + ' mV');
-    set('ts',  now);
+    set('ov-v',   v.toFixed(2)   + ' V');
+    set('ov-soc', soc.toFixed(1) + '%');
+    set('ov-socpct', soc.toFixed(0) + '%');
+    set('ov-i',   (i >= 0 ? '+' : '') + i.toFixed(1) + ' A');
+    set('ov-p',   p.toFixed(0)   + ' W');
+    set('ov-tmax',tmax.toFixed(1)+ ' °C');
+    set('ov-dlt', dlt.toFixed(0) + ' mV');
+    set('ov-ts',  now);
 
-    // Barre SOC
-    const bar = document.getElementById('bar-' + addr);
+    const bar = document.getElementById('ov-bar-' + a);
     if (bar) {
       bar.style.width = Math.min(100, Math.max(0, soc)).toFixed(0) + '%';
       bar.style.background = soc > 60 ? 'var(--green)' : soc > 25 ? 'var(--yellow)' : 'var(--red)';
     }
-    // Couleur courant
-    const iEl = document.getElementById('i-' + addr);
-    if (iEl) { iEl.className = 'kpi4-val ' + (i >= 0 ? 'chg' : 'dch'); }
-    const pEl = document.getElementById('p-' + addr);
-    if (pEl) { pEl.className = 'kpi4-val ' + (p >= 0 ? 'chg' : 'dch'); }
+    const curEl = document.getElementById('ov-i-' + a);
+    if (curEl) curEl.className = 'kpi4-val ' + (i >= 0 ? 'chg' : 'dch');
+    const powEl = document.getElementById('ov-p-' + a);
+    if (powEl) powEl.className = 'kpi4-val ' + (p >= 0 ? 'chg' : 'dch');
   });
 };
 
-// ── ET112 gauges ECharts ───────────────────────────────────────────────────
-const et112Charts = {};
-
-// Liste des ET112 configurés (adresse → service_type)
-const ET112_DEVICES = [
+// ── ET112 polling ──────────────────────────────────────────────────────
+const ET112_DEVS = [
 {% for dev in et112_list %}
   { addr: {{ dev.address }}, type: "{{ dev.service_type }}" },
 {% endfor %}
 ];
 
-ET112_DEVICES.forEach(function(dev) {
-  const domId = 'et112-chart-' + dev.addr;
-  const dom   = document.getElementById(domId);
-  if (!dom) return;
-
-  const color = dev.type === 'pvinverter' ? '#1a7f37' : '#6f42c1';
-  const chart = echarts.init(dom);
-  chart.setOption({
-    series: [{
-      type: 'gauge',
-      radius: '95%',
-      min: 0, max: 3000,
-      axisLine: { lineStyle: { width: 10, color: [[0.33, '#1a7f37'], [0.66, '#9a6700'], [1, '#cf222e']] } },
-      pointer: { length: '60%', width: 4 },
-      axisTick: { show: false },
-      splitLine: { show: false },
-      axisLabel: { show: false },
-      detail: {
-        formatter: '{value} W',
-        fontSize: 16,
-        fontWeight: 700,
-        color: color,
-        offsetCenter: [0, '65%'],
-      },
-      data: [{ value: 0, name: '' }],
-    }],
-  });
-  et112Charts[dev.addr] = chart;
-  window.addEventListener('resize', () => chart.resize());
-});
-
 async function updateEt112() {
-  for (const dev of ET112_DEVICES) {
+  for (const dev of ET112_DEVS) {
     try {
       const resp = await fetch('/api/v1/et112/' + dev.addr + '/status');
       if (!resp.ok) continue;
       const d = await resp.json();
-
-      const powEl    = document.getElementById('et112-pow-'    + dev.addr);
-      const energyEl = document.getElementById('et112-energy-' + dev.addr);
-      if (powEl)    powEl.textContent    = d.power_w.toFixed(0) + ' W';
-      if (energyEl) energyEl.textContent = (d.energy_import_wh / 1000).toFixed(2) + ' kWh';
-
-      if (et112Charts[dev.addr]) {
-        et112Charts[dev.addr].setOption({ series: [{ data: [{ value: d.power_w.toFixed(1) }] }] });
+      const powEl = document.getElementById('ov-et-pow-' + dev.addr);
+      const impEl = document.getElementById('ov-et-imp-' + dev.addr);
+      if (powEl) {
+        powEl.textContent = d.power_w.toFixed(0) + ' W';
+        powEl.className = 'power-hero-val ' + (dev.type === 'pvinverter' ? 'green' : 'orange');
       }
+      if (impEl) impEl.textContent = (d.energy_import_wh / 1000).toFixed(2) + ' kWh';
     } catch(e) {}
   }
 }
 
-// ── Irradiance gauge ECharts ───────────────────────────────────────────────
+// ── Irradiance gauge ECharts ───────────────────────────────────────────
 const irrHistory = { xs: [], ys: [] };
-let irrGauge = null;
-let irrHistChart = null;
+let irrGauge = null, irrHist = null;
 
 const irrGaugeDom = document.getElementById('irr-gauge');
 if (irrGaugeDom) {
@@ -324,44 +376,69 @@ if (irrGaugeDom) {
   irrGauge.setOption({
     series: [{
       type: 'gauge',
-      radius: '95%',
+      radius: '92%',
+      startAngle: 210, endAngle: -30,
       min: 0, max: 1200,
-      axisLine: { lineStyle: { width: 10, color: [[0.25, '#57606a'], [0.65, '#9a6700'], [1, '#cf222e']] } },
-      pointer: { length: '65%', width: 4 },
+      axisLine: {
+        lineStyle: {
+          width: 14,
+          color: [[0.25,'#2d333b'],[0.65,'rgba(210,153,34,0.7)'],[1,'rgba(248,81,73,0.8)']]
+        }
+      },
+      progress: { show: true, width: 14, roundCap: true, itemStyle: { color: '#d29922' } },
+      pointer: { length: '58%', width: 5, itemStyle: { color: '#d29922' } },
       axisTick: { show: false },
       splitLine: { show: false },
       axisLabel: { show: false },
+      anchor: { show: true, size: 12, itemStyle: { color: '#d29922' } },
       detail: {
-        formatter: '{value}',
-        fontSize: 20,
-        fontWeight: 700,
-        color: '#9a6700',
-        offsetCenter: [0, '65%'],
+        formatter: '{value} W/m²',
+        fontSize: 18, fontWeight: 800,
+        fontFamily: "'JetBrains Mono', monospace",
+        color: '#d29922',
+        offsetCenter: [0, '70%'],
       },
       data: [{ value: {% if let Some(wm2) = irradiance_wm2 %}{{ wm2|f0 }}{% else %}0{% endif %} }],
     }],
+    backgroundColor: 'transparent',
   });
-  window.addEventListener('resize', () => irrGauge.resize());
+  window.addEventListener('resize', () => irrGauge && irrGauge.resize());
 }
 
-const irrHistDom = document.getElementById('irr-history-chart');
+const irrHistDom = document.getElementById('irr-hist');
 if (irrHistDom) {
-  irrHistChart = echarts.init(irrHistDom);
-  irrHistChart.setOption({
-    tooltip: { trigger: 'axis', formatter: p => p[0].name + '<br/>Irradiance: <b>' + p[0].value + ' W/m²</b>' },
-    xAxis: { type: 'category', data: [], axisLabel: { fontSize: 10 }, boundaryGap: false },
-    yAxis: { type: 'value', name: 'W/m²', nameTextStyle: { fontSize: 10 }, min: 0 },
+  irrHist = echarts.init(irrHistDom);
+  irrHist.setOption({
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: '#21262d',
+      borderColor: '#30363d',
+      textStyle: { color: '#e6edf3', fontSize: 11 },
+      formatter: p => p[0].name + '<br/>Irradiance : <b>' + p[0].value + ' W/m²</b>'
+    },
+    xAxis: {
+      type: 'category', data: [],
+      axisLine: { lineStyle: { color: '#30363d' } },
+      axisLabel: { color: '#6e7681', fontSize: 10 },
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: 'value', min: 0,
+      axisLine: { show: false },
+      axisLabel: { color: '#6e7681', fontSize: 10 },
+      splitLine: { lineStyle: { color: '#21262d' } },
+    },
     series: [{
-      type: 'line',
-      data: [],
-      smooth: true,
-      lineStyle: { color: '#9a6700', width: 2 },
-      areaStyle: { opacity: 0.15, color: '#9a6700' },
-      symbol: 'none',
+      type: 'line', data: [], smooth: true, symbol: 'none',
+      lineStyle: { color: '#d29922', width: 2 },
+      areaStyle: { color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
+        colorStops: [{ offset: 0, color: 'rgba(210,153,34,0.3)' }, { offset: 1, color: 'rgba(210,153,34,0.02)' }]
+      }},
     }],
-    grid: { left: 45, right: 10, top: 10, bottom: 25 },
+    grid: { left: 40, right: 12, top: 12, bottom: 28 },
   });
-  window.addEventListener('resize', () => irrHistChart.resize());
+  window.addEventListener('resize', () => irrHist && irrHist.resize());
 }
 
 async function updateIrradiance() {
@@ -370,32 +447,23 @@ async function updateIrradiance() {
     if (!resp.ok) return;
     const d = await resp.json();
     if (!d.connected) return;
-
     const wm2 = d.irradiance_wm2;
-    document.getElementById('irr-ts').textContent = new Date(d.timestamp).toLocaleTimeString();
-
-    if (irrGauge) {
-      irrGauge.setOption({ series: [{ data: [{ value: wm2.toFixed(0) }] }] });
-    }
-
-    // Historique local (glissant 60 points = 10 min à 10s)
-    const t = new Date(d.timestamp).toLocaleTimeString();
-    irrHistory.xs.push(t);
+    const ts   = new Date(d.timestamp).toLocaleTimeString('fr-FR');
+    const tsEl = document.getElementById('irr-ts');
+    const lblEl = document.getElementById('irr-val-label');
+    if (tsEl)  tsEl.textContent  = ts;
+    if (lblEl) lblEl.textContent = wm2.toFixed(0) + ' W/m²';
+    if (irrGauge) irrGauge.setOption({ series: [{ data: [{ value: wm2.toFixed(0) }] }] });
+    irrHistory.xs.push(ts);
     irrHistory.ys.push(wm2.toFixed(1));
-    if (irrHistory.xs.length > 60) {
-      irrHistory.xs.shift();
-      irrHistory.ys.shift();
-    }
-    if (irrHistChart) {
-      irrHistChart.setOption({ xAxis: { data: irrHistory.xs }, series: [{ data: irrHistory.ys }] });
-    }
+    if (irrHistory.xs.length > 60) { irrHistory.xs.shift(); irrHistory.ys.shift(); }
+    if (irrHist) irrHist.setOption({ xAxis: { data: irrHistory.xs }, series: [{ data: irrHistory.ys }] });
   } catch(e) {}
 }
 
-// ── Démarrage ─────────────────────────────────────────────────────────────
 updateEt112();
 updateIrradiance();
-setInterval(updateEt112, 5000);
+setInterval(updateEt112,    5000);
 setInterval(updateIrradiance, 10000);
 </script>
 {% endblock %}

--- a/crates/daly-bms-server/templates/settings.html
+++ b/crates/daly-bms-server/templates/settings.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
-{% block title %}Paramètres BMS — Monitoring{% endblock %}
+{% block title %}Paramètres — ESS Monitor{% endblock %}
+{% block page_title %}Paramètres{% endblock %}
+{% block nav_settings %}active{% endblock %}
 
 {% block content %}
 <style>

--- a/crates/daly-bms-server/templates/tasmota.html
+++ b/crates/daly-bms-server/templates/tasmota.html
@@ -1,116 +1,208 @@
 {% extends "base.html" %}
 
-{% block title %}{{ name }} — Tasmota{% endblock %}
+{% block title %}{{ name }} — Tasmota — ESS Monitor{% endblock %}
+{% block page_title %}Tasmota — {{ name }}{% endblock %}
+{% block nav_tasmota %}active{% endblock %}
 
 {% block content %}
 
-{# ─── En-tête ────────────────────────────────────────────────────────────── #}
-<div class="info-bar">
-  <strong>🔌 {{ name }}</strong>
-  <span>
-    {% if connected %}
-      {% if power_on %}<span style="color:var(--green);font-weight:600">ON</span>{% else %}<span style="color:var(--red);font-weight:600">OFF</span>{% endif %}
-    {% else %}
-      <span style="color:var(--muted)">Hors ligne</span>
-    {% endif %}
-    — {{ tasmota_id }} — Màj : {{ last_ts }}
+<div class="page-hdr">
+  <a href="/dashboard/tasmota" class="btn btn-outline" style="font-size:0.75rem;padding:0.3rem 0.7rem;">← Retour</a>
+  <h1>🔌 {{ name }}</h1>
+  <span class="badge {% if connected %}{% if power_on %}ok{% else %}alarm{% endif %}{% else %}muted{% endif %}">
+    {% if connected %}{% if power_on %}● ON{% else %}● OFF{% endif %}{% else %}○ Hors ligne{% endif %}
   </span>
-  <a href="/dashboard/tasmota" style="font-size:0.8rem">← Retour liste</a>
-</div>
-
-{% if !connected %}
-<div style="margin:2rem auto;max-width:500px;padding:2rem;background:var(--surface);border-radius:var(--radius);text-align:center;color:var(--muted);box-shadow:var(--shadow);">
-  <div style="font-size:2rem;margin-bottom:1rem">⏳</div>
-  <div>En attente du premier message MQTT…</div>
-  <div style="font-size:0.8rem;margin-top:0.5rem">
-    Vérifier que <code>tele/{{ tasmota_id }}/SENSOR</code> est publié sur le broker.
+  <div class="page-hdr-meta" style="margin-left:auto">
+    <span>{{ tasmota_id }}</span>
+    <span class="sep">·</span>
+    <span>Dernière mesure : <span id="last-ts">{{ last_ts }}</span></span>
   </div>
 </div>
+
+{% if connected %}
+
+{# ─── Métriques instantanées ──────────────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:0.85rem;margin-bottom:1.25rem;">
+
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Puissance active</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;
+                color:{% if power_w > 0.0 %}var(--yellow){% else %}var(--muted){% endif %}" id="val-power">
+      {{ power_w|f1 }} W
+    </div>
+    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.2rem">
+      {% if power_on %}Relais ON{% else %}Relais OFF{% endif %}
+    </div>
+  </div>
+
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Tension</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--accent)" id="val-voltage">
+      {{ voltage_v|f1 }} V
+    </div>
+  </div>
+
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Courant</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--orange)" id="val-current">
+      {{ current_a|f2 }} A
+    </div>
+  </div>
+
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Puiss. apparente</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--muted)" id="val-apparent">
+      {{ apparent_power_va|f1 }} VA
+    </div>
+  </div>
+
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Facteur puissance</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--text2)" id="val-pf">
+      {{ power_factor|f2 }}
+    </div>
+  </div>
+
+  <div class="card card-p" style="text-align:center;">
+    <div class="card-title" style="margin-bottom:0.3rem">Signal WiFi</div>
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--muted)" id="val-rssi">
+      {{ rssi }}
+    </div>
+    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.2rem">dBm</div>
+  </div>
+
+</div>
+
+{# ─── Énergie cumulée ─────────────────────────────────────────────────── #}
+<div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:1rem;margin-bottom:1.25rem;">
+  <div class="card card-p">
+    <div class="card-title">☀ Aujourd'hui</div>
+    <div style="font-size:2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--accent)" id="val-today">
+      {{ energy_today_kwh|f3 }} kWh
+    </div>
+  </div>
+  <div class="card card-p">
+    <div class="card-title">⏮ Hier</div>
+    <div style="font-size:2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--muted)" id="val-yesterday">
+      {{ energy_yesterday_kwh|f3 }} kWh
+    </div>
+  </div>
+  <div class="card card-p">
+    <div class="card-title">∑ Total</div>
+    <div style="font-size:2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--text)" id="val-total">
+      {{ energy_total_kwh|f1 }} kWh
+    </div>
+    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.4rem">Type : {{ service_type }}</div>
+  </div>
+</div>
+
+{# ─── Historique puissance ─────────────────────────────────────────────── #}
+<div class="chart-card">
+  <div class="chart-hdr">
+    <span class="chart-hdr-title">Historique puissance</span>
+    <span class="chart-hdr-meta">Dernières mesures — rafraîchi toutes les 5s</span>
+  </div>
+  <div id="chart-power" style="height:260px;"></div>
+</div>
+
 {% else %}
 
-{# ─── Puissance instantanée ───────────────────────────────────────────────── #}
-<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:1rem;margin-bottom:1rem;">
-
-  <div class="bms-card-ng" style="padding:1rem;">
-    <div class="kpi4-lbl">Puissance active</div>
-    <div class="kpi4-val" style="font-size:2rem;color:var(--accent)" id="pw">{{ power_w|f1 }} W</div>
-  </div>
-
-  <div class="bms-card-ng" style="padding:1rem;">
-    <div class="kpi4-lbl">Tension</div>
-    <div class="kpi4-val" style="font-size:2rem;" id="vv">{{ voltage_v|f1 }} V</div>
-  </div>
-
-  <div class="bms-card-ng" style="padding:1rem;">
-    <div class="kpi4-lbl">Courant</div>
-    <div class="kpi4-val" style="font-size:2rem;" id="iv">{{ current_a|f2 }} A</div>
-  </div>
-
-  <div class="bms-card-ng" style="padding:1rem;">
-    <div class="kpi4-lbl">Puissance apparente</div>
-    <div class="kpi4-val" style="font-size:2rem;" id="pva">{{ apparent_power_va|f1 }} VA</div>
-  </div>
-
-  <div class="bms-card-ng" style="padding:1rem;">
-    <div class="kpi4-lbl">Facteur de puissance</div>
-    <div class="kpi4-val" style="font-size:2rem;" id="pf">{{ power_factor|f2 }}</div>
-  </div>
-
-  <div class="bms-card-ng" style="padding:1rem;">
-    <div class="kpi4-lbl">Signal WiFi</div>
-    <div class="kpi4-val" style="font-size:2rem;color:var(--muted)" id="rssi">{{ rssi }}</div>
-  </div>
-
-</div>
-
-{# ─── Énergie ─────────────────────────────────────────────────────────────── #}
-<div class="bms-card-ng" style="margin-bottom:1rem;">
-  <div class="bms-hdr" style="background:#1a5f8a;">
-    <div class="bms-hdr-title">Énergie consommée</div>
-    <div class="bms-hdr-right"><span>{{ service_type }}</span></div>
-  </div>
-  <div style="display:grid;grid-template-columns:1fr 1fr 1fr;">
-    <div style="padding:1rem;border-right:1px solid var(--border);">
-      <div class="kpi4-lbl">Aujourd'hui</div>
-      <div class="kpi4-val" style="font-size:1.8rem;color:var(--accent)" id="etd">{{ energy_today_kwh|f3 }} kWh</div>
-    </div>
-    <div style="padding:1rem;border-right:1px solid var(--border);">
-      <div class="kpi4-lbl">Hier</div>
-      <div class="kpi4-val" style="font-size:1.8rem;color:var(--muted)" id="eyd">{{ energy_yesterday_kwh|f3 }} kWh</div>
-    </div>
-    <div style="padding:1rem;">
-      <div class="kpi4-lbl">Total</div>
-      <div class="kpi4-val" style="font-size:1.8rem;" id="etot">{{ energy_total_kwh|f1 }} kWh</div>
+<div class="card">
+  <div class="empty-state">
+    <div class="empty-icon">⏳</div>
+    <div class="empty-title">En attente du premier message MQTT</div>
+    <div class="empty-sub">
+      Vérifiez que <code>tele/{{ tasmota_id }}/SENSOR</code><br>
+      est publié sur le broker MQTT.
     </div>
   </div>
 </div>
 
 {% endif %}
 
-{# ─── Mise à jour automatique ─────────────────────────────────────────────── #}
+{% endblock %}
+
+{% block scripts %}
 <script>
 const TASMOTA_ID = {{ id }};
 
+// ── ECharts power chart ────────────────────────────────────────────────
+const chartDom = document.getElementById('chart-power');
+let myChart = null;
+if (chartDom) {
+  myChart = echarts.init(chartDom);
+  myChart.setOption({
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: '#21262d',
+      borderColor: '#30363d',
+      textStyle: { color: '#e6edf3', fontSize: 11 },
+      formatter: p => p[0].name + '<br/>Puissance : <b>' + p[0].value + ' W</b>'
+    },
+    xAxis: {
+      type: 'category', data: [],
+      axisLine: { lineStyle: { color: '#30363d' } },
+      axisLabel: { color: '#6e7681', fontSize: 10 },
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: 'value',
+      axisLine: { show: false },
+      axisLabel: { color: '#6e7681', fontSize: 10 },
+      splitLine: { lineStyle: { color: '#21262d' } },
+    },
+    series: [{
+      name: 'Puissance', type: 'line', data: [],
+      smooth: true, symbol: 'none',
+      lineStyle: { color: '#d29922', width: 2 },
+      areaStyle: { color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
+        colorStops: [{ offset: 0, color: 'rgba(210,153,34,0.25)' }, { offset: 1, color: 'rgba(210,153,34,0.02)' }]
+      }},
+    }],
+    grid: { left: 50, right: 16, top: 16, bottom: 30 },
+  });
+  window.addEventListener('resize', () => myChart && myChart.resize());
+}
+
+const powerHistory = [];
+const MAX_PTS = 120;
+
 async function update() {
-    try {
-        const resp = await fetch(`/api/v1/tasmota/${TASMOTA_ID}/status`);
-        if (!resp.ok) return;
-        const d = await resp.json();
-        const el = (id) => document.getElementById(id);
-        if (el('pw'))   el('pw').textContent   = d.power_w.toFixed(1) + ' W';
-        if (el('vv'))   el('vv').textContent   = d.voltage_v.toFixed(1) + ' V';
-        if (el('iv'))   el('iv').textContent   = d.current_a.toFixed(2) + ' A';
-        if (el('pva'))  el('pva').textContent  = d.apparent_power_va.toFixed(1) + ' VA';
-        if (el('pf'))   el('pf').textContent   = d.power_factor.toFixed(2);
-        if (el('etd'))  el('etd').textContent  = d.energy_today_kwh.toFixed(3) + ' kWh';
-        if (el('eyd'))  el('eyd').textContent  = d.energy_yesterday_kwh.toFixed(3) + ' kWh';
-        if (el('etot')) el('etot').textContent = d.energy_total_kwh.toFixed(1) + ' kWh';
-        if (el('rssi') && d.rssi != null) el('rssi').textContent = d.rssi + ' dBm';
-    } catch(e) {}
+  try {
+    const resp = await fetch(`/api/v1/tasmota/${TASMOTA_ID}/status`);
+    if (!resp.ok) return;
+    const d = await resp.json();
+    const set = (id, txt) => { const el = document.getElementById(id); if (el) el.textContent = txt; };
+
+    set('val-power',     d.power_w.toFixed(1) + ' W');
+    set('val-voltage',   d.voltage_v.toFixed(1) + ' V');
+    set('val-current',   d.current_a.toFixed(2) + ' A');
+    set('val-apparent',  d.apparent_power_va.toFixed(1) + ' VA');
+    set('val-pf',        d.power_factor.toFixed(2));
+    set('val-today',     d.energy_today_kwh.toFixed(3) + ' kWh');
+    set('val-yesterday', d.energy_yesterday_kwh.toFixed(3) + ' kWh');
+    set('val-total',     d.energy_total_kwh.toFixed(1) + ' kWh');
+    set('last-ts',       new Date().toLocaleTimeString('fr-FR'));
+    if (d.rssi != null) set('val-rssi', d.rssi + ' dBm');
+
+    const powEl = document.getElementById('val-power');
+    if (powEl) powEl.style.color = d.power_w > 0 ? 'var(--yellow)' : 'var(--muted)';
+
+    // Rolling chart
+    if (myChart) {
+      const t = new Date().toLocaleTimeString('fr-FR');
+      powerHistory.push({ t, v: d.power_w.toFixed(1) });
+      if (powerHistory.length > MAX_PTS) powerHistory.shift();
+      myChart.setOption({
+        xAxis: { data: powerHistory.map(p => p.t) },
+        series: [{ data: powerHistory.map(p => p.v) }]
+      });
+    }
+  } catch(e) {}
 }
 
 update();
 setInterval(update, 5000);
 </script>
-
 {% endblock %}

--- a/crates/daly-bms-server/templates/tasmota_all.html
+++ b/crates/daly-bms-server/templates/tasmota_all.html
@@ -1,100 +1,91 @@
 {% extends "base.html" %}
 
-{% block title %}Prises Tasmota — Monitoring{% endblock %}
+{% block title %}Prises Tasmota — ESS Monitor{% endblock %}
+{% block page_title %}Prises Tasmota{% endblock %}
+{% block nav_tasmota %}active{% endblock %}
 
 {% block content %}
 
-{# ─── En-tête ────────────────────────────────────────────────────────────── #}
-<div class="info-bar">
-  <strong>Prises connectées Tasmota</strong>
-  <span>{{ device_count }} appareil(s) configuré(s)</span>
+<div class="page-hdr">
+  <h1>🔌 Prises Tasmota</h1>
+  <div class="page-hdr-meta">
+    <span><strong style="color:var(--text)">{{ device_count }}</strong> appareil(s) configuré(s)</span>
+    <span class="sep">·</span>
+    <span>Màj : <span id="tasmota-ts">—</span></span>
+  </div>
 </div>
 
-{# ─── Grille des prises ───────────────────────────────────────────────────── #}
-<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(360px,1fr));gap:1rem;">
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1.25rem;">
 
 {% for d in devices %}
-<div class="bms-card-ng" id="tasmota-card-{{ d.id }}" style="{% if !d.connected %}opacity:0.7;{% endif %}">
+<div class="bms-card {% if !d.connected %}" style="opacity:0.7{% endif %}" id="tasmota-card-{{ d.id }}">
 
-  {# ── En-tête carte ──── #}
-  <div class="bms-hdr" style="{% if d.connected %}{% if d.power_on %}background:#1a5f1a;{% else %}background:#5f1a1a;{% endif %}{% else %}background:#57606a;{% endif %}">
-    <div class="bms-hdr-title">
-      🔌 {{ d.name }}
+  {# Header #}
+  <div class="bms-hdr" style="{% if d.connected %}{% if d.power_on %}background:linear-gradient(135deg,#0e3320 0%,#081a10 100%){% else %}background:linear-gradient(135deg,#3b1010 0%,#200808 100%){% endif %}{% else %}background:linear-gradient(135deg,#2d333b 0%,#1c2128 100%){% endif %}">
+    <div class="bms-hdr-left">
+      {% if d.connected %}
+        <div class="bms-live"><div class="live-dot" style="{% if !d.power_on %}background:var(--red);box-shadow:0 0 6px var(--red){% endif %}"></div>{% if d.power_on %}ON{% else %}OFF{% endif %}</div>
+      {% else %}
+        <span style="font-size:0.62rem;color:rgba(255,255,255,0.35)">Hors ligne</span>
+      {% endif %}
+      <span class="bms-hdr-name">🔌 {{ d.name }}</span>
     </div>
     <div class="bms-hdr-right">
-      {% if d.connected %}
-        <div class="bms-live-dot"></div>
-        {% if d.power_on %}
-          <span style="color:#90ee90;font-weight:600">ON</span>
-        {% else %}
-          <span style="color:#ff9999;font-weight:600">OFF</span>
-        {% endif %}
-      {% else %}
-        <span style="color:rgba(255,255,255,0.5)">Hors ligne</span>
-      {% endif %}
-      <div class="bms-can-badge">{{ d.tasmota_id }}</div>
-      <span class="bms-hdr-ts" id="ts-{{ d.id }}">{{ d.last_ts }}</span>
+      <span class="bms-badge">{{ d.tasmota_id }}</span>
+      <span class="bms-ts" id="ts-{{ d.id }}">{{ d.last_ts }}</span>
     </div>
   </div>
 
   {% if d.connected %}
 
-  {# ── KPI 4 colonnes ── #}
+  {# KPI 4 col #}
   <div class="kpi4">
-    <div class="kpi4-cell kpi4-p">
+    <div class="kpi4-cell t-yellow">
       <div class="kpi4-lbl">Puissance</div>
-      <div class="kpi4-val chg" id="p-{{ d.id }}">{{ d.power_w|f1 }} W</div>
+      <div class="kpi4-val {% if d.power_w > 0.0 %}chg{% else %}muted{% endif %}" id="p-{{ d.id }}">{{ d.power_w|f1 }} W</div>
     </div>
-    <div class="kpi4-cell kpi4-v">
+    <div class="kpi4-cell t-blue">
       <div class="kpi4-lbl">Tension</div>
       <div class="kpi4-val" id="v-{{ d.id }}">{{ d.voltage_v|f1 }} V</div>
     </div>
-    <div class="kpi4-cell kpi4-i">
+    <div class="kpi4-cell t-orange">
       <div class="kpi4-lbl">Courant</div>
       <div class="kpi4-val" id="i-{{ d.id }}">{{ d.current_a|f2 }} A</div>
     </div>
     <div class="kpi4-cell">
       <div class="kpi4-lbl">Cos φ</div>
-      <div class="kpi4-val" id="pf-{{ d.id }}">{{ d.power_factor|f2 }}</div>
+      <div class="kpi4-val muted" id="pf-{{ d.id }}">{{ d.power_factor|f2 }}</div>
     </div>
   </div>
 
-  {# ── Énergie ── #}
-  <div style="display:grid;grid-template-columns:1fr 1fr 1fr;border-bottom:1px solid var(--border);">
-    <div style="padding:0.45rem 0.65rem;border-right:1px solid var(--border);">
-      <div class="kpi4-lbl">Aujourd'hui</div>
-      <div class="kpi4-val" style="color:var(--accent)" id="etd-{{ d.id }}">
-        {{ d.energy_today_kwh|f2 }} kWh
-      </div>
+  {# Énergie #}
+  <div class="istrip c3">
+    <div class="icell">
+      <span class="i-lbl">Aujourd'hui</span>
+      <span class="i-val blue" id="etd-{{ d.id }}">{{ d.energy_today_kwh|f2 }} kWh</span>
     </div>
-    <div style="padding:0.45rem 0.65rem;border-right:1px solid var(--border);">
-      <div class="kpi4-lbl">Hier</div>
-      <div class="kpi4-val" style="color:var(--muted)" id="eyd-{{ d.id }}">
-        {{ d.energy_yesterday_kwh|f2 }} kWh
-      </div>
+    <div class="icell">
+      <span class="i-lbl">Hier</span>
+      <span class="i-val muted" id="eyd-{{ d.id }}">{{ d.energy_yesterday_kwh|f2 }} kWh</span>
     </div>
-    <div style="padding:0.45rem 0.65rem;">
-      <div class="kpi4-lbl">Total</div>
-      <div class="kpi4-val" id="etot-{{ d.id }}">
-        {{ d.energy_total_kwh|f1 }} kWh
-      </div>
+    <div class="icell">
+      <span class="i-lbl">Total</span>
+      <span class="i-val" id="etot-{{ d.id }}">{{ d.energy_total_kwh|f1 }} kWh</span>
     </div>
   </div>
 
   {% else %}
 
-  {# ── Hors ligne ── #}
-  <div style="padding:1.5rem;text-align:center;color:var(--muted);">
-    <div style="font-size:1.5rem;margin-bottom:0.5rem">⏳</div>
-    <div style="font-size:0.8rem">En attente du premier message MQTT…</div>
-    <div style="font-size:0.7rem;margin-top:0.25rem">Topic : <code>tele/{{ d.tasmota_id }}/SENSOR</code></div>
+  <div class="empty-state" style="padding:2rem 1rem;">
+    <div class="empty-icon" style="font-size:1.5rem">⏳</div>
+    <div class="empty-title">En attente de données</div>
+    <div class="empty-sub">Topic : <code>tele/{{ d.tasmota_id }}/SENSOR</code></div>
   </div>
 
   {% endif %}
 
-  {# ── Lien détail ── #}
-  <div style="padding:0.4rem 0.75rem;display:flex;justify-content:flex-end;border-top:1px solid var(--border);">
-    <a class="link-detail" href="/dashboard/tasmota/{{ d.id }}">Détails →</a>
+  <div style="padding:0.5rem 0.75rem;display:flex;justify-content:flex-end;border-top:1px solid var(--border);">
+    <a href="/dashboard/tasmota/{{ d.id }}" class="btn btn-outline" style="font-size:0.72rem;padding:0.3rem 0.7rem;">Détails →</a>
   </div>
 
 </div>
@@ -102,38 +93,40 @@
 
 </div>
 
-{# ─── Scripts de mise à jour ─────────────────────────────────────────────── #}
+{% endblock %}
+
+{% block scripts %}
 <script>
 const TASMOTA_IDS = [{% for d in devices %}{{ d.id }}{% if !loop.last %}, {% endif %}{% endfor %}];
 
 async function updateAll() {
-    for (const id of TASMOTA_IDS) {
-        try {
-            const resp = await fetch(`/api/v1/tasmota/${id}/status`);
-            if (!resp.ok) continue;
-            const d = await resp.json();
-            const pw  = document.getElementById(`p-${id}`);
-            const vv  = document.getElementById(`v-${id}`);
-            const iv  = document.getElementById(`i-${id}`);
-            const pf  = document.getElementById(`pf-${id}`);
-            const etd = document.getElementById(`etd-${id}`);
-            const eyd = document.getElementById(`eyd-${id}`);
-            const tot = document.getElementById(`etot-${id}`);
-            const ts  = document.getElementById(`ts-${id}`);
-            if (pw)  pw.textContent  = d.power_w.toFixed(1) + ' W';
-            if (vv)  vv.textContent  = d.voltage_v.toFixed(1) + ' V';
-            if (iv)  iv.textContent  = d.current_a.toFixed(2) + ' A';
-            if (pf)  pf.textContent  = d.power_factor.toFixed(2);
-            if (etd) etd.textContent = d.energy_today_kwh.toFixed(2) + ' kWh';
-            if (eyd) eyd.textContent = d.energy_yesterday_kwh.toFixed(2) + ' kWh';
-            if (tot) tot.textContent = d.energy_total_kwh.toFixed(1) + ' kWh';
-            if (ts)  ts.textContent  = new Date().toLocaleTimeString();
-        } catch(e) {}
-    }
+  const ts = new Date().toLocaleTimeString('fr-FR');
+  const tsEl = document.getElementById('tasmota-ts');
+  if (tsEl) tsEl.textContent = ts;
+
+  for (const id of TASMOTA_IDS) {
+    try {
+      const resp = await fetch(`/api/v1/tasmota/${id}/status`);
+      if (!resp.ok) continue;
+      const d = await resp.json();
+
+      const set = (elId, txt) => { const el = document.getElementById(elId); if (el) el.textContent = txt; };
+      set(`p-${id}`,    d.power_w.toFixed(1) + ' W');
+      set(`v-${id}`,    d.voltage_v.toFixed(1) + ' V');
+      set(`i-${id}`,    d.current_a.toFixed(2) + ' A');
+      set(`pf-${id}`,   d.power_factor.toFixed(2));
+      set(`etd-${id}`,  d.energy_today_kwh.toFixed(2) + ' kWh');
+      set(`eyd-${id}`,  d.energy_yesterday_kwh.toFixed(2) + ' kWh');
+      set(`etot-${id}`, d.energy_total_kwh.toFixed(1) + ' kWh');
+      set(`ts-${id}`,   ts);
+
+      const pw = document.getElementById(`p-${id}`);
+      if (pw) { pw.className = 'kpi4-val ' + (d.power_w > 0 ? 'chg' : 'muted'); }
+    } catch(e) {}
+  }
 }
 
 updateAll();
 setInterval(updateAll, 5000);
 </script>
-
 {% endblock %}


### PR DESCRIPTION
- base.html: dark design system (#0d1117 bg, sidebar nav, Inter+JetBrains Mono fonts, ECharts CDN, WebSocket client)
- index.html: BMS overview cards with gradient headers, KPI4 strips, SOC bars, cell voltage grid
- overview.html: unified system view (BMS + ET112 + irradiance gauge)
- bms_detail.html: full BMS detail with bar chart, boxplot, alarm table, SOC/MOS modals
- et112_all.html: ET112 overview cards with type-specific gradient headers
- et112.html: ET112 detail page with 6 metric cards and power history chart
- tasmota_all.html: Tasmota overview cards with ON/OFF state headers
- tasmota.html: Tasmota detail page with 6 metric cards and rolling power chart
- logs.html / settings.html: nav block declarations added

https://claude.ai/code/session_016AUdPNSLEhGDvAGfvEZ5qq