### PR TITLE
fix(viz): chauffe-eau affiche température LG ThinQ (mqtt_index 8→1)

### DIFF
--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -1155,7 +1155,7 @@ const atsExecRef = useRef(null);
     const ats = d.ats;
     const tasmotaDevices = d.tasmotaDevices || [];
     const heatpumps = d.heatpumps || [];
-    const hp8 = heatpumps.find(h => h.mqtt_index === 8) ?? null;
+    const hp1 = heatpumps.find(h => h.mqtt_index === 1) ?? null;  // LG ThinQ chauffe-eau (temp/mode)
     const hp9 = heatpumps.find(h => h.mqtt_index === 9) ?? null;
 
     const validBms = [bms1, bms2].filter(Boolean);
@@ -1276,7 +1276,7 @@ const atsExecRef = useRef(null);
         case 'et112-reseau': return { ...n, data: { ...n.data, live: et9 ?? null } };
         case 'et112-maison': return { ...n, data: { ...n.data, live: et8 ?? null } };
         case 'onduleur':    return { ...n, data: { ...n.data, live: inverter ?? null } };
-        case 'chauffe-eau':   return { ...n, data: { ...n.data, live: et8 ?? null, heatpump: hp8 } };
+        case 'chauffe-eau':   return { ...n, data: { ...n.data, live: et8 ?? null, heatpump: hp1 } };
         case 'climatisation': return { ...n, data: { ...n.data, live: et9 ?? null, heatpump: hp9 } };
         case 'mppt':        return { ...n, data: { ...n.data, mppts: mpptList, totalPowerW: mpptTotalPowerW, totalDcA: mpptTotalDcA } };
         case 'smartshunt':  return { ...n, data: { ...n.data, live: shunt ?? null } };


### PR DESCRIPTION
Le node WaterHeaterNode cherchait mqtt_index===8 (ET112 PAC, pas de température) au lieu de mqtt_index===1 (LG ThinQ API → Temperature + TargetTemperature). Fix : hp1 = heatpumps.find(idx===1) pour le node chauffe-eau.

https://claude.ai/code/session_015dk45c32YdW5Kt9AxVzfnY