### PR TITLE
fix(mppt): purger les MPPT orphelins lors d'un snapshot v2 complet

### DIFF
--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -531,8 +531,11 @@ async fn handle_meteo_topic(state: &AppState, json: &Value) {
     let yield_kwh  = json.get("TodaysYield").and_then(|v| v.as_f64()).map(|v| v as f32);
     let mppt_power = json.get("MpptPower").and_then(|v| v.as_f64()).map(|v| v as f32);
 
-    // Format v2 : tableau Mppts avec données individuelles par chargeur
+    // Format v2 : tableau Mppts avec données individuelles par chargeur.
+    // On remplace toute la map en une seule opération pour purger les entrées
+    // orphelines (ex : MPPT qui n'est plus connecté disparaît du message).
     if let Some(arr) = json.get("Mppts").and_then(|v| v.as_array()) {
+        let mut new_mppts = Vec::with_capacity(arr.len());
         for item in arr {
             let instance = item.get("Instance").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
             let name     = format!("MPPT-{}", instance);
@@ -542,7 +545,7 @@ async fn handle_meteo_topic(state: &AppState, json: &Value) {
             let power    = item.get("Power").and_then(|v| v.as_f64()).map(|v| v as f32);
             let yield_t  = item.get("YieldToday").and_then(|v| v.as_f64()).map(|v| v as f32);
             let max_pw   = item.get("MaxPowerToday").and_then(|v| v.as_f64()).map(|v| v as f32);
-            let mppt = VenusMppt {
+            new_mppts.push(VenusMppt {
                 instance,
                 name,
                 power_w: power,
@@ -552,9 +555,9 @@ async fn handle_meteo_topic(state: &AppState, json: &Value) {
                 pv_voltage_v: pv_v,
                 dc_current_a: dc_i,
                 timestamp: Utc::now(),
-            };
-            state.on_venus_mppt(mppt).await;
+            });
         }
+        state.on_venus_mppts_replace(new_mppts).await;
         return; // format v2 traité, pas de fallback nécessaire
     }
 

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -433,10 +433,22 @@ impl AppState {
     // Méthodes Venus OS
     // ==========================================================================
 
-    /// Enregistre/met à jour un snapshot MPPT.
+    /// Enregistre/met à jour un snapshot MPPT unique (format v1 legacy).
     pub async fn on_venus_mppt(&self, mppt: VenusMppt) {
         let mut mppts = self.venus_mppts.write().await;
         mppts.insert(mppt.instance, mppt);
+    }
+
+    /// Remplace atomiquement toute la liste MPPT (format v2 — tableau complet).
+    ///
+    /// Utilisé quand Venus OS publie un snapshot complet de tous les chargeurs.
+    /// Les entrées orphelines (MPPT déconnecté) sont ainsi purgées automatiquement.
+    pub async fn on_venus_mppts_replace(&self, mppts: Vec<VenusMppt>) {
+        let mut map = self.venus_mppts.write().await;
+        map.clear();
+        for mppt in mppts {
+            map.insert(mppt.instance, mppt);
+        }
     }
 
     /// Retourne tous les MPPT actuels.


### PR DESCRIPTION
Cause : la BTreeMap<u32, VenusMppt> ne supprimait jamais les entrées existantes — un MPPT déconnecté restait affiché indéfiniment.

Correction :
- Ajout de `on_venus_mppts_replace()` dans AppState qui remplace atomiquement toute la map avec les seuls chargeurs du message courant.
- `handle_meteo_topic` utilise cette méthode pour le format v2 (tableau Mppts), au lieu d'insérer entrée par entrée.

Le format v1 (legacy, MPPT unique) conserve le comportement insert. Scalable : 2 ou 5 MPPT s'affichent automatiquement selon ce que Venus OS publie, sans autre modification.

https://claude.ai/code/session_014sWyiU6eD9gQ5rYiWtd723