### PR TITLE
fix(grafana): allow time range selection in dashboard

### DIFF
--- a/crates/daly-bms-server/templates/grafana_dashboard.html
+++ b/crates/daly-bms-server/templates/grafana_dashboard.html
@@ -29,7 +29,7 @@
   const protocol = window.location.protocol;
   const host = window.location.hostname;
   const port = 3001;
-  const dashUrl = `${protocol}//${host}:${port}/d/santuario?orgId=1&refresh=30s&from=now-24h&to=now`;
+  const dashUrl = `${protocol}//${host}:${port}/d/santuario?orgId=1&refresh=30s`;
   document.write(`<iframe id="grafana-frame" src="${dashUrl}" allow="clipboard-write" allowfullscreen></iframe>`);
 </script>
 {% endblock %}


### PR DESCRIPTION
Remove hardcoded from/to parameters from Grafana dashboard URL to allow users to change the time interval using Grafana's time picker.

Previously, from=now-24h&to=now locked the time range to 24 hours. Now the time picker is fully interactive and users can select any interval.

https://claude.ai/code/session_01ACFqrcYPA3q1rm4BzzaEHa