### PR TITLE
feat(visualization): 6h current history chart on hover over edges

### DIFF
--- a/crates/daly-bms-server/src/api/chart.rs
+++ b/crates/daly-bms-server/src/api/chart.rs
@@ -2,6 +2,9 @@
 //!
 //! GET /api/v1/chart/history?minutes=60
 //! Retourne { solar:[{t,v}], soc:[{t,v}], load:[{t,v}] }
+//!
+//! GET /api/v1/chart/edge-history?measurement=bms_status&field=current&address=0x01&minutes=360
+//! Retourne { ok, series:[{t,v}], unit }
 
 use axum::{
     extract::{Query, State},
@@ -15,6 +18,14 @@ use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct HistoryParams {
+    pub minutes: Option<u32>,
+}
+
+#[derive(Deserialize)]
+pub struct EdgeHistoryParams {
+    pub measurement: String,
+    pub field: String,
+    pub address: String,
     pub minutes: Option<u32>,
 }
 
@@ -159,4 +170,77 @@ fn sum_by_time(rows: Vec<(String, f64)>) -> Vec<Value> {
     map.into_iter()
         .map(|(t, v)| json!({"t": t, "v": v.round()}))
         .collect()
+}
+
+/// GET /api/v1/chart/edge-history?measurement=...&field=...&address=...&minutes=360
+///
+/// Renvoie la série temporelle brute d'un champ (courant) pour un appareil donné.
+/// Utilisé par les overlays de graphique sur les edges de la page visualisation.
+pub async fn get_edge_history(
+    State(state): State<AppState>,
+    Query(q): Query<EdgeHistoryParams>,
+) -> impl IntoResponse {
+    let minutes = q.minutes.unwrap_or(360).clamp(1, 1440);
+    let cfg = &state.config.influxdb;
+
+    if !cfg.enabled || cfg.token.is_empty() {
+        return Json(json!({ "ok": false, "series": [], "reason": "influxdb_disabled" }));
+    }
+
+    // Whitelist stricte pour éviter l'injection Flux.
+    let measurement = match q.measurement.as_str() {
+        "bms_status"      => "bms_status",
+        "et112_status"    => "et112_status",
+        _ => return Json(json!({ "ok": false, "series": [], "reason": "bad_measurement" })),
+    };
+    let field = match q.field.as_str() {
+        "current"   => "current",
+        "current_a" => "current_a",
+        _ => return Json(json!({ "ok": false, "series": [], "reason": "bad_field" })),
+    };
+    // Adresse : accepte "0x01" / "0x01" ou décimal — on re-normalise au format "0x%02x".
+    let addr_num: u32 = if let Some(hex) = q.address.strip_prefix("0x").or_else(|| q.address.strip_prefix("0X")) {
+        match u32::from_str_radix(hex, 16) {
+            Ok(n) => n,
+            Err(_) => return Json(json!({ "ok": false, "series": [], "reason": "bad_address" })),
+        }
+    } else {
+        match q.address.parse::<u32>() {
+            Ok(n) => n,
+            Err(_) => return Json(json!({ "ok": false, "series": [], "reason": "bad_address" })),
+        }
+    };
+    let address = format!("{:#04x}", addr_num);
+
+    let window = if minutes <= 60 { "1m" } else if minutes <= 360 { "3m" } else { "10m" };
+    let b = &cfg.bucket;
+
+    let flux = format!(
+        "from(bucket: \"{b}\") |> range(start: -{minutes}m) \
+         |> filter(fn: (r) => r._measurement == \"{measurement}\" and r._field == \"{field}\" and r.address == \"{address}\") \
+         |> aggregateWindow(every: {window}, fn: mean, createEmpty: false)"
+    );
+
+    let url  = format!("{}/api/v2/query?org={}", cfg.url, cfg.org);
+    let auth = format!("Token {}", cfg.token);
+    let client = reqwest::Client::new();
+
+    let series: Vec<Value> = match influx_query(&client, &url, &auth, &flux).await {
+        Some(rows) => rows.into_iter()
+            .map(|(t, v)| json!({ "t": t, "v": (v * 100.0).round() / 100.0 }))
+            .collect(),
+        None => Vec::new(),
+    };
+
+    let unit = if field == "current" || field == "current_a" { "A" } else { "" };
+
+    Json(json!({
+        "ok":      true,
+        "series":  series,
+        "unit":    unit,
+        "address": address,
+        "field":   field,
+        "measurement": measurement,
+        "minutes": minutes,
+    }))
 }

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -93,6 +93,7 @@ pub fn build_router(state: AppState) -> Router {
 
         // ── Chart historique InfluxDB ─────────────────────────────────────────
         .route("/api/v1/chart/history",           get(chart::get_chart_history))
+        .route("/api/v1/chart/edge-history",      get(chart::get_edge_history))
 
         // ── Tasmota ──────────────────────────────────────────────────────────
         .route("/api/v1/tasmota",                 get(tasmota::list_tasmota))

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -16,12 +16,13 @@
 <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
 <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
 <script src="https://unpkg.com/reactflow@11/dist/umd/index.js" crossorigin></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
 <script>
 'use strict';
 
 const h = React.createElement;
 const { useState, useEffect, useCallback, useRef, useMemo, memo } = React;
-const { ReactFlow, Background, Controls, Panel, Handle, Position, useNodesState, useEdgesState, getSmoothStepPath, getBezierPath } = window.ReactFlow;
+const { ReactFlow, Background, Controls, Panel, Handle, Position, useNodesState, useEdgesState, getSmoothStepPath, getBezierPath, EdgeLabelRenderer } = window.ReactFlow;
 
 const fmtKw  = w  => w  != null ? `${(w / 1000).toFixed(2)} kW` : '—';
 const socColor = s => s > 60 ? '#16a34a' : s > 30 ? '#ca8a04' : '#dc2626';
@@ -809,13 +810,229 @@ function InverterNode({ data }) {
   );
 }
 
+// ── EDGE CHART OVERLAY (hover sur milieu d'edge → mini-graphique 6h ECharts) ──
+// Chart ~415x260 (≈1.5× carte ET112 de 275px). Déclenché par un marqueur 22px
+// positionné sur (labelX, labelY) via EdgeLabelRenderer.
+function EdgeChartOverlay({ labelX, labelY, history, color }) {
+  const [hover, setHover]     = useState(false);
+  const [payload, setPayload] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const chartDivRef = useRef(null);
+  const chartRef    = useRef(null);
+  const hideTimer   = useRef(null);
+
+  const measurement = history?.measurement;
+  const field       = history?.field;
+  const addr        = history?.address;
+
+  function scheduleShow() {
+    if (hideTimer.current) { clearTimeout(hideTimer.current); hideTimer.current = null; }
+    setHover(true);
+  }
+  function scheduleHide() {
+    if (hideTimer.current) clearTimeout(hideTimer.current);
+    hideTimer.current = setTimeout(() => setHover(false), 120);
+  }
+
+  useEffect(function () {
+    if (!hover || !measurement) return;
+    let cancelled = false;
+    setLoading(true);
+    const url = '/api/v1/chart/edge-history?measurement=' + encodeURIComponent(measurement)
+      + '&field='   + encodeURIComponent(field)
+      + '&address=' + encodeURIComponent(addr)
+      + '&minutes=360';
+    fetch(url)
+      .then(r => r.json())
+      .then(j => { if (!cancelled) { setPayload(j); setLoading(false); } })
+      .catch(err => {
+        console.warn('[EdgeChartOverlay] fetch error:', err);
+        if (!cancelled) { setLoading(false); setPayload({ ok: false, series: [] }); }
+      });
+    return function () { cancelled = true; };
+  }, [hover, measurement, field, addr]);
+
+  useEffect(function () {
+    if (!hover) return;
+    if (!payload || !payload.ok) return;
+    if (!chartDivRef.current || !window.echarts) return;
+
+    if (!chartRef.current) {
+      chartRef.current = window.echarts.init(chartDivRef.current);
+    }
+    const series = payload.series || [];
+    const times  = series.map(p => p.t);
+    const vals   = series.map(p => p.v);
+    const hasNeg = vals.some(v => v < 0);
+    const hasPos = vals.some(v => v > 0);
+    const option = {
+      animation: false,
+      grid: { top: 24, right: 10, bottom: 24, left: 40 },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'line' },
+        formatter: function (p) {
+          if (!p || !p.length) return '';
+          const a = p[0];
+          const v = typeof a.value === 'number' ? a.value : 0;
+          return a.axisValue + '<br/><b>' + v.toFixed(2) + ' ' + (payload.unit || '') + '</b>';
+        },
+      },
+      xAxis: {
+        type: 'category',
+        data: times,
+        axisLabel: { fontSize: 9, color: '#64748b' },
+        axisLine:  { lineStyle: { color: '#cbd5e1' } },
+        boundaryGap: false,
+      },
+      yAxis: {
+        type: 'value',
+        name: payload.unit || '',
+        nameTextStyle: { fontSize: 9, color: '#64748b' },
+        axisLabel:     { fontSize: 9, color: '#64748b' },
+        axisLine:      { lineStyle: { color: '#cbd5e1' } },
+        splitLine:     { lineStyle: { color: '#e2e8f0' } },
+      },
+      series: [{
+        type: 'line',
+        smooth: true,
+        showSymbol: false,
+        data: vals,
+        sampling: 'lttb',
+        lineStyle: { color: color, width: 2 },
+        areaStyle: hasNeg && hasPos
+          ? {
+              origin: 0,
+              color: {
+                type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
+                colorStops: [
+                  { offset: 0,   color: 'rgba(34,197,94,0.35)' },
+                  { offset: 0.5, color: 'rgba(34,197,94,0)'    },
+                  { offset: 0.5, color: 'rgba(239,68,68,0)'    },
+                  { offset: 1,   color: 'rgba(239,68,68,0.35)' },
+                ],
+              },
+            }
+          : { color: color, opacity: 0.22 },
+        markLine: {
+          silent: true,
+          symbol: 'none',
+          label: { show: false },
+          lineStyle: { color: '#94a3b8', type: 'dashed', width: 1 },
+          data: [{ yAxis: 0 }],
+        },
+      }],
+    };
+    chartRef.current.setOption(option, true);
+    chartRef.current.resize();
+  }, [hover, payload, color]);
+
+  useEffect(function () {
+    return function () {
+      if (chartRef.current) {
+        try { chartRef.current.dispose(); } catch (_) {}
+        chartRef.current = null;
+      }
+      if (hideTimer.current) { clearTimeout(hideTimer.current); hideTimer.current = null; }
+    };
+  }, []);
+
+  if (!history || !EdgeLabelRenderer) return null;
+
+  const triggerStyle = {
+    position:      'absolute',
+    transform:     `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+    width:         22,
+    height:        22,
+    borderRadius:  '50%',
+    background:    hover ? color : '#ffffff',
+    border:        `2px solid ${color}`,
+    color:         hover ? '#fff' : color,
+    pointerEvents: 'all',
+    cursor:        'pointer',
+    display:       'flex',
+    alignItems:    'center',
+    justifyContent:'center',
+    fontSize:      11,
+    fontWeight:    700,
+    boxShadow:     '0 2px 5px rgba(0,0,0,0.15)',
+    transition:    'background 0.15s, color 0.15s',
+    zIndex:        9,
+    userSelect:    'none',
+  };
+
+  const popupStyle = {
+    position:      'absolute',
+    transform:     `translate(-50%, 16px) translate(${labelX}px, ${labelY}px)`,
+    width:         415,
+    height:        260,
+    background:    '#ffffff',
+    borderRadius:  10,
+    boxShadow:     '0 8px 24px rgba(0,0,0,0.22)',
+    border:        `1px solid ${color}`,
+    pointerEvents: 'all',
+    zIndex:        20,
+    padding:       '6px 8px 8px 8px',
+    display:       'flex',
+    flexDirection: 'column',
+    gap:           4,
+  };
+
+  const headerStyle = {
+    fontSize:   11,
+    fontWeight: 600,
+    color:      '#334155',
+    display:    'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  };
+
+  const hoverElements = [];
+  if (hover) {
+    hoverElements.push(h('div', {
+      key: 'popup',
+      style: popupStyle,
+      onMouseEnter: scheduleShow,
+      onMouseLeave: scheduleHide,
+    },
+      h('div', { style: headerStyle },
+        h('span', null, history.label || 'Courant — 6h'),
+        h('span', { style: { color: '#94a3b8', fontWeight: 400 } }, 'InfluxDB'),
+      ),
+      h('div', {
+        ref:   chartDivRef,
+        style: { flex: 1, width: '100%', minHeight: 0 },
+      }),
+      loading && h('div', {
+        style: { position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#64748b', fontSize: 11 },
+      }, 'Chargement…'),
+      (!loading && payload && (!payload.ok || !payload.series || payload.series.length === 0)) && h('div', {
+        style: { position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#94a3b8', fontSize: 11 },
+      }, 'Pas de données sur 6 h'),
+    ));
+  }
+
+  return h(EdgeLabelRenderer, null,
+    h('div', {
+      style:        triggerStyle,
+      onMouseEnter: scheduleShow,
+      onMouseLeave: scheduleHide,
+      title:        'Historique 6 h',
+    }, '📈'),
+    ...hoverElements,
+  );
+}
+
 // ── ANIMATED FLOW EDGE (WAAPI offset-distance) ───────────────────────────────
 function AnimatedFlowEdge({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, style, data }) {
   const color      = style?.stroke ?? '#2563eb';
-  const edgePath   = useMemo(
-    () => getSmoothStepPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, borderRadius: 5 })[0],
+  const pathResult = useMemo(
+    () => getSmoothStepPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, borderRadius: 5 }),
     [sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition]
   );
+  const edgePath = pathResult[0];
+  const labelX   = pathResult[1];
+  const labelY   = pathResult[2];
   const isH        = Math.abs(targetX - sourceX) >= Math.abs(targetY - sourceY);
   const ox         = isH ? 0 : 3;
   const oy         = isH ? 3 : 0;
@@ -889,16 +1106,22 @@ function AnimatedFlowEdge({ sourceX, sourceY, targetX, targetY, sourcePosition, 
     }
   }
 
-  return h('g', null, ...children);
+  return h(React.Fragment, null,
+    h('g', null, ...children),
+    data?.history ? h(EdgeChartOverlay, { labelX, labelY, history: data.history, color }) : null,
+  );
 }
 
 // ── CUSTOM BEZIER EDGE (même animation que AnimatedFlowEdge, chemin Bézier) ────
 function CustomBezierEdge({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, style, data }) {
-  const color    = style?.stroke ?? '#2563eb';
-  const edgePath = useMemo(
-    () => getBezierPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition })[0],
+  const color      = style?.stroke ?? '#2563eb';
+  const pathResult = useMemo(
+    () => getBezierPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition }),
     [sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition]
   );
+  const edgePath = pathResult[0];
+  const labelX   = pathResult[1];
+  const labelY   = pathResult[2];
   const isH      = Math.abs(targetX - sourceX) >= Math.abs(targetY - sourceY);
   const ox       = isH ? 0 : 3;
   const oy       = isH ? 3 : 0;
@@ -963,7 +1186,10 @@ function CustomBezierEdge({ sourceX, sourceY, targetX, targetY, sourcePosition, 
       }));
     }
   }
-  return h('g', null, ...children);
+  return h(React.Fragment, null,
+    h('g', null, ...children),
+    data?.history ? h(EdgeChartOverlay, { labelX, labelY, history: data.history, color }) : null,
+  );
 }
 
 // ── TRIPLE ATS EDGE (3 lignes pointillées parallèles, point sur la ligne centrale) ─
@@ -972,11 +1198,14 @@ function TripleAtsEdge({ sourceX, sourceY, targetX, targetY, sourcePosition, tar
   const GAP    = 5;
   const useBez = data?.useBezier ?? false;
 
-  const edgePath = useMemo(function () {
+  const pathResult = useMemo(function () {
     return useBez
-      ? getBezierPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition })[0]
-      : getSmoothStepPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, borderRadius: 5 })[0];
+      ? getBezierPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition })
+      : getSmoothStepPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, borderRadius: 5 });
   }, [sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, useBez]);
+  const edgePath = pathResult[0];
+  const labelX   = pathResult[1];
+  const labelY   = pathResult[2];
 
   const isH = Math.abs(targetX - sourceX) >= Math.abs(targetY - sourceY);
   const ox  = isH ? 0 : GAP;
@@ -1035,7 +1264,10 @@ function TripleAtsEdge({ sourceX, sourceY, targetX, targetY, sourcePosition, tar
       },
     }));
   }
-  return h('g', null, ...children);
+  return h(React.Fragment, null,
+    h('g', null, ...children),
+    data?.history ? h(EdgeChartOverlay, { labelX, labelY, history: data.history, color }) : null,
+  );
 }
 
 const nodeTypes = {
@@ -1076,23 +1308,40 @@ const NODES0 = [
 const COLOR = { ac: '#2563eb', dc: '#ea580c', bat: '#16a34a', gray: '#94a3b8' };
 
 function mkEdge(id, src, tgt, color, opts = {}) {
-  return { id, source: src, target: tgt, type: 'doubleLine', animated: false, style: { stroke: color, strokeWidth: 2.5 }, ...opts };
+  const { history, ...rest } = opts;
+  const data = history ? { history } : undefined;
+  return {
+    id, source: src, target: tgt,
+    type: 'doubleLine', animated: false,
+    style: { stroke: color, strokeWidth: 2.5 },
+    ...(data ? { data } : {}),
+    ...rest,
+  };
 }
 
+// Descripteurs d'historique InfluxDB par edge (courant 6h).
+// measurement + field + address correspondent aux tags stockés par bridges/influx.rs.
+const HIST_ET112_7 = { measurement: 'et112_status', field: 'current_a', address: '0x07', label: 'Micro-Onduleurs — I (6h)' };
+const HIST_ET112_8 = { measurement: 'et112_status', field: 'current_a', address: '0x08', label: 'Chauffe-eau — I (6h)' };
+const HIST_ET112_9 = { measurement: 'et112_status', field: 'current_a', address: '0x09', label: 'Climatisation — I (6h)' };
+const HIST_BMS_1   = { measurement: 'bms_status',   field: 'current',   address: '0x01', label: 'BMS-360Ah — I (6h)' };
+const HIST_BMS_2   = { measurement: 'bms_status',   field: 'current',   address: '0x02', label: 'BMS-320Ah — I (6h)' };
+const HIST_BMS_3   = { measurement: 'bms_status',   field: 'current',   address: '0x03', label: 'BMS-3 — I (6h)' };
+
 const EDGES0 = [
-  mkEdge('e-ats-maison', 'ats-main', 'et112-maison',   COLOR.ac,  { sourceHandle: 'main-right', targetHandle: 'tl', type: 'customBezier' }),
-  mkEdge('e-ats-micro', 'micro-ond', 'ats-onduleur',   COLOR.ac,  { sourceHandle: 'sl', targetHandle: 'onduleur-right', type: 'customBezier' }),
+  mkEdge('e-ats-maison', 'ats-main', 'et112-maison',   COLOR.ac,  { sourceHandle: 'main-right', targetHandle: 'tl', type: 'customBezier', history: HIST_ET112_8 }),
+  mkEdge('e-ats-micro', 'micro-ond', 'ats-onduleur',   COLOR.ac,  { sourceHandle: 'sl', targetHandle: 'onduleur-right', type: 'customBezier', history: HIST_ET112_7 }),
   mkEdge('e-onduleur-ats', 'ats-onduleur', 'onduleur',   COLOR.ac,  { sourceHandle: 'onduleur-bottom', targetHandle: 'tt' }),
-  mkEdge('e-maison-switchs', 'et112-maison', 'tongou-group',   COLOR.ac,  { sourceHandle: 'sr', targetHandle: 'tl', type: 'customBezier' }),
-  mkEdge('e-ats-reseau', 'ats-reseau', 'et112-reseau',   COLOR.ac,  { sourceHandle: 'reseau-et112reseau', targetHandle: 'tt' }),
-  mkEdge('e-reseau-onduleur', 'et112-reseau', 'onduleur',   COLOR.ac,  { sourceHandle: 'sr', targetHandle: 'tl' }),
+  mkEdge('e-maison-switchs', 'et112-maison', 'tongou-group',   COLOR.ac,  { sourceHandle: 'sr', targetHandle: 'tl', type: 'customBezier', history: HIST_ET112_8 }),
+  mkEdge('e-ats-reseau', 'ats-reseau', 'et112-reseau',   COLOR.ac,  { sourceHandle: 'reseau-et112reseau', targetHandle: 'tt', history: HIST_ET112_9 }),
+  mkEdge('e-reseau-onduleur', 'et112-reseau', 'onduleur',   COLOR.ac,  { sourceHandle: 'sr', targetHandle: 'tl', history: HIST_ET112_9 }),
   mkEdge('e-mppt-shu', 'mppt',      'hubMPPT', COLOR.dc,  { sourceHandle: 'sl', targetHandle: 'tr', type: 'customBezier' }),
   mkEdge('e-ond-shu',  'onduleur',  'hubMPPT', COLOR.dc,  { sourceHandle: 'sb', targetHandle: 'tt' }),
   mkEdge('e-hub-shu',  'hubMPPT',  'smartshunt', COLOR.dc,  { sourceHandle: 'sb', targetHandle: 'tt' }),
   mkEdge('e-shu-hubBMS', 'smartshunt','hubBMS',       COLOR.bat, { sourceHandle: 'sb', targetHandle: 'tt' }),
-  mkEdge('e-hubBMS-b1',  'hubBMS', 'bms1',       COLOR.bat, { sourceHandle: 'sl', targetHandle: 'tt', type: 'customBezier' }),
-  mkEdge('e-hubBMS-b2', 'hubBMS', 'bms2',       COLOR.bat, { sourceHandle: 'sb', targetHandle: 'tt' }),
-  mkEdge('e-hubBMS-b3', 'hubBMS', 'bms3',       COLOR.bat, { sourceHandle: 'sr', targetHandle: 'tt', type: 'customBezier' }),
+  mkEdge('e-hubBMS-b1',  'hubBMS', 'bms1',       COLOR.bat, { sourceHandle: 'sl', targetHandle: 'tt', type: 'customBezier', history: HIST_BMS_1 }),
+  mkEdge('e-hubBMS-b2', 'hubBMS', 'bms2',       COLOR.bat, { sourceHandle: 'sb', targetHandle: 'tt', history: HIST_BMS_2 }),
+  mkEdge('e-hubBMS-b3', 'hubBMS', 'bms3',       COLOR.bat, { sourceHandle: 'sr', targetHandle: 'tt', type: 'customBezier', history: HIST_BMS_3 }),
 ];
 
 
@@ -1206,6 +1455,7 @@ const atsExecRef = useRef(null);
         return {
           ...e,
           data: {
+            ...(e.data || {}),
             flowValue:     fv,
             reverse:       rev,
             flowSpeed:     Math.min(4, Math.max(0.4, fv / 500)),


### PR DESCRIPTION
Add an ECharts-powered mini chart that pops up when hovering the midpoint of an edge in the visualization page. Shows the last 6 hours of current (positive/negative flow) from InfluxDB for BMS and ET112 devices.

- New endpoint GET /api/v1/chart/edge-history with strict whitelist on measurement/field and hex-normalized address tag (bms_status.current, et112_status.current_a).
- EdgeChartOverlay React component renders a 22px trigger dot via EdgeLabelRenderer at the edge's labelX/labelY, lazy-fetches the series on hover and draws a 415x260 line chart (≈1.5× ET112 card) with a dashed zero axis and bi-color area fill for bidirectional flow.
- AnimatedFlowEdge / CustomBezierEdge / TripleAtsEdge now expose labelX and labelY from getSmoothStepPath/getBezierPath and optionally mount the overlay when edge.data.history is set.
- EDGES0 gets history descriptors for ET112 addresses 0x07/0x08/0x09 and BMS 0x01/0x02/0x03. Edges without stored current series (onduleur/mppt/ shunt/hub links) skip the overlay.
- setEdges flow-update preserves existing data (history) with a spread.