### PR TITLE
fix(visualization): dispose ECharts instance when edge chart popup cl…

### DIFF
--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -927,6 +927,17 @@ function EdgeChartOverlay({ labelX, labelY, history, color }) {
     chartRef.current.resize();
   }, [hover, payload, color]);
 
+  // Le popup est démonté quand hover=false : l'instance ECharts garde alors un
+  // handle vers un DOM décroché. On la détruit explicitement pour que le survol
+  // suivant ré-initialise une instance neuve sur le nouveau <div>.
+  useEffect(function () {
+    if (hover) return;
+    if (chartRef.current) {
+      try { chartRef.current.dispose(); } catch (_) {}
+      chartRef.current = null;
+    }
+  }, [hover]);
+
   useEffect(function () {
     return function () {
       if (chartRef.current) {


### PR DESCRIPTION
…oses

On the first hover the overlay renders fine, but on the second hover the chart was empty. The ECharts instance was initialized against the popup <div> then kept alive after the <div> was unmounted. The next hover mounted a fresh <div>, but the stale instance still pointed at the detached node, so setOption painted nothing.

Dispose chartRef.current whenever hover flips back to false so the next open re-inits a clean instance on the new DOM node.