### PR TITLE
fix: use direct grafana access instead of subpath proxy

### DIFF
--- a/crates/daly-bms-server/templates/grafana_dashboard.html
+++ b/crates/daly-bms-server/templates/grafana_dashboard.html
@@ -25,5 +25,11 @@
   📊 Dashboard Grafana Santuario Solar System (données InfluxDB en direct, refresh 30s)
 </div>
 
-<iframe id="grafana-frame" src="/api/v1/grafana/d/santuario?orgId=1&refresh=30s&from=now-24h&to=now" allow="clipboard-write" allowfullscreen></iframe>
+<script>
+  const protocol = window.location.protocol;
+  const host = window.location.hostname;
+  const port = 3001;
+  const dashUrl = `${protocol}//${host}:${port}/d/santuario?orgId=1&refresh=30s&from=now-24h&to=now`;
+  document.write(`<iframe id="grafana-frame" src="${dashUrl}" allow="clipboard-write" allowfullscreen></iframe>`);
+</script>
 {% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,8 +143,6 @@ services:
       GF_USERS_ALLOW_SIGN_UP:        "false"
       GF_AUTH_ANONYMOUS_ENABLED:     "false"
       GF_SECURITY_ALLOW_EMBEDDING:   "true"
-      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
-      GF_SERVER_ROOT_URL:            "http://localhost:8080/api/v1/grafana/"
       GF_LOG_LEVEL:                  info
       INFLUX_TOKEN:                  ${INFLUX_TOKEN:?INFLUX_TOKEN manquant dans .env}
       INFLUX_ORG:                    ${INFLUX_ORG:-santuario}


### PR DESCRIPTION
Remove GF_SERVER_SERVE_FROM_SUB_PATH and GF_SERVER_ROOT_URL configuration. Use iframe that accesses Grafana directly on port 3001 with correct protocol and hostname from window.location. This is simpler and works reliably.