### PR TITLE
feat(overview): add MPPT yield to solar daily total

### DIFF
--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -33,6 +33,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/config",         get(system::get_config))
         .route("/api/v1/discover",       get(system::discover))
         .route("/api/v1/irradiance/status", get(system::get_irradiance_status))
+        .route("/api/v1/solar/mppt-yield",  post(system::set_mppt_yield))
 
         // ── BMS — Lecture ────────────────────────────────────────────────────
         .route("/api/v1/bms/:id/status",      get(bms::get_bms_status))

--- a/crates/daly-bms-server/src/api/system.rs
+++ b/crates/daly-bms-server/src/api/system.rs
@@ -7,7 +7,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::sync::atomic::Ordering;
 
@@ -96,6 +96,7 @@ pub async fn get_irradiance_status(State(state): State<AppState>) -> impl IntoRe
                 "name": snap.name,
                 "irradiance_wm2": snap.irradiance_wm2,
                 "timestamp": snap.timestamp.to_rfc3339(),
+                "mppt_yield_kwh": *state.mppt_yield_kwh.read().await,
             })),
         ),
         None => (
@@ -103,9 +104,29 @@ pub async fn get_irradiance_status(State(state): State<AppState>) -> impl IntoRe
             Json(json!({
                 "connected": false,
                 "irradiance_wm2": 0.0,
+                "mppt_yield_kwh": *state.mppt_yield_kwh.read().await,
             })),
         ),
     }
+}
+
+/// Corps de la requête POST /api/v1/solar/mppt-yield
+#[derive(Deserialize, Serialize)]
+pub struct MpptYieldBody {
+    /// Production MPPT aujourd'hui en kWh (publiée par Node-RED).
+    pub mppt_yield_kwh: f32,
+}
+
+/// POST /api/v1/solar/mppt-yield
+///
+/// Permet à Node-RED de pousser la production MPPT journalière.
+/// Node-RED appelle ce endpoint chaque fois que `mppt_yield_today` est mis à jour.
+pub async fn set_mppt_yield(
+    State(state): State<AppState>,
+    Json(body): Json<MpptYieldBody>,
+) -> impl IntoResponse {
+    *state.mppt_yield_kwh.write().await = body.mppt_yield_kwh;
+    (StatusCode::OK, Json(json!({ "ok": true, "mppt_yield_kwh": body.mppt_yield_kwh })))
 }
 
 /// GET /api/v1/discover

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -155,6 +155,9 @@ pub struct AppState {
 
     /// Ring buffers Tasmota indexés par id de device.
     pub tasmota_buffers: Arc<RwLock<BTreeMap<u8, TasmotaRingBuffer>>>,
+
+    /// Production MPPT aujourd'hui en kWh (publiée par Node-RED via POST /api/v1/solar/mppt-yield).
+    pub mppt_yield_kwh: Arc<RwLock<f32>>,
 }
 
 impl AppState {
@@ -192,6 +195,7 @@ impl AppState {
             et112_buffers: Arc::new(RwLock::new(et112_buffers)),
             irradiance_value: Arc::new(RwLock::new(None)),
             tasmota_buffers: Arc::new(RwLock::new(tasmota_buffers)),
+            mppt_yield_kwh: Arc::new(RwLock::new(0.0)),
         }
     }
 

--- a/crates/daly-bms-server/templates/overview.html
+++ b/crates/daly-bms-server/templates/overview.html
@@ -564,9 +564,9 @@ async function pollEt112() {
     } catch(_) {}
   }
 
-  // Update solar panel
+  // Update solar panel — total = micro-onduleurs ET112 + MPPT (mis à jour par pollIrr)
   set('solar-w',    f0(solarW));
-  set('solar-kwh',  solarKwh.toFixed(2));
+  set('solar-kwh',  (solarKwh + mpptKwh).toFixed(2));
   set('solar-ts',   ts);
   set('f-solar-w',  f0(solarW) + ' W');
 
@@ -580,12 +580,14 @@ async function pollEt112() {
   return { solarW, loadW, solarKwh };
 }
 
-// ── Irradiance polling ───────────────────────────────────────────
+// ── Irradiance + MPPT polling ────────────────────────────────────
+let mpptKwh = 0;
 async function pollIrr() {
   try {
     const r = await fetch('/api/v1/irradiance/status');
     if (!r.ok) return null;
     const d = await r.json();
+    mpptKwh = d.mppt_yield_kwh || 0;
     if (!d.connected) return 0;
     irrWm2 = d.irradiance_wm2;
     set('irr-w',    f0(irrWm2));


### PR DESCRIPTION
- AppState: add mppt_yield_kwh (Arc<RwLock<f32>>) field
- POST /api/v1/solar/mppt-yield: Node-RED pushes mppt_yield_today (kWh)
- GET /api/v1/irradiance/status: now includes mppt_yield_kwh in response
- overview.html: pollIrr() reads mppt_yield_kwh; pollEt112() adds it to solar-kwh display so total = micro-inverters ET112 + MPPT yield

https://claude.ai/code/session_016AUdPNSLEhGDvAGfvEZ5qq