### PR TITLE
fix(switch): ajoute ValidTypes=2 pour activer le widget toggle dans V…

### DIFF
--- a/crates/dbus-mqtt-venus/src/switch_service.rs
+++ b/crates/dbus-mqtt-venus/src/switch_service.rs
@@ -208,6 +208,11 @@ impl SwitchValues {
                 DbusItem::str(&self.product_name));
             m.insert("/SwitchableOutput/0/Settings/Type".into(),
                 DbusItem::i32(1));   // 1 = toggle
+            // ValidTypes : champ binaire — bit N = type N supporté.
+            // Bit 1 (valeur 2) = toggle. OBLIGATOIRE pour que le GUI
+            // affiche le widget de contrôle ON/OFF (sans lui, output = non-contrôlable).
+            m.insert("/SwitchableOutput/0/Settings/ValidTypes".into(),
+                DbusItem::i32(0b0010));  // 2 = toggle uniquement
             m.insert("/SwitchableOutput/0/Settings/CustomName".into(),
                 DbusItem::str(&self.custom_name));
             m.insert("/SwitchableOutput/0/Settings/Group".into(),


### PR DESCRIPTION
…enus OS

Sans /SwitchableOutput/0/Settings/ValidTypes, le GUI Victron interprète le switch comme non-contrôlable et affiche uniquement l'état (On/Off) sans le widget de basculement. Ce comportement est documenté dans le wiki : "In case the output is not controllable, set /ValidTypes to 0 and invalidate /Type."

ValidTypes = 0b0010 (2) → bit 1 activé = toggle disponible. Identique à l'implémentation dbus-shelly de Victron.

https://claude.ai/code/session_01X8DH1VRviN1mgVCPXDnKt3