### PR TITLE
feat(visualization): persist Venus OS singletons for DC/AC edge history

### DIFF
--- a/crates/daly-bms-server/src/api/chart.rs
+++ b/crates/daly-bms-server/src/api/chart.rs
@@ -25,7 +25,9 @@ pub struct HistoryParams {
 pub struct EdgeHistoryParams {
     pub measurement: String,
     pub field: String,
-    pub address: String,
+    /// Optionnel — requis uniquement pour les measurements taggés par adresse
+    /// (`bms_status`, `et112_status`). Absent pour les singletons Venus.
+    pub address: Option<String>,
     pub minutes: Option<u32>,
 }
 
@@ -188,36 +190,55 @@ pub async fn get_edge_history(
     }
 
     // Whitelist stricte pour éviter l'injection Flux.
-    let measurement = match q.measurement.as_str() {
-        "bms_status"      => "bms_status",
-        "et112_status"    => "et112_status",
+    // address_required indique si le filtre `r.address == …` doit être appliqué.
+    let (measurement, address_required) = match q.measurement.as_str() {
+        "bms_status"        => ("bms_status",        true),
+        "et112_status"      => ("et112_status",      true),
+        "venus_mppt_total"  => ("venus_mppt_total",  false),
+        "venus_smartshunt"  => ("venus_smartshunt",  false),
+        "venus_inverter"    => ("venus_inverter",    false),
         _ => return Json(json!({ "ok": false, "series": [], "reason": "bad_measurement" })),
     };
     let field = match q.field.as_str() {
-        "current"   => "current",
-        "current_a" => "current_a",
+        "current"              => "current",
+        "current_a"            => "current_a",
+        "ac_output_current_a"  => "ac_output_current_a",
+        "power_w"              => "power_w",
         _ => return Json(json!({ "ok": false, "series": [], "reason": "bad_field" })),
     };
-    // Adresse : accepte "0x01" / "0x01" ou décimal — on re-normalise au format "0x%02x".
-    let addr_num: u32 = if let Some(hex) = q.address.strip_prefix("0x").or_else(|| q.address.strip_prefix("0X")) {
-        match u32::from_str_radix(hex, 16) {
-            Ok(n) => n,
-            Err(_) => return Json(json!({ "ok": false, "series": [], "reason": "bad_address" })),
-        }
+
+    // Adresse : requise (et re-normalisée) seulement pour les measurements tagués.
+    let address = if address_required {
+        let raw = match q.address.as_deref() {
+            Some(s) if !s.is_empty() => s,
+            _ => return Json(json!({ "ok": false, "series": [], "reason": "missing_address" })),
+        };
+        let addr_num: u32 = if let Some(hex) = raw.strip_prefix("0x").or_else(|| raw.strip_prefix("0X")) {
+            match u32::from_str_radix(hex, 16) {
+                Ok(n) => n,
+                Err(_) => return Json(json!({ "ok": false, "series": [], "reason": "bad_address" })),
+            }
+        } else {
+            match raw.parse::<u32>() {
+                Ok(n) => n,
+                Err(_) => return Json(json!({ "ok": false, "series": [], "reason": "bad_address" })),
+            }
+        };
+        Some(format!("{:#04x}", addr_num))
     } else {
-        match q.address.parse::<u32>() {
-            Ok(n) => n,
-            Err(_) => return Json(json!({ "ok": false, "series": [], "reason": "bad_address" })),
-        }
+        None
     };
-    let address = format!("{:#04x}", addr_num);
 
     let window = if minutes <= 60 { "1m" } else if minutes <= 360 { "3m" } else { "10m" };
     let b = &cfg.bucket;
 
+    let addr_filter = match &address {
+        Some(a) => format!(" and r.address == \"{a}\""),
+        None    => String::new(),
+    };
     let flux = format!(
         "from(bucket: \"{b}\") |> range(start: -{minutes}m) \
-         |> filter(fn: (r) => r._measurement == \"{measurement}\" and r._field == \"{field}\" and r.address == \"{address}\") \
+         |> filter(fn: (r) => r._measurement == \"{measurement}\" and r._field == \"{field}\"{addr_filter}) \
          |> aggregateWindow(every: {window}, fn: mean, createEmpty: false)"
     );
 
@@ -232,7 +253,11 @@ pub async fn get_edge_history(
         None => Vec::new(),
     };
 
-    let unit = if field == "current" || field == "current_a" { "A" } else { "" };
+    let unit = match field {
+        "current" | "current_a" | "ac_output_current_a" => "A",
+        "power_w" => "W",
+        _ => "",
+    };
 
     Json(json!({
         "ok":      true,

--- a/crates/daly-bms-server/src/bridges/influx.rs
+++ b/crates/daly-bms-server/src/bridges/influx.rs
@@ -7,9 +7,10 @@
 use crate::config::InfluxConfig;
 use crate::et112::Et112Snapshot;
 use crate::irradiance::IrradianceSnapshot;
-use crate::state::AppState;
+use crate::state::{AppState, VenusInverter, VenusSmartShunt};
 use crate::tasmota::TasmotaSnapshot;
 use daly_bms_core::types::BmsSnapshot;
+use chrono::Utc;
 use influxdb2::Client;
 use influxdb2::models::DataPoint;
 use tracing::{error, info, warn};
@@ -41,6 +42,9 @@ pub async fn run_influx_bridge(state: AppState, cfg: InfluxConfig) {
     let mut tasmota_ticker = tokio::time::interval(tasmota_interval);
     let irradiance_interval = Duration::from_secs(30);
     let mut irradiance_ticker = tokio::time::interval(irradiance_interval);
+    // Ticker Venus OS (MPPT total + SmartShunt + Inverter) — pour historique des edges DC/AC.
+    let venus_interval = Duration::from_secs(10);
+    let mut venus_ticker = tokio::time::interval(venus_interval);
 
     loop {
         tokio::select! {
@@ -79,6 +83,27 @@ pub async fn run_influx_bridge(state: AppState, cfg: InfluxConfig) {
             _ = irradiance_ticker.tick() => {
                 if let Some(snap) = state.latest_irradiance().await {
                     if let Ok(p) = irradiance_snapshot_to_point(&snap) {
+                        batch.push(p);
+                    }
+                }
+                if !batch.is_empty() {
+                    flush_batch(&client, &cfg.bucket, &mut batch).await;
+                }
+            }
+            _ = venus_ticker.tick() => {
+                // Total MPPT (somme de toutes les instances SolarCharger).
+                let mppt_power   = state.venus_mppt_total_power().await;
+                let mppt_current = state.venus_mppt_total_dc_current().await;
+                if let Ok(p) = venus_mppt_total_to_point(mppt_power, mppt_current) {
+                    batch.push(p);
+                }
+                if let Some(shunt) = state.venus_smartshunt_get().await {
+                    if let Ok(p) = venus_smartshunt_to_point(&shunt) {
+                        batch.push(p);
+                    }
+                }
+                if let Some(inv) = state.venus_inverter_get().await {
+                    if let Ok(p) = venus_inverter_to_point(&inv) {
                         batch.push(p);
                     }
                 }
@@ -196,6 +221,53 @@ fn snapshot_to_points(snap: &BmsSnapshot) -> Vec<DataPoint> {
     }
 
     points
+}
+
+/// Point InfluxDB « total MPPT » — somme des instances SolarCharger actives.
+///
+/// Measurement : `venus_mppt_total`
+/// Pas de tag — singleton.
+fn venus_mppt_total_to_point(power_w: f32, current_a: f32) -> anyhow::Result<DataPoint> {
+    let ts_ns = Utc::now().timestamp_nanos_opt().unwrap_or(0);
+    let point = DataPoint::builder("venus_mppt_total")
+        .field("power_w",   power_w as f64)
+        .field("current_a", current_a as f64)
+        .timestamp(ts_ns)
+        .build()?;
+    Ok(point)
+}
+
+/// Point InfluxDB SmartShunt.
+///
+/// Measurement : `venus_smartshunt`
+/// Pas de tag — singleton.
+fn venus_smartshunt_to_point(s: &VenusSmartShunt) -> anyhow::Result<DataPoint> {
+    let ts_ns = s.timestamp.timestamp_nanos_opt().unwrap_or(0);
+    let mut b = DataPoint::builder("venus_smartshunt");
+    if let Some(v) = s.voltage_v      { b = b.field("voltage_v",   v as f64); }
+    if let Some(v) = s.current_a      { b = b.field("current_a",   v as f64); }
+    if let Some(v) = s.power_w        { b = b.field("power_w",     v as f64); }
+    if let Some(v) = s.soc_percent    { b = b.field("soc_percent", v as f64); }
+    if let Some(v) = s.energy_in_kwh  { b = b.field("energy_in_kwh",  v as f64); }
+    if let Some(v) = s.energy_out_kwh { b = b.field("energy_out_kwh", v as f64); }
+    Ok(b.timestamp(ts_ns).build()?)
+}
+
+/// Point InfluxDB Onduleur/Charger Victron.
+///
+/// Measurement : `venus_inverter`
+/// Pas de tag — singleton.
+fn venus_inverter_to_point(i: &VenusInverter) -> anyhow::Result<DataPoint> {
+    let ts_ns = i.timestamp.timestamp_nanos_opt().unwrap_or(0);
+    let mut b = DataPoint::builder("venus_inverter");
+    if let Some(v) = i.voltage_v            { b = b.field("voltage_v",            v as f64); }
+    if let Some(v) = i.current_a            { b = b.field("current_a",            v as f64); }
+    if let Some(v) = i.power_w              { b = b.field("power_w",              v as f64); }
+    if let Some(v) = i.ac_output_voltage_v  { b = b.field("ac_output_voltage_v",  v as f64); }
+    if let Some(v) = i.ac_output_current_a  { b = b.field("ac_output_current_a",  v as f64); }
+    if let Some(v) = i.ac_output_power_w    { b = b.field("ac_output_power_w",    v as f64); }
+    if let Some(v) = i.ac_out_frequency_hz  { b = b.field("ac_out_frequency_hz",  v as f64); }
+    Ok(b.timestamp(ts_ns).build()?)
 }
 
 /// Convertit un [`Et112Snapshot`] en un point InfluxDB.

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -838,10 +838,10 @@ function EdgeChartOverlay({ labelX, labelY, history, color }) {
     if (!hover || !measurement) return;
     let cancelled = false;
     setLoading(true);
-    const url = '/api/v1/chart/edge-history?measurement=' + encodeURIComponent(measurement)
+    let url = '/api/v1/chart/edge-history?measurement=' + encodeURIComponent(measurement)
       + '&field='   + encodeURIComponent(field)
-      + '&address=' + encodeURIComponent(addr)
       + '&minutes=360';
+    if (addr) url += '&address=' + encodeURIComponent(addr);
     fetch(url)
       .then(r => r.json())
       .then(j => { if (!cancelled) { setPayload(j); setLoading(false); } })
@@ -1321,24 +1321,29 @@ function mkEdge(id, src, tgt, color, opts = {}) {
 
 // Descripteurs d'historique InfluxDB par edge (courant 6h).
 // measurement + field + address correspondent aux tags stockés par bridges/influx.rs.
-const HIST_ET112_7 = { measurement: 'et112_status', field: 'current_a', address: '0x07', label: 'Micro-Onduleurs — I (6h)' };
-const HIST_ET112_8 = { measurement: 'et112_status', field: 'current_a', address: '0x08', label: 'Chauffe-eau — I (6h)' };
-const HIST_ET112_9 = { measurement: 'et112_status', field: 'current_a', address: '0x09', label: 'Climatisation — I (6h)' };
-const HIST_BMS_1   = { measurement: 'bms_status',   field: 'current',   address: '0x01', label: 'BMS-360Ah — I (6h)' };
-const HIST_BMS_2   = { measurement: 'bms_status',   field: 'current',   address: '0x02', label: 'BMS-320Ah — I (6h)' };
-const HIST_BMS_3   = { measurement: 'bms_status',   field: 'current',   address: '0x03', label: 'BMS-3 — I (6h)' };
+const HIST_ET112_7 = { measurement: 'et112_status',     field: 'current_a',           address: '0x07', label: 'Micro-Onduleurs — I (6h)' };
+const HIST_ET112_8 = { measurement: 'et112_status',     field: 'current_a',           address: '0x08', label: 'Chauffe-eau — I (6h)' };
+const HIST_ET112_9 = { measurement: 'et112_status',     field: 'current_a',           address: '0x09', label: 'Climatisation — I (6h)' };
+const HIST_BMS_1   = { measurement: 'bms_status',       field: 'current',             address: '0x01', label: 'BMS-360Ah — I (6h)' };
+const HIST_BMS_2   = { measurement: 'bms_status',       field: 'current',             address: '0x02', label: 'BMS-320Ah — I (6h)' };
+const HIST_BMS_3   = { measurement: 'bms_status',       field: 'current',             address: '0x03', label: 'BMS-3 — I (6h)' };
+// Venus OS (singletons D-Bus) — pas de tag address.
+const HIST_MPPT    = { measurement: 'venus_mppt_total', field: 'current_a',           label: 'MPPT total — I DC (6h)' };
+const HIST_INV_DC  = { measurement: 'venus_inverter',   field: 'current_a',           label: 'Onduleur — I DC (6h)' };
+const HIST_INV_AC  = { measurement: 'venus_inverter',   field: 'ac_output_current_a', label: 'Onduleur — I AC sortie (6h)' };
+const HIST_SHUNT   = { measurement: 'venus_smartshunt', field: 'current_a',           label: 'SmartShunt — I batterie (6h)' };
 
 const EDGES0 = [
   mkEdge('e-ats-maison', 'ats-main', 'et112-maison',   COLOR.ac,  { sourceHandle: 'main-right', targetHandle: 'tl', type: 'customBezier', history: HIST_ET112_8 }),
   mkEdge('e-ats-micro', 'micro-ond', 'ats-onduleur',   COLOR.ac,  { sourceHandle: 'sl', targetHandle: 'onduleur-right', type: 'customBezier', history: HIST_ET112_7 }),
-  mkEdge('e-onduleur-ats', 'ats-onduleur', 'onduleur',   COLOR.ac,  { sourceHandle: 'onduleur-bottom', targetHandle: 'tt' }),
+  mkEdge('e-onduleur-ats', 'ats-onduleur', 'onduleur',   COLOR.ac,  { sourceHandle: 'onduleur-bottom', targetHandle: 'tt', history: HIST_INV_AC }),
   mkEdge('e-maison-switchs', 'et112-maison', 'tongou-group',   COLOR.ac,  { sourceHandle: 'sr', targetHandle: 'tl', type: 'customBezier', history: HIST_ET112_8 }),
   mkEdge('e-ats-reseau', 'ats-reseau', 'et112-reseau',   COLOR.ac,  { sourceHandle: 'reseau-et112reseau', targetHandle: 'tt', history: HIST_ET112_9 }),
   mkEdge('e-reseau-onduleur', 'et112-reseau', 'onduleur',   COLOR.ac,  { sourceHandle: 'sr', targetHandle: 'tl', history: HIST_ET112_9 }),
-  mkEdge('e-mppt-shu', 'mppt',      'hubMPPT', COLOR.dc,  { sourceHandle: 'sl', targetHandle: 'tr', type: 'customBezier' }),
-  mkEdge('e-ond-shu',  'onduleur',  'hubMPPT', COLOR.dc,  { sourceHandle: 'sb', targetHandle: 'tt' }),
-  mkEdge('e-hub-shu',  'hubMPPT',  'smartshunt', COLOR.dc,  { sourceHandle: 'sb', targetHandle: 'tt' }),
-  mkEdge('e-shu-hubBMS', 'smartshunt','hubBMS',       COLOR.bat, { sourceHandle: 'sb', targetHandle: 'tt' }),
+  mkEdge('e-mppt-shu', 'mppt',      'hubMPPT', COLOR.dc,  { sourceHandle: 'sl', targetHandle: 'tr', type: 'customBezier', history: HIST_MPPT }),
+  mkEdge('e-ond-shu',  'onduleur',  'hubMPPT', COLOR.dc,  { sourceHandle: 'sb', targetHandle: 'tt', history: HIST_INV_DC }),
+  mkEdge('e-hub-shu',  'hubMPPT',  'smartshunt', COLOR.dc,  { sourceHandle: 'sb', targetHandle: 'tt', history: HIST_SHUNT }),
+  mkEdge('e-shu-hubBMS', 'smartshunt','hubBMS',       COLOR.bat, { sourceHandle: 'sb', targetHandle: 'tt', history: HIST_SHUNT }),
   mkEdge('e-hubBMS-b1',  'hubBMS', 'bms1',       COLOR.bat, { sourceHandle: 'sl', targetHandle: 'tt', type: 'customBezier', history: HIST_BMS_1 }),
   mkEdge('e-hubBMS-b2', 'hubBMS', 'bms2',       COLOR.bat, { sourceHandle: 'sb', targetHandle: 'tt', history: HIST_BMS_2 }),
   mkEdge('e-hubBMS-b3', 'hubBMS', 'bms3',       COLOR.bat, { sourceHandle: 'sr', targetHandle: 'tt', type: 'customBezier', history: HIST_BMS_3 }),


### PR DESCRIPTION
Extend the influx bridge with a 10s ticker that writes three singleton measurements so the edge-history overlay works on the onduleur/MPPT/ shunt/hub links too:

- venus_mppt_total   — power_w, current_a (sum of SolarCharger instances)
- venus_smartshunt   — voltage_v, current_a, power_w, soc_percent, energy_{in,out}_kwh
- venus_inverter     — DC + AC voltage/current/power + AC out frequency

The edge-history endpoint accepts these new measurements (address tag skipped for singletons), plus new fields ac_output_current_a and power_w, and returns unit W or A accordingly.

Frontend wires history descriptors for:
- e-onduleur-ats   → venus_inverter.ac_output_current_a
- e-mppt-shu       → venus_mppt_total.current_a
- e-ond-shu        → venus_inverter.current_a (DC battery-side)
- e-hub-shu        → venus_smartshunt.current_a
- e-shu-hubBMS     → venus_smartshunt.current_a

All 13 edges now expose the 📈 hover marker with a 6h ECharts popup.