### PR TITLE
feat(visualization): redesign SmartShunt, MPPT group and Onduleur AC …

### DIFF
--- a/crates/daly-bms-server/src/api/system.rs
+++ b/crates/daly-bms-server/src/api/system.rs
@@ -197,6 +197,7 @@ pub async fn get_venus_mppt(State(state): State<AppState>) -> impl IntoResponse 
         "count": mppts.len(),
         "mppts": mppts,
         "total_power_w": state.venus_mppt_total_power().await,
+        "total_dc_current_a": state.venus_mppt_total_dc_current().await,
     })))
 }
 

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -520,19 +520,55 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
 }
 
 /// Traite le topic `santuario/meteo/venus`
-/// Payload : { "Irradiance": 750, "TodaysYield": 12.5, "MpptPower": 2500 }
+///
+/// Payload format v1 (legacy) : { "Irradiance": 750, "TodaysYield": 12.5, "MpptPower": 2500 }
+/// Payload format v2 (étendu) : { ..., "Mppts": [
+///   { "Instance": 273, "State": "Float", "PvVoltage": 72.5, "DcCurrent": 12.3, "Power": 1250, "YieldToday": 8.5 },
+///   { "Instance": 289, ... }
+/// ] }
 async fn handle_meteo_topic(state: &AppState, json: &Value) {
-    if let Some(yield_kwh) = json.get("TodaysYield").and_then(|v| v.as_f64()).map(|v| v as f32) {
-        // Power peut venir de MpptPower ou calculée depuis irradiance (fallback)
-        let irradiance = json.get("Irradiance").and_then(|v| v.as_f64()).map(|v| v as f32).unwrap_or(0.0);
-        let mppt_power = json.get("MpptPower").and_then(|v| v.as_f64()).map(|v| v as f32);
+    let irradiance = json.get("Irradiance").and_then(|v| v.as_f64()).map(|v| v as f32).unwrap_or(0.0);
+    let yield_kwh  = json.get("TodaysYield").and_then(|v| v.as_f64()).map(|v| v as f32);
+    let mppt_power = json.get("MpptPower").and_then(|v| v.as_f64()).map(|v| v as f32);
 
+    // Format v2 : tableau Mppts avec données individuelles par chargeur
+    if let Some(arr) = json.get("Mppts").and_then(|v| v.as_array()) {
+        for item in arr {
+            let instance = item.get("Instance").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+            let name     = format!("MPPT-{}", instance);
+            let state_str = item.get("State").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let pv_v     = item.get("PvVoltage").and_then(|v| v.as_f64()).map(|v| v as f32);
+            let dc_i     = item.get("DcCurrent").and_then(|v| v.as_f64()).map(|v| v as f32);
+            let power    = item.get("Power").and_then(|v| v.as_f64()).map(|v| v as f32);
+            let yield_t  = item.get("YieldToday").and_then(|v| v.as_f64()).map(|v| v as f32);
+            let max_pw   = item.get("MaxPowerToday").and_then(|v| v.as_f64()).map(|v| v as f32);
+            let mppt = VenusMppt {
+                instance,
+                name,
+                power_w: power,
+                yield_today_kwh: yield_t,
+                max_power_today_w: max_pw,
+                state: state_str,
+                pv_voltage_v: pv_v,
+                dc_current_a: dc_i,
+                timestamp: Utc::now(),
+            };
+            state.on_venus_mppt(mppt).await;
+        }
+        return; // format v2 traité, pas de fallback nécessaire
+    }
+
+    // Format v1 (legacy) : un seul MPPT agrégé
+    if let Some(yield_kwh) = yield_kwh {
         let mppt = VenusMppt {
             instance: 0,
             name: "MPPT SolarCharger".to_string(),
             power_w: mppt_power.or(if irradiance > 0.0 { Some(irradiance) } else { None }),
             yield_today_kwh: Some(yield_kwh),
             max_power_today_w: None,
+            state: None,
+            pv_voltage_v: None,
+            dc_current_a: None,
             timestamp: Utc::now(),
         };
         state.on_venus_mppt(mppt).await;
@@ -583,14 +619,32 @@ async fn handle_temperature_topic(state: &AppState, json: &Value) {
 }
 
 /// Traite le topic `santuario/system/venus`
-/// Payload : SmartShunt data { "Soc": 75.2, "Voltage": 48.32, "Current": 5.5, ... }
+///
+/// Payload v1 : { "Soc": 75.2, "Voltage": 48.32, "Current": 5.5, "Power": 266.0, "EnergyIn": 1000000, "EnergyOut": 500000 }
+/// Payload v2 : { ..., "State": 3, "TimeToGo": 3600 }
+///   State : 0=Idle, 1=Charging, 2=Discharging
+///   TimeToGo : secondes (None si en charge)
 async fn handle_system_topic(state: &AppState, json: &Value) {
     if let Some(soc) = json.get("Soc").and_then(|v| v.as_f64()).map(|v| v as f32) {
-        let voltage = json.get("Voltage").and_then(|v| v.as_f64()).map(|v| v as f32);
-        let current = json.get("Current").and_then(|v| v.as_f64()).map(|v| v as f32);
-        let power = json.get("Power").and_then(|v| v.as_f64()).map(|v| v as f32);
-        let energy_in = json.get("EnergyIn").and_then(|v| v.as_f64()).map(|v| v as f32);
+        let voltage    = json.get("Voltage").and_then(|v| v.as_f64()).map(|v| v as f32);
+        let current    = json.get("Current").and_then(|v| v.as_f64()).map(|v| v as f32);
+        let power      = json.get("Power").and_then(|v| v.as_f64()).map(|v| v as f32);
+        let energy_in  = json.get("EnergyIn").and_then(|v| v.as_f64()).map(|v| v as f32);
         let energy_out = json.get("EnergyOut").and_then(|v| v.as_f64()).map(|v| v as f32);
+
+        // State : entier Victron → libellé
+        let state_str = json.get("State").and_then(|v| v.as_u64()).map(|s| match s {
+            0 => "Idle".to_string(),
+            1 => "Charging".to_string(),
+            2 => "Discharging".to_string(),
+            _ => format!("State {}", s),
+        });
+
+        // TimeToGo : secondes → minutes (None si absent ou ≥ 864000 s = 10 j → "∞")
+        let time_to_go_min = json.get("TimeToGo")
+            .and_then(|v| v.as_f64())
+            .map(|secs| secs as f32 / 60.0)
+            .filter(|&m| m < 14400.0); // > 10 jours → ignorer (= en charge)
 
         let shunt = VenusSmartShunt {
             soc_percent: Some(soc),
@@ -599,6 +653,8 @@ async fn handle_system_topic(state: &AppState, json: &Value) {
             power_w: power,
             energy_in_kwh: energy_in.map(|e| e / 1000.0),
             energy_out_kwh: energy_out.map(|e| e / 1000.0),
+            state: state_str,
+            time_to_go_min,
             timestamp: Utc::now(),
         };
 
@@ -607,15 +663,52 @@ async fn handle_system_topic(state: &AppState, json: &Value) {
 }
 
 /// Traite le topic `santuario/inverter/venus`
-/// Payload : Inverter data { "Voltage": 48.32, "Current": 5.5, "Power": 250.0, "AcVoltage": 230.0, ... }
+///
+/// Payload v1 : { "Voltage": 48.32, "Current": 5.5, "Power": 250.0, "AcVoltage": 230.0, "AcCurrent": 1.09, "AcPower": 250.0, "State": "on", "Mode": "inverter" }
+/// Payload v2 : { ..., "AcFrequency": 50.03, "IgnoreAcIn": 0, "VebusState": 244 }
+///   VebusState : entier VEBus → libellé État (240=External, 241=Active, 243=Bulk, 244=Absorption, 245=Float,
+///                 246=Storage, 249=Passthru, 250=Inverting, 252=Power assist, 254=Charge, 255=Inverter Only, etc.)
 async fn handle_inverter_topic(state: &AppState, json: &Value) {
-    let voltage = json.get("Voltage").and_then(|v| v.as_f64()).map(|v| v as f32);
-    let current = json.get("Current").and_then(|v| v.as_f64()).map(|v| v as f32);
-    let power = json.get("Power").and_then(|v| v.as_f64()).map(|v| v as f32);
+    let voltage    = json.get("Voltage").and_then(|v| v.as_f64()).map(|v| v as f32);
+    let current    = json.get("Current").and_then(|v| v.as_f64()).map(|v| v as f32);
+    let power      = json.get("Power").and_then(|v| v.as_f64()).map(|v| v as f32);
     let ac_voltage = json.get("AcVoltage").and_then(|v| v.as_f64()).map(|v| v as f32);
     let ac_current = json.get("AcCurrent").and_then(|v| v.as_f64()).map(|v| v as f32);
-    let ac_power = json.get("AcPower").and_then(|v| v.as_f64()).map(|v| v as f32);
-    let state_str = json.get("State").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+    let ac_power   = json.get("AcPower").and_then(|v| v.as_f64()).map(|v| v as f32);
+
+    // Fréquence AC sortie (Hz)
+    let ac_freq = json.get("AcFrequency").and_then(|v| v.as_f64()).map(|v| v as f32);
+
+    // IgnoreAcIn1 : 0=normal, 1=ignoré (mode îlotage forcé)
+    let ac_in_ignore = json.get("IgnoreAcIn").and_then(|v| v.as_u64()).map(|v| v != 0);
+
+    // VebusState → libellé lisible (VEBus numeric state)
+    let state_str = if let Some(vs) = json.get("VebusState").and_then(|v| v.as_u64()) {
+        match vs {
+            0   => "Off".to_string(),
+            1   => "Low Power".to_string(),
+            2   => "Fault".to_string(),
+            3   => "Bulk".to_string(),
+            4   => "Absorption".to_string(),
+            5   => "Float".to_string(),
+            6   => "Storage".to_string(),
+            7   => "Equalize".to_string(),
+            8   => "Passthru".to_string(),
+            9   => "Inverting".to_string(),
+            10  => "Power assist".to_string(),
+            11  => "Power supply".to_string(),
+            244 => "Absorption".to_string(),
+            245 => "Float".to_string(),
+            246 => "Storage".to_string(),
+            249 => "Passthru".to_string(),
+            250 => "Inverting".to_string(),
+            252 => "Bulk".to_string(),
+            _   => json.get("State").and_then(|v| v.as_str()).unwrap_or("—").to_string(),
+        }
+    } else {
+        json.get("State").and_then(|v| v.as_str()).unwrap_or("unknown").to_string()
+    };
+
     let mode_str = json.get("Mode").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
 
     let inverter = crate::state::VenusInverter {
@@ -625,6 +718,8 @@ async fn handle_inverter_topic(state: &AppState, json: &Value) {
         ac_output_voltage_v: ac_voltage,
         ac_output_current_a: ac_current,
         ac_output_power_w: ac_power,
+        ac_out_frequency_hz: ac_freq,
+        ac_in_ignore,
         state: state_str,
         mode: mode_str,
         timestamp: Utc::now(),

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -140,6 +140,12 @@ pub struct VenusMppt {
     pub power_w: Option<f32>,
     pub yield_today_kwh: Option<f32>,
     pub max_power_today_w: Option<f32>,
+    /// État MPPT : "Off", "Fault", "Bulk", "Absorption", "Float", "Storage", etc.
+    pub state: Option<String>,
+    /// Tension panneau solaire PV (V).
+    pub pv_voltage_v: Option<f32>,
+    /// Courant DC sortie chargeur (A).
+    pub dc_current_a: Option<f32>,
     pub timestamp: DateTime<Utc>,
 }
 
@@ -152,6 +158,10 @@ pub struct VenusSmartShunt {
     pub power_w: Option<f32>,
     pub energy_in_kwh: Option<f32>,
     pub energy_out_kwh: Option<f32>,
+    /// État batterie : "Idle", "Charging", "Discharging".
+    pub state: Option<String>,
+    /// Temps restant en minutes (None = inconnu ou en charge).
+    pub time_to_go_min: Option<f32>,
     pub timestamp: DateTime<Utc>,
 }
 
@@ -164,7 +174,11 @@ pub struct VenusInverter {
     pub ac_output_voltage_v: Option<f32>,
     pub ac_output_current_a: Option<f32>,
     pub ac_output_power_w: Option<f32>,
-    pub state: String, // "off", "on", "error", etc.
+    /// Fréquence AC sortie (Hz).
+    pub ac_out_frequency_hz: Option<f32>,
+    /// IgnoreAcIn1 : true si l'AC input est ignoré (mode îlotage).
+    pub ac_in_ignore: Option<bool>,
+    pub state: String, // "off", "on", "inverting", "charger", etc.
     pub mode: String,  // "charger", "inverter", "passthrough", etc.
     pub timestamp: DateTime<Utc>,
 }
@@ -435,6 +449,12 @@ impl AppState {
     pub async fn venus_mppt_total_power(&self) -> f32 {
         let mppts = self.venus_mppts.read().await;
         mppts.values().filter_map(|m| m.power_w).sum()
+    }
+
+    /// Retourne le courant DC total MPPT en A (somme de tous les chargeurs).
+    pub async fn venus_mppt_total_dc_current(&self) -> f32 {
+        let mppts = self.venus_mppts.read().await;
+        mppts.values().filter_map(|m| m.dc_current_a).sum()
     }
 
     /// Enregistre/met à jour le SmartShunt.

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -279,6 +279,159 @@
     font-style: italic;
     padding: 12px;
   }
+
+  /* ── SMARTSHUNT NODE ─────────────────────────────────────────────── */
+  .ss-card {
+    width: 230px;
+    background: #fff;
+    border-radius: 10px;
+    border: 1px solid #d6dce5;
+    box-shadow: 0 1px 3px rgba(15,23,42,.06), 0 2px 8px rgba(15,23,42,.04);
+    overflow: hidden;
+  }
+  .ss-hdr {
+    display: flex; align-items: center; gap: 7px;
+    padding: 7px 10px;
+    background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 100%);
+    color: white;
+    border-bottom: 2px solid #1e40af;
+  }
+  .ss-hdr-icon { font-size: 1.1rem; line-height: 1; }
+  .ss-hdr-title { font-size: 0.82rem; font-weight: 700; flex: 1; letter-spacing: 0.02em; }
+  .ss-state-badge {
+    font-size: 0.6rem; font-weight: 700; padding: 2px 6px; border-radius: 10px;
+    background: rgba(255,255,255,0.15); letter-spacing: 0.04em; white-space: nowrap;
+  }
+  .ss-state-badge.charging  { background: rgba(22,163,74,.25); color: #4ade80; }
+  .ss-state-badge.discharging { background: rgba(239,68,68,.25); color: #fca5a5; }
+  .ss-state-badge.idle      { background: rgba(148,163,184,.2); color: #cbd5e1; }
+  .ss-dot { width: 6px; height: 6px; border-radius: 50%; background: #94a3b8; flex-shrink: 0; }
+  .ss-dot.live { background: #4ade80; box-shadow: 0 0 5px rgba(74,222,128,.6); animation: nd-blink 2.5s infinite; }
+  .ss-bar-bg { background: #e2e8f0; height: 4px; margin: 0; overflow: hidden; }
+  .ss-bar-fill { height: 100%; transition: width 1.2s ease, background 0.6s; }
+  .ss-grid {
+    display: grid; grid-template-columns: 1fr 1fr 1fr;
+    border-bottom: 1px solid #f0f4f8;
+  }
+  .ss-cell {
+    padding: 5px 6px; text-align: center; border-right: 1px solid #f0f4f8;
+  }
+  .ss-cell:last-child { border-right: none; }
+  .ss-cell-lbl { font-size: 0.52rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em; display: block; margin-bottom: 2px; font-weight: 600; }
+  .ss-cell-val { font-size: 0.82rem; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: #0f172a; }
+  .ss-cell-val.pos { color: #16a34a; }
+  .ss-cell-val.neg { color: #dc2626; }
+  .ss-row {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 4px 10px; border-bottom: 1px solid #f0f4f8; font-size: 0.67rem;
+  }
+  .ss-row:last-child { border-bottom: none; }
+  .ss-row-lbl { color: #6b7280; font-weight: 500; }
+  .ss-row-val { font-family: 'JetBrains Mono', monospace; font-weight: 700; color: #0f172a; }
+  .ss-row-val.ttg { color: #2563eb; }
+  .ss-wait { text-align: center; font-size: 0.7rem; color: #94a3b8; font-style: italic; padding: 14px; }
+
+  /* ── MPPT GROUP NODE ─────────────────────────────────────────────── */
+  .mppt-group-card {
+    width: 310px; min-width: 310px;
+    background: #fff; border-radius: 12px;
+    border: 1px solid #d6dce5;
+    box-shadow: 0 4px 12px rgba(15,23,42,.08); overflow: hidden;
+  }
+  .mg-header {
+    display: flex; align-items: center; gap: 8px; padding: 9px 12px;
+    background: linear-gradient(135deg, #78350f 0%, #92400e 100%);
+    color: white; border-bottom: 2px solid #b45309;
+  }
+  .mg-header-icon { font-size: 1.3rem; line-height: 1; }
+  .mg-header-title { font-weight: 700; font-size: 0.92rem; flex: 1; letter-spacing: 0.02em; }
+  .mg-totals {
+    display: flex; gap: 10px; padding: 6px 12px;
+    background: #fffbeb; border-bottom: 1px solid #fde68a;
+  }
+  .mg-total-chip {
+    flex: 1; background: #fff; border: 1px solid #fde68a; border-radius: 6px;
+    padding: 4px 6px; text-align: center;
+  }
+  .mg-total-lbl { font-size: 0.52rem; color: #92400e; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; display: block; }
+  .mg-total-val { font-size: 1rem; font-weight: 800; font-family: 'JetBrains Mono', monospace; color: #0f172a; }
+  .mg-mppt-list { padding: 2px 0; }
+  .mg-mppt-row {
+    display: flex; align-items: center; gap: 6px;
+    padding: 5px 10px; border-bottom: 1px solid #f0f4f8; font-size: 0.72rem;
+  }
+  .mg-mppt-row:last-child { border-bottom: none; }
+  .mg-mppt-name { font-weight: 700; color: #0f172a; min-width: 68px; font-size: 0.73rem; font-family: 'JetBrains Mono', monospace; }
+  .mg-mppt-state {
+    font-size: 0.58rem; font-weight: 700; padding: 1px 5px; border-radius: 8px;
+    background: #f0fdf4; color: #16a34a; white-space: nowrap; min-width: 52px; text-align: center;
+  }
+  .mg-mppt-state.off  { background: #f1f5f9; color: #94a3b8; }
+  .mg-mppt-state.fault { background: #fef2f2; color: #dc2626; }
+  .mg-mppt-metrics { display: flex; gap: 8px; margin-left: auto; }
+  .mg-metric { display: flex; flex-direction: column; align-items: flex-end; }
+  .mg-metric-lbl { font-size: 0.51rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.04em; }
+  .mg-metric-val { font-size: 0.72rem; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: #0f172a; }
+  .mg-wait { text-align: center; font-size: 0.7rem; color: #94a3b8; font-style: italic; padding: 12px; }
+
+  /* ── ONDULEUR AC NODE ────────────────────────────────────────────── */
+  /* Largeur : ~280px (1.5% > 275px ET112)                             */
+  .inv-card {
+    width: 280px;
+    background: #fff; border-radius: 10px;
+    border: 1px solid #d6dce5;
+    box-shadow: 0 1px 3px rgba(15,23,42,.06), 0 2px 8px rgba(15,23,42,.04);
+    overflow: visible; position: relative;
+  }
+  /* Badge fréquence positionné au-dessus du nœud (futur label d'edge vers ATS-Onduleur) */
+  .inv-freq-badge {
+    position: absolute; top: -14px; left: 50%; transform: translateX(-50%);
+    background: #2563eb; color: white;
+    font-size: 0.65rem; font-weight: 700; font-family: 'JetBrains Mono', monospace;
+    padding: 2px 10px; border-radius: 10px;
+    box-shadow: 0 2px 6px rgba(37,99,235,.35); white-space: nowrap; z-index: 2;
+    letter-spacing: 0.03em;
+  }
+  .inv-hdr {
+    display: flex; align-items: center; gap: 7px; padding: 7px 10px;
+    background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%);
+    color: white; border-bottom: 2px solid #4338ca;
+  }
+  .inv-hdr-icon { font-size: 1.1rem; line-height: 1; }
+  .inv-hdr-title { font-size: 0.82rem; font-weight: 700; flex: 1; letter-spacing: 0.02em; }
+  .inv-state-badge {
+    font-size: 0.59rem; font-weight: 700; padding: 2px 6px; border-radius: 9px;
+    background: rgba(255,255,255,0.15); white-space: nowrap;
+  }
+  .inv-state-badge.inverting { background: rgba(99,102,241,.3); color: #c7d2fe; }
+  .inv-state-badge.charging  { background: rgba(22,163,74,.25); color: #4ade80; }
+  .inv-state-badge.off       { background: rgba(148,163,184,.2); color: #cbd5e1; }
+  .inv-dot { width: 6px; height: 6px; border-radius: 50%; background: #94a3b8; flex-shrink: 0; }
+  .inv-dot.live { background: #a5b4fc; box-shadow: 0 0 5px rgba(165,180,252,.6); animation: nd-blink 2.5s infinite; }
+  .inv-ignore-bar {
+    display: flex; align-items: center; gap: 6px;
+    padding: 3px 10px; font-size: 0.63rem;
+    background: #fef9c3; border-bottom: 1px solid #fde68a;
+  }
+  .inv-ignore-lbl { color: #92400e; font-weight: 600; flex: 1; }
+  .inv-ignore-val { font-weight: 700; font-family: 'JetBrains Mono', monospace; }
+  .inv-ignore-val.active { color: #dc2626; }
+  .inv-ignore-val.normal { color: #16a34a; }
+  .inv-section-hdr {
+    font-size: 0.58rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
+    color: #6b7280; padding: 3px 10px 1px; background: #f8fafc; border-bottom: 1px solid #f0f4f8;
+  }
+  .inv-kpi-row {
+    display: grid; grid-template-columns: repeat(3, 1fr);
+    border-bottom: 1px solid #f0f4f8;
+  }
+  .inv-kpi { padding: 5px 6px; text-align: center; border-right: 1px solid #f0f4f8; }
+  .inv-kpi:last-child { border-right: none; }
+  .inv-kpi-lbl { font-size: 0.52rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.04em; display: block; margin-bottom: 1px; font-weight: 600; }
+  .inv-kpi-val { font-size: 0.82rem; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: #0f172a; }
+  .inv-kpi-val.ac { color: #2563eb; }
+  .inv-kpi-val.dc { color: #ea580c; }
+  .inv-wait { text-align: center; font-size: 0.7rem; color: #94a3b8; font-style: italic; padding: 14px; }
 </style>
 {% endblock %}
 
@@ -475,52 +628,141 @@ function PlaceholderNode({ data }) {
   );
 }
 
-function MPPTNode({ data }) {
-  const live = data.live;
-  const power = live?.power_w ?? null;
-  const yieldToday = live?.yield_today_kwh ?? null;
+function MPPTGroupNode({ data }) {
+  const mppts       = data.mppts       ?? [];
+  const totalPowerW = data.totalPowerW ?? 0;
+  const totalDcA    = data.totalDcA    ?? 0;
 
-  return h('div', { className: 'dev-nd' },
+  const stateClass = (s) => {
+    if (!s) return '';
+    const l = s.toLowerCase();
+    if (l === 'off')   return 'off';
+    if (l === 'fault') return 'fault';
+    return '';
+  };
+
+  return h('div', { className: 'mppt-group-card' },
     mkHandle('target', Position.Top,    'tt'),
     mkHandle('source', Position.Bottom, 'sb'),
     mkHandle('target', Position.Left,   'tl'),
     mkHandle('source', Position.Right,  'sr'),
     mkHandle('target', Position.Right,  'tr', { top: '65%' }),
     mkHandle('source', Position.Left,   'sl', { top: '65%' }),
-    h('div', { className: 'dev-hdr' },
-      h('span', null, data.icon ?? '☀️'),
-      h('span', { className: 'dev-lbl' }, data.label),
-      h('div', { className: `dev-dot${live ? ' on' : ''}` })
+    h('div', { className: 'mg-header' },
+      h('span', { className: 'mg-header-icon' }, '☀️'),
+      h('span', { className: 'mg-header-title' }, 'MPPT Solaire'),
+      h('span', { style: { fontSize:'0.65rem', opacity:0.8, marginLeft:'auto' } }, `${mppts.length} chargeur${mppts.length > 1 ? 's' : ''}`)
     ),
-    live ? h('div', null,
-      h('div', { className: 'dev-pwr' }, power != null ? `${power.toFixed(0)} W` : '—'),
-      h('div', { className: 'dev-nrj' }, yieldToday != null ? `${yieldToday.toFixed(2)} kWh` : '—')
-    ) : h('div', { className: 'dev-wait' }, 'En attente…')
+    h('div', { className: 'mg-totals' },
+      h('div', { className: 'mg-total-chip' },
+        h('span', { className: 'mg-total-lbl' }, 'Total Puissance'),
+        h('span', { className: 'mg-total-val' }, `${Math.round(totalPowerW)} W`)
+      ),
+      h('div', { className: 'mg-total-chip' },
+        h('span', { className: 'mg-total-lbl' }, 'Total DC'),
+        h('span', { className: 'mg-total-val' }, `${Math.round(totalDcA)} A`)
+      )
+    ),
+    mppts.length > 0 ? h('div', { className: 'mg-mppt-list' },
+      mppts.map((m, i) => {
+        const inst  = m.instance ?? i;
+        const name  = inst > 0 ? `MPPT-${inst}` : `MPPT-${i+1}`;
+        const s     = m.state ?? null;
+        const pvV   = m.pv_voltage_v ?? null;
+        const dcA   = m.dc_current_a ?? null;
+        const pw    = m.power_w ?? null;
+        return h('div', { key: inst, className: 'mg-mppt-row' },
+          h('span', { className: 'mg-mppt-name' }, name),
+          h('span', { className: `mg-mppt-state ${stateClass(s)}` }, s ?? '—'),
+          h('div', { className: 'mg-mppt-metrics' },
+            h('div', { className: 'mg-metric' },
+              h('span', { className: 'mg-metric-lbl' }, 'PV'),
+              h('span', { className: 'mg-metric-val' }, pvV != null ? `${pvV.toFixed(1)}V` : '—')
+            ),
+            h('div', { className: 'mg-metric' },
+              h('span', { className: 'mg-metric-lbl' }, 'DC'),
+              h('span', { className: 'mg-metric-val' }, dcA != null ? `${dcA.toFixed(1)}A` : '—')
+            ),
+            h('div', { className: 'mg-metric' },
+              h('span', { className: 'mg-metric-lbl' }, 'W'),
+              h('span', { className: 'mg-metric-val' }, pw != null ? `${Math.round(pw)}` : '—')
+            )
+          )
+        );
+      })
+    ) : h('div', { className: 'mg-wait' }, 'En attente des chargeurs…')
   );
 }
 
 function SmartShuntNode({ data }) {
-  const live = data.live;
-  const soc = live?.soc_percent ?? null;
-  const voltage = live?.voltage_v ?? null;
-  const current = live?.current_a ?? null;
+  const live    = data.live;
+  const soc     = live?.soc_percent   ?? null;
+  const voltage = live?.voltage_v     ?? null;
+  const current = live?.current_a     ?? null;
+  const power   = live?.power_w       ?? null;
+  const eIn     = live?.energy_in_kwh ?? null;
+  const eOut    = live?.energy_out_kwh ?? null;
+  const state   = live?.state         ?? null;
+  const ttgMin  = live?.time_to_go_min ?? null;
 
-  return h('div', { className: 'dev-nd' },
+  const stateClass = state === 'Charging' ? 'charging' : state === 'Discharging' ? 'discharging' : 'idle';
+
+  const fmtTtg = (min) => {
+    if (min == null) return '—';
+    if (min >= 1440) return `${(min/1440).toFixed(0)}j`;
+    if (min >= 60)   return `${Math.floor(min/60)}h${Math.round(min%60).toString().padStart(2,'0')}`;
+    return `${Math.round(min)} min`;
+  };
+
+  return h('div', { className: 'ss-card' },
     mkHandle('target', Position.Top,    'tt'),
     mkHandle('source', Position.Bottom, 'sb'),
     mkHandle('target', Position.Left,   'tl'),
     mkHandle('source', Position.Right,  'sr'),
     mkHandle('target', Position.Right,  'tr', { top: '65%' }),
     mkHandle('source', Position.Left,   'sl', { top: '65%' }),
-    h('div', { className: 'dev-hdr' },
-      h('span', null, data.icon ?? '⚡'),
-      h('span', { className: 'dev-lbl' }, data.label),
-      h('div', { className: `dev-dot${live ? ' on' : ''}` })
+    h('div', { className: 'ss-hdr' },
+      h('span', { className: 'ss-hdr-icon' }, '⚡'),
+      h('span', { className: 'ss-hdr-title' }, 'SmartShunt'),
+      state && h('span', { className: `ss-state-badge ${stateClass}` }, state),
+      h('div', { className: `ss-dot${live ? ' live' : ''}` })
+    ),
+    h('div', { className: 'ss-bar-bg' },
+      h('div', { className: 'ss-bar-fill', style: { width: `${soc ?? 0}%`, background: soc != null ? socColor(soc) : '#e2e8f0' } })
     ),
     live ? h('div', null,
-      h('div', { className: 'dev-pwr', style: { color: soc != null ? socColor(soc) : undefined } }, soc != null ? `${soc.toFixed(1)}%` : '—'),
-      h('div', { className: 'dev-nrj' }, `${voltage?.toFixed(1)}V • ${current?.toFixed(1)}A`)
-    ) : h('div', { className: 'dev-wait' }, 'En attente…')
+      h('div', { className: 'ss-grid' },
+        h('div', { className: 'ss-cell' },
+          h('span', { className: 'ss-cell-lbl' }, 'SOC'),
+          h('span', { className: 'ss-cell-val', style: { color: soc != null ? socColor(soc) : undefined } }, soc != null ? `${soc.toFixed(1)}%` : '—')
+        ),
+        h('div', { className: 'ss-cell' },
+          h('span', { className: 'ss-cell-lbl' }, 'Tension'),
+          h('span', { className: 'ss-cell-val' }, voltage != null ? `${voltage.toFixed(1)}V` : '—')
+        ),
+        h('div', { className: 'ss-cell' },
+          h('span', { className: 'ss-cell-lbl' }, 'Courant'),
+          h('span', { className: `ss-cell-val ${current != null ? (current < 0 ? 'neg' : current > 0.1 ? 'pos' : '') : ''}` },
+            current != null ? `${current > 0 ? '+' : ''}${current.toFixed(1)}A` : '—')
+        )
+      ),
+      h('div', { className: 'ss-row' },
+        h('span', { className: 'ss-row-lbl' }, 'Puissance'),
+        h('span', { className: 'ss-row-val' }, power != null ? `${power > 0 ? '+' : ''}${power.toFixed(0)} W` : '—')
+      ),
+      h('div', { className: 'ss-row' },
+        h('span', { className: 'ss-row-lbl' }, 'Temps restant'),
+        h('span', { className: 'ss-row-val ttg' }, fmtTtg(ttgMin))
+      ),
+      h('div', { className: 'ss-row' },
+        h('span', { className: 'ss-row-lbl' }, '⬆ Chargée'),
+        h('span', { className: 'ss-row-val' }, eIn != null ? `${eIn.toFixed(1)} kWh` : '—')
+      ),
+      h('div', { className: 'ss-row' },
+        h('span', { className: 'ss-row-lbl' }, '⬇ Déchargée'),
+        h('span', { className: 'ss-row-val' }, eOut != null ? `${eOut.toFixed(1)} kWh` : '—')
+      )
+    ) : h('div', { className: 'ss-wait' }, 'En attente…')
   );
 }
 
@@ -833,11 +1075,103 @@ function AtsMainNode({ data }) {
   );
 }
 
+// ── ONDULEUR AC NODE ─────────────────────────────────────────────────
+function InverterNode({ data }) {
+  const inv = data.live;
+  if (!inv) return h('div', { className: 'inv-card' },
+    mkHandle('target', Position.Top,    'tt'),
+    mkHandle('source', Position.Bottom, 'sb'),
+    mkHandle('target', Position.Left,   'tl'),
+    mkHandle('source', Position.Right,  'sr'),
+    mkHandle('target', Position.Right,  'tr', { top: '65%' }),
+    mkHandle('source', Position.Left,   'sl', { top: '65%' }),
+    h('div', { className: 'inv-hdr' },
+      h('span', { className: 'inv-hdr-icon' }, '⚡'),
+      h('span', { className: 'inv-hdr-title' }, 'Onduleur AC'),
+      h('div', { className: 'inv-dot' })
+    ),
+    h('div', { className: 'inv-wait' }, 'En attente…')
+  );
+
+  const acV   = inv.ac_output_voltage_v  ?? null;
+  const acI   = inv.ac_output_current_a  ?? null;
+  const acP   = inv.ac_output_power_w    ?? null;
+  const acF   = inv.ac_out_frequency_hz  ?? null;
+  const dcV   = inv.voltage_v            ?? null;
+  const dcI   = inv.current_a            ?? null;
+  const dcP   = inv.power_w              ?? null;
+  const ignAc = inv.ac_in_ignore         ?? null;
+  const state = inv.state                ?? '—';
+
+  const stateClass = (() => {
+    const l = state.toLowerCase();
+    if (l.includes('invert')) return 'inverting';
+    if (l.includes('charg') || l.includes('bulk') || l.includes('absorb') || l.includes('float')) return 'charging';
+    return 'off';
+  })();
+
+  const fmtFreq = (f) => f != null ? `${f.toFixed(2)} Hz` : null;
+
+  return h('div', { className: 'inv-card' },
+    // Badge fréquence entre ce nœud et ATS-Onduleur (en haut)
+    acF != null && h('div', { className: 'inv-freq-badge' }, fmtFreq(acF)),
+    mkHandle('target', Position.Top,    'tt'),
+    mkHandle('source', Position.Bottom, 'sb'),
+    mkHandle('target', Position.Left,   'tl'),
+    mkHandle('source', Position.Right,  'sr'),
+    mkHandle('target', Position.Right,  'tr', { top: '65%' }),
+    mkHandle('source', Position.Left,   'sl', { top: '65%' }),
+    h('div', { className: 'inv-hdr' },
+      h('span', { className: 'inv-hdr-icon' }, '⚡'),
+      h('span', { className: 'inv-hdr-title' }, 'Onduleur AC'),
+      h('span', { className: `inv-state-badge ${stateClass}` }, state),
+      h('div', { className: 'inv-dot live' })
+    ),
+    ignAc != null && h('div', { className: 'inv-ignore-bar' },
+      h('span', { className: 'inv-ignore-lbl' }, 'AC In Ignore'),
+      h('span', { className: `inv-ignore-val ${ignAc ? 'active' : 'normal'}` }, ignAc ? 'ACTIF' : 'Normal')
+    ),
+    // Section AC Out
+    h('div', { className: 'inv-section-hdr' }, 'AC Out'),
+    h('div', { className: 'inv-kpi-row' },
+      h('div', { className: 'inv-kpi' },
+        h('span', { className: 'inv-kpi-lbl' }, 'Tension'),
+        h('span', { className: 'inv-kpi-val ac' }, acV != null ? `${acV.toFixed(1)}V` : '—')
+      ),
+      h('div', { className: 'inv-kpi' },
+        h('span', { className: 'inv-kpi-lbl' }, 'Courant'),
+        h('span', { className: 'inv-kpi-val ac' }, acI != null ? `${acI.toFixed(1)}A` : '—')
+      ),
+      h('div', { className: 'inv-kpi' },
+        h('span', { className: 'inv-kpi-lbl' }, 'Puissance'),
+        h('span', { className: 'inv-kpi-val ac' }, acP != null ? `${acP.toFixed(0)}W` : '—')
+      )
+    ),
+    // Section DC
+    h('div', { className: 'inv-section-hdr' }, 'DC'),
+    h('div', { className: 'inv-kpi-row' },
+      h('div', { className: 'inv-kpi' },
+        h('span', { className: 'inv-kpi-lbl' }, 'Tension'),
+        h('span', { className: 'inv-kpi-val dc' }, dcV != null ? `${dcV.toFixed(1)}V` : '—')
+      ),
+      h('div', { className: 'inv-kpi' },
+        h('span', { className: 'inv-kpi-lbl' }, 'Courant'),
+        h('span', { className: 'inv-kpi-val dc' }, dcI != null ? `${dcI.toFixed(1)}A` : '—')
+      ),
+      h('div', { className: 'inv-kpi' },
+        h('span', { className: 'inv-kpi-lbl' }, 'Puissance'),
+        h('span', { className: 'inv-kpi-val dc' }, dcP != null ? `${dcP.toFixed(0)}W` : '—')
+      )
+    )
+  );
+}
+
 const nodeTypes = {
   summary: SummaryNode, bms: BmsNode, et112card: Et112CardNode, device: DeviceNode,
-  hub: HubNode, placeholder: PlaceholderNode, mppt: MPPTNode, smartshunt: SmartShuntNode,
+  hub: HubNode, placeholder: PlaceholderNode, mpptGroup: MPPTGroupNode, smartshunt: SmartShuntNode,
   temperature: TemperatureNode,
   tongouGroup: TongouGroupNode,
+  inverter: InverterNode,
   atsreseau: AtsReseauNode, atsonduleur: AtsOnduleurNode, atsmain: AtsMainNode
 };
 
@@ -851,9 +1185,9 @@ const NODES0 = [
   { id: 'micro-ond',   type: 'et112card',   position: { x: 400, y: 300 }, data: { label: 'Micro-onduleurs', address: 7, live: null } },
   { id: 'et112-reseau',   type: 'et112card',   position: { x: -350, y: 315 }, data: { label: 'ET112-reseau', address: 9, live: null } },
   { id: 'et112-maison',   type: 'et112card',   position: { x: 400, y: 145 }, data: { label: 'ET112-Maison', address: 8, live: null } },
-  { id: 'onduleur',    type: 'device',      position: { x: 65,   y: 500 }, data: { label: 'Onduleur AC',     icon: '⚡', value: '—', dotClass: '' } },
-  { id: 'mppt',        type: 'mppt',        position: { x: 500,  y: 600 }, data: { label: 'MPPT',            icon: '☀️', live: null } },
-  { id: 'smartshunt',  type: 'smartshunt',  position: { x: 65,   y: 640 }, data: { label: 'SmartShunt',      icon: '📏', live: null } },
+  { id: 'onduleur',    type: 'inverter',    position: { x: 65,   y: 500 }, data: { live: null } },
+  { id: 'mppt',        type: 'mpptGroup',   position: { x: 480,  y: 580 }, data: { mppts: [], totalPowerW: 0, totalDcA: 0 } },
+  { id: 'smartshunt',  type: 'smartshunt',  position: { x: 65,   y: 680 }, data: { live: null } },
   { id: 'bms1',        type: 'bms',         position: { x: -100, y: 790 }, data: { label: 'BMS-360Ah',       live: null } },
   { id: 'bms2',        type: 'bms',         position: { x: 165,  y: 790 }, data: { label: 'BMS-320Ah',       live: null } },
   { id: 'tongou-group', type: 'tongouGroup', position: { x: 780, y: 145 }, data: { switches: [], disabled: false, _rev: 0 } },
@@ -926,7 +1260,9 @@ function ESSFlow() {
     const bms1 = d.bms1, bms2 = d.bms2;
     const et7  = d.et7,  et8  = d.et8, et9 = d.et9;
     const irr  = d.irr;
-    const mppt = d.mppt;
+    const mpptList       = d.mpptList       ?? [];
+    const mpptTotalPowerW = d.mpptTotalPowerW ?? 0;
+    const mpptTotalDcA   = d.mpptTotalDcA   ?? 0;
     const shunt = d.shunt;
     const inverter = d.inverter;
     const temp = d.temp;
@@ -943,10 +1279,10 @@ function ESSFlow() {
     const batDot   = avgSoc == null ? '' : avgSoc > 50 ? 'live' : avgSoc > 20 ? 'warn' : 'alarm';
 
     const microPwr = et7?.power_w ?? 0;
-    const mpptPwr = mppt?.power_w ?? 0;
+    const mpptPwr  = mpptTotalPowerW;
     const totalProdPwr = microPwr + mpptPwr;
     const prodVal  = fmtKw(totalProdPwr);
-    const prodDot  = (et7?.connected || mppt) ? (totalProdPwr > 50 ? 'live' : '') : '';
+    const prodDot  = (et7?.connected || mpptList.length > 0) ? (totalProdPwr > 50 ? 'live' : '') : '';
 
     const irrVal  = irr?.irradiance_wm2 != null ? `${irr.irradiance_wm2.toFixed(0)} W/m²` : '—';
     const irrSub  = irr?.total_yield_kwh != null ? `☀ ${irr.total_yield_kwh.toFixed(1)} kWh` : 'Irradiance solaire';
@@ -984,7 +1320,8 @@ function ESSFlow() {
         case 'batteries':
           return { ...n, data: { ...n.data, value: batVal, sub: batSub, dotClass: batDot } };
         case 'production':
-          const prodSub = et7 ? `${((et7.energy_export_wh ?? 0) / 1000).toFixed(1)} kWh ET112` : mppt ? `${(mppt.yield_today_kwh ?? 0).toFixed(2)} kWh MPPT` : 'Micro-onduleurs';
+          const mpptYieldSum = mpptList.reduce((s, m) => s + (m.yield_today_kwh ?? 0), 0);
+          const prodSub = et7 ? `${((et7.energy_export_wh ?? 0) / 1000).toFixed(1)} kWh ET112` : mpptList.length > 0 ? `${mpptYieldSum.toFixed(2)} kWh MPPT` : 'Micro-onduleurs';
           return { ...n, data: { ...n.data, value: prodVal, sub: prodSub, dotClass: prodDot } };
         case 'meteo':
           return { ...n, data: { ...n.data, value: irrVal, sub: irrSub, dotClass: irrDot } };
@@ -993,10 +1330,10 @@ function ESSFlow() {
         case 'micro-ond':   return { ...n, data: { ...n.data, live: et7  ?? null } };
         case 'et112-reseau': return { ...n, data: { ...n.data, live: et9 ?? null } };
         case 'et112-maison': return { ...n, data: { ...n.data, live: et8 ?? null } };
-        case 'onduleur':    return { ...n, data: { ...n.data, value: inverter ? `${(inverter.ac_output_power_w ?? 0).toFixed(0)}W` : '—', dotClass: inverter ? 'live' : '' } };
+        case 'onduleur':    return { ...n, data: { ...n.data, live: inverter ?? null } };
         case 'chauffe-eau': return { ...n, data: { ...n.data, live: et8  ?? null } };
         case 'climatisation': return { ...n, data: { ...n.data, live: et9 ?? null } };
-        case 'mppt':        return { ...n, data: { ...n.data, live: mppt ?? null } };
+        case 'mppt':        return { ...n, data: { ...n.data, mppts: mpptList, totalPowerW: mpptTotalPowerW, totalDcA: mpptTotalDcA } };
         case 'smartshunt':  return { ...n, data: { ...n.data, live: shunt ?? null } };
         case 'temp-ext':    return { ...n, data: { ...n.data, live: temp ?? null } };
         case 'tongou-group': return { ...n, data: { ...n.data, switches: tasmotaDevices, disabled: atsProcessing, _rev: newRev } };
@@ -1079,7 +1416,9 @@ function ESSFlow() {
       });
       const tasmotaDevices = (await Promise.all(tasmotaPromises)).filter(Boolean);
 
-      const mppt = venusResp?.mppts?.[0] ?? null;
+      const mpptList        = venusResp?.mppts         ?? [];
+      const mpptTotalPowerW = venusResp?.total_power_w  ?? 0;
+      const mpptTotalDcA    = venusResp?.total_dc_current_a ?? 0;
       const shuntResp = await safe(fetch('/api/v1/venus/smartshunt').then(r => r.ok ? r.json() : null));
       const shunt = shuntResp?.shunt ?? null;
       const inverterResp = await safe(fetch('/api/v1/venus/inverter').then(r => r.ok ? r.json() : null));
@@ -1088,7 +1427,7 @@ function ESSFlow() {
       const temp = temps.length > 0 ? temps[0] : null;
       const ats = atsResp?.values ?? null;
 
-      applyData({ bms1, bms2, et7, et8, et9, irr, mppt, shunt, inverter, temp, ats, tasmotaDevices });
+      applyData({ bms1, bms2, et7, et8, et9, irr, mpptList, mpptTotalPowerW, mpptTotalDcA, shunt, inverter, temp, ats, tasmotaDevices });
     }
     fetchAll();
     const timer = setInterval(fetchAll, 2000);

--- a/flux-nodered/Solar_power.json
+++ b/flux-nodered/Solar_power.json
@@ -1,298 +1,618 @@
 [
-    {
-        "id": "414598e48f123ab2",
-        "type": "tab",
-        "label": "Solar_power",
-        "disabled": false,
-        "info": "",
-        "env": []
-    },
-    {
-        "id": "183ba1473a496661",
-        "type": "mqtt in",
-        "z": "414598e48f123ab2",
-        "name": "SmartSolar Charger MPPT 150/35 VRM 289 (W)",
-        "topic": "N/c0619ab9929a/solarcharger/289/Yield/Power",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 220,
-        "y": 220,
-        "wires": [
-            [
-                "505f07406818598d"
-            ]
-        ]
-    },
-    {
-        "id": "5ca9f28db0a9a3a0",
-        "type": "mqtt in",
-        "z": "414598e48f123ab2",
-        "name": "PV Inverter ET112 VRM 32 (W)",
-        "topic": "N/c0619ab9929a/pvinverter/32/Ac/L1/Power",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 160,
-        "y": 280,
-        "wires": [
-            [
-                "ee9cc3805807ab69"
-            ]
-        ]
-    },
-    {
-        "id": "0878904b656a48e3",
-        "type": "mqtt in",
-        "z": "414598e48f123ab2",
-        "name": "SmartSolar MPPT VE.Can 250/100 VRM 273 (W)",
-        "topic": "N/c0619ab9929a/solarcharger/273/Yield/Power",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 220,
-        "y": 160,
-        "wires": [
-            [
-                "d0bf53bab44b8e32"
-            ]
-        ]
-    },
-    {
-        "id": "505f07406818598d",
-        "type": "function",
-        "z": "414598e48f123ab2",
-        "name": "Stocker vrm 289 power",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('w_vrm_289', v);\nnode.status({fill:'blue',shape:'dot',text:`vrm_289: ${v}W`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 560,
-        "y": 220,
-        "wires": [
-            [
-                "10911d81284c4bc3"
-            ]
-        ]
-    },
-    {
-        "id": "d0bf53bab44b8e32",
-        "type": "function",
-        "z": "414598e48f123ab2",
-        "name": "Stocker vrm 273 power",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('w_vrm_273', v);\nnode.status({fill:'blue',shape:'dot',text:`vrm_273: ${v}W`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 660,
-        "y": 160,
-        "wires": [
-            [
-                "10911d81284c4bc3"
-            ]
-        ]
-    },
-    {
-        "id": "ee9cc3805807ab69",
-        "type": "function",
-        "z": "414598e48f123ab2",
-        "name": "Stocker vrm 32 power",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('w_vrm_32', v);\nnode.status({fill:'blue',shape:'dot',text:`vrm_32: ${v}W`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 400,
-        "y": 280,
-        "wires": [
-            [
-                "10911d81284c4bc3"
-            ]
-        ]
-    },
-    {
-        "id": "10911d81284c4bc3",
-        "type": "function",
-        "z": "414598e48f123ab2",
-        "name": "Formater + POST serveur BMS + MQTT",
-        "func": "const token  = env.get('INFLUX_TOKEN');\nconst org    = env.get('INFLUX_ORG')    || 'santuario';\nconst bucket = env.get('INFLUX_BUCKET') || 'daly_bms';\n\nconst mppt_273   = flow.get('w_vrm_273')     || 0;\nconst mppt_289   = flow.get('w_vrm_289')     || 0;\nconst pvinverter = flow.get('w_vrm_32')      || 0;\nconst house_pw   = flow.get('house_power_w') || 0;\n\nconst mppt_only   = mppt_273 + mppt_289;\nconst solar_total = mppt_only + pvinverter;\n\nglobal.set('mppt_power_w', mppt_only);\nflow.set('solar_pw', solar_total);\nnode.status({ fill: 'green', shape: 'dot', text: `Sol: ${solar_total}W  Maison: ${house_pw}W` });\n\n// — Output 1 : InfluxDB line protocol —\nlet influxMsg = null;\nif (token) {\n    const now = new Date();\n    const parisISO = now.toLocaleString('sv-SE', { timeZone: 'Europe/Paris' });\n    const day = parisISO.substring(0, 10);\n    const ts  = Math.floor(Date.now() / 1000);\n    const hostname = (env.get('HOSTNAME') || 'pi5').replace(/[^a-zA-Z0-9_-]/g, '_');\n    const line = `solar_power,day=${day},host=${hostname} w_vrm_273=${mppt_273},w_vrm_289=${mppt_289},w_vrm_32=${pvinverter},solar_total=${solar_total},house_power=${house_pw} ${ts}`;\n    influxMsg = {\n        url:     `http://dalybms-influxdb:8086/api/v2/write?org=${org}&bucket=${bucket}&precision=s`,\n        method:  'POST',\n        payload: line,\n        headers: {\n            'Authorization': 'Token ' + token,\n            'Content-Type':  'text/plain; charset=utf-8'\n        }\n    };\n}\n\n// — Output 2 : POST vers daly-bms-server —\nconst serverMsg = {\n    url:     'http://192.168.1.141:8080/api/v1/solar/mppt-yield',\n    method:  'POST',\n    payload: JSON.stringify({ solar_total_w: solar_total, mppt_power_w: mppt_only, house_power_w: house_pw }),\n    headers: { 'Content-Type': 'application/json' }\n};\n\n// — Output 3 : MQTT pour santuario/meteo/venus (daly-bms-server l'écoute) —\nconst mqttMsg = {\n    topic: 'santuario/meteo/venus',\n    payload: JSON.stringify({\n        Irradiance: global.get('irradiance_wm2') || 0,\n        TodaysYield: Math.round((global.get('total_yield_today') || 0) * 10) / 10,\n        YieldYesterday: global.get('yield_yesterday') || 0,\n        WindSpeed: global.get('outdoor_wind_speed') || 0,\n        WindDirection: global.get('outdoor_wind_dir') || 0,\n        MpptPower: mppt_only,\n        SolarTotal: solar_total\n    }),\n    retain: true\n};\n\nreturn [influxMsg, serverMsg, mqttMsg];",
-        "outputs": 3,
-        "timeout": "",
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 530,
-        "y": 380,
-        "wires": [
-            [
-                "1bb0b7c97b9aab63"
-            ],
-            [
-                "c7e8f9a0b1d2e3f4"
-            ],
-            [
-                "mppt_mqtt_out"
-            ]
-        ]
-    },
-    {
-        "id": "1bb0b7c97b9aab63",
-        "type": "http request",
-        "z": "414598e48f123ab2",
-        "name": "InfluxDB Write (solar_power)",
-        "method": "use",
-        "ret": "txt",
-        "paytoqs": "ignore",
-        "url": "",
-        "tls": "",
-        "persist": false,
-        "proxy": "",
-        "insecureHTTPParser": false,
-        "authType": "",
-        "senderr": false,
-        "headers": [],
-        "x": 400,
-        "y": 480,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "c7e8f9a0b1d2e3f4",
-        "type": "http request",
-        "z": "414598e48f123ab2",
-        "name": "POST mppt_power_w → daly-bms-server",
-        "method": "use",
-        "ret": "txt",
-        "paytoqs": "ignore",
-        "url": "",
-        "tls": "",
-        "persist": false,
-        "proxy": "",
-        "insecureHTTPParser": false,
-        "authType": "",
-        "senderr": false,
-        "headers": [],
-        "x": 690,
-        "y": 480,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "6311801a23e09439",
-        "type": "comment",
-        "z": "414598e48f123ab2",
-        "name": "Solar power → InfluxDB + daly-bms-server",
-        "info": "Sujets MQTT utilisés :\n\nSmartSolar MPPT VE.Can 250/100 (instance 273)\nN/c0619ab9929a/solarcharger/273/Yield/Power\n\nSmartSolar Charger MPPT 150/35 (instance 289)\nN/c0619ab9929a/solarcharger/289/Yield/Power\n\nPV Inverter ET112 addr 0x07 (instance 32)\nN/c0619ab9929a/pvinverter/32/Ac/L1/Power\n\nESS AC Output Consumption (Maison)\nN/c0619ab9929a/system/0/Ac/ConsumptionOnOutput/L1/Power\n\n---\nPOST /api/v1/solar/mppt-yield envoie :\n  solar_total_w = 273+289+ET112 (source de vérité VRM)\n  mppt_power_w  = 273+289 seulement (pour meteo.json Venus OS)\n  house_power_w = ConsumptionOnOutput (valeur directe VRM, pas calculée)\n\nglobal.mppt_power_w est aussi lu par meteo.json keepalive (push Venus OS).",
-        "x": 190,
-        "y": 100,
-        "wires": []
-    },
-    {
-        "id": "f1a2b3c4d5e6f7a8",
-        "type": "mqtt in",
-        "z": "414598e48f123ab2",
-        "name": "ESS AC Output Consumption L1 (W)",
-        "topic": "N/c0619ab9929a/system/0/Ac/ConsumptionOnOutput/L1/Power",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 220,
-        "y": 340,
-        "wires": [
-            [
-                "a8b7c6d5e4f3a2b1"
-            ]
-        ]
-    },
-    {
-        "id": "a8b7c6d5e4f3a2b1",
-        "type": "function",
-        "z": "414598e48f123ab2",
-        "name": "Stocker house_power_w",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('house_power_w', v);\nnode.status({fill:'purple',shape:'dot',text:`maison: ${v}W`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 520,
-        "y": 340,
-        "wires": [
-            [
-                "10911d81284c4bc3"
-            ]
-        ]
-    },
-    {
-        "id": "mppt_mqtt_out",
-        "type": "mqtt out",
-        "z": "414598e48f123ab2",
-        "name": "MQTT out santuario/meteo/venus",
-        "topic": "",
-        "qos": "1",
-        "retain": true,
-        "broker": "pi5_mqtt_broker",
-        "x": 900,
-        "y": 380,
-        "wires": []
-    },
-    {
-        "id": "pi5_mqtt_broker",
-        "type": "mqtt-broker",
-        "name": "Pi5 MQTT",
-        "broker": "dalybms-mosquitto",
-        "port": "1883",
-        "clientid": "",
-        "autoConnect": true,
-        "usetls": false,
-        "protocolVersion": "4",
-        "keepalive": "60",
-        "cleansession": true,
-        "autoUnsubscribe": true,
-        "birthTopic": "",
-        "birthQos": "0",
-        "birthRetain": "false",
-        "birthPayload": "",
-        "birthMsg": {},
-        "closeTopic": "",
-        "closeQos": "0",
-        "closeRetain": "false",
-        "closePayload": "",
-        "closeMsg": {},
-        "willTopic": "",
-        "willQos": "0",
-        "willRetain": "false",
-        "willPayload": "",
-        "willMsg": {},
-        "userProps": "",
-        "sessionExpiry": ""
-    }
+  {
+    "id": "414598e48f123ab2",
+    "type": "tab",
+    "label": "Solar_power",
+    "disabled": false,
+    "info": "",
+    "env": []
+  },
+  {
+    "id": "183ba1473a496661",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "SmartSolar Charger MPPT 150/35 VRM 289 (W)",
+    "topic": "N/c0619ab9929a/solarcharger/289/Yield/Power",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 220,
+    "y": 220,
+    "wires": [
+      [
+        "505f07406818598d"
+      ]
+    ]
+  },
+  {
+    "id": "5ca9f28db0a9a3a0",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "PV Inverter ET112 VRM 32 (W)",
+    "topic": "N/c0619ab9929a/pvinverter/32/Ac/L1/Power",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 160,
+    "y": 280,
+    "wires": [
+      [
+        "ee9cc3805807ab69"
+      ]
+    ]
+  },
+  {
+    "id": "0878904b656a48e3",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "SmartSolar MPPT VE.Can 250/100 VRM 273 (W)",
+    "topic": "N/c0619ab9929a/solarcharger/273/Yield/Power",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 220,
+    "y": 160,
+    "wires": [
+      [
+        "d0bf53bab44b8e32"
+      ]
+    ]
+  },
+  {
+    "id": "505f07406818598d",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Stocker vrm 289 power",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('w_vrm_289', v);\nnode.status({fill:'blue',shape:'dot',text:`vrm_289: ${v}W`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 560,
+    "y": 220,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "d0bf53bab44b8e32",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Stocker vrm 273 power",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('w_vrm_273', v);\nnode.status({fill:'blue',shape:'dot',text:`vrm_273: ${v}W`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 660,
+    "y": 160,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "ee9cc3805807ab69",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Stocker vrm 32 power",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('w_vrm_32', v);\nnode.status({fill:'blue',shape:'dot',text:`vrm_32: ${v}W`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 400,
+    "y": 280,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "10911d81284c4bc3",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Formater + POST serveur BMS + MQTT",
+    "func": "const token  = env.get('INFLUX_TOKEN');\nconst org    = env.get('INFLUX_ORG')    || 'santuario';\nconst bucket = env.get('INFLUX_BUCKET') || 'daly_bms';\n\nconst mppt_273   = flow.get('w_vrm_273')     || 0;\nconst mppt_289   = flow.get('w_vrm_289')     || 0;\nconst pvinverter = flow.get('w_vrm_32')      || 0;\nconst house_pw   = flow.get('house_power_w') || 0;\n\nconst mppt_only   = mppt_273 + mppt_289;\nconst solar_total = mppt_only + pvinverter;\n\nglobal.set('mppt_power_w', mppt_only);\nflow.set('solar_pw', solar_total);\nnode.status({ fill: 'green', shape: 'dot', text: `Sol: ${solar_total}W  Maison: ${house_pw}W` });\n\n// — Output 1 : InfluxDB line protocol —\nlet influxMsg = null;\nif (token) {\n    const now = new Date();\n    const parisISO = now.toLocaleString('sv-SE', { timeZone: 'Europe/Paris' });\n    const day = parisISO.substring(0, 10);\n    const ts  = Math.floor(Date.now() / 1000);\n    const hostname = (env.get('HOSTNAME') || 'pi5').replace(/[^a-zA-Z0-9_-]/g, '_');\n    const line = `solar_power,day=${day},host=${hostname} w_vrm_273=${mppt_273},w_vrm_289=${mppt_289},w_vrm_32=${pvinverter},solar_total=${solar_total},house_power=${house_pw} ${ts}`;\n    influxMsg = {\n        url:     `http://dalybms-influxdb:8086/api/v2/write?org=${org}&bucket=${bucket}&precision=s`,\n        method:  'POST',\n        payload: line,\n        headers: {\n            'Authorization': 'Token ' + token,\n            'Content-Type':  'text/plain; charset=utf-8'\n        }\n    };\n}\n\n// — Output 2 : POST vers daly-bms-server —\nconst serverMsg = {\n    url:     'http://192.168.1.141:8080/api/v1/solar/mppt-yield',\n    method:  'POST',\n    payload: JSON.stringify({ solar_total_w: solar_total, mppt_power_w: mppt_only, house_power_w: house_pw }),\n    headers: { 'Content-Type': 'application/json' }\n};\n\n// — Données individuelles par MPPT (format v2) —\nconst mppts = [\n    {\n        Instance:   273,\n        State:      flow.get('mppt_273_state')     || null,\n        PvVoltage:  flow.get('mppt_273_pv_v')      !== undefined ? flow.get('mppt_273_pv_v')  : null,\n        DcCurrent:  flow.get('mppt_273_dc_i')      !== undefined ? flow.get('mppt_273_dc_i')  : null,\n        Power:      mppt_273,\n        YieldToday: flow.get('mppt_273_yield_kwh') !== undefined ? flow.get('mppt_273_yield_kwh') : null\n    },\n    {\n        Instance:   289,\n        State:      flow.get('mppt_289_state')     || null,\n        PvVoltage:  flow.get('mppt_289_pv_v')      !== undefined ? flow.get('mppt_289_pv_v')  : null,\n        DcCurrent:  flow.get('mppt_289_dc_i')      !== undefined ? flow.get('mppt_289_dc_i')  : null,\n        Power:      mppt_289,\n        YieldToday: flow.get('mppt_289_yield_kwh') !== undefined ? flow.get('mppt_289_yield_kwh') : null\n    }\n];\n\n// — Output 3 : MQTT pour santuario/meteo/venus (daly-bms-server l'écoute) —\nconst mqttMsg = {\n    topic: 'santuario/meteo/venus',\n    payload: JSON.stringify({\n        Irradiance:     global.get('irradiance_wm2') || 0,\n        TodaysYield:    Math.round((global.get('total_yield_today') || 0) * 10) / 10,\n        YieldYesterday: global.get('yield_yesterday') || 0,\n        WindSpeed:      global.get('outdoor_wind_speed') || 0,\n        WindDirection:  global.get('outdoor_wind_dir') || 0,\n        MpptPower:      mppt_only,\n        SolarTotal:     solar_total,\n        Mppts:          mppts\n    }),\n    retain: true\n};\n\nreturn [influxMsg, serverMsg, mqttMsg];",
+    "outputs": 3,
+    "timeout": "",
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 530,
+    "y": 380,
+    "wires": [
+      [
+        "1bb0b7c97b9aab63"
+      ],
+      [
+        "c7e8f9a0b1d2e3f4"
+      ],
+      [
+        "mppt_mqtt_out"
+      ]
+    ]
+  },
+  {
+    "id": "1bb0b7c97b9aab63",
+    "type": "http request",
+    "z": "414598e48f123ab2",
+    "name": "InfluxDB Write (solar_power)",
+    "method": "use",
+    "ret": "txt",
+    "paytoqs": "ignore",
+    "url": "",
+    "tls": "",
+    "persist": false,
+    "proxy": "",
+    "insecureHTTPParser": false,
+    "authType": "",
+    "senderr": false,
+    "headers": [],
+    "x": 400,
+    "y": 480,
+    "wires": [
+      []
+    ]
+  },
+  {
+    "id": "c7e8f9a0b1d2e3f4",
+    "type": "http request",
+    "z": "414598e48f123ab2",
+    "name": "POST mppt_power_w → daly-bms-server",
+    "method": "use",
+    "ret": "txt",
+    "paytoqs": "ignore",
+    "url": "",
+    "tls": "",
+    "persist": false,
+    "proxy": "",
+    "insecureHTTPParser": false,
+    "authType": "",
+    "senderr": false,
+    "headers": [],
+    "x": 690,
+    "y": 480,
+    "wires": [
+      []
+    ]
+  },
+  {
+    "id": "6311801a23e09439",
+    "type": "comment",
+    "z": "414598e48f123ab2",
+    "name": "Solar power → InfluxDB + daly-bms-server",
+    "info": "Sujets MQTT utilisés :\n\nSmartSolar MPPT VE.Can 250/100 (instance 273)\nN/c0619ab9929a/solarcharger/273/Yield/Power\n\nSmartSolar Charger MPPT 150/35 (instance 289)\nN/c0619ab9929a/solarcharger/289/Yield/Power\n\nPV Inverter ET112 addr 0x07 (instance 32)\nN/c0619ab9929a/pvinverter/32/Ac/L1/Power\n\nESS AC Output Consumption (Maison)\nN/c0619ab9929a/system/0/Ac/ConsumptionOnOutput/L1/Power\n\n---\nPOST /api/v1/solar/mppt-yield envoie :\n  solar_total_w = 273+289+ET112 (source de vérité VRM)\n  mppt_power_w  = 273+289 seulement (pour meteo.json Venus OS)\n  house_power_w = ConsumptionOnOutput (valeur directe VRM, pas calculée)\n\nglobal.mppt_power_w est aussi lu par meteo.json keepalive (push Venus OS).",
+    "x": 190,
+    "y": 100,
+    "wires": []
+  },
+  {
+    "id": "f1a2b3c4d5e6f7a8",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "ESS AC Output Consumption L1 (W)",
+    "topic": "N/c0619ab9929a/system/0/Ac/ConsumptionOnOutput/L1/Power",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 220,
+    "y": 340,
+    "wires": [
+      [
+        "a8b7c6d5e4f3a2b1"
+      ]
+    ]
+  },
+  {
+    "id": "a8b7c6d5e4f3a2b1",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Stocker house_power_w",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('house_power_w', v);\nnode.status({fill:'purple',shape:'dot',text:`maison: ${v}W`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 520,
+    "y": 340,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "mppt_mqtt_out",
+    "type": "mqtt out",
+    "z": "414598e48f123ab2",
+    "name": "MQTT out santuario/meteo/venus",
+    "topic": "",
+    "qos": "1",
+    "retain": true,
+    "broker": "pi5_mqtt_broker",
+    "x": 900,
+    "y": 380,
+    "wires": []
+  },
+  {
+    "id": "pi5_mqtt_broker",
+    "type": "mqtt-broker",
+    "name": "Pi5 MQTT",
+    "broker": "dalybms-mosquitto",
+    "port": "1883",
+    "clientid": "",
+    "autoConnect": true,
+    "usetls": false,
+    "protocolVersion": "4",
+    "keepalive": "60",
+    "cleansession": true,
+    "autoUnsubscribe": true,
+    "birthTopic": "",
+    "birthQos": "0",
+    "birthRetain": "false",
+    "birthPayload": "",
+    "birthMsg": {},
+    "closeTopic": "",
+    "closeQos": "0",
+    "closeRetain": "false",
+    "closePayload": "",
+    "closeMsg": {},
+    "willTopic": "",
+    "willQos": "0",
+    "willRetain": "false",
+    "willPayload": "",
+    "willMsg": {},
+    "userProps": "",
+    "sessionExpiry": ""
+  },
+  {
+    "id": "mqtt_mppt_273_state",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "MPPT 273 State",
+    "topic": "N/c0619ab9929a/solarcharger/273/State",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 500,
+    "wires": [
+      [
+        "fn_mppt_273_state"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_mppt_273_pv",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "MPPT 273 PV Voltage",
+    "topic": "N/c0619ab9929a/solarcharger/273/Pv/V",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 540,
+    "wires": [
+      [
+        "fn_mppt_273_pv"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_mppt_273_dc",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "MPPT 273 DC Current",
+    "topic": "N/c0619ab9929a/solarcharger/273/Dc/0/Current",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 580,
+    "wires": [
+      [
+        "fn_mppt_273_dc"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_mppt_273_yield",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "MPPT 273 Yield Today",
+    "topic": "N/c0619ab9929a/solarcharger/273/History/Daily/0/Yield",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 620,
+    "wires": [
+      [
+        "fn_mppt_273_yield"
+      ]
+    ]
+  },
+  {
+    "id": "fn_mppt_273_state",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Store MPPT 273 State",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nconst labels = {0:'Off',2:'Fault',3:'Bulk',4:'Absorption',5:'Float',6:'Storage',7:'Equalize',11:'HV Solar',252:'Ext Ctrl'};\nconst lbl = labels[v] || `State ${v}`;\nflow.set('mppt_273_state', lbl);\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 500,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "fn_mppt_273_pv",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Store MPPT 273 PV V",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('mppt_273_pv_v', v);\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 540,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "fn_mppt_273_dc",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Store MPPT 273 DC I",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('mppt_273_dc_i', v);\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 580,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "fn_mppt_273_yield",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Store MPPT 273 Yield",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('mppt_273_yield_kwh', v);\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 620,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_mppt_289_state",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "MPPT 289 State",
+    "topic": "N/c0619ab9929a/solarcharger/289/State",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 1780,
+    "wires": [
+      [
+        "fn_mppt_289_state"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_mppt_289_pv",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "MPPT 289 PV Voltage",
+    "topic": "N/c0619ab9929a/solarcharger/289/Pv/V",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 1820,
+    "wires": [
+      [
+        "fn_mppt_289_pv"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_mppt_289_dc",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "MPPT 289 DC Current",
+    "topic": "N/c0619ab9929a/solarcharger/289/Dc/0/Current",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 1860,
+    "wires": [
+      [
+        "fn_mppt_289_dc"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_mppt_289_yield",
+    "type": "mqtt in",
+    "z": "414598e48f123ab2",
+    "name": "MPPT 289 Yield Today",
+    "topic": "N/c0619ab9929a/solarcharger/289/History/Daily/0/Yield",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 1900,
+    "wires": [
+      [
+        "fn_mppt_289_yield"
+      ]
+    ]
+  },
+  {
+    "id": "fn_mppt_289_state",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Store MPPT 289 State",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nconst labels = {0:'Off',2:'Fault',3:'Bulk',4:'Absorption',5:'Float',6:'Storage',7:'Equalize',11:'HV Solar',252:'Ext Ctrl'};\nconst lbl = labels[v] || `State ${v}`;\nflow.set('mppt_289_state', lbl);\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 1780,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "fn_mppt_289_pv",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Store MPPT 289 PV V",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('mppt_289_pv_v', v);\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 1820,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "fn_mppt_289_dc",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Store MPPT 289 DC I",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('mppt_289_dc_i', v);\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 1860,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  },
+  {
+    "id": "fn_mppt_289_yield",
+    "type": "function",
+    "z": "414598e48f123ab2",
+    "name": "Store MPPT 289 Yield",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('mppt_289_yield_kwh', v);\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 1900,
+    "wires": [
+      [
+        "10911d81284c4bc3"
+      ]
+    ]
+  }
 ]

--- a/flux-nodered/inverter.json
+++ b/flux-nodered/inverter.json
@@ -1,611 +1,771 @@
 [
-    {
-        "id": "inverter_tab",
-        "type": "tab",
-        "label": "Inverter/Charger → santuario/inverter/venus",
-        "disabled": false,
-        "info": "Victron MultiPlus / CGWACS données → MQTT\nPublie sur santuario/inverter/venus pour daly-bms-server"
-    },
-    {
-        "id": "mqtt_inverter_voltage",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "Inverter DC Voltage",
-        "topic": "N/c0619ab9929a/vebus/275/Dc/0/Voltage",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_inv",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 150,
-        "y": 60,
-        "wires": [
-            [
-                "inverter_voltage_fn"
-            ]
-        ]
-    },
-    {
-        "id": "mqtt_inverter_current",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "Inverter DC Current",
-        "topic": "N/c0619ab9929a/vebus/275/Dc/0/Current",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_inv",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 150,
-        "y": 120,
-        "wires": [
-            [
-                "inverter_current_fn"
-            ]
-        ]
-    },
-    {
-        "id": "mqtt_inverter_power",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "Inverter DC Power",
-        "topic": "N/c0619ab9929a/vebus/275/Dc/0/Power",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_inv",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 150,
-        "y": 180,
-        "wires": [
-            [
-                "inverter_power_fn"
-            ]
-        ]
-    },
-    {
-        "id": "mqtt_inverter_ac_voltage",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "Inverter AC L1 Voltage",
-        "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/V",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_inv",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 140,
-        "y": 240,
-        "wires": [
-            [
-                "inverter_ac_voltage_fn"
-            ]
-        ]
-    },
-    {
-        "id": "mqtt_inverter_ac_power",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "Inverter AC Output Power",
-        "topic": "N/c0619ab9929a/system/0/Ac/ConsumptionOnOutput/L1/Power",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_inv",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 150,
-        "y": 300,
-        "wires": [
-            [
-                "inverter_ac_power_fn"
-            ]
-        ]
-    },
-    {
-        "id": "inverter_voltage_fn",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "Store Voltage",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('voltage_v', v);\nnode.status({fill:'blue', text:`Voltage: ${v}V`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 350,
-        "y": 60,
-        "wires": [
-            [
-                "inverter_aggregate_fn"
-            ]
-        ]
-    },
-    {
-        "id": "inverter_current_fn",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "Store Current",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('current_a', v);\nnode.status({fill:'blue', text:`Current: ${v}A`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 350,
-        "y": 120,
-        "wires": [
-            [
-                "inverter_aggregate_fn"
-            ]
-        ]
-    },
-    {
-        "id": "inverter_power_fn",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "Store Power",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('power_w', v);\nnode.status({fill:'blue', text:`Power: ${v}W`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 350,
-        "y": 180,
-        "wires": [
-            [
-                "inverter_aggregate_fn"
-            ]
-        ]
-    },
-    {
-        "id": "inverter_ac_voltage_fn",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "Store AC Voltage",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('ac_voltage_v', v);\nnode.status({fill:'green', text:`AC Voltage: ${v}V`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 350,
-        "y": 240,
-        "wires": [
-            [
-                "inverter_aggregate_fn"
-            ]
-        ]
-    },
-    {
-        "id": "inverter_ac_power_fn",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "Store AC Power",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('ac_power_w', v);\nnode.status({fill:'green', text:`AC Power: ${v}W`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 350,
-        "y": 300,
-        "wires": [
-            [
-                "inverter_aggregate_fn"
-            ]
-        ]
-    },
-    {
-        "id": "inverter_aggregate_fn",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "Publish to MQTT",
-        "func": "const voltage = flow.get('voltage_v') || 0;\nconst current = flow.get('current_a') || 0;\nconst power = flow.get('power_w') || 0;\nconst ac_voltage = flow.get('ac_voltage_v') || 0;\nconst ac_current = flow.get('ac_current_a') || 0;\nconst ac_power = flow.get('ac_power_w') || 0;\n\nnode.status({fill:'green', shape:'dot', text:`DC: ${voltage}V ${current}A | AC: ${ac_voltage}V ${ac_power}W`});\n\nconst msg_out = {\n    topic: 'santuario/inverter/venus',\n    payload: JSON.stringify({\n        Voltage: voltage,\n        Current: current,\n        Power: power,\n        AcVoltage: ac_voltage,\n        AcCurrent: ac_current,\n        AcPower: ac_power,\n        State: 'on',\n        Mode: 'inverter'\n    }),\n    retain: true\n};\n\nreturn msg_out;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 550,
-        "y": 180,
-        "wires": [
-            [
-                "inverter_mqtt_out"
-            ]
-        ]
-    },
-    {
-        "id": "inverter_mqtt_out",
-        "type": "mqtt out",
-        "z": "inverter_tab",
-        "name": "MQTT out",
-        "topic": "",
-        "qos": "1",
-        "retain": true,
-        "broker": "pi5_mqtt_broker_inv",
-        "x": 750,
-        "y": 180,
-        "wires": []
-    },
-    {
-        "id": "6f9bf2ea72d090ae",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "Fréquence AC Out",
-        "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/F",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "victron_mqtt",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 150,
-        "y": 400,
-        "wires": [
-            [
-                "e0ecdf7fb3721a3f"
-            ]
-        ]
-    },
-    {
-        "id": "24f8a2746f85004a",
-        "type": "debug",
-        "z": "inverter_tab",
-        "name": "debug 14",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 720,
-        "y": 400,
-        "wires": []
-    },
-    {
-        "id": "869a8ac3fdc7bcf0",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "AC Out Voltage",
-        "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/V",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "victron_mqtt",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 140,
-        "y": 460,
-        "wires": [
-            [
-                "a21cd363fdef67d8"
-            ]
-        ]
-    },
-    {
-        "id": "66f1ba60993d547b",
-        "type": "debug",
-        "z": "inverter_tab",
-        "name": "debug 15",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 720,
-        "y": 460,
-        "wires": []
-    },
-    {
-        "id": "04c8dba9c5d408a3",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "AC Out Current",
-        "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/I",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "victron_mqtt",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 140,
-        "y": 520,
-        "wires": [
-            [
-                "e19e5b659f45fd8e"
-            ]
-        ]
-    },
-    {
-        "id": "60318245fa170fea",
-        "type": "debug",
-        "z": "inverter_tab",
-        "name": "debug 16",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 720,
-        "y": 520,
-        "wires": []
-    },
-    {
-        "id": "147b989fc33bb998",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "vebus/275/Energy/InverterToAcOut (kWh)",
-        "topic": "N/c0619ab9929a/vebus/275/Energy/InverterToAcOut",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "victron_mqtt",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 220,
-        "y": 580,
-        "wires": [
-            [
-                "1c55a586e1219fe5"
-            ]
-        ]
-    },
-    {
-        "id": "9a6ad1f71a8de3b2",
-        "type": "debug",
-        "z": "inverter_tab",
-        "name": "debug 18",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 720,
-        "y": 580,
-        "wires": []
-    },
-    {
-        "id": "5ab163c5f9381fb1",
-        "type": "comment",
-        "z": "inverter_tab",
-        "name": "/Energy/OutToInverter",
-        "info": "",
-        "x": 940,
-        "y": 600,
-        "wires": []
-    },
-    {
-        "id": "30d80f7da3b89c60",
-        "type": "mqtt in",
-        "z": "inverter_tab",
-        "name": "/Energy/OutToInverter (kWh)",
-        "topic": "N/c0619ab9929a/vebus/275/Energy/OutToInverter",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "victron_mqtt",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 180,
-        "y": 640,
-        "wires": [
-            [
-                "63bd4041c9543d4c"
-            ]
-        ]
-    },
-    {
-        "id": "160b948d3e2bef5e",
-        "type": "debug",
-        "z": "inverter_tab",
-        "name": "debug 19",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 720,
-        "y": 640,
-        "wires": []
-    },
-    {
-        "id": "e0ecdf7fb3721a3f",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "function 1",
-        "func": "\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 420,
-        "y": 400,
-        "wires": [
-            [
-                "24f8a2746f85004a"
-            ]
-        ]
-    },
-    {
-        "id": "a21cd363fdef67d8",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "function 2",
-        "func": "\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 420,
-        "y": 460,
-        "wires": [
-            [
-                "66f1ba60993d547b"
-            ]
-        ]
-    },
-    {
-        "id": "e19e5b659f45fd8e",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "function 3",
-        "func": "\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 420,
-        "y": 520,
-        "wires": [
-            [
-                "60318245fa170fea"
-            ]
-        ]
-    },
-    {
-        "id": "1c55a586e1219fe5",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "function 4",
-        "func": "\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 520,
-        "y": 580,
-        "wires": [
-            [
-                "9a6ad1f71a8de3b2"
-            ]
-        ]
-    },
-    {
-        "id": "63bd4041c9543d4c",
-        "type": "function",
-        "z": "inverter_tab",
-        "name": "function 5",
-        "func": "\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 460,
-        "y": 640,
-        "wires": [
-            [
-                "160b948d3e2bef5e"
-            ]
-        ]
-    },
-    {
-        "id": "2acfd2d5bc1d7ece",
-        "type": "comment",
-        "z": "inverter_tab",
-        "name": "Path À mettre en place",
-        "info": "N/c0619ab9929a/vebus/275/Ac/State/IgnoreAcIn1\n\n/Ac/State/IgnoreAcIn1\n\n/State\n0=Off;1=Low Power;\n2=Fault;3=Bulk;\n4=Absorption;5=Float;\n6=Storage;7=Equalize;\n8=Passthru;9=Inverting;1\n0=Power assist;11=Power supply;\n244=Sustain;252=External control\n\n/Energy/AcIn1ToAcOut\n/Ac/ActiveIn/L1/I\n/Ac/ActiveIn/L1/F\n/Ac/ActiveIn/L1/P\n/Ac/ActiveIn/L1/V",
-        "x": 620,
-        "y": 280,
-        "wires": []
-    },
-    {
-        "id": "pi5_mqtt_broker_inv",
-        "type": "mqtt-broker",
-        "name": "Pi5 MQTT",
-        "broker": "dalybms-mosquitto",
-        "port": "1883",
-        "clientid": "",
-        "autoConnect": true,
-        "usetls": false,
-        "protocolVersion": "4",
-        "keepalive": "60",
-        "cleansession": true,
-        "autoUnsubscribe": true,
-        "birthTopic": "",
-        "birthQos": "0",
-        "birthRetain": "false",
-        "birthPayload": "",
-        "birthMsg": {},
-        "closeTopic": "",
-        "closeQos": "0",
-        "closeRetain": "false",
-        "closePayload": "",
-        "closeMsg": {},
-        "willTopic": "",
-        "willQos": "0",
-        "willRetain": "false",
-        "willPayload": "",
-        "willMsg": {},
-        "userProps": "",
-        "sessionExpiry": ""
-    },
-    {
-        "id": "victron_mqtt",
-        "type": "mqtt-broker",
-        "name": "Pi5 MQTT",
-        "broker": "dalybms-mosquitto",
-        "port": "1883",
-        "clientid": "nodered_shelly",
-        "autoConnect": true,
-        "usetls": false,
-        "protocolVersion": "4",
-        "keepalive": "60",
-        "cleansession": true,
-        "autoUnsubscribe": true,
-        "birthTopic": "",
-        "birthQos": "0",
-        "birthPayload": "",
-        "birthMsg": {},
-        "closeTopic": "",
-        "closeQos": "0",
-        "closePayload": "",
-        "closeMsg": {},
-        "willTopic": "",
-        "willQos": "0",
-        "willPayload": "",
-        "willMsg": {},
-        "userProps": "",
-        "sessionExpiry": ""
-    }
+  {
+    "id": "inverter_tab",
+    "type": "tab",
+    "label": "Inverter/Charger → santuario/inverter/venus",
+    "disabled": false,
+    "info": "Victron MultiPlus / CGWACS données → MQTT\nPublie sur santuario/inverter/venus pour daly-bms-server"
+  },
+  {
+    "id": "mqtt_inverter_voltage",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "Inverter DC Voltage",
+    "topic": "N/c0619ab9929a/vebus/275/Dc/0/Voltage",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_inv",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 60,
+    "wires": [
+      [
+        "inverter_voltage_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_inverter_current",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "Inverter DC Current",
+    "topic": "N/c0619ab9929a/vebus/275/Dc/0/Current",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_inv",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 120,
+    "wires": [
+      [
+        "inverter_current_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_inverter_power",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "Inverter DC Power",
+    "topic": "N/c0619ab9929a/vebus/275/Dc/0/Power",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_inv",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 180,
+    "wires": [
+      [
+        "inverter_power_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_inverter_ac_voltage",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "Inverter AC L1 Voltage",
+    "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/V",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_inv",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 140,
+    "y": 240,
+    "wires": [
+      [
+        "inverter_ac_voltage_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_inverter_ac_power",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "Inverter AC Output Power",
+    "topic": "N/c0619ab9929a/system/0/Ac/ConsumptionOnOutput/L1/Power",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_inv",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 300,
+    "wires": [
+      [
+        "inverter_ac_power_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_voltage_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Store Voltage",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('voltage_v', v);\nnode.status({fill:'blue', text:`Voltage: ${v}V`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 350,
+    "y": 60,
+    "wires": [
+      [
+        "inverter_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_current_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Store Current",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('current_a', v);\nnode.status({fill:'blue', text:`Current: ${v}A`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 350,
+    "y": 120,
+    "wires": [
+      [
+        "inverter_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_power_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Store Power",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('power_w', v);\nnode.status({fill:'blue', text:`Power: ${v}W`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 350,
+    "y": 180,
+    "wires": [
+      [
+        "inverter_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_ac_voltage_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Store AC Voltage",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('ac_voltage_v', v);\nnode.status({fill:'green', text:`AC Voltage: ${v}V`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 350,
+    "y": 240,
+    "wires": [
+      [
+        "inverter_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_ac_power_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Store AC Power",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('ac_power_w', v);\nnode.status({fill:'green', text:`AC Power: ${v}W`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 350,
+    "y": 300,
+    "wires": [
+      [
+        "inverter_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_aggregate_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Publish to MQTT",
+    "func": "const voltage    = flow.get('voltage_v')    || 0;\nconst current    = flow.get('current_a')    || 0;\nconst power      = flow.get('power_w')      || 0;\nconst ac_voltage = flow.get('ac_voltage_v') || 0;\nconst ac_current = flow.get('ac_current_a') || 0;\nconst ac_power   = flow.get('ac_power_w')   || 0;\nconst ac_freq    = flow.get('ac_freq_hz');\nconst ignore_acin = flow.get('ignore_acin');\nconst vebus_state = flow.get('vebus_state');\n\nnode.status({fill:'green', shape:'dot', text:`DC:${voltage}V ${current}A | AC:${ac_voltage}V ${ac_power}W`});\n\nconst payload = {\n    Voltage:   voltage,\n    Current:   current,\n    Power:     power,\n    AcVoltage: ac_voltage,\n    AcCurrent: ac_current,\n    AcPower:   ac_power,\n    State:     'on',\n    Mode:      'inverter'\n};\n\nif (ac_freq    !== undefined && ac_freq    !== null) payload.AcFrequency = ac_freq;\nif (ignore_acin !== undefined && ignore_acin !== null) payload.IgnoreAcIn = ignore_acin;\nif (vebus_state !== undefined && vebus_state !== null) payload.VebusState = vebus_state;\n\nconst msg_out = {\n    topic:   'santuario/inverter/venus',\n    payload: JSON.stringify(payload),\n    retain:  true\n};\n\nreturn msg_out;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 550,
+    "y": 180,
+    "wires": [
+      [
+        "inverter_mqtt_out"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_mqtt_out",
+    "type": "mqtt out",
+    "z": "inverter_tab",
+    "name": "MQTT out",
+    "topic": "",
+    "qos": "1",
+    "retain": true,
+    "broker": "pi5_mqtt_broker_inv",
+    "x": 750,
+    "y": 180,
+    "wires": []
+  },
+  {
+    "id": "6f9bf2ea72d090ae",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "Fréquence AC Out",
+    "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/F",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "victron_mqtt",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 400,
+    "wires": [
+      [
+        "e0ecdf7fb3721a3f"
+      ]
+    ]
+  },
+  {
+    "id": "24f8a2746f85004a",
+    "type": "debug",
+    "z": "inverter_tab",
+    "name": "debug 14",
+    "active": false,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 720,
+    "y": 400,
+    "wires": []
+  },
+  {
+    "id": "869a8ac3fdc7bcf0",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "AC Out Voltage",
+    "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/V",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "victron_mqtt",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 140,
+    "y": 460,
+    "wires": [
+      [
+        "a21cd363fdef67d8"
+      ]
+    ]
+  },
+  {
+    "id": "66f1ba60993d547b",
+    "type": "debug",
+    "z": "inverter_tab",
+    "name": "debug 15",
+    "active": false,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 720,
+    "y": 460,
+    "wires": []
+  },
+  {
+    "id": "04c8dba9c5d408a3",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "AC Out Current",
+    "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/I",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "victron_mqtt",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 140,
+    "y": 520,
+    "wires": [
+      [
+        "e19e5b659f45fd8e"
+      ]
+    ]
+  },
+  {
+    "id": "60318245fa170fea",
+    "type": "debug",
+    "z": "inverter_tab",
+    "name": "debug 16",
+    "active": false,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 720,
+    "y": 520,
+    "wires": []
+  },
+  {
+    "id": "147b989fc33bb998",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "vebus/275/Energy/InverterToAcOut (kWh)",
+    "topic": "N/c0619ab9929a/vebus/275/Energy/InverterToAcOut",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "victron_mqtt",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 220,
+    "y": 580,
+    "wires": [
+      [
+        "1c55a586e1219fe5"
+      ]
+    ]
+  },
+  {
+    "id": "9a6ad1f71a8de3b2",
+    "type": "debug",
+    "z": "inverter_tab",
+    "name": "debug 18",
+    "active": false,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 720,
+    "y": 580,
+    "wires": []
+  },
+  {
+    "id": "5ab163c5f9381fb1",
+    "type": "comment",
+    "z": "inverter_tab",
+    "name": "/Energy/OutToInverter",
+    "info": "",
+    "x": 940,
+    "y": 600,
+    "wires": []
+  },
+  {
+    "id": "30d80f7da3b89c60",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "/Energy/OutToInverter (kWh)",
+    "topic": "N/c0619ab9929a/vebus/275/Energy/OutToInverter",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "victron_mqtt",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 180,
+    "y": 640,
+    "wires": [
+      [
+        "63bd4041c9543d4c"
+      ]
+    ]
+  },
+  {
+    "id": "160b948d3e2bef5e",
+    "type": "debug",
+    "z": "inverter_tab",
+    "name": "debug 19",
+    "active": false,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 720,
+    "y": 640,
+    "wires": []
+  },
+  {
+    "id": "e0ecdf7fb3721a3f",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "function 1",
+    "func": "\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 400,
+    "wires": [
+      [
+        "24f8a2746f85004a"
+      ]
+    ]
+  },
+  {
+    "id": "a21cd363fdef67d8",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "function 2",
+    "func": "\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 460,
+    "wires": [
+      [
+        "66f1ba60993d547b"
+      ]
+    ]
+  },
+  {
+    "id": "e19e5b659f45fd8e",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "function 3",
+    "func": "\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 520,
+    "wires": [
+      [
+        "60318245fa170fea"
+      ]
+    ]
+  },
+  {
+    "id": "1c55a586e1219fe5",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "function 4",
+    "func": "\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 520,
+    "y": 580,
+    "wires": [
+      [
+        "9a6ad1f71a8de3b2"
+      ]
+    ]
+  },
+  {
+    "id": "63bd4041c9543d4c",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "function 5",
+    "func": "\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 460,
+    "y": 640,
+    "wires": [
+      [
+        "160b948d3e2bef5e"
+      ]
+    ]
+  },
+  {
+    "id": "2acfd2d5bc1d7ece",
+    "type": "comment",
+    "z": "inverter_tab",
+    "name": "Path À mettre en place",
+    "info": "N/c0619ab9929a/vebus/275/Ac/State/IgnoreAcIn1\n\n/Ac/State/IgnoreAcIn1\n\n/State\n0=Off;1=Low Power;\n2=Fault;3=Bulk;\n4=Absorption;5=Float;\n6=Storage;7=Equalize;\n8=Passthru;9=Inverting;1\n0=Power assist;11=Power supply;\n244=Sustain;252=External control\n\n/Energy/AcIn1ToAcOut\n/Ac/ActiveIn/L1/I\n/Ac/ActiveIn/L1/F\n/Ac/ActiveIn/L1/P\n/Ac/ActiveIn/L1/V",
+    "x": 620,
+    "y": 280,
+    "wires": []
+  },
+  {
+    "id": "pi5_mqtt_broker_inv",
+    "type": "mqtt-broker",
+    "name": "Pi5 MQTT",
+    "broker": "dalybms-mosquitto",
+    "port": "1883",
+    "clientid": "",
+    "autoConnect": true,
+    "usetls": false,
+    "protocolVersion": "4",
+    "keepalive": "60",
+    "cleansession": true,
+    "autoUnsubscribe": true,
+    "birthTopic": "",
+    "birthQos": "0",
+    "birthRetain": "false",
+    "birthPayload": "",
+    "birthMsg": {},
+    "closeTopic": "",
+    "closeQos": "0",
+    "closeRetain": "false",
+    "closePayload": "",
+    "closeMsg": {},
+    "willTopic": "",
+    "willQos": "0",
+    "willRetain": "false",
+    "willPayload": "",
+    "willMsg": {},
+    "userProps": "",
+    "sessionExpiry": ""
+  },
+  {
+    "id": "victron_mqtt",
+    "type": "mqtt-broker",
+    "name": "Pi5 MQTT",
+    "broker": "dalybms-mosquitto",
+    "port": "1883",
+    "clientid": "nodered_shelly",
+    "autoConnect": true,
+    "usetls": false,
+    "protocolVersion": "4",
+    "keepalive": "60",
+    "cleansession": true,
+    "autoUnsubscribe": true,
+    "birthTopic": "",
+    "birthQos": "0",
+    "birthPayload": "",
+    "birthMsg": {},
+    "closeTopic": "",
+    "closeQos": "0",
+    "closePayload": "",
+    "closeMsg": {},
+    "willTopic": "",
+    "willQos": "0",
+    "willPayload": "",
+    "willMsg": {},
+    "userProps": "",
+    "sessionExpiry": ""
+  },
+  {
+    "id": "mqtt_inverter_vebus_state",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "VEBus State",
+    "topic": "N/c0619ab9929a/vebus/275/State",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_inv",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 380,
+    "wires": [
+      [
+        "inverter_vebus_state_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_inverter_ignore_acin",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "IgnoreAcIn1",
+    "topic": "N/c0619ab9929a/vebus/275/Ac/State/IgnoreAcIn1",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_inv",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 420,
+    "wires": [
+      [
+        "inverter_ignore_acin_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_inverter_ac_freq",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "AC Out Frequency",
+    "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/F",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_inv",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 460,
+    "wires": [
+      [
+        "inverter_ac_freq_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_inverter_ac_current_real",
+    "type": "mqtt in",
+    "z": "inverter_tab",
+    "name": "AC Out Current",
+    "topic": "N/c0619ab9929a/vebus/275/Ac/Out/L1/I",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_inv",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 500,
+    "wires": [
+      [
+        "inverter_ac_current_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_vebus_state_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Store VEBus State",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('vebus_state', v);\nnode.status({fill:'blue', text:`VEBus: ${v}`});\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 400,
+    "y": 380,
+    "wires": [
+      [
+        "inverter_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_ignore_acin_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Store IgnoreAcIn",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('ignore_acin', v);\nnode.status({fill:'blue', text:`IgnoreAcIn: ${v}`});\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 400,
+    "y": 420,
+    "wires": [
+      [
+        "inverter_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_ac_freq_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Store AC Frequency",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('ac_freq_hz', v);\nnode.status({fill:'blue', text:`Freq: ${v}Hz`});\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 400,
+    "y": 460,
+    "wires": [
+      [
+        "inverter_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "inverter_ac_current_fn",
+    "type": "function",
+    "z": "inverter_tab",
+    "name": "Store AC Current",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('ac_current_a', v);\nnode.status({fill:'blue', text:`I AC: ${v}A`});\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 400,
+    "y": 500,
+    "wires": [
+      [
+        "inverter_aggregate_fn"
+      ]
+    ]
+  }
 ]

--- a/flux-nodered/smartshunt.json
+++ b/flux-nodered/smartshunt.json
@@ -1,349 +1,429 @@
 [
-    {
-        "id": "smartshunt_tab",
-        "type": "tab",
-        "label": "SmartShunt → santuario/system/venus",
-        "disabled": false,
-        "info": "SmartShunt 500A → D-Bus NanoPi → MQTT → Pi5 daly-bms-server\nPublie à santuario/system/venus avec format attendu par le serveur",
-        "env": []
-    },
-    {
-        "id": "mqtt_smartshunt_soc",
-        "type": "mqtt in",
-        "z": "smartshunt_tab",
-        "name": "SmartShunt SOC",
-        "topic": "N/c0619ab9929a/system/0/Dc/Battery/Soc",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_ss",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 150,
-        "y": 60,
-        "wires": [
-            [
-                "smartshunt_soc_fn"
-            ]
-        ]
-    },
-    {
-        "id": "mqtt_smartshunt_voltage",
-        "type": "mqtt in",
-        "z": "smartshunt_tab",
-        "name": "SmartShunt Voltage",
-        "topic": "N/c0619ab9929a/system/0/Dc/Battery/Voltage",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_ss",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 150,
-        "y": 120,
-        "wires": [
-            [
-                "smartshunt_voltage_fn"
-            ]
-        ]
-    },
-    {
-        "id": "mqtt_smartshunt_current",
-        "type": "mqtt in",
-        "z": "smartshunt_tab",
-        "name": "SmartShunt Current",
-        "topic": "N/c0619ab9929a/system/0/Dc/Battery/Current",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_ss",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 150,
-        "y": 180,
-        "wires": [
-            [
-                "smartshunt_current_fn"
-            ]
-        ]
-    },
-    {
-        "id": "mqtt_smartshunt_power",
-        "type": "mqtt in",
-        "z": "smartshunt_tab",
-        "name": "SmartShunt Power",
-        "topic": "N/c0619ab9929a/system/0/Dc/Battery/Power",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_ss",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 150,
-        "y": 240,
-        "wires": [
-            [
-                "smartshunt_power_fn"
-            ]
-        ]
-    },
-    {
-        "id": "smartshunt_soc_fn",
-        "type": "function",
-        "z": "smartshunt_tab",
-        "name": "Store SOC",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('soc_percent', v);\nnode.status({fill:'blue', text:`SOC: ${v}%`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 350,
-        "y": 60,
-        "wires": [
-            [
-                "smartshunt_aggregate_fn"
-            ]
-        ]
-    },
-    {
-        "id": "smartshunt_voltage_fn",
-        "type": "function",
-        "z": "smartshunt_tab",
-        "name": "Store Voltage",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('voltage_v', v);\nnode.status({fill:'blue', text:`V: ${v}V`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 350,
-        "y": 120,
-        "wires": [
-            [
-                "smartshunt_aggregate_fn"
-            ]
-        ]
-    },
-    {
-        "id": "smartshunt_current_fn",
-        "type": "function",
-        "z": "smartshunt_tab",
-        "name": "Store Current",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('current_a', v);\nnode.status({fill:'blue', text:`I: ${v}A`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 350,
-        "y": 180,
-        "wires": [
-            [
-                "smartshunt_aggregate_fn"
-            ]
-        ]
-    },
-    {
-        "id": "smartshunt_power_fn",
-        "type": "function",
-        "z": "smartshunt_tab",
-        "name": "Store Power",
-        "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('power_w', v);\nnode.status({fill:'blue', text:`P: ${v}W`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 350,
-        "y": 240,
-        "wires": [
-            [
-                "smartshunt_aggregate_fn"
-            ]
-        ]
-    },
-    {
-        "id": "smartshunt_aggregate_fn",
-        "type": "function",
-        "z": "smartshunt_tab",
-        "name": "Publish to MQTT",
-        "func": "const soc      = flow.get('soc_percent') || 0;\nconst voltage  = flow.get('voltage_v')   || 0;\nconst current  = flow.get('current_a')   || 0;\nconst power    = flow.get('power_w')     || 0;\n\nnode.status({fill:'green', shape:'dot', text:`${soc}% | ${voltage}V | ${current}A | ${power}W`});\n\nconst msg_out = {\n    topic: 'santuario/system/venus',\n    payload: JSON.stringify({\n        Soc: soc,\n        Voltage: voltage,\n        Current: current,\n        Power: power\n    }),\n    retain: true\n};\n\nreturn msg_out;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 550,
-        "y": 150,
-        "wires": [
-            [
-                "smartshunt_mqtt_out"
-            ]
-        ]
-    },
-    {
-        "id": "smartshunt_mqtt_out",
-        "type": "mqtt out",
-        "z": "smartshunt_tab",
-        "name": "MQTT out",
-        "topic": "",
-        "qos": "1",
-        "retain": true,
-        "broker": "pi5_mqtt_broker_ss",
-        "x": 750,
-        "y": 150,
-        "wires": []
-    },
-    {
-        "id": "efa3778e1d50a581",
-        "type": "mqtt in",
-        "z": "smartshunt_tab",
-        "name": "N/c0619ab9929a/vebus/274/Dc/0/Power",
-        "topic": "N/c0619ab9929a/vebus/274/Dc/0/Power",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_ss",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 220,
-        "y": 320,
-        "wires": [
-            [
-                "103e787fa221ca77"
-            ]
-        ]
-    },
-    {
-        "id": "103e787fa221ca77",
-        "type": "debug",
-        "z": "smartshunt_tab",
-        "name": "debug 17",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 520,
-        "y": 320,
-        "wires": []
-    },
-    {
-        "id": "f5dab144268195f6",
-        "type": "mqtt in",
-        "z": "smartshunt_tab",
-        "name": "N/c0619ab9929a/vebus/274/Dc/0/Voltage",
-        "topic": "N/c0619ab9929a/vebus/274/Dc/0/Voltage",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_ss",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 220,
-        "y": 400,
-        "wires": [
-            [
-                "e83f92fbcddfe299"
-            ]
-        ]
-    },
-    {
-        "id": "e83f92fbcddfe299",
-        "type": "debug",
-        "z": "smartshunt_tab",
-        "name": "debug 20",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 520,
-        "y": 400,
-        "wires": []
-    },
-    {
-        "id": "a076aa6c2a1ca328",
-        "type": "mqtt in",
-        "z": "smartshunt_tab",
-        "name": "N/c0619ab9929a/vebus/274/Dc/0/Current",
-        "topic": "N/c0619ab9929a/vebus/274/Dc/0/Current",
-        "qos": "0",
-        "datatype": "json",
-        "broker": "pi5_mqtt_broker_ss",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 220,
-        "y": 480,
-        "wires": [
-            [
-                "e897083eb7251732"
-            ]
-        ]
-    },
-    {
-        "id": "e897083eb7251732",
-        "type": "debug",
-        "z": "smartshunt_tab",
-        "name": "debug 21",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 520,
-        "y": 480,
-        "wires": []
-    },
-    {
-        "id": "pi5_mqtt_broker_ss",
-        "type": "mqtt-broker",
-        "name": "Pi5 MQTT",
-        "broker": "dalybms-mosquitto",
-        "port": "1883",
-        "clientid": "",
-        "autoConnect": true,
-        "usetls": false,
-        "protocolVersion": "4",
-        "keepalive": "60",
-        "cleansession": true,
-        "autoUnsubscribe": true,
-        "birthTopic": "",
-        "birthQos": "0",
-        "birthRetain": "false",
-        "birthPayload": "",
-        "birthMsg": {},
-        "closeTopic": "",
-        "closeQos": "0",
-        "closeRetain": "false",
-        "closePayload": "",
-        "closeMsg": {},
-        "willTopic": "",
-        "willQos": "0",
-        "willRetain": "false",
-        "willPayload": "",
-        "willMsg": {},
-        "userProps": "",
-        "sessionExpiry": ""
-    }
+  {
+    "id": "smartshunt_tab",
+    "type": "tab",
+    "label": "SmartShunt → santuario/system/venus",
+    "disabled": false,
+    "info": "SmartShunt 500A → D-Bus NanoPi → MQTT → Pi5 daly-bms-server\nPublie à santuario/system/venus avec format attendu par le serveur",
+    "env": []
+  },
+  {
+    "id": "mqtt_smartshunt_soc",
+    "type": "mqtt in",
+    "z": "smartshunt_tab",
+    "name": "SmartShunt SOC",
+    "topic": "N/c0619ab9929a/system/0/Dc/Battery/Soc",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_ss",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 60,
+    "wires": [
+      [
+        "smartshunt_soc_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_smartshunt_voltage",
+    "type": "mqtt in",
+    "z": "smartshunt_tab",
+    "name": "SmartShunt Voltage",
+    "topic": "N/c0619ab9929a/system/0/Dc/Battery/Voltage",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_ss",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 120,
+    "wires": [
+      [
+        "smartshunt_voltage_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_smartshunt_current",
+    "type": "mqtt in",
+    "z": "smartshunt_tab",
+    "name": "SmartShunt Current",
+    "topic": "N/c0619ab9929a/system/0/Dc/Battery/Current",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_ss",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 180,
+    "wires": [
+      [
+        "smartshunt_current_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_smartshunt_power",
+    "type": "mqtt in",
+    "z": "smartshunt_tab",
+    "name": "SmartShunt Power",
+    "topic": "N/c0619ab9929a/system/0/Dc/Battery/Power",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_ss",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 240,
+    "wires": [
+      [
+        "smartshunt_power_fn"
+      ]
+    ]
+  },
+  {
+    "id": "smartshunt_soc_fn",
+    "type": "function",
+    "z": "smartshunt_tab",
+    "name": "Store SOC",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('soc_percent', v);\nnode.status({fill:'blue', text:`SOC: ${v}%`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 350,
+    "y": 60,
+    "wires": [
+      [
+        "smartshunt_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "smartshunt_voltage_fn",
+    "type": "function",
+    "z": "smartshunt_tab",
+    "name": "Store Voltage",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('voltage_v', v);\nnode.status({fill:'blue', text:`V: ${v}V`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 350,
+    "y": 120,
+    "wires": [
+      [
+        "smartshunt_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "smartshunt_current_fn",
+    "type": "function",
+    "z": "smartshunt_tab",
+    "name": "Store Current",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('current_a', v);\nnode.status({fill:'blue', text:`I: ${v}A`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 350,
+    "y": 180,
+    "wires": [
+      [
+        "smartshunt_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "smartshunt_power_fn",
+    "type": "function",
+    "z": "smartshunt_tab",
+    "name": "Store Power",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('power_w', v);\nnode.status({fill:'blue', text:`P: ${v}W`});\nreturn msg;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 350,
+    "y": 240,
+    "wires": [
+      [
+        "smartshunt_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "smartshunt_aggregate_fn",
+    "type": "function",
+    "z": "smartshunt_tab",
+    "name": "Publish to MQTT",
+    "func": "const soc       = flow.get('soc_percent')  || 0;\nconst voltage   = flow.get('voltage_v')    || 0;\nconst current   = flow.get('current_a')    || 0;\nconst power     = flow.get('power_w')      || 0;\nconst state_raw = flow.get('battery_state');\nconst ttg_s     = flow.get('time_to_go_s');\n\nnode.status({fill:'green', shape:'dot', text:`${soc}% | ${voltage}V | ${current}A`});\n\nconst msg_out = {\n    topic: 'santuario/system/venus',\n    payload: JSON.stringify({\n        Soc:      soc,\n        Voltage:  voltage,\n        Current:  current,\n        Power:    power,\n        State:    state_raw !== undefined ? state_raw : undefined,\n        TimeToGo: ttg_s     !== undefined ? ttg_s     : undefined\n    }),\n    retain: true\n};\n\nreturn msg_out;",
+    "outputs": 1,
+    "timeout": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 550,
+    "y": 150,
+    "wires": [
+      [
+        "smartshunt_mqtt_out"
+      ]
+    ]
+  },
+  {
+    "id": "smartshunt_mqtt_out",
+    "type": "mqtt out",
+    "z": "smartshunt_tab",
+    "name": "MQTT out",
+    "topic": "",
+    "qos": "1",
+    "retain": true,
+    "broker": "pi5_mqtt_broker_ss",
+    "x": 750,
+    "y": 150,
+    "wires": []
+  },
+  {
+    "id": "efa3778e1d50a581",
+    "type": "mqtt in",
+    "z": "smartshunt_tab",
+    "name": "N/c0619ab9929a/vebus/274/Dc/0/Power",
+    "topic": "N/c0619ab9929a/vebus/274/Dc/0/Power",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_ss",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 220,
+    "y": 320,
+    "wires": [
+      [
+        "103e787fa221ca77"
+      ]
+    ]
+  },
+  {
+    "id": "103e787fa221ca77",
+    "type": "debug",
+    "z": "smartshunt_tab",
+    "name": "debug 17",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 520,
+    "y": 320,
+    "wires": []
+  },
+  {
+    "id": "f5dab144268195f6",
+    "type": "mqtt in",
+    "z": "smartshunt_tab",
+    "name": "N/c0619ab9929a/vebus/274/Dc/0/Voltage",
+    "topic": "N/c0619ab9929a/vebus/274/Dc/0/Voltage",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_ss",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 220,
+    "y": 400,
+    "wires": [
+      [
+        "e83f92fbcddfe299"
+      ]
+    ]
+  },
+  {
+    "id": "e83f92fbcddfe299",
+    "type": "debug",
+    "z": "smartshunt_tab",
+    "name": "debug 20",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 520,
+    "y": 400,
+    "wires": []
+  },
+  {
+    "id": "a076aa6c2a1ca328",
+    "type": "mqtt in",
+    "z": "smartshunt_tab",
+    "name": "N/c0619ab9929a/vebus/274/Dc/0/Current",
+    "topic": "N/c0619ab9929a/vebus/274/Dc/0/Current",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_ss",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 220,
+    "y": 480,
+    "wires": [
+      [
+        "e897083eb7251732"
+      ]
+    ]
+  },
+  {
+    "id": "e897083eb7251732",
+    "type": "debug",
+    "z": "smartshunt_tab",
+    "name": "debug 21",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 520,
+    "y": 480,
+    "wires": []
+  },
+  {
+    "id": "pi5_mqtt_broker_ss",
+    "type": "mqtt-broker",
+    "name": "Pi5 MQTT",
+    "broker": "dalybms-mosquitto",
+    "port": "1883",
+    "clientid": "",
+    "autoConnect": true,
+    "usetls": false,
+    "protocolVersion": "4",
+    "keepalive": "60",
+    "cleansession": true,
+    "autoUnsubscribe": true,
+    "birthTopic": "",
+    "birthQos": "0",
+    "birthRetain": "false",
+    "birthPayload": "",
+    "birthMsg": {},
+    "closeTopic": "",
+    "closeQos": "0",
+    "closeRetain": "false",
+    "closePayload": "",
+    "closeMsg": {},
+    "willTopic": "",
+    "willQos": "0",
+    "willRetain": "false",
+    "willPayload": "",
+    "willMsg": {},
+    "userProps": "",
+    "sessionExpiry": ""
+  },
+  {
+    "id": "mqtt_smartshunt_state",
+    "type": "mqtt in",
+    "z": "smartshunt_tab",
+    "name": "SmartShunt State",
+    "topic": "N/c0619ab9929a/system/0/Dc/Battery/State",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_ss",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 220,
+    "wires": [
+      [
+        "smartshunt_state_fn"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt_smartshunt_ttg",
+    "type": "mqtt in",
+    "z": "smartshunt_tab",
+    "name": "SmartShunt TimeToGo",
+    "topic": "N/c0619ab9929a/system/0/Dc/Battery/TimeToGo",
+    "qos": "0",
+    "datatype": "json",
+    "broker": "pi5_mqtt_broker_ss",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 260,
+    "wires": [
+      [
+        "smartshunt_ttg_fn"
+      ]
+    ]
+  },
+  {
+    "id": "smartshunt_state_fn",
+    "type": "function",
+    "z": "smartshunt_tab",
+    "name": "Store State",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('battery_state', v);\nnode.status({fill:'blue', text:`State: ${v}`});\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 390,
+    "y": 220,
+    "wires": [
+      [
+        "smartshunt_aggregate_fn"
+      ]
+    ]
+  },
+  {
+    "id": "smartshunt_ttg_fn",
+    "type": "function",
+    "z": "smartshunt_tab",
+    "name": "Store TimeToGo",
+    "func": "const v = msg.payload.value !== undefined ? msg.payload.value : msg.payload;\nflow.set('time_to_go_s', v);\nnode.status({fill:'blue', text:`TTG: ${Math.round(v/60)}min`});\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 390,
+    "y": 260,
+    "wires": [
+      [
+        "smartshunt_aggregate_fn"
+      ]
+    ]
+  }
 ]


### PR DESCRIPTION
…nodes

SmartShunt: full card with State, Power, Current, Voltage, SOC bar, TimeToGo,
  Charged/Discharged energy — all from real VenusSmartShunt data.

MPPT: group card (max 5 chargers) with individual rows showing MPPT-<instance>,
  State, PV Voltage, DC Current, Instant Power. Total Power/Total DC Current
  are calculated values displayed in the header. Backed by VenusMppt.state,
  pv_voltage_v, dc_current_a new fields.

Onduleur AC: rectangular card (280px, +1.5% vs ET112) with AC In Ignore badge,
  AC Out section (V/I/P), DC section (V/I/P). AC frequency badge floats at top
  (future edge label position between Onduleur AC top and ATS-Onduleur bottom).
  Backed by VenusInverter.ac_out_frequency_hz, ac_in_ignore new fields.

Rust backend: VenusSmartShunt + VenusMppt + VenusInverter structs extended with
  new optional fields. MQTT handlers updated (format v2 with Mppts array,
  VebusState numeric mapping, TimeToGo seconds→minutes). API /venus/mppt now
  exposes total_dc_current_a.

Node-RED flows: smartshunt.json adds State+TimeToGo from VRM Battery topics.
  inverter.json adds AcFrequency, IgnoreAcIn1, AC current, VebusState.
  Solar_power.json adds per-MPPT State/PvV/DcI/Yield for instances 273+289
  and publishes Mppts array in santuario/meteo/venus payload.

0 compilation warnings. No regressions on existing nodes/edges/animations.

https://claude.ai/code/session_01VDy4YgbHsfJM5qDTiQd5YZ