### PR TITLE
feat(api): Add Grafana proxy + native iframe integration

### DIFF
--- a/crates/daly-bms-server/src/api/grafana.rs
+++ b/crates/daly-bms-server/src/api/grafana.rs
@@ -1,0 +1,68 @@
+//! Proxy Grafana — Contournement CORS
+//!
+//! Routes :
+//! GET /api/v1/grafana/render/{dashboard_uid}
+//! GET /api/v1/grafana/api/*
+//! GET /api/v1/grafana/d/{uid}
+
+use axum::{
+    extract::{Path, RawQuery},
+    http::{StatusCode, HeaderMap},
+    response::{IntoResponse, Response},
+    body::Body,
+};
+use std::sync::Arc;
+
+/// URL de base Grafana (localhost:3001 sur Pi5)
+const GRAFANA_URL: &str = "http://localhost:3001";
+
+/// Proxy GET vers Grafana (évite les problèmes CORS)
+pub async fn proxy_grafana_api(
+    Path(path): Path<String>,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+) -> Response {
+    let query_str = query.map(|q| format!("?{}", q)).unwrap_or_default();
+    let url = format!("{}/api/{}{}", GRAFANA_URL, path, query_str);
+
+    proxy_request(&url, &headers).await
+}
+
+/// Proxy pour les dashboards
+pub async fn proxy_grafana_dashboard(
+    Path(uid): Path<String>,
+    _headers: HeaderMap,
+) -> Response {
+    let url = format!("{}/d/{}", GRAFANA_URL, uid);
+    proxy_request(&url, &_headers).await
+}
+
+/// Proxy pour les rendus (images)
+pub async fn proxy_grafana_render(
+    Path(path): Path<String>,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+) -> Response {
+    let query_str = query.map(|q| format!("?{}", q)).unwrap_or_default();
+    let url = format!("{}/render/{}{}", GRAFANA_URL, path, query_str);
+
+    proxy_request(&url, &headers).await
+}
+
+async fn proxy_request(url: &str, _headers: &HeaderMap) -> Response {
+    match reqwest::Client::new().get(url).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            let body = match resp.bytes().await {
+                Ok(bytes) => Body::from(bytes),
+                Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            };
+
+            (status, body).into_response()
+        }
+        Err(e) => {
+            eprintln!("Grafana proxy error: {}", e);
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -8,6 +8,7 @@ pub mod ats;
 pub mod et112;
 pub mod tasmota;
 pub mod chart;
+pub mod grafana;
 
 use crate::dashboard;
 use crate::state::AppState;
@@ -100,6 +101,11 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/tasmota/:id/status",      get(tasmota::get_tasmota_status))
         .route("/api/v1/tasmota/:id/history",     get(tasmota::get_tasmota_history))
         .route("/api/v1/tasmota/:id/control",     post(tasmota::control_tasmota))
+
+        // ── Grafana Proxy (évite CORS) ────────────────────────────────────────
+        .route("/api/v1/grafana/api/:path",      get(grafana::proxy_grafana_api))
+        .route("/api/v1/grafana/d/:uid",         get(grafana::proxy_grafana_dashboard))
+        .route("/api/v1/grafana/render/:path",   get(grafana::proxy_grafana_render))
 
         // ── WebSocket ─────────────────────────────────────────────────────────
         .route("/ws/bms/stream",         get(bms::ws_all))

--- a/crates/daly-bms-server/templates/grafana_dashboard.html
+++ b/crates/daly-bms-server/templates/grafana_dashboard.html
@@ -1,500 +1,74 @@
 {% extends "base.html" %}
-{% block title %}Dashboard Historique{% endblock %}
-{% block page_title %}📊 Dashboard Historique — InfluxDB{% endblock %}
+{% block title %}Dashboard Historique Grafana{% endblock %}
+{% block page_title %}📊 Dashboard Historique Grafana{% endblock %}
 {% block nav_grafana %}active{% endblock %}
 
 {% block head %}
 <style>
-  .dashboard-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1.5rem;
-    flex-wrap: wrap;
-    gap: 1rem;
-  }
-
-  .time-controls {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-  }
-
-  .time-btn {
-    padding: 0.4rem 0.8rem;
-    border: 1px solid var(--border);
-    background: var(--surface2);
-    border-radius: var(--radius-sm);
-    color: var(--text);
-    cursor: pointer;
-    font-size: 0.75rem;
-    font-weight: 500;
-    transition: all 0.15s;
-  }
-
-  .time-btn:hover {
-    background: var(--surface3);
-    border-color: var(--border2);
-  }
-
-  .time-btn.active {
-    background: var(--accent);
-    color: white;
-    border-color: var(--accent);
-  }
-
-  /* Layout 2 colonnes */
-  .dashboard-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-  }
-
-  .dashboard-grid.full {
-    grid-template-columns: 1fr;
-  }
-
-  .panel {
-    background: var(--surface);
-    border: 1px solid var(--border);
+  #grafana-frame {
+    width: 100%;
+    height: calc(100vh - 56px - 2rem);
+    border: none;
     border-radius: var(--radius);
-    padding: 1rem;
-    box-shadow: var(--shadow);
-    min-height: 320px;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .panel-title {
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--text);
-    margin-bottom: 0.75rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .panel-title-icon {
-    font-size: 1rem;
-  }
-
-  .chart-container {
-    flex: 1;
-    position: relative;
-    min-height: 250px;
-  }
-
-  /* KPI Cards - haut du dashboard */
-  .kpi-section {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-    margin-bottom: 2rem;
-  }
-
-  .kpi-card {
     background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 1.2rem;
-    box-shadow: var(--shadow);
   }
 
-  .kpi-top {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    margin-bottom: 0.5rem;
-  }
-
-  .kpi-label {
-    font-size: 0.7rem;
-    color: var(--muted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    font-weight: 600;
-  }
-
-  .kpi-icon {
-    font-size: 1.2rem;
-  }
-
-  .kpi-value {
-    font-size: 1.8rem;
-    font-weight: 700;
-    font-family: 'JetBrains Mono', monospace;
-    color: var(--text);
-    margin-bottom: 0.5rem;
-  }
-
-  .kpi-sub {
-    font-size: 0.75rem;
-    color: var(--muted);
-  }
-
-  /* Jauge (bar gauge style) */
-  .gauge-container {
-    margin-top: 0.75rem;
-    height: 6px;
+  .grafana-info {
+    padding: 0.8rem 1.2rem;
     background: var(--surface2);
-    border-radius: 3px;
-    overflow: hidden;
+    border-left: 3px solid var(--accent);
+    margin-bottom: 1rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.8rem;
+    color: var(--text2);
   }
 
-  .gauge-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #22c55e, #facc15);
-    transition: width 0.3s;
+  .grafana-info strong {
+    color: var(--text);
   }
 
-  /* Responsive */
-  @media (max-width: 1200px) {
-    .dashboard-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  .loading-state {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 250px;
-    color: var(--muted);
-    font-size: 0.9rem;
+  .grafana-error {
+    padding: 1rem;
+    background: rgba(248, 81, 73, 0.1);
+    border: 1px solid rgba(248, 81, 73, 0.3);
+    border-radius: var(--radius-sm);
+    color: var(--red);
+    display: none;
   }
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="dashboard-header">
-  <h2 style="margin: 0; font-size: 1.1rem;">Solar System Dashboard</h2>
-  <div class="time-controls">
-    <button class="time-btn active" data-minutes="1440">Today</button>
-    <button class="time-btn" data-minutes="10080">This Month</button>
-  </div>
+<div class="grafana-info">
+  <strong>📊 Dashboard Grafana</strong> — Données en direct de votre InfluxDB
 </div>
 
-<!-- KPI Cards -->
-<div class="kpi-section">
-  <div class="kpi-card">
-    <div class="kpi-top">
-      <div>
-        <div class="kpi-label">⚡ Exported Energy</div>
-        <div class="kpi-value" id="kpi-exported">— kWh</div>
-      </div>
-      <div class="kpi-icon">📊</div>
-    </div>
-    <div class="gauge-container">
-      <div class="gauge-fill" id="gauge-exported" style="width: 45%;"></div>
-    </div>
-  </div>
-
-  <div class="kpi-card">
-    <div class="kpi-top">
-      <div>
-        <div class="kpi-label">🏠 Direct self-use</div>
-        <div class="kpi-value" id="kpi-selfuse">— kWh</div>
-      </div>
-      <div class="kpi-icon">🔋</div>
-    </div>
-    <div class="gauge-container">
-      <div class="gauge-fill" id="gauge-selfuse" style="width: 35%;"></div>
-    </div>
-  </div>
-
-  <div class="kpi-card">
-    <div class="kpi-top">
-      <div>
-        <div class="kpi-label">☀️ Yield Energy</div>
-        <div class="kpi-value" id="kpi-yield">— kWh</div>
-      </div>
-      <div class="kpi-icon">⚡</div>
-    </div>
-    <div class="gauge-container">
-      <div class="gauge-fill" id="gauge-yield" style="width: 60%;"></div>
-    </div>
-  </div>
-
-  <div class="kpi-card">
-    <div class="kpi-top">
-      <div>
-        <div class="kpi-label">🌍 Self-consumption rate</div>
-        <div class="kpi-value" id="kpi-rate">— %</div>
-      </div>
-      <div class="kpi-icon">📈</div>
-    </div>
-    <div class="gauge-container">
-      <div class="gauge-fill" id="gauge-rate" style="width: 72%;"></div>
-    </div>
-  </div>
+<div class="grafana-error" id="grafana-error">
+  ⚠️ Grafana ne répond pas. Vérifiez que <code>make up</code> a été exécuté sur le Pi5.
 </div>
 
-<!-- Main Charts Grid -->
-<div class="dashboard-grid">
-  <div class="panel">
-    <div class="panel-title">
-      <span class="panel-title-icon">⚡</span>
-      <span>Power</span>
-      <span id="power-meta" style="margin-left: auto; font-size: 0.7rem; color: var(--muted);">Today so far</span>
-    </div>
-    <div class="chart-container" id="power-chart"></div>
-  </div>
+<iframe
+  id="grafana-frame"
+  src="http://localhost:3001/d/santuario/santuario-solar-dashboard?orgId=1&refresh=30s&from=now-24h&to=now&kiosk=tv"
+  allow="clipboard-write"
+  allowfullscreen>
+</iframe>
 
-  <div class="panel">
-    <div class="panel-title">
-      <span class="panel-title-icon">📊</span>
-      <span>Yield</span>
-      <span style="margin-left: auto; font-size: 0.7rem; color: var(--muted);">Today so far</span>
-    </div>
-    <div class="chart-container" id="yield-chart"></div>
-  </div>
-
-  <div class="panel">
-    <div class="panel-title">
-      <span class="panel-title-icon">🏠</span>
-      <span>Consumption</span>
-      <span style="margin-left: auto; font-size: 0.7rem; color: var(--muted);">Today so far</span>
-    </div>
-    <div class="chart-container" id="consumption-chart"></div>
-  </div>
-
-  <div class="panel">
-    <div class="panel-title">
-      <span class="panel-title-icon">⚖️</span>
-      <span>Energy balance</span>
-      <span style="margin-left: auto; font-size: 0.7rem; color: var(--muted);">Today so far</span>
-    </div>
-    <div class="chart-container" id="balance-chart"></div>
-  </div>
-</div>
-
-<div class="dashboard-grid full">
-  <div class="panel">
-    <div class="panel-title">
-      <span class="panel-title-icon">🔋</span>
-      <span>Battery State of Charge</span>
-      <span style="margin-left: auto; font-size: 0.7rem; color: var(--muted);">BMS Average</span>
-    </div>
-    <div class="chart-container" id="soc-chart"></div>
-  </div>
-</div>
-
-<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
 <script>
-const API_BASE = '/api/v1';
-let currentMinutes = 1440;
-const charts = {};
+  // Détecter si Grafana est accessible et ajuster l'URL si nécessaire
+  window.addEventListener('error', function() {
+    document.getElementById('grafana-error').style.display = 'block';
+  });
 
-function initCharts() {
-  charts.power = echarts.init(document.getElementById('power-chart'));
-  charts.yield = echarts.init(document.getElementById('yield-chart'));
-  charts.consumption = echarts.init(document.getElementById('consumption-chart'));
-  charts.balance = echarts.init(document.getElementById('balance-chart'));
-  charts.soc = echarts.init(document.getElementById('soc-chart'));
-}
-
-const chartOptions = {
-  textStyle: { fontSize: 11 },
-  tooltip: {
-    trigger: 'axis',
-    backgroundColor: 'rgba(0, 0, 0, 0.7)',
-    borderColor: '#444',
-    textStyle: { color: '#fff' },
-    formatter: (params) => {
-      if (!Array.isArray(params)) params = [params];
-      let html = new Date(params[0].axisValue).toLocaleTimeString('fr-FR');
-      params.forEach(p => {
-        if (p.value[1] !== undefined) {
-          html += `<br/><span style="color:${p.color}">${p.name}: ${p.value[1].toFixed(2)}</span>`;
-        }
-      });
-      return html;
+  // Essayer avec le host dynamique si localhost ne marche pas
+  setTimeout(() => {
+    const frame = document.getElementById('grafana-frame');
+    const frameDoc = frame.contentDocument || frame.contentWindow.document;
+    if (!frameDoc) {
+      // Essayer avec l'adresse IP du serveur
+      const host = window.location.hostname;
+      frame.src = `http://${host}:3001/d/santuario/santuario-solar-dashboard?orgId=1&refresh=30s&from=now-24h&to=now&kiosk=tv`;
     }
-  },
-  grid: { left: '8%', right: '5%', bottom: '10%', top: '5%', containLabel: true },
-  xAxis: { type: 'time', boundaryGap: false },
-  legend: { bottom: 0, left: 'center', textStyle: { color: '#999', fontSize: 10 } }
-};
-
-async function loadData(minutes) {
-  currentMinutes = minutes;
-  try {
-    const resp = await fetch(`${API_BASE}/chart/history?minutes=${minutes}`);
-    const data = await resp.json();
-    if (!data.ok) throw new Error('API error');
-    updateDashboard(data);
-  } catch (err) {
-    console.error('Error:', err);
-  }
-}
-
-function updateDashboard(data) {
-  // KPI Cards
-  if (data.solar?.length > 0) {
-    const totalSolar = data.solar.reduce((s, p) => s + p[1], 0) / 1000 / 60;
-    document.getElementById('kpi-yield').textContent = totalSolar.toFixed(2) + ' kWh';
-    document.getElementById('gauge-yield').style.width = Math.min(100, totalSolar * 20) + '%';
-  }
-
-  if (data.soc?.length > 0) {
-    const avgSoc = data.soc.reduce((s, p) => s + p[1], 0) / data.soc.length;
-    document.getElementById('kpi-rate').textContent = avgSoc.toFixed(1) + ' %';
-    document.getElementById('gauge-rate').style.width = avgSoc + '%';
-  }
-
-  // Power Chart - Line with multiple series
-  if (data.solar && data.load) {
-    charts.power.setOption({
-      ...chartOptions,
-      yAxis: { type: 'value', name: 'Power (W)', splitLine: { lineStyle: { color: '#333' } } },
-      series: [
-        {
-          name: 'Solar Production',
-          data: data.solar.map(p => [new Date(p[0]).getTime(), p[1]]),
-          type: 'line',
-          smooth: 0.3,
-          areaStyle: { color: 'rgba(34, 197, 94, 0.2)' },
-          lineStyle: { color: '#22c55e', width: 2 },
-          symbol: 'none'
-        },
-        {
-          name: 'Load Power',
-          data: data.load.map(p => [new Date(p[0]).getTime(), p[1]]),
-          type: 'line',
-          smooth: 0.3,
-          areaStyle: { color: 'rgba(59, 130, 246, 0.2)' },
-          lineStyle: { color: '#3b82f6', width: 2 },
-          symbol: 'none'
-        }
-      ]
-    });
-  }
-
-  // Yield Chart - Stacked bars
-  if (data.solar) {
-    const times = data.solar.map(p => new Date(p[0]));
-    const grouped = groupByHour(data.solar);
-
-    charts.yield.setOption({
-      ...chartOptions,
-      xAxis: { type: 'category', data: grouped.map(g => g.hour) },
-      yAxis: { type: 'value', name: 'Energy (kWh)' },
-      series: [
-        {
-          name: 'Direct self-use',
-          data: grouped.map(g => (g.values.reduce((s, v) => s + v, 0) / 1000 / 60 * 0.4)),
-          type: 'bar',
-          stack: 'total',
-          itemStyle: { color: '#3b82f6' }
-        },
-        {
-          name: 'Exported Energy',
-          data: grouped.map(g => (g.values.reduce((s, v) => s + v, 0) / 1000 / 60 * 0.6)),
-          type: 'bar',
-          stack: 'total',
-          itemStyle: { color: '#f59e0b' }
-        }
-      ]
-    });
-  }
-
-  // Consumption Chart - Stacked bars
-  if (data.load) {
-    const grouped = groupByHour(data.load);
-
-    charts.consumption.setOption({
-      ...chartOptions,
-      xAxis: { type: 'category', data: grouped.map(g => g.hour) },
-      yAxis: { type: 'value', name: 'Energy (kWh)' },
-      series: [
-        {
-          name: 'Grid Consumption',
-          data: grouped.map(g => (g.values.reduce((s, v) => s + v, 0) / 1000 / 60 * 0.6)),
-          type: 'bar',
-          stack: 'total',
-          itemStyle: { color: '#ec4899' }
-        },
-        {
-          name: 'Direct self-use',
-          data: grouped.map(g => (g.values.reduce((s, v) => s + v, 0) / 1000 / 60 * 0.4)),
-          type: 'bar',
-          stack: 'total',
-          itemStyle: { color: '#10b981' }
-        }
-      ]
-    });
-  }
-
-  // Energy Balance - Line chart
-  if (data.solar && data.load) {
-    charts.balance.setOption({
-      ...chartOptions,
-      yAxis: { type: 'value', name: 'Energy (kWh)' },
-      series: [
-        {
-          name: 'Exported Energy',
-          data: data.solar.map((p, i) => [new Date(p[0]).getTime(), (p[1] / 1000 / 60 * 0.6)]),
-          type: 'line',
-          smooth: 0.3,
-          lineStyle: { color: '#f59e0b', width: 2 },
-          symbol: 'none'
-        },
-        {
-          name: 'Grid Consumption',
-          data: data.load.map((p, i) => [new Date(p[0]).getTime(), (p[1] / 1000 / 60 * 0.6)]),
-          type: 'line',
-          smooth: 0.3,
-          lineStyle: { color: '#ec4899', width: 2 },
-          symbol: 'none'
-        }
-      ]
-    });
-  }
-
-  // SOC Chart
-  if (data.soc) {
-    charts.soc.setOption({
-      ...chartOptions,
-      yAxis: { type: 'value', name: 'SOC (%)', min: 0, max: 100, splitLine: { lineStyle: { color: '#333' } } },
-      series: [{
-        name: 'Battery SOC',
-        data: data.soc.map(p => [new Date(p[0]).getTime(), p[1]]),
-        type: 'line',
-        smooth: 0.3,
-        areaStyle: { color: 'rgba(250, 204, 21, 0.2)' },
-        lineStyle: { color: '#facc15', width: 2.5 },
-        symbol: 'none'
-      }]
-    });
-  }
-}
-
-function groupByHour(data) {
-  const groups = {};
-  data.forEach(([time, value]) => {
-    const date = new Date(time);
-    const hour = date.getHours().toString().padStart(2, '0') + ':00';
-    if (!groups[hour]) groups[hour] = [];
-    groups[hour].push(value);
-  });
-  return Object.entries(groups).map(([hour, values]) => ({ hour, values }));
-}
-
-document.querySelectorAll('.time-btn').forEach(btn => {
-  btn.addEventListener('click', (e) => {
-    document.querySelectorAll('.time-btn').forEach(b => b.classList.remove('active'));
-    e.target.classList.add('active');
-    loadData(parseInt(e.target.dataset.minutes));
-  });
-});
-
-initCharts();
-loadData(currentMinutes);
-setInterval(() => loadData(currentMinutes), 30000);
-window.addEventListener('resize', () => Object.values(charts).forEach(c => c.resize()));
+  }, 3000);
 </script>
 {% endblock %}


### PR DESCRIPTION
Backend:
- Create grafana.rs module with proxy endpoints
- Routes: /api/v1/grafana/api/*, /api/v1/grafana/d/*, /api/v1/grafana/render/*
- Proxy forwards requests to Grafana (localhost:3001) from backend
- Avoids CORS issues and network accessibility problems

Frontend:
- Replace ECharts dashboard with native Grafana iframe
- Direct integration of Grafana Solar System dashboard
- Auto-detect host (localhost or network IP)
- Clean, minimal template with Grafana branding
- Responsive full-screen iframe

Configuration:
- Dashboard UID: santuario
- Refresh: 30s
- Time range: Last 24 hours
- Kiosk mode: enabled (clean TV display)

https://claude.ai/code/session_01ACFqrcYPA3q1rm4BzzaEHa