### PR TITLE
fix(dashboard): add length filter to custom filters module

### DIFF
--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -61,6 +61,11 @@ mod filters {
     pub fn pluralize(v: &usize) -> ::askama::Result<String> {
         Ok(if *v == 1 { String::new() } else { "s".to_string() })
     }
+    /// Longueur d'un slice/Vec — remplace le filtre built-in Askama
+    /// (nécessaire quand un module `filters` custom est défini dans le crate)
+    pub fn length<T>(v: &[T]) -> ::askama::Result<usize> {
+        Ok(v.len())
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
Quand un module `filters` custom est défini dans le crate, Askama 0.12 cherche TOUS les filtres (y compris les built-ins) dans ce module. `{{ detail.alarms|length }}` dans bms_detail.html échouait donc à la compilation avec "cannot find function `length` in module `filters`".

Fix : ajout de `pub fn length<T>(v: &[T]) -> askama::Result<usize>` dans le module filters. Compatible Vec<T> par déréférencement automatique.

https://claude.ai/code/session_016AUdPNSLEhGDvAGfvEZ5qq