### PR TITLE
feat(monitor): RS485 bus health metrics per device (timeouts/CRC)

### DIFF
--- a/crates/daly-bms-core/src/lib.rs
+++ b/crates/daly-bms-core/src/lib.rs
@@ -29,4 +29,4 @@ pub use protocol::{DataId, RequestFrame, ResponseFrame, FRAME_LEN};
 pub use bus::{DalyPort, DalyBusManager};
 // Re-export SharedBus pour les consommateurs du bus unifié
 pub use rs485_bus::SharedBus;
-pub use poll::PollConfig;
+pub use poll::{PollConfig, PollErrorKind};

--- a/crates/daly-bms-core/src/poll.rs
+++ b/crates/daly-bms-core/src/poll.rs
@@ -39,20 +39,40 @@ impl Default for PollConfig {
     }
 }
 
+/// Catégorie d'erreur RS485 exposée à l'appelant via le callback `on_error`.
+#[derive(Clone, Copy, Debug)]
+pub enum PollErrorKind {
+    /// Timeout : aucune réponse du BMS dans le délai imparti.
+    Timeout,
+    /// CRC / trame invalide (checksum, start flag, adresse inattendue…).
+    Crc,
+    /// Autre erreur non-fatale (ReadOnly, VerifyFailed, etc).
+    Other,
+    /// Erreur port série (backoff déclenché). L'appelant peut tracer une
+    /// dégradation globale du bus.
+    Serial,
+}
+
 /// Exécute la boucle de polling infinie pour tous les BMS du manager.
 ///
 /// Pour chaque BMS, toutes les commandes de lecture sont émises séquentiellement.
 /// Le snapshot résultant est passé au callback `on_snapshot`.
 ///
+/// Le callback `on_error` reçoit `(adresse_bms, catégorie, message)` pour chaque
+/// erreur non-fatale et permet de tenir des compteurs de santé RS485.
+///
 /// En cas d'erreur série (port perdu), la boucle attend `backoff` ms et retente.
-pub async fn poll_loop<F>(
+pub async fn poll_loop<F, E>(
     manager: Arc<DalyBusManager>,
     config: PollConfig,
     on_snapshot: F,
+    on_error: E,
 ) where
     F: Fn(BmsSnapshot) + Send + Sync + 'static,
+    E: Fn(u8, PollErrorKind, String) + Send + Sync + 'static,
 {
     let on_snapshot = Arc::new(on_snapshot);
+    let on_error = Arc::new(on_error);
     let mut backoff_ms = config.backoff_initial_ms;
     // Cache des versions firmware (lues une seule fois par BMS)
     let mut fw_cache: HashMap<u8, (String, String)> = HashMap::new();
@@ -93,18 +113,31 @@ pub async fn poll_loop<F>(
                         bms = format!("{:#04x}", device.address),
                         "Timeout — BMS peut-être hors ligne"
                     );
+                    on_error(device.address, PollErrorKind::Timeout, "timeout".to_string());
                 }
                 Err(DalyError::Serial(e)) => {
+                    let msg = e.to_string();
                     error!("Erreur port série : {} — backoff {}ms", e, backoff_ms);
+                    on_error(device.address, PollErrorKind::Serial, msg);
                     tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                     backoff_ms = (backoff_ms * 2).min(config.backoff_max_ms);
                     break; // sortir de la boucle devices et réessayer le cycle
                 }
                 Err(e) => {
+                    let msg = format!("{:?}", e);
                     warn!(
                         bms = format!("{:#04x}", device.address),
-                        "Erreur : {:?}", e
+                        "Erreur : {}", msg
                     );
+                    let kind = match &e {
+                        DalyError::Checksum { .. }
+                        | DalyError::InvalidFrame { .. }
+                        | DalyError::InvalidStartFlag(_)
+                        | DalyError::UnexpectedAddress { .. }
+                        | DalyError::UnexpectedDataId { .. } => PollErrorKind::Crc,
+                        _ => PollErrorKind::Other,
+                    };
+                    on_error(device.address, kind, msg);
                 }
             }
         }

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -46,7 +46,8 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/venus/heatpumps",   get(system::get_venus_heatpumps))
 
         // ── Monitoring système Pi5 ────────────────────────────────────────────
-        .route("/api/v1/monitor/status",    get(system::get_monitor_status))
+        .route("/api/v1/monitor/status",        get(system::get_monitor_status))
+        .route("/api/v1/monitor/rs485-health",  get(system::get_rs485_health))
 
         // ── BMS — Lecture ────────────────────────────────────────────────────
         .route("/api/v1/bms/:id/status",      get(bms::get_bms_status))

--- a/crates/daly-bms-server/src/api/system.rs
+++ b/crates/daly-bms-server/src/api/system.rs
@@ -278,6 +278,32 @@ pub async fn get_monitor_status(State(state): State<AppState>) -> impl IntoRespo
     }
 }
 
+/// GET /api/v1/monitor/rs485-health
+///
+/// Retourne les compteurs de santé par appareil RS485 (BMS, ET112, ATS, PRALRAN).
+/// Contient : polls réussis, timeouts, erreurs CRC, autres erreurs, horodatages
+/// du dernier succès et de la dernière erreur.
+pub async fn get_rs485_health(State(state): State<AppState>) -> impl IntoResponse {
+    let stats = state.rs485_stats_all().await;
+    let total_success: u64 = stats.iter().map(|s| s.successful_polls).sum();
+    let total_timeouts: u64 = stats.iter().map(|s| s.timeout_count).sum();
+    let total_crc: u64 = stats.iter().map(|s| s.crc_error_count).sum();
+    let total_other: u64 = stats.iter().map(|s| s.other_error_count).sum();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "count": stats.len(),
+            "devices": stats,
+            "totals": {
+                "successful_polls":  total_success,
+                "timeout_count":     total_timeouts,
+                "crc_error_count":   total_crc,
+                "other_error_count": total_other,
+            },
+        })),
+    )
+}
+
 /// GET /api/v1/system/totals
 ///
 /// Retourne les totaux agrégés du système :

--- a/crates/daly-bms-server/src/ats/poll.rs
+++ b/crates/daly-bms-server/src/ats/poll.rs
@@ -115,13 +115,15 @@ fn validate_fc06_response(addr: u8, response: &[u8]) -> anyhow::Result<()> {
 // Polling principal
 // =============================================================================
 
-pub async fn run_ats_poll_loop<F>(
+pub async fn run_ats_poll_loop<F, E>(
     bus: Arc<SharedBus>,
     cfg: AtsConfig,
     mut on_snapshot: F,
+    mut on_result: E,
 )
 where
     F: FnMut(AtsSnapshot) + Send + 'static,
+    E: FnMut(u8, &str, Result<(), String>) + Send + 'static,
 {
     let addr = cfg.address;
     let poll_interval = Duration::from_millis(cfg.poll_interval_ms);
@@ -149,17 +151,20 @@ where
                     "ATS snapshot OK"
                 );
                 consecutive_errors = 0;
+                on_result(addr, &cfg.name, Ok(()));
                 on_snapshot(snap);
             }
             Err(e) => {
                 consecutive_errors += 1;
+                let msg = format!("{:#}", e);
                 if consecutive_errors == 1 || consecutive_errors % 10 == 0 {
                     warn!(
                         addr   = format!("{:#04x}", addr),
                         errors = consecutive_errors,
-                        "ATS erreur lecture : {:#}", e
+                        "ATS erreur lecture : {}", msg
                     );
                 }
+                on_result(addr, &cfg.name, Err(msg));
             }
         }
 

--- a/crates/daly-bms-server/src/et112/poll.rs
+++ b/crates/daly-bms-server/src/et112/poll.rs
@@ -46,14 +46,16 @@ fn regs_to_i32(lo: u16, hi: u16) -> i32 {
 /// - `devices`       : liste des ET112 configurés (adresse + nom + ...)
 /// - `poll_interval` : intervalle entre deux cycles complets
 /// - `on_snapshot`   : callback appelé pour chaque snapshot valide
-pub async fn run_et112_poll_loop<F>(
+pub async fn run_et112_poll_loop<F, E>(
     bus: Arc<SharedBus>,
     devices: Vec<Et112DeviceConfig>,
     poll_interval: Duration,
     mut on_snapshot: F,
+    mut on_result: E,
 )
 where
     F: FnMut(Et112Snapshot) + Send + 'static,
+    E: FnMut(u8, &str, Result<(), String>) + Send + 'static,
 {
     if devices.is_empty() {
         info!("ET112 : aucun appareil configuré, polling désactivé");
@@ -76,15 +78,18 @@ where
                         power_w = snap.power_w,
                         "ET112 snapshot OK"
                     );
+                    on_result(address, &dev.name, Ok(()));
                     on_snapshot(snap);
                 }
                 Err(e) => {
+                    let msg = format!("{:#}", e);
                     warn!(
                         addr = format!("{:#04x}", address),
                         name = %dev.name,
-                        "ET112 erreur lecture : {:#}",
-                        e
+                        "ET112 erreur lecture : {}",
+                        msg
                     );
+                    on_result(address, &dev.name, Err(msg));
                 }
             }
         }

--- a/crates/daly-bms-server/src/irradiance/poll.rs
+++ b/crates/daly-bms-server/src/irradiance/poll.rs
@@ -28,13 +28,15 @@ use tracing::{debug, info, warn};
 /// - `bus`         : bus RS485 partagé (même instance que le bus Daly BMS)
 /// - `cfg`         : configuration du capteur
 /// - `on_snapshot` : callback appelé à chaque mesure valide
-pub async fn run_irradiance_poll_loop<F>(
+pub async fn run_irradiance_poll_loop<F, E>(
     bus: Arc<SharedBus>,
     cfg: IrradianceConfig,
     mut on_snapshot: F,
+    mut on_result: E,
 )
 where
     F: FnMut(IrradianceSnapshot) + Send + 'static,
+    E: FnMut(u8, &str, Result<(), String>) + Send + 'static,
 {
     let addr = cfg.parsed_address();
     let poll_interval = Duration::from_millis(cfg.poll_interval_ms);
@@ -57,19 +59,22 @@ where
                     "Irradiance OK"
                 );
                 consecutive_errors = 0;
+                on_result(addr, &cfg.name, Ok(()));
                 on_snapshot(snap);
             }
             Err(e) => {
                 consecutive_errors += 1;
+                let msg = format!("{:#}", e);
                 // Log seulement à la 1ère erreur, puis toutes les 12 (même fréquence que Python)
                 if consecutive_errors == 1 || consecutive_errors % 12 == 0 {
                     warn!(
                         addr   = format!("{:#04x}", addr),
                         errors = consecutive_errors,
-                        "Irradiance erreur lecture : {:#}",
-                        e
+                        "Irradiance erreur lecture : {}",
+                        msg
                     );
                 }
+                on_result(addr, &cfg.name, Err(msg));
             }
         }
 

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -30,7 +30,7 @@ use crate::bridges::{alerts, influx, mqtt};
 use crate::config::AppConfig;
 use crate::state::{AppState, LogBuffer, LogEntry};
 use daly_bms_core::bus::{BmsConfig, DalyBusManager, DalyPort};
-use daly_bms_core::poll::{poll_loop, PollConfig};
+use daly_bms_core::poll::{poll_loop, PollConfig, PollErrorKind};
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
@@ -338,7 +338,8 @@ async fn main() -> anyhow::Result<()> {
                             count = config.et112.devices.len(),
                             "Démarrage polling ET112 (bus RS485 unifié)"
                         );
-                        let state_et  = state.clone();
+                        let state_et     = state.clone();
+                        let state_et_err = state.clone();
                         let bus_et    = shared_bus.clone();
                         let et112_cfg = config.et112.clone();
                         tokio::spawn(async move {
@@ -349,6 +350,16 @@ async fn main() -> anyhow::Result<()> {
                                 move |snap| {
                                     let s = state_et.clone();
                                     tokio::spawn(async move { s.on_et112_snapshot(snap).await });
+                                },
+                                move |addr, name, res| {
+                                    let s = state_et_err.clone();
+                                    let name = name.to_string();
+                                    tokio::spawn(async move {
+                                        match res {
+                                            Ok(()) => s.record_rs485_success(addr, "ET112", &name).await,
+                                            Err(msg) => s.record_rs485_error(addr, "ET112", &name, &msg).await,
+                                        }
+                                    });
                                 },
                             )
                             .await;
@@ -361,7 +372,8 @@ async fn main() -> anyhow::Result<()> {
                             addr = %irrad_cfg.address,
                             "Démarrage polling irradiance PRALRAN (bus RS485 unifié)"
                         );
-                        let state_irrad = state.clone();
+                        let state_irrad     = state.clone();
+                        let state_irrad_err = state.clone();
                         let bus_irrad   = shared_bus.clone();
                         tokio::spawn(async move {
                             irradiance::run_irradiance_poll_loop(
@@ -370,6 +382,16 @@ async fn main() -> anyhow::Result<()> {
                                 move |snap| {
                                     let s = state_irrad.clone();
                                     tokio::spawn(async move { s.on_irradiance_snapshot(snap).await });
+                                },
+                                move |addr, name, res| {
+                                    let s = state_irrad_err.clone();
+                                    let name = name.to_string();
+                                    tokio::spawn(async move {
+                                        match res {
+                                            Ok(()) => s.record_rs485_success(addr, "PRALRAN", &name).await,
+                                            Err(msg) => s.record_rs485_error(addr, "PRALRAN", &name, &msg).await,
+                                        }
+                                    });
                                 },
                             )
                             .await;
@@ -386,7 +408,8 @@ async fn main() -> anyhow::Result<()> {
                                 name = %ats_cfg.name,
                                 "Démarrage polling ATS CHINT (bus RS485 unifié)"
                             );
-                            let state_ats = state.clone();
+                            let state_ats     = state.clone();
+                            let state_ats_err = state.clone();
                             let bus_ats   = shared_bus.clone();
                             state.set_ats_bus(shared_bus.clone()).await;
                             tokio::spawn(async move {
@@ -396,6 +419,16 @@ async fn main() -> anyhow::Result<()> {
                                     move |snap| {
                                         let s = state_ats.clone();
                                         tokio::spawn(async move { s.on_ats_snapshot(snap).await });
+                                    },
+                                    move |addr, name, res| {
+                                        let s = state_ats_err.clone();
+                                        let name = name.to_string();
+                                        tokio::spawn(async move {
+                                            match res {
+                                                Ok(()) => s.record_rs485_success(addr, "ATS", &name).await,
+                                                Err(msg) => s.record_rs485_error(addr, "ATS", &name, &msg).await,
+                                            }
+                                        });
                                     },
                                 )
                                 .await;
@@ -440,17 +473,50 @@ async fn main() -> anyhow::Result<()> {
                         info!("Polling de {} BMS : {:?}", devices.len(),
                               devices.iter().map(|d| format!("{:#04x}", d.address)).collect::<Vec<_>>());
 
+                        // Map adresse → nom pour enrichir les stats RS485.
+                        let bms_names: std::collections::BTreeMap<u8, String> = devices
+                            .iter()
+                            .map(|d| (d.address, d.name.clone()))
+                            .collect();
+
                         let manager  = Arc::new(DalyBusManager::new(port, devices));
                         let poll_cfg = PollConfig {
                             interval_ms: config.serial.poll_interval_ms,
                             ..Default::default()
                         };
                         let state_poll = state.clone();
+                        let state_err  = state.clone();
                         tokio::spawn(async move {
-                            poll_loop(manager, poll_cfg, move |snap| {
-                                let s = state_poll.clone();
-                                tokio::spawn(async move { s.on_snapshot(snap).await });
-                            })
+                            poll_loop(
+                                manager,
+                                poll_cfg,
+                                move |snap| {
+                                    let s = state_poll.clone();
+                                    let addr = snap.address;
+                                    let name = snap.name.clone();
+                                    tokio::spawn(async move {
+                                        s.record_rs485_success(addr, "BMS", &name).await;
+                                        s.on_snapshot(snap).await;
+                                    });
+                                },
+                                move |addr, kind, msg| {
+                                    let s = state_err.clone();
+                                    let name = bms_names
+                                        .get(&addr)
+                                        .cloned()
+                                        .unwrap_or_else(|| format!("BMS {:#04x}", addr));
+                                    let err_tag = match kind {
+                                        PollErrorKind::Timeout => "timeout",
+                                        PollErrorKind::Crc     => "crc",
+                                        PollErrorKind::Serial  => "timeout", // port série → traité comme timeout
+                                        PollErrorKind::Other   => "other",
+                                    };
+                                    let err_msg = format!("{}: {}", err_tag, msg);
+                                    tokio::spawn(async move {
+                                        s.record_rs485_error(addr, "BMS", &name, &err_msg).await;
+                                    });
+                                },
+                            )
                             .await;
                         });
                     }

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -226,6 +226,62 @@ pub struct ServiceStatus {
     pub active: bool,
 }
 
+/// Compteurs de santé par appareil RS485 (BMS, ET112, ATS, PRALRAN).
+///
+/// Les compteurs sont monotones depuis le démarrage du serveur ; l'UI
+/// peut calculer un taux de succès = `successful_polls / (successful_polls
+/// + timeout_count + crc_error_count + other_error_count)`.
+#[derive(Clone, Serialize, Debug, Default)]
+pub struct Rs485DeviceStats {
+    pub address: u8,
+    pub name: String,
+    /// Catégorie d'appareil : "BMS", "ET112", "PRALRAN", "ATS".
+    pub kind: String,
+    pub successful_polls:  u64,
+    pub timeout_count:     u64,
+    pub crc_error_count:   u64,
+    pub other_error_count: u64,
+    pub last_success_ts:   Option<DateTime<Utc>>,
+    pub last_error_ts:     Option<DateTime<Utc>>,
+    /// Catégorie de la dernière erreur : "timeout", "crc", "other".
+    pub last_error_kind:    Option<String>,
+    pub last_error_message: Option<String>,
+}
+
+impl Rs485DeviceStats {
+    pub fn new(address: u8, name: String, kind: &str) -> Self {
+        Self {
+            address,
+            name,
+            kind: kind.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn record_success(&mut self) {
+        self.successful_polls += 1;
+        self.last_success_ts = Some(Utc::now());
+    }
+
+    /// Classe une erreur à partir de son message (heuristique).
+    pub fn record_error(&mut self, err_msg: &str) {
+        let lc = err_msg.to_lowercase();
+        let kind = if lc.contains("timeout") || lc.contains("aucune réponse") {
+            self.timeout_count += 1;
+            "timeout"
+        } else if lc.contains("crc") {
+            self.crc_error_count += 1;
+            "crc"
+        } else {
+            self.other_error_count += 1;
+            "other"
+        };
+        self.last_error_ts = Some(Utc::now());
+        self.last_error_kind = Some(kind.to_string());
+        self.last_error_message = Some(err_msg.chars().take(200).collect());
+    }
+}
+
 /// Snapshot de monitoring système Pi5.
 #[derive(Clone, Serialize, Debug)]
 pub struct MonitorSnapshot {
@@ -315,6 +371,10 @@ pub struct AppState {
 
     /// Bus RS485 dédié à l'ATS (parité Even) — pour les commandes d'écriture via API.
     pub ats_bus: Arc<RwLock<Option<Arc<rs485_bus::SharedBus>>>>,
+
+    /// Compteurs de santé par appareil RS485 (indexés par adresse).
+    /// Alimenté par les boucles de polling BMS / ET112 / irradiance / ATS.
+    pub rs485_stats: Arc<RwLock<BTreeMap<u8, Rs485DeviceStats>>>,
 }
 
 impl AppState {
@@ -364,7 +424,34 @@ impl AppState {
             monitor_snapshot: Arc::new(RwLock::new(None)),
             ats_snapshot: Arc::new(RwLock::new(None)),
             ats_bus: Arc::new(RwLock::new(None)),
+            rs485_stats: Arc::new(RwLock::new(BTreeMap::new())),
         }
+    }
+
+    /// Incrémente le compteur de polls réussis pour un appareil RS485.
+    /// Crée l'entrée si elle n'existe pas.
+    pub async fn record_rs485_success(&self, addr: u8, kind: &str, name: &str) {
+        let mut stats = self.rs485_stats.write().await;
+        stats
+            .entry(addr)
+            .or_insert_with(|| Rs485DeviceStats::new(addr, name.to_string(), kind))
+            .record_success();
+    }
+
+    /// Incrémente le compteur d'erreurs pour un appareil RS485 (timeout/CRC/autre).
+    /// Crée l'entrée si elle n'existe pas.
+    pub async fn record_rs485_error(&self, addr: u8, kind: &str, name: &str, err_msg: &str) {
+        let mut stats = self.rs485_stats.write().await;
+        stats
+            .entry(addr)
+            .or_insert_with(|| Rs485DeviceStats::new(addr, name.to_string(), kind))
+            .record_error(err_msg);
+    }
+
+    /// Retourne la liste actuelle des statistiques RS485 (triée par adresse).
+    pub async fn rs485_stats_all(&self) -> Vec<Rs485DeviceStats> {
+        let stats = self.rs485_stats.read().await;
+        stats.values().cloned().collect()
     }
 
     /// Enregistre le port série ouvert (mode hardware uniquement).

--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -104,6 +104,21 @@
     </div>
   </div>
 
+  <!-- ── Santé bus RS485 (timeouts/CRC par appareil) ─────────── -->
+  <div class="bms-card" id="card-rs485" style="grid-column:1/-1">
+    <div class="bms-hdr" style="background:linear-gradient(135deg,#eef2ff 0%,#e0e7ff 100%)">
+      <div class="bms-hdr-left">
+        <span class="bms-hdr-name">🔌 Santé bus RS485</span>
+      </div>
+      <div class="bms-hdr-right">
+        <span id="rs485-totals" class="bms-badge">—</span>
+      </div>
+    </div>
+    <div id="rs485-table-wrap" style="padding:0.25rem 0.25rem 0.5rem 0.25rem;overflow-x:auto;">
+      <div class="empty-state"><div class="empty-icon">⏳</div><div class="empty-title">Chargement…</div></div>
+    </div>
+  </div>
+
   <!-- ── Journal des actions automatiques ──────────────────── -->
   <div class="bms-card" id="card-actions">
     <div class="bms-hdr" style="background:linear-gradient(135deg,#fffbeb 0%,#fef3c7 100%)">
@@ -222,7 +237,105 @@ async function fetchMonitor() {
   } catch(e) {}
 }
 
+function fmtRs485Age(iso) {
+  if (!iso) return '—';
+  const ts = new Date(iso).getTime();
+  if (isNaN(ts)) return '—';
+  const age = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (age < 60)    return age + 's';
+  if (age < 3600)  return Math.floor(age / 60) + 'min';
+  if (age < 86400) return Math.floor(age / 3600) + 'h';
+  return Math.floor(age / 86400) + 'j';
+}
+
+function kindBadge(kind) {
+  const palette = {
+    'BMS':     { bg: '#dbeafe', fg: '#1d4ed8' },
+    'ET112':   { bg: '#fef3c7', fg: '#a16207' },
+    'ATS':     { bg: '#f3e8ff', fg: '#7e22ce' },
+    'PRALRAN': { bg: '#dcfce7', fg: '#15803d' },
+  };
+  const c = palette[kind] || { bg: '#e2e8f0', fg: '#475569' };
+  return `<span style="background:${c.bg};color:${c.fg};padding:2px 6px;border-radius:4px;font-size:0.65rem;font-weight:600">${kind}</span>`;
+}
+
+function renderRs485Health(payload) {
+  const el = document.getElementById('rs485-table-wrap');
+  if (!el) return;
+  const devices = (payload && payload.devices) || [];
+  if (devices.length === 0) {
+    el.innerHTML = '<div class="empty-state"><div class="empty-icon">—</div><div class="empty-title">Aucun appareil instrumenté</div></div>';
+    return;
+  }
+
+  const rows = devices.map(d => {
+    const total   = (d.successful_polls || 0) + (d.timeout_count || 0) + (d.crc_error_count || 0) + (d.other_error_count || 0);
+    const success = d.successful_polls || 0;
+    const rate    = total > 0 ? (success / total) * 100 : 0;
+    const rateCol = rate >= 95 ? '#16a34a' : rate >= 80 ? '#ca8a04' : '#dc2626';
+    const lastErr = d.last_error_ts
+      ? `<span title="${(d.last_error_message || '').replace(/"/g,'&quot;')}">${fmtRs485Age(d.last_error_ts)}</span>`
+      : '—';
+    const addrHex = '0x' + (d.address != null ? d.address.toString(16).padStart(2,'0') : '?');
+    return `
+      <tr>
+        <td style="padding:0.4rem 0.6rem;font-family:monospace;font-weight:600">${addrHex}</td>
+        <td style="padding:0.4rem 0.6rem">${kindBadge(d.kind || '—')}</td>
+        <td style="padding:0.4rem 0.6rem">${d.name || '—'}</td>
+        <td style="padding:0.4rem 0.6rem;text-align:right;font-family:monospace;color:${rateCol};font-weight:600">${rate.toFixed(1)}%</td>
+        <td style="padding:0.4rem 0.6rem;text-align:right;font-family:monospace">${success}</td>
+        <td style="padding:0.4rem 0.6rem;text-align:right;font-family:monospace;color:${d.timeout_count > 0 ? '#dc2626' : 'inherit'}">${d.timeout_count || 0}</td>
+        <td style="padding:0.4rem 0.6rem;text-align:right;font-family:monospace;color:${d.crc_error_count > 0 ? '#dc2626' : 'inherit'}">${d.crc_error_count || 0}</td>
+        <td style="padding:0.4rem 0.6rem;text-align:right;font-family:monospace;color:${d.other_error_count > 0 ? '#ca8a04' : 'inherit'}">${d.other_error_count || 0}</td>
+        <td style="padding:0.4rem 0.6rem;text-align:right;font-size:0.7rem;color:var(--muted2)">${fmtRs485Age(d.last_success_ts)}</td>
+        <td style="padding:0.4rem 0.6rem;text-align:right;font-size:0.7rem;color:var(--muted2)">${lastErr}</td>
+      </tr>
+    `;
+  }).join('');
+
+  el.innerHTML = `
+    <table style="width:100%;border-collapse:collapse;font-size:0.78rem">
+      <thead>
+        <tr style="background:var(--bg2);color:var(--muted2);text-align:left;font-size:0.7rem">
+          <th style="padding:0.4rem 0.6rem">Addr</th>
+          <th style="padding:0.4rem 0.6rem">Type</th>
+          <th style="padding:0.4rem 0.6rem">Nom</th>
+          <th style="padding:0.4rem 0.6rem;text-align:right">Succès</th>
+          <th style="padding:0.4rem 0.6rem;text-align:right">OK</th>
+          <th style="padding:0.4rem 0.6rem;text-align:right">Timeout</th>
+          <th style="padding:0.4rem 0.6rem;text-align:right">CRC</th>
+          <th style="padding:0.4rem 0.6rem;text-align:right">Autre</th>
+          <th style="padding:0.4rem 0.6rem;text-align:right">Dern. OK</th>
+          <th style="padding:0.4rem 0.6rem;text-align:right">Dern. err.</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+
+  const t = (payload && payload.totals) || {};
+  const badge = document.getElementById('rs485-totals');
+  if (badge) {
+    const tot = (t.successful_polls||0) + (t.timeout_count||0) + (t.crc_error_count||0) + (t.other_error_count||0);
+    const rate = tot > 0 ? ((t.successful_polls||0) / tot) * 100 : 0;
+    badge.textContent = `${rate.toFixed(1)}% (${t.successful_polls||0}/${tot})`;
+    badge.style.background = rate >= 95 ? '#dcfce7' : rate >= 80 ? '#fef3c7' : '#fee2e2';
+    badge.style.color      = rate >= 95 ? '#15803d' : rate >= 80 ? '#a16207' : '#dc2626';
+  }
+}
+
+async function fetchRs485Health() {
+  try {
+    const resp = await fetch('/api/v1/monitor/rs485-health');
+    if (!resp.ok) return;
+    const d = await resp.json();
+    renderRs485Health(d);
+  } catch(e) {}
+}
+
 fetchMonitor();
+fetchRs485Health();
 setInterval(fetchMonitor, 10000);
+setInterval(fetchRs485Health, 10000);
 </script>
 {% endblock %}


### PR DESCRIPTION
Adds Rs485DeviceStats counters tracked for each device polled on the shared RS485 bus (BMS, ET112, ATS, PRALRAN). Counters are updated from the polling loops' success/error paths and classified by category (timeout, CRC, other).

Exposes GET /api/v1/monitor/rs485-health and renders a new table card on /dashboard/monitor showing success rate, timeouts, CRC errors, other errors, last-success and last-error ages per device.

- daly-bms-core::poll::poll_loop: adds on_error callback + PollErrorKind
- et112/irradiance/ats::run_*_poll_loop: add on_result callback
- AppState: rs485_stats map + record_rs485_success/_error helpers