### PR TITLE
feat: complete grafana dashboard integration in web app

### DIFF
--- a/crates/daly-bms-server/templates/grafana_dashboard.html
+++ b/crates/daly-bms-server/templates/grafana_dashboard.html
@@ -49,7 +49,7 @@
 
 <iframe
   id="grafana-frame"
-  src="/api/v1/grafana/d/santuario?orgId=1&refresh=30s&from=now-24h&to=now"
+  src="http://192.168.1.141:3001/d/santuario?orgId=1&refresh=30s&from=now-24h&to=now"
   allow="clipboard-write"
   allowfullscreen>
 </iframe>


### PR DESCRIPTION
## Summary

Complete Grafana dashboard integration in the web app navigation with automatic data visualization from InfluxDB.

## Changes

### Web App Integration
- Added **"📊 Historique"** tab to navbar (between Visualization and Batteries BMS)
- Created `/dashboard/grafana` route with Askama template
- Direct iframe to Grafana dashboard at `http://192.168.1.141:3001/d/santuario`
- Auto-refresh 30s, default time range 24 hours

### Grafana Dashboard
- **Exact replica of Grafana 13295** (Home Energy Dashboard) adapted to Santuario installation
- **10 panels** covering complete energy flow:
  1. Power (timeseries) - Inverter, Grid, Load power in real-time
  2. Today (bargauge) - Daily exported energy, direct self-use, yield, grid consumption, self-consumption rate
  3. This Month (bargauge) - Monthly aggregates of above metrics
  4. Yield (daily) - Daily solar production (7-day history)
  5. Yield (monthly) - Monthly aggregates
  6. Consumption (daily) - Daily consumption (7-day history)
  7. Consumption (monthly) - Monthly aggregates
  8. Energy Balance (daily) - Grid vs exported energy
  9. Energy Balance (monthly) - Monthly balance
  10. Solar System (text) - Documentation panel

### Data Source Integration
- All queries use **Flux language** for InfluxDB 2.7.10 compatibility (not InfluxQL)
- Measurements mapped to Santuario devices:
  - **Solar generation**: venus_mppt_total (power_w)
  - **Grid power**: et112_status (power_w, energy_import_wh, energy_export_wh)
  - **Consumption**: bms_status (power), tasmota_status (energy_today_kwh)
  - **Irradiance**: irradiance_status (from PRALRAN sensor)

### Backend Support
- Grafana proxy routes in API (`/api/v1/grafana/*`) for future CORS-free access
- Responsive layout, dark theme matching web app UI
- Dashboard UID: `santuario` (persistent across imports)

## Test Plan

- [ ] Deploy binary on Pi5 with `make build-arm && sudo systemctl restart daly-bms`
- [ ] Open `http://192.168.1.141:8080`
- [ ] Click **"📊 Historique"** tab in navbar
- [ ] Verify Grafana dashboard loads with 10 panels
- [ ] Check Power, Today, This Month panels show actual data
- [ ] Verify Yield and Consumption bars display daily history
- [ ] Confirm 30s auto-refresh working
- [ ] Test time range selector (1h, 24h, 7d, custom)
- [ ] Check responsive layout on mobile
- [ ] Verify no console errors (F12)

## Files Modified

- `crates/daly-bms-server/templates/base.html` - Added "📊 Historique" tab
- `crates/daly-bms-server/templates/grafana_dashboard.html` - New Grafana iframe template
- `crates/daly-bms-server/src/api/grafana.rs` - New proxy module
- `crates/daly-bms-server/src/api/mod.rs` - Registered proxy routes
- `grafana/dashboards/santuario-solar-system.json` - Complete dashboard configuration
- Documentation: `GRAFANA_SETUP.md`, `START_HERE.md`, `GRAFANA_INDEX.md`, `grafana/README.md`, `scripts/import-grafana-dashboard.sh`

## Deployment Checklist

On Pi5:
```bash
cd ~/Daly-BMS-Rust
make sync
make build-arm
sudo systemctl stop daly-bms
sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
sudo systemctl start daly-bms

# Import dashboard
export GRAFANA_URL=http://192.168.1.141:3001
export GRAFANA_ADMIN_USER=admin
export GRAFANA_ADMIN_PASSWORD=admin
./scripts/import-grafana-dashboard.sh
```

Access dashboard: `http://192.168.1.141:8080/dashboard/grafana` or via navbar "📊 Historique" tab.