### PR TITLE
feat(dashboard): Add Grafana historical dashboard nav

### DIFF
--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -721,6 +721,19 @@ pub async fn dashboard_ats(State(_state): State<AppState>) -> Response {
 }
 
 // =============================================================================
+// Dashboard Grafana — Historique avec InfluxDB
+// =============================================================================
+
+#[derive(Template)]
+#[template(path = "grafana_dashboard.html")]
+struct GrafanaDashboardTemplate {}
+
+/// Page du dashboard Grafana (affiche l'historique via iframe).
+pub async fn dashboard_grafana() -> Response {
+    render(GrafanaDashboardTemplate {})
+}
+
+// =============================================================================
 // Dashboard Monitoring système Pi5
 // =============================================================================
 
@@ -747,6 +760,7 @@ pub fn build_dashboard_router() -> Router<AppState> {
         .route("/dashboard/tasmota/:id",       get(dashboard_tasmota))
         .route("/dashboard/ats",               get(dashboard_ats))
         .route("/dashboard/monitor",           get(dashboard_monitor))
+        .route("/dashboard/grafana",           get(dashboard_grafana))
         .route("/dashboard/visualization",     get(dashboard_visualization))
         .route("/visualization",               get(dashboard_visualization))
 }

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -822,6 +822,9 @@
     <a href="/dashboard/visualization" class="nav-link {% block nav_viz %}{% endblock %}">
       <span class="nav-icon">⚡</span> Visualisation
     </a>
+    <a href="/dashboard/grafana" class="nav-link {% block nav_grafana %}{% endblock %}">
+      <span class="nav-icon">📊</span> Historique
+    </a>
     <a href="/dashboard" class="nav-link {% block nav_bms %}{% endblock %}">
       <span class="nav-icon">🔋</span> Batteries BMS
     </a>

--- a/crates/daly-bms-server/templates/grafana_dashboard.html
+++ b/crates/daly-bms-server/templates/grafana_dashboard.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% block title %}Dashboard Historique{% endblock %}
+{% block page_title %}📊 Dashboard Historique Grafana{% endblock %}
+{% block nav_grafana %}active{% endblock %}
+
+{% block head %}
+<style>
+  #grafana-container {
+    width: 100%;
+    height: calc(100vh - 56px - 3rem);
+    border: none;
+    border-radius: var(--radius);
+  }
+
+  .grafana-note {
+    padding: 0.8rem 1.2rem;
+    background: var(--surface2);
+    border-left: 3px solid var(--accent);
+    margin-bottom: 1rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.8rem;
+    color: var(--text2);
+  }
+
+  .grafana-note strong {
+    color: var(--text);
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="grafana-note">
+  <strong>📊 Dashboard Grafana</strong> — Historique complet avec InfluxDB.
+  <a href="http://localhost:3001" target="_blank" style="margin-left: auto; float: right;">Ouvrir en plein écran →</a>
+</div>
+
+<iframe
+  id="grafana-container"
+  src="http://localhost:3001/d-solo/santuario/santuario-solar-dashboard?orgId=1&refresh=5m&from=now-24h&to=now&kiosk=tv"
+  allowfullscreen
+  allow="clipboard-write">
+</iframe>
+
+<script>
+// Recalculer la hauteur de l'iframe au chargement et au redimensionnement
+function adjustIframeHeight() {
+  const container = document.getElementById('grafana-container');
+  if (container) {
+    const topbarHeight = document.querySelector('.topbar')?.offsetHeight || 56;
+    const mainPadding = 24; // padding de main (1.5rem * 2 côtés)
+    const noteHeight = document.querySelector('.grafana-note')?.offsetHeight || 80;
+    const availableHeight = window.innerHeight - topbarHeight - noteHeight - mainPadding;
+    container.style.height = Math.max(availableHeight, 400) + 'px';
+  }
+}
+
+adjustIframeHeight();
+window.addEventListener('resize', adjustIframeHeight);
+</script>
+{% endblock %}


### PR DESCRIPTION
- Add new 'Historique' tab in sidebar between Visualisation and Batteries BMS
- Create grafana_dashboard.html template with iframe to Grafana 3001
- Add dashboard_grafana handler and route to /dashboard/grafana
- Dashboard displays historical data from InfluxDB via Grafana

https://claude.ai/code/session_01ACFqrcYPA3q1rm4BzzaEHa