### PR TITLE
feat(viz): add custom double-line animated edges for EDGES0

### DIFF
--- a/crates/daly-bms-server/templates/visualization.css
+++ b/crates/daly-bms-server/templates/visualization.css
@@ -424,3 +424,4 @@
   .inv-kpi-val.ac { color: #2563eb; }
   .inv-kpi-val.dc { color: #ea580c; }
   .inv-wait { text-align: center; font-size: 0.7rem; color: #94a3b8; font-style: italic; padding: 14px; }
+  @keyframes dle-flow { from { stroke-dashoffset: 18; } to { stroke-dashoffset: 0; } }

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -21,7 +21,7 @@
 
 const h = React.createElement;
 const { useState, useEffect, useCallback, useRef, memo } = React;
-const { ReactFlow, Background, Controls, Panel, Handle, Position, useNodesState, useEdgesState } = window.ReactFlow;
+const { ReactFlow, Background, Controls, Panel, Handle, Position, useNodesState, useEdgesState, getSmoothStepPath } = window.ReactFlow;
 
 const fmtKw  = w  => w  != null ? `${(w / 1000).toFixed(2)} kW` : '—';
 const socColor = s => s > 60 ? '#16a34a' : s > 30 ? '#ca8a04' : '#dc2626';
@@ -748,6 +748,21 @@ function InverterNode({ data }) {
   );
 }
 
+function DoubleLineEdge({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, style }) {
+  const color = style?.stroke ?? '#2563eb';
+  const [edgePath] = getSmoothStepPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, borderRadius: 5 });
+  const isH = Math.abs(targetX - sourceX) >= Math.abs(targetY - sourceY);
+  const ox = isH ? 0 : 3, oy = isH ? 3 : 0;
+  const base = { fill: 'none', stroke: color, strokeWidth: 2, strokeOpacity: 0.25, strokeLinecap: 'round' };
+  const flow = (delay) => ({ fill: 'none', stroke: color, strokeWidth: 2, strokeLinecap: 'round', strokeDasharray: '10 8', animation: `dle-flow 1.1s linear ${delay} infinite` });
+  return h('g', null,
+    h('path', { d: edgePath, style: base, transform: `translate(${ox},${oy})` }),
+    h('path', { d: edgePath, style: base, transform: `translate(${-ox},${-oy})` }),
+    h('path', { d: edgePath, style: flow('0s'), transform: `translate(${ox},${oy})` }),
+    h('path', { d: edgePath, style: flow('0.55s'), transform: `translate(${-ox},${-oy})` }),
+  );
+}
+
 const nodeTypes = {
   summary: SummaryNode, bms: BmsNode, et112card: Et112CardNode, device: DeviceNode,
   hub: HubNode, placeholder: PlaceholderNode, mpptGroup: MPPTGroupNode, smartshunt: SmartShuntNode,
@@ -756,6 +771,7 @@ const nodeTypes = {
   inverter: InverterNode,
   atsreseau: AtsReseauNode, atsonduleur: AtsOnduleurNode, atsmain: AtsMainNode
 };
+const edgeTypes = { doubleLine: DoubleLineEdge };
 
 const NODES0 = [
   { id: 'production',  type: 'summary',     position: { x: -350,  y: 10  }, data: { label: 'Production',      icon: '☀️',  value: '—',   sub: 'Micro-onduleurs',        dotClass: '' } },
@@ -784,7 +800,7 @@ const NODES0 = [
 const COLOR = { ac: '#2563eb', dc: '#ea580c', bat: '#16a34a', gray: '#94a3b8' };
 
 function mkEdge(id, src, tgt, color, opts = {}) {
-  return { id, source: src, target: tgt, type: 'smoothstep', animated: false, style: { stroke: color, strokeWidth: 2.5 }, ...opts };
+  return { id, source: src, target: tgt, type: 'doubleLine', animated: false, style: { stroke: color, strokeWidth: 2.5 }, ...opts };
 }
 
 const EDGES0 = [
@@ -1034,7 +1050,7 @@ function ESSFlow() {
   ];
 
   return h(ReactFlow, {
-    nodes, edges, onNodesChange, onEdgesChange, nodeTypes, fitView: true,
+    nodes, edges, onNodesChange, onEdgesChange, nodeTypes, edgeTypes, fitView: true,
     fitViewOptions: { padding: 0.06 }, minZoom: 0.2, maxZoom: 2.5,
     nodesDraggable: false, nodesConnectable: false, elementsSelectable: false, preventScrolling: false,
   },


### PR DESCRIPTION
Replace smoothstep edges with DoubleLineEdge custom component for all 13 EDGES0 connections. Each edge renders two parallel lines (6px center-to-center gap) with flowing dash animation (1.1s, staggered 0.55s between rails) showing current direction source→target.

ATS dynamic edges (ats-e1, ats-e2) remain smoothstep and are unaffected.

https://claude.ai/code/session_01WkW1NFSpz6KuJV4ZbRDZVH