### PR TITLE
feat: complete grafana dashboard integration with iframe embedding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 # =============================================================================
 # DalyBMS — Stack complète Docker Compose
 # =============================================================================
-# Inclut : Mosquitto · InfluxDB · daly-bms-server · Node-RED
-# (Grafana supprimé — dashboard intégré dans daly-bms-server via ECharts)
+# Inclut : Mosquitto · InfluxDB · Grafana · daly-bms-server · Node-RED
 #
 # Prérequis :
 #   cp .env.docker .env && nano .env   # adapter les secrets
@@ -131,6 +130,43 @@ services:
     networks:
       - dalybms-net
 
+  # ── Grafana (visualisation & dashboards) ────────────────────────────────────
+  grafana:
+    image: grafana/grafana:11.6.0
+    container_name: dalybms-grafana
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER:        ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD:    ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP:        "false"
+      GF_AUTH_ANONYMOUS_ENABLED:     "false"
+      GF_SECURITY_ALLOW_EMBEDDING:   "true"
+      GF_LOG_LEVEL:                  info
+      INFLUX_TOKEN:                  ${INFLUX_TOKEN:?INFLUX_TOKEN manquant dans .env}
+      INFLUX_ORG:                    ${INFLUX_ORG:-santuario}
+      INFLUX_BUCKET:                 ${INFLUX_BUCKET:-daly_bms}
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - dalybms-net
+
   # ── Node-RED (automatisation / logique métier) ───────────────────────────────
   nodered:
     image: nodered/node-red:4.0.2
@@ -205,6 +241,8 @@ volumes:
     name: dalybms-influxdb-data
   influxdb-config:
     name: dalybms-influxdb-config
+  grafana-data:
+    name: dalybms-grafana-data
   nodered-data:
     name: dalybms-nodered-data
   dalybms-alerts:

--- a/grafana/provisioning/datasources/influxdb.yaml
+++ b/grafana/provisioning/datasources/influxdb.yaml
@@ -13,7 +13,7 @@ datasources:
     type: influxdb
     uid: influxdb-dalybms
     access: proxy
-    url: http://192.168.1.141:8086
+    url: http://influxdb:8086
     isDefault: true
     editable: true
     orgId: 1


### PR DESCRIPTION
## Summary
Complete integration of Grafana historical dashboard into the web app navigation. The dashboard displays real-time solar system energy monitoring with live InfluxDB data through an embedded iframe on the new "📊 Historique" tab.

## Key Changes

### 1. Web App Navigation & Templates
- **base.html**: Added "📊 Historique" tab to navigation sidebar with `nav_grafana` block
- **grafana_dashboard.html**: New template for embedded Grafana dashboard using iframe
  - Dynamic hostname resolution using JavaScript: `window.location.hostname`
  - Full-height responsive iframe with 30s refresh rate
  - Automatically adjusts URL based on accessing host

### 2. Docker & Grafana Configuration
- **docker-compose.yml**: Added Grafana 11.6.0 service with critical configuration:
  - Port: 3001
  - **CRITICAL**: `GF_SECURITY_ALLOW_EMBEDDING=true` (enables iframe embedding)
  - Automatic datasource provisioning for InfluxDB
  - Automatic dashboard import from `/grafana/provisioning/dashboards/`
  
- **grafana/provisioning/datasources/influxdb.yaml**: 
  - Updated to use Docker internal hostname `influxdb:8086` for container environment
  - Configured Flux query support for InfluxDB 2.7.10
  - UID: `influxdb-dalybms` (referenced in dashboard JSON)

### 3. Grafana Dashboard
- **grafana/dashboards/santuario-solar-system.json**: 3-panel dashboard with verified Flux queries
  - **Power Panel** (timeseries): Solar generation, grid meter, and battery power
    - venus_mppt_total.power_w (solar generation)
    - et112_status.power_w (grid meter)
    - bms_status.power (battery system)
  - **Today Panel** (bargauge): Grid energy export (last 24h)
    - et112_status.energy_export_wh (converted to kWh)
  - **This Month Panel** (bargauge): Grid energy export (last 30 days)
    - et112_status.energy_export_wh (converted to kWh)
  
  Dashboard properties:
  - UID: `santuario` (required for navigation)
  - Refresh: 30s
  - Time range: -24h to now
  - Theme: dark
  - Timezone: Europe/Paris

### 4. API Changes (Earlier Commits)
- **crates/daly-bms-server/src/api/grafana.rs**: Grafana API proxy routes
- **crates/daly-bms-server/src/api/mod.rs**: Route registration

## Deployment Process

### Step 1: Deploy on Pi5
```bash
cd ~/Daly-BMS-Rust
git fetch origin
git checkout claude/add-grafana-dashboard-nav-XPdvb
make sync
```

### Step 2: Update Docker Stack
```bash
# Stop current stack
make down

# Start new stack with Grafana
make up

# Verify all services are healthy
docker compose ps
docker compose logs grafana | head -20
```

Expected output:
```
dalybms-grafana        "grafana-server ..."  Up (healthy)
dalybms-influxdb       "/entrypoint.sh"      Up (healthy)
dalybms-mosquitto      "mosquitto -c /mo"    Up (healthy)
```

### Step 3: Build and Deploy Server
```bash
make build-arm
sudo systemctl stop daly-bms
sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
sudo systemctl start daly-bms
```

### Step 4: Verify Deployment
```bash
# Check Grafana is accessible
curl -s http://192.168.1.141:3001/api/health | jq .

# Check web app
curl -s http://192.168.1.141:8080/ | grep "Historique"

# Verify InfluxDB datasource
curl -s http://192.168.1.141:3001/api/datasources | jq '.[] | {name, uid}'
```

### Step 5: Test in Browser
1. Open http://192.168.1.141:8080 (or your hostname)
2. Click "📊 Historique" tab in sidebar
3. Verify embedded Grafana dashboard loads and displays data
4. Check browser console (F12) for any errors

## Configuration Notes

### Environment Variables (.env.docker)
Ensure these are set before `make up`:
```env
INFLUX_TOKEN=<your-token>
INFLUX_ORG=santuario
INFLUX_BUCKET=daly_bms
GRAFANA_ADMIN_USER=admin
GRAFANA_ADMIN_PASSWORD=<strong-password>
```

### Grafana Security Settings
All critical security flags are configured in docker-compose.yml:
- `GF_SECURITY_ALLOW_EMBEDDING=true` - Required for iframe
- `GF_USERS_ALLOW_SIGN_UP=false` - Disable anonymous signup
- `GF_AUTH_ANONYMOUS_ENABLED=false` - Disable anonymous access

### InfluxDB Measurements
Dashboard uses these verified measurements from your RS485 bus:
- `venus_mppt_total` - Solar MPPT system
- `et112_status` - Grid meter / energy export
- `bms_status` - Battery management system

## Troubleshooting

### Iframe shows "Grafana has failed to load its application files"
**Cause**: `GF_SECURITY_ALLOW_EMBEDDING=true` not set
**Solution**: Verify docker-compose.yml has this environment variable and restart containers

### Dashboard shows no data
**Cause**: InfluxDB measurements not being recorded
**Solution**: 
```bash
# Check InfluxDB has data
curl -s http://192.168.1.141:8086/api/v1/query \
  -H "Authorization: Token $INFLUX_TOKEN" \
  -d 'org=santuario' \
  -d 'bucket=daly_bms' \
  -d 'query=from(bucket:"daly_bms")|>range(start:-24h)|>limit(n:1)'
```

### Connection refused to 192.168.1.141:3001
**Cause**: Grafana port mapping not working
**Solution**:
```bash
# Verify Grafana is running
docker compose logs grafana
# Verify port mapping
docker compose ps grafana
```

## Testing Checklist
- [ ] `make down && make up` completes without errors
- [ ] `docker compose ps` shows all services healthy
- [ ] Grafana accessible at http://192.168.1.141:3001
- [ ] Web app builds successfully: `make build-arm`
- [ ] Web app starts and serves on port 8080
- [ ] "📊 Historique" tab visible in sidebar
- [ ] Clicking tab loads embedded Grafana dashboard
- [ ] Dashboard displays power and energy data

## Files Modified
- docker-compose.yml (+41 lines)
- grafana/provisioning/datasources/influxdb.yaml (hostname change)
- crates/daly-bms-server/templates/base.html (navigation)
- crates/daly-bms-server/templates/grafana_dashboard.html (new)
- crates/daly-bms-server/src/api/grafana.rs (new)
- crates/daly-bms-server/src/api/mod.rs (routes)
- grafana/dashboards/santuario-solar-system.json (new)

https://claude.ai/code/session_01ACFqrcYPA3q1rm4BzzaEHa

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACFqrcYPA3q1rm4BzzaEHa)_