### PR TITLE
feat: monitoring Pi5 complet + corrections données Venus + UI

### DIFF
--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -720,6 +720,19 @@ pub async fn dashboard_ats(State(_state): State<AppState>) -> Response {
     render(AtsTemplate {})
 }
 
+// =============================================================================
+// Dashboard Monitoring système Pi5
+// =============================================================================
+
+#[derive(Template)]
+#[template(path = "monitor.html")]
+struct MonitorTemplate {}
+
+/// Page de monitoring système Pi5 (standalone, données via API JS).
+pub async fn dashboard_monitor() -> Response {
+    render(MonitorTemplate {})
+}
+
 /// Construit le routeur du dashboard (à fusionner dans le routeur principal).
 pub fn build_dashboard_router() -> Router<AppState> {
     Router::new()
@@ -733,6 +746,7 @@ pub fn build_dashboard_router() -> Router<AppState> {
         .route("/dashboard/tasmota",           get(dashboard_tasmota_list))
         .route("/dashboard/tasmota/:id",       get(dashboard_tasmota))
         .route("/dashboard/ats",               get(dashboard_ats))
+        .route("/dashboard/monitor",           get(dashboard_monitor))
         .route("/dashboard/visualization",     get(dashboard_visualization))
         .route("/visualization",               get(dashboard_visualization))
 }

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -1,26 +1,32 @@
-//! Agent de monitoring autonome — surveille les processus Pi5.
+//! Agent de monitoring autonome — surveille l'ensemble du système Pi5.
 //!
 //! Vérifie toutes les 30 secondes :
-//! - État des services systemd critiques (daly-bms, mosquitto, influxdb, grafana, nodered)
-//! - État des conteneurs Docker
-//! - Utilisation CPU/mémoire/disque
+//! - Service systemd daly-bms (via systemctl)
+//! - Services réseau via sonde TCP : mosquitto, influxdb, grafana, nodered, venus MQTT
+//! - Port série RS485 (/dev/ttyUSB0)
+//! - CPU, RAM, disque, charge système, uptime
 //!
-//! Actions automatiques :
-//! - Si un conteneur Docker critique est arrêté → `docker restart <nom>`
-//! - Résultats stockés dans AppState pour exposition via `/api/v1/monitor/status`
+//! Action automatique : si un conteneur Docker est injoignable → `docker restart`
 
 use crate::state::{AppState, MonitorSnapshot, ServiceStatus};
 use chrono::Utc;
 use std::time::Duration;
+use tokio::net::TcpStream;
 use tokio::process::Command;
 use tokio::time::interval;
 use tracing::{info, warn};
 
-/// Services systemd à surveiller.
-const SYSTEMD_SERVICES: &[&str] = &["daly-bms", "mosquitto"];
+/// Services réseau à sonder : (label, host, port, conteneur_docker_pour_restart).
+const TCP_SERVICES: &[(&str, &str, u16, Option<&str>)] = &[
+    ("mosquitto",  "127.0.0.1",     1883, Some("mosquitto")),
+    ("influxdb",   "127.0.0.1",     8086, Some("influxdb")),
+    ("grafana",    "127.0.0.1",     3001, Some("grafana")),
+    ("nodered",    "127.0.0.1",     1880, Some("nodered")),
+    ("venus-mqtt", "192.168.1.120", 1883, None),
+];
 
-/// Conteneurs Docker à surveiller (nom tel que configuré dans docker-compose).
-const DOCKER_CONTAINERS: &[&str] = &["influxdb", "grafana", "nodered", "mosquitto"];
+/// Port série RS485.
+const RS485_PORT: &str = "/dev/ttyUSB0";
 
 /// Démarre l'agent de monitoring en arrière-plan.
 pub async fn run_monitor_agent(state: AppState) {
@@ -29,76 +35,82 @@ pub async fn run_monitor_agent(state: AppState) {
 
     loop {
         ticker.tick().await;
-
         let snap = collect_snapshot(&state).await;
         state.on_monitor_snapshot(snap).await;
     }
 }
 
 /// Collecte un snapshot complet de l'état du système.
-async fn collect_snapshot(state: &AppState) -> MonitorSnapshot {
+async fn collect_snapshot(_state: &AppState) -> MonitorSnapshot {
     let mut services = Vec::new();
+    let mut network_services = Vec::new();
     let mut auto_actions = Vec::new();
 
-    // ── Services systemd ──────────────────────────────────────────────────────
-    for &name in SYSTEMD_SERVICES {
-        let status = check_systemd_service(name).await;
-        services.push(ServiceStatus {
-            name: name.to_string(),
-            active: status == "active",
-            status,
-        });
-    }
+    // ── Service systemd daly-bms ──────────────────────────────────────────────
+    // Nous sommes le processus en cours — on force active:true pour signaler
+    // que le service tourne (le systemd peut retourner "activating" au démarrage).
+    let daly_status = check_systemd_service("daly-bms").await;
+    services.push(ServiceStatus {
+        name: "daly-bms".to_string(),
+        active: true,
+        status: if daly_status.is_empty() { "active".to_string() } else { daly_status },
+    });
 
-    // ── Conteneurs Docker ─────────────────────────────────────────────────────
-    for &name in DOCKER_CONTAINERS {
-        // Éviter les doublons si déjà en systemd (mosquitto peut être les deux)
-        if services.iter().any(|s| s.name == name) {
-            continue;
-        }
-        let (status, was_down) = check_docker_container(name).await;
-        let active = status == "running";
+    // ── Sondes TCP ───────────────────────────────────────────────────────────
+    for &(name, host, port, docker_name) in TCP_SERVICES {
+        let reachable = tcp_probe(host, port).await;
 
-        // Action auto : redémarrer si arrêté
-        if was_down {
-            match restart_docker_container(name).await {
-                true  => {
-                    let msg = format!("Redémarré conteneur Docker: {}", name);
+        if !reachable {
+            if let Some(cname) = docker_name {
+                if restart_docker_container(cname).await {
+                    let msg = format!("Redémarré conteneur Docker: {}", cname);
                     info!("{}", msg);
                     auto_actions.push(msg);
-                    services.push(ServiceStatus { name: name.to_string(), active: true, status: "restarted".to_string() });
+                    network_services.push(ServiceStatus {
+                        name: name.to_string(),
+                        active: false,
+                        status: "restarted".to_string(),
+                    });
+                } else {
+                    warn!("Échec redémarrage conteneur Docker: {}", cname);
+                    network_services.push(ServiceStatus {
+                        name: name.to_string(),
+                        active: false,
+                        status: "down".to_string(),
+                    });
                 }
-                false => {
-                    warn!("Échec redémarrage conteneur Docker: {}", name);
-                    services.push(ServiceStatus { name: name.to_string(), active, status });
-                }
+            } else {
+                network_services.push(ServiceStatus {
+                    name: name.to_string(),
+                    active: false,
+                    status: "unreachable".to_string(),
+                });
             }
         } else {
-            services.push(ServiceStatus { name: name.to_string(), active, status });
+            network_services.push(ServiceStatus {
+                name: name.to_string(),
+                active: true,
+                status: format!("{}:{}", host, port),
+            });
         }
     }
 
-    // ── Métriques système ─────────────────────────────────────────────────────
+    // ── Port série RS485 ─────────────────────────────────────────────────────
+    let serial_port_ok = tokio::fs::metadata(RS485_PORT).await.is_ok();
+
+    // ── Métriques système ────────────────────────────────────────────────────
+    let load_avg       = read_load_avg().await;
     let cpu_percent    = read_cpu_percent().await;
     let memory_percent = read_memory_percent().await;
     let disk_percent   = read_disk_percent().await;
     let uptime_secs    = read_uptime_secs().await;
 
-    // Vérifier la cohérence : si le service daly-bms est marqué inactif,
-    // c'est normal — nous sommes le service daly-bms lui-même.
-    if let Some(s) = services.iter_mut().find(|s| s.name == "daly-bms") {
-        if !s.active {
-            // Le processus tourne (nous sommes ici), le systemd peut lire "active"
-            // ou "activating" selon le timing — on force à true
-            s.active = true;
-            s.status = "active".to_string();
-        }
-    }
-
-    let _ = state; // Pas d'autre appel nécessaire ici
     MonitorSnapshot {
         timestamp: Utc::now(),
         services,
+        network_services,
+        serial_port_ok,
+        load_avg,
         cpu_percent,
         memory_percent,
         disk_percent,
@@ -107,49 +119,31 @@ async fn collect_snapshot(state: &AppState) -> MonitorSnapshot {
     }
 }
 
-/// Vérifie l'état d'un service systemd via `systemctl is-active`.
+/// Sonde TCP avec timeout 2 secondes.
+async fn tcp_probe(host: &str, port: u16) -> bool {
+    let addr = format!("{}:{}", host, port);
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        TcpStream::connect(addr),
+    )
+    .await
+    .map(|r| r.is_ok())
+    .unwrap_or(false)
+}
+
+/// Vérifie l'état d'un service systemd.
 async fn check_systemd_service(name: &str) -> String {
     match Command::new("systemctl")
-        .args(["is-active", "--quiet", name])
+        .args(["is-active", name])
         .output()
         .await
     {
-        Ok(out) => {
-            if out.status.success() { "active".to_string() }
-            else {
-                // Lire le statut textuel
-                match Command::new("systemctl")
-                    .args(["is-active", name])
-                    .output()
-                    .await
-                {
-                    Ok(o) => String::from_utf8_lossy(&o.stdout).trim().to_string(),
-                    Err(_) => "unknown".to_string(),
-                }
-            }
-        }
+        Ok(o) => String::from_utf8_lossy(&o.stdout).trim().to_string(),
         Err(_) => "unknown".to_string(),
     }
 }
 
-/// Vérifie l'état d'un conteneur Docker.
-/// Retourne (status_str, was_down).
-async fn check_docker_container(name: &str) -> (String, bool) {
-    match Command::new("docker")
-        .args(["inspect", "--format", "{{.State.Status}}", name])
-        .output()
-        .await
-    {
-        Ok(out) if out.status.success() => {
-            let status = String::from_utf8_lossy(&out.stdout).trim().to_string();
-            let was_down = status != "running";
-            (status, was_down)
-        }
-        _ => ("unknown".to_string(), false),
-    }
-}
-
-/// Tente de redémarrer un conteneur Docker arrêté.
+/// Tente de redémarrer un conteneur Docker.
 async fn restart_docker_container(name: &str) -> bool {
     match Command::new("docker")
         .args(["restart", name])
@@ -159,6 +153,21 @@ async fn restart_docker_container(name: &str) -> bool {
         Ok(out) => out.status.success(),
         Err(_)  => false,
     }
+}
+
+/// Lit la charge système depuis `/proc/loadavg` → [1min, 5min, 15min].
+async fn read_load_avg() -> [f32; 3] {
+    tokio::fs::read_to_string("/proc/loadavg")
+        .await
+        .ok()
+        .and_then(|s| {
+            let mut p = s.split_whitespace();
+            let a: f32 = p.next()?.parse().ok()?;
+            let b: f32 = p.next()?.parse().ok()?;
+            let c: f32 = p.next()?.parse().ok()?;
+            Some([a, b, c])
+        })
+        .unwrap_or([0.0, 0.0, 0.0])
 }
 
 /// Lit l'utilisation CPU depuis `/proc/stat` (deux lectures avec 200ms d'écart).
@@ -217,7 +226,7 @@ async fn read_disk_percent() -> f32 {
         Ok(out) => {
             let s = String::from_utf8_lossy(&out.stdout);
             s.lines()
-                .nth(1) // Skip header
+                .nth(1)
                 .and_then(|l| l.trim().trim_end_matches('%').parse::<f32>().ok())
                 .unwrap_or(0.0)
         }

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -230,7 +230,14 @@ pub struct ServiceStatus {
 #[derive(Clone, Serialize, Debug)]
 pub struct MonitorSnapshot {
     pub timestamp: DateTime<Utc>,
+    /// Services systemd (daly-bms).
     pub services: Vec<ServiceStatus>,
+    /// Services réseau vérifiés par sonde TCP (mosquitto, influxdb, grafana, nodered, venus).
+    pub network_services: Vec<ServiceStatus>,
+    /// Port série RS485 présent sur le système.
+    pub serial_port_ok: bool,
+    /// Charge système [1min, 5min, 15min].
+    pub load_avg: [f32; 3],
     pub cpu_percent: f32,
     pub memory_percent: f32,
     pub disk_percent: f32,
@@ -569,6 +576,7 @@ impl AppState {
     }
 
     /// Retourne un heatpump par index MQTT.
+    #[allow(dead_code)]
     pub async fn venus_heatpump_get(&self, idx: u8) -> Option<VenusHeatpump> {
         let hps = self.venus_heatpumps.read().await;
         hps.get(&idx).cloned()

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -703,6 +703,9 @@
     </a>
 
     <span class="nav-sep">Système</span>
+    <a href="/dashboard/monitor" class="nav-link {% block nav_monitor %}{% endblock %}">
+      <span class="nav-icon">🖥</span> Monitoring
+    </a>
     <a href="/dashboard/settings" class="nav-link {% block nav_settings %}{% endblock %}">
       <span class="nav-icon">⚙</span> Paramètres
     </a>

--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -1,0 +1,228 @@
+{% extends "base.html" %}
+
+{% block title %}Monitoring Pi5 — ESS Monitor{% endblock %}
+{% block page_title %}Monitoring Pi5{% endblock %}
+{% block nav_monitor %}active{% endblock %}
+
+{% block content %}
+
+<div class="page-hdr">
+  <h1>🖥 Monitoring Pi5</h1>
+  <div class="page-hdr-meta">
+    <span>Màj : <span id="mon-ts">—</span></span>
+    <span class="sep">·</span>
+    <span id="mon-status-badge" class="bms-badge" style="background:#e2e8f0;color:#64748b">En attente…</span>
+  </div>
+</div>
+
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1.25rem;">
+
+  <!-- ── Services systemd ───────────────────────────────────── -->
+  <div class="bms-card" id="card-systemd">
+    <div class="bms-hdr" style="background:linear-gradient(135deg,#f0f9ff 0%,#e0f2fe 100%)">
+      <div class="bms-hdr-left">
+        <span class="bms-hdr-name">⚙ Services Systemd</span>
+      </div>
+    </div>
+    <div id="systemd-list" style="padding:0.75rem;">
+      <div class="empty-state"><div class="empty-icon">⏳</div><div class="empty-title">Chargement…</div></div>
+    </div>
+  </div>
+
+  <!-- ── Services réseau (TCP) ─────────────────────────────── -->
+  <div class="bms-card" id="card-network">
+    <div class="bms-hdr" style="background:linear-gradient(135deg,#fdf4ff 0%,#fae8ff 100%)">
+      <div class="bms-hdr-left">
+        <span class="bms-hdr-name">🌐 Services Réseau</span>
+      </div>
+    </div>
+    <div id="network-list" style="padding:0.75rem;">
+      <div class="empty-state"><div class="empty-icon">⏳</div><div class="empty-title">Chargement…</div></div>
+    </div>
+  </div>
+
+  <!-- ── Métriques système ──────────────────────────────────── -->
+  <div class="bms-card" id="card-system">
+    <div class="bms-hdr" style="background:linear-gradient(135deg,#f0fdf4 0%,#dcfce7 100%)">
+      <div class="bms-hdr-left">
+        <span class="bms-hdr-name">📊 Métriques Système</span>
+      </div>
+      <div class="bms-hdr-right">
+        <span id="uptime-badge" class="bms-badge">—</span>
+      </div>
+    </div>
+    <div style="padding:0.75rem 0.9rem;">
+
+      <div style="margin-bottom:0.85rem;">
+        <div style="display:flex;justify-content:space-between;font-size:0.72rem;margin-bottom:3px;">
+          <span style="color:var(--muted2)">CPU</span>
+          <span id="cpu-val" style="font-family:monospace;font-weight:600">—</span>
+        </div>
+        <div style="height:6px;background:var(--bg2);border-radius:3px;overflow:hidden">
+          <div id="cpu-bar" style="height:100%;width:0%;background:#16a34a;border-radius:3px;transition:width 0.6s"></div>
+        </div>
+      </div>
+
+      <div style="margin-bottom:0.85rem;">
+        <div style="display:flex;justify-content:space-between;font-size:0.72rem;margin-bottom:3px;">
+          <span style="color:var(--muted2)">RAM</span>
+          <span id="ram-val" style="font-family:monospace;font-weight:600">—</span>
+        </div>
+        <div style="height:6px;background:var(--bg2);border-radius:3px;overflow:hidden">
+          <div id="ram-bar" style="height:100%;width:0%;background:#2563eb;border-radius:3px;transition:width 0.6s"></div>
+        </div>
+      </div>
+
+      <div style="margin-bottom:0.85rem;">
+        <div style="display:flex;justify-content:space-between;font-size:0.72rem;margin-bottom:3px;">
+          <span style="color:var(--muted2)">Disque</span>
+          <span id="disk-val" style="font-family:monospace;font-weight:600">—</span>
+        </div>
+        <div style="height:6px;background:var(--bg2);border-radius:3px;overflow:hidden">
+          <div id="disk-bar" style="height:100%;width:0%;background:#9333ea;border-radius:3px;transition:width 0.6s"></div>
+        </div>
+      </div>
+
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.5rem;margin-top:0.75rem;font-size:0.72rem;">
+        <div style="background:var(--bg2);border-radius:6px;padding:0.5rem 0.65rem;">
+          <div style="color:var(--muted2);margin-bottom:2px">Charge 1 min</div>
+          <div id="load1" style="font-weight:700;font-size:0.9rem">—</div>
+        </div>
+        <div style="background:var(--bg2);border-radius:6px;padding:0.5rem 0.65rem;">
+          <div style="color:var(--muted2);margin-bottom:2px">Charge 5 min</div>
+          <div id="load5" style="font-weight:700;font-size:0.9rem">—</div>
+        </div>
+      </div>
+
+      <!-- RS485 port -->
+      <div style="display:flex;align-items:center;gap:0.5rem;margin-top:0.85rem;padding:0.5rem 0.65rem;background:var(--bg2);border-radius:6px;font-size:0.72rem;">
+        <span id="rs485-dot" style="width:10px;height:10px;border-radius:50%;background:#e2e8f0;display:inline-block;flex-shrink:0"></span>
+        <span style="color:var(--muted2)">Port RS485</span>
+        <span id="rs485-label" style="margin-left:auto;font-family:monospace;font-weight:600">/dev/ttyUSB0</span>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ── Journal des actions automatiques ──────────────────── -->
+  <div class="bms-card" id="card-actions">
+    <div class="bms-hdr" style="background:linear-gradient(135deg,#fffbeb 0%,#fef3c7 100%)">
+      <div class="bms-hdr-left">
+        <span class="bms-hdr-name">📋 Actions Automatiques</span>
+      </div>
+    </div>
+    <div id="actions-list" style="padding:0.75rem;max-height:200px;overflow-y:auto;">
+      <div class="empty-state"><div class="empty-icon">✅</div><div class="empty-title">Aucune action</div></div>
+    </div>
+  </div>
+
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+function barColor(p) {
+  return p > 85 ? '#dc2626' : p > 65 ? '#ca8a04' : '#16a34a';
+}
+
+function fmtUptime(s) {
+  if (s >= 86400) return `${Math.floor(s/86400)}j ${Math.floor((s%86400)/3600)}h`;
+  if (s >= 3600)  return `${Math.floor(s/3600)}h ${Math.floor((s%3600)/60)}m`;
+  return `${Math.floor(s/60)}m`;
+}
+
+function renderServiceList(containerId, services) {
+  const el = document.getElementById(containerId);
+  if (!el) return;
+  if (!services || services.length === 0) {
+    el.innerHTML = '<div class="empty-state"><div class="empty-icon">—</div><div class="empty-title">Aucun service</div></div>';
+    return;
+  }
+  el.innerHTML = services.map(s => `
+    <div style="display:flex;align-items:center;gap:0.6rem;padding:0.4rem 0.1rem;border-bottom:1px solid var(--border)">
+      <span style="width:10px;height:10px;border-radius:50%;flex-shrink:0;background:${s.active ? '#16a34a' : '#dc2626'};${s.active ? 'box-shadow:0 0 5px #16a34a55' : ''}"></span>
+      <span style="font-weight:600;font-size:0.8rem;flex:1">${s.name}</span>
+      <span style="font-size:0.68rem;color:var(--muted2);font-family:monospace">${s.status}</span>
+    </div>
+  `).join('');
+}
+
+async function fetchMonitor() {
+  try {
+    const resp = await fetch('/api/v1/monitor/status');
+    if (!resp.ok) return;
+    const d = await resp.json();
+    if (!d.available || !d.monitor) return;
+    const m = d.monitor;
+
+    // Timestamp + badge
+    const ts = new Date().toLocaleTimeString('fr-FR');
+    const tsEl = document.getElementById('mon-ts');
+    if (tsEl) tsEl.textContent = ts;
+
+    const allOk = [...(m.services || []), ...(m.network_services || [])].every(s => s.active);
+    const badge = document.getElementById('mon-status-badge');
+    if (badge) {
+      badge.textContent = allOk ? '✅ Tout nominal' : '⚠ Anomalie détectée';
+      badge.style.background = allOk ? '#dcfce7' : '#fee2e2';
+      badge.style.color = allOk ? '#15803d' : '#dc2626';
+    }
+
+    // Services systemd
+    renderServiceList('systemd-list', m.services);
+
+    // Services réseau
+    renderServiceList('network-list', m.network_services);
+
+    // Barres CPU/RAM/Disk
+    function updateBar(barId, valId, pct) {
+      const bar = document.getElementById(barId);
+      const val = document.getElementById(valId);
+      if (bar) { bar.style.width = pct + '%'; bar.style.background = barColor(pct); }
+      if (val) { val.style.color = barColor(pct); val.textContent = pct.toFixed(0) + '%'; }
+    }
+    updateBar('cpu-bar',  'cpu-val',  m.cpu_percent  ?? 0);
+    updateBar('ram-bar',  'ram-val',  m.memory_percent ?? 0);
+    updateBar('disk-bar', 'disk-val', m.disk_percent  ?? 0);
+
+    // Load average
+    if (m.load_avg && m.load_avg.length >= 2) {
+      const l1 = document.getElementById('load1');
+      const l5 = document.getElementById('load5');
+      if (l1) l1.textContent = m.load_avg[0].toFixed(2);
+      if (l5) l5.textContent = m.load_avg[1].toFixed(2);
+    }
+
+    // Uptime
+    const up = document.getElementById('uptime-badge');
+    if (up) up.textContent = '⏱ ' + fmtUptime(m.uptime_secs ?? 0);
+
+    // RS485
+    const dot = document.getElementById('rs485-dot');
+    const lbl = document.getElementById('rs485-label');
+    if (dot) dot.style.background = m.serial_port_ok ? '#16a34a' : '#dc2626';
+    if (lbl) lbl.textContent = m.serial_port_ok ? '/dev/ttyUSB0 ✓' : '/dev/ttyUSB0 ✗';
+
+    // Actions automatiques
+    const actEl = document.getElementById('actions-list');
+    if (actEl) {
+      const acts = m.auto_actions || [];
+      if (acts.length === 0) {
+        actEl.innerHTML = '<div class="empty-state"><div class="empty-icon">✅</div><div class="empty-title">Aucune action récente</div></div>';
+      } else {
+        actEl.innerHTML = acts.map(a => `
+          <div style="padding:0.35rem 0.1rem;border-bottom:1px solid var(--border);font-size:0.75rem;color:var(--muted2)">
+            <span style="margin-right:0.4rem">🔄</span>${a}
+          </div>
+        `).join('');
+      }
+    }
+
+  } catch(e) {}
+}
+
+fetchMonitor();
+setInterval(fetchMonitor, 10000);
+</script>
+{% endblock %}

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -1095,46 +1095,6 @@ const EDGES0 = [
   mkEdge('e-hubBMS-b3', 'hubBMS', 'bms3',       COLOR.bat, { sourceHandle: 'sr', targetHandle: 'tt', type: 'customBezier' }),
 ];
 
-function MonitorPanel({ data }) {
-  if (!data) return h('div', { className: 'viz-panel', style: { opacity: 0.5 } }, '⏳ Monitoring…');
-  const m = data;
-  const fmtUptime = (s) => {
-    if (s >= 86400) return `${Math.floor(s/86400)}j ${Math.floor((s%86400)/3600)}h`;
-    if (s >= 3600)  return `${Math.floor(s/3600)}h ${Math.floor((s%3600)/60)}m`;
-    return `${Math.floor(s/60)}m`;
-  };
-  const barColor = (p) => p > 85 ? '#dc2626' : p > 65 ? '#ca8a04' : '#16a34a';
-
-  return h('div', { className: 'viz-panel', style: { minWidth: 210, fontSize: '0.72rem', lineHeight: 1.6 } },
-    h('div', { style: { fontWeight: 700, marginBottom: 5, fontSize: '0.78rem' } }, '🖥 Pi5 Monitor'),
-    ['cpu_percent','memory_percent','disk_percent'].map(key => {
-      const val = m[key] ?? 0;
-      const label = key === 'cpu_percent' ? 'CPU' : key === 'memory_percent' ? 'RAM' : 'Disque';
-      return h('div', { key, style: { marginBottom: 3 } },
-        h('div', { style: { display:'flex', justifyContent:'space-between' } },
-          h('span', { style: { color: '#64748b' } }, label),
-          h('span', { style: { fontFamily:'monospace', color: barColor(val) } }, `${val.toFixed(0)}%`)
-        ),
-        h('div', { style: { height: 4, background: '#e2e8f0', borderRadius: 2, overflow:'hidden' } },
-          h('div', { style: { height:'100%', width:`${val}%`, background: barColor(val), borderRadius:2, transition:'width 0.5s' } })
-        )
-      );
-    }),
-    h('div', { style: { marginTop: 5, color:'#64748b' } }, `⏱ ${fmtUptime(m.uptime_secs ?? 0)}`),
-    m.services && h('div', { style: { marginTop: 4, display:'flex', flexWrap:'wrap', gap: 3 } },
-      m.services.map(s => h('span', {
-        key: s.name,
-        title: s.status,
-        style: {
-          padding: '1px 6px', borderRadius: 10, fontSize: '0.6rem', fontWeight: 600,
-          background: s.active ? '#dcfce7' : '#fee2e2',
-          color: s.active ? '#15803d' : '#dc2626',
-          border: `1px solid ${s.active ? '#bbf7d0' : '#fecaca'}`
-        }
-      }, s.name))
-    )
-  );
-}
 
 function ESSFlow() {
   const [nodes, setNodes, onNodesChange] = useNodesState(NODES0);
@@ -1142,8 +1102,7 @@ function ESSFlow() {
   const [lastUpdate, setLastUpdate] = useState('—');
   const [atsProcessing, setAtsProcessing] = useState(false);
   const [atsRev, setAtsRev] = useState(0);
-  const [monitorData, setMonitorData] = useState(null);
-  const atsExecRef = useRef(null);
+const atsExecRef = useRef(null);
   const atsBusyRef = useRef(false);
   
   atsExecRef.current = async function(steps) {
@@ -1366,20 +1325,6 @@ function ESSFlow() {
   }, [atsProcessing, atsRev, handleAtsReseauForce, handleAtsOnduleurForce, handleAtsToggleRemote, handleAtsForceOff]);
 
   useEffect(function() {
-    async function fetchMonitor() {
-      try {
-        const resp = await fetch('/api/v1/monitor/status');
-        if (!resp.ok) return;
-        const d = await resp.json();
-        if (d.available && d.monitor) setMonitorData(d.monitor);
-      } catch(_) {}
-    }
-    fetchMonitor();
-    const t = setInterval(fetchMonitor, 10000);
-    return () => clearInterval(t);
-  }, []);
-
-  useEffect(function() {
     const safe = p => p.catch(() => null);
     async function fetchAll() {
       const [bms1, bms2, et7, et8, et9, irr, venusResp, tempResp, atsResp] = await Promise.all([
@@ -1462,9 +1407,6 @@ function ESSFlow() {
     h(Panel, { position: 'bottom-right' },
       h('div', { className: 'viz-panel' }, `Màj : ${lastUpdate}`)
     ),
-    h(Panel, { position: 'top-right' },
-      h(MonitorPanel, { data: monitorData })
-    )
   );
 }
 


### PR DESCRIPTION
## Résumé

- **Fix données Venus gelées** : reconnexion MQTT avec re-souscription des topics au ConnAck (clean_session=true vidait les subs)
- **Nouveaux nœuds visualization** : WaterHeaterNode (chauffe-eau) et ClimatisationNode avec mode/température/énergie
- **Page ATS** convertie vers `base.html` (sidebar + nav)
- **Boutons On/Off Tasmota** : toggle animé sur la page des prises
- **Page Monitoring dédiée** (`/dashboard/monitor`) accessible depuis la sidebar — sondes TCP complètes pour tous les services (mosquitto, influxdb, grafana, nodered, venus-mqtt), vérification RS485, charge système
- **Fix warning** `dead_code` sur `venus_heatpump_get`

## Déploiement requis

```bash
make sync && make build-arm
# puis sur Pi5 :
sudo systemctl stop daly-bms
sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
sudo systemctl start daly-bms
```

https://claude.ai/code/session_015dk45c32YdW5Kt9AxVzfnY