### PR TITLE
fix: configure grafana for subpath proxy with serve_from_sub_path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,8 @@ services:
       GF_USERS_ALLOW_SIGN_UP:        "false"
       GF_AUTH_ANONYMOUS_ENABLED:     "false"
       GF_SECURITY_ALLOW_EMBEDDING:   "true"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      GF_SERVER_ROOT_URL:            "http://localhost:8080/api/v1/grafana/"
       GF_LOG_LEVEL:                  info
       INFLUX_TOKEN:                  ${INFLUX_TOKEN:?INFLUX_TOKEN manquant dans .env}
       INFLUX_ORG:                    ${INFLUX_ORG:-santuario}


### PR DESCRIPTION
Add GF_SERVER_SERVE_FROM_SUB_PATH=true and GF_SERVER_ROOT_URL to tell Grafana it's behind a proxy on /api/v1/grafana/ subpath. This fixes the 'failed to load its application files' error when loading via iframe proxy.