### PR TITLE
chore: remove all alarm UI elements and styles globally

### DIFF
--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -80,9 +80,6 @@
     html.dark .bms-hdr {
       background: linear-gradient(135deg, #1a2f4e 0%, #1e3a5f 100%);
     }
-    html.dark .bms-hdr.alarm-hdr {
-      background: linear-gradient(135deg, #3b1212 0%, #4c1a1a 100%);
-    }
     html.dark .bms-hdr-name  { color: #93c5fd; }
     html.dark .bms-live       { color: rgba(147,197,253,.65); }
     html.dark .bms-badge      { background: rgba(147,197,253,.08); border-color: rgba(147,197,253,.18); color: rgba(147,197,253,.85); }
@@ -280,11 +277,6 @@
       box-shadow: 0 0 8px rgba(63,185,80,0.5);
       animation: pulse-dot 2s infinite;
     }
-    .ws-dot.alarm {
-      background: var(--red);
-      box-shadow: 0 0 8px rgba(248,81,73,0.5);
-      animation: pulse-dot 1s infinite;
-    }
     @keyframes pulse-dot {
       0%, 100% { opacity: 1; }
       50%       { opacity: 0.4; }
@@ -448,10 +440,6 @@
       box-shadow: var(--shadow-lg);
       text-decoration: none;
     }
-    .bms-card.alarm {
-      border-color: rgba(248,81,73,0.45);
-      box-shadow: 0 0 0 1px rgba(248,81,73,0.15), var(--shadow);
-    }
 
     .bms-hdr {
       padding: 0.75rem 0.9rem;
@@ -461,9 +449,6 @@
       background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
       border-bottom: 1px solid rgba(255,255,255,0.05);
       flex-shrink: 0;
-    }
-    .bms-hdr.alarm-hdr {
-      background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%);
     }
     .bms-hdr-left  { display: flex; align-items: center; gap: 0.55rem; }
     .bms-hdr-name  { font-size: 0.92rem; font-weight: 700; color: #1e3a5f; }
@@ -627,7 +612,6 @@
     }
     .badge.ok    { background: rgba(63,185,80,0.12);  color: var(--green);  border: 1px solid rgba(63,185,80,0.25); }
     .badge.warn  { background: rgba(210,153,34,0.12); color: var(--yellow); border: 1px solid rgba(210,153,34,0.25); }
-    .badge.alarm { background: rgba(248,81,73,0.14);  color: var(--red);    border: 1px solid rgba(248,81,73,0.3); }
     .badge.muted { background: var(--surface2);        color: var(--muted);  border: 1px solid var(--border); }
     .badge.blue  { background: rgba(88,166,255,0.12); color: var(--accent); border: 1px solid rgba(88,166,255,0.25); }
 

--- a/crates/daly-bms-server/templates/bms_detail.html
+++ b/crates/daly-bms-server/templates/bms_detail.html
@@ -29,9 +29,6 @@
 <div class="page-hdr" style="margin-bottom:1.25rem">
   <a href="/dashboard" class="btn btn-outline" style="font-size:0.75rem;padding:0.3rem 0.7rem;">← Retour</a>
   <h1>🔋 {{ detail.summary.name }}</h1>
-  <span class="badge {% if detail.summary.any_alarm %}alarm{% else %}ok{% endif %}">
-    {% if detail.summary.any_alarm %}⚠ ALARME{% else %}✓ Normal{% endif %}
-  </span>
   <div class="page-hdr-meta" style="margin-left:auto">
     <span>{{ detail.summary.address_hex }}</span>
     <span class="sep">·</span>
@@ -146,36 +143,6 @@
     <span class="chart-hdr-meta">min · Q1 · médiane · Q3 · max — 30 dernières secondes</span>
   </div>
   <div id="chart-boxplot" style="height:240px"></div>
-</div>
-
-{# ─── Alarmes ─────────────────────────────────────────────────────────── #}
-<div class="chart-card" style="margin-bottom:1rem">
-  <div class="chart-hdr">
-    <span class="chart-hdr-title">État des alarmes</span>
-    <span class="chart-hdr-meta">{{ detail.alarms|length }} alarmes surveillées</span>
-  </div>
-  <table>
-    <thead>
-      <tr>
-        <th>Alarme</th>
-        <th style="text-align:center;width:120px">État</th>
-      </tr>
-    </thead>
-    <tbody>
-    {% for alarm in detail.alarms %}
-      <tr>
-        <td style="color:var(--text2)">{{ alarm.name }}</td>
-        <td style="text-align:center">
-          {% if alarm.active %}
-            <span class="badge alarm">⚠ ACTIF</span>
-          {% else %}
-            <span class="badge ok">✓ OK</span>
-          {% endif %}
-        </td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
 </div>
 
 {# ─── Actions BMS ─────────────────────────────────────────────────────── #}


### PR DESCRIPTION
Remove from all templates and CSS:
- Alarm status badge from BMS detail header
- Complete 'État des alarmes' section table from BMS detail page
- All alarm-related CSS classes and styles:
  * .ws-dot.alarm
  * .bms-card.alarm
  * .bms-hdr.alarm-hdr
  * .badge.alarm
- Alarm gradient animations and decorations

The system still tracks alarm data internally, but no alarm notifications or status indicators are displayed in the UI.