### PR TITLE
fix(viz): MPPT two chargers, ATS main banner, Onduleur AC ignore display

### DIFF
--- a/crates/daly-bms-server/templates/visualization.css
+++ b/crates/daly-bms-server/templates/visualization.css
@@ -459,7 +459,7 @@
   }
   .mg-mppt-state.off  { background: #f1f5f9; color: #94a3b8; }
   .mg-mppt-state.fault { background: #fef2f2; color: #dc2626; }
-  .mg-mppt-metrics { display: flex; gap: 8px; margin-left: auto; }
+  .mg-mppt-metrics { display: flex; gap: 5px; margin-left: auto; }
   .mg-metric { display: flex; flex-direction: column; align-items: flex-end; }
   .mg-metric-lbl { font-size: 0.51rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.04em; }
   .mg-metric-val { font-size: 0.72rem; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: #0f172a; }

--- a/crates/daly-bms-server/templates/viz_nodes_ats.js
+++ b/crates/daly-bms-server/templates/viz_nodes_ats.js
@@ -131,23 +131,29 @@ function AtsMainNode({ data }) {
     mkHandle('target', Position.Left,   'ats-in-reseau'),
     mkHandle('source', Position.Right,  'main-right'),
     mkHandle('target', Position.Bottom, 'ats-in-onduleur', { top: '65%' }),
-    h('div', { style: { display:'flex', justifyContent:'space-between', alignItems:'center', padding:'5px 8px', background:'#f8fafc', borderBottom:'2px solid #6366f1', gap:5 } },
-      h('div', { style: { display:'flex', alignItems:'center', gap:4, fontWeight:600, fontSize:10 } },
+    h('div', { className: 'pn-banner' },
+      h('div', { className: 'pn-banner-left' },
         h('div', { className: 'pn-bicon pn-bicon-ats' }, '🔀'),
         h('span', null, 'ATS')
       ),
-      h('div', {
+      h('div', { className: 'pn-banner-center',
         'data-is-interactive': 'true',
         'data-rev': data._rev,
-        style: { display:'flex', alignItems:'center', gap:4, cursor: data.disabled ? 'default' : 'pointer', opacity: data.disabled ? 0.5 : 1, pointerEvents: 'auto' },
+        style: { cursor: data.disabled ? 'default' : 'pointer', pointerEvents: 'auto' },
         onClick: handleToggleClick,
         onMouseDown: (e) => { e.stopPropagation(); e.preventDefault(); },
         onTouchStart: (e) => { e.stopPropagation(); e.preventDefault(); }
       },
-        h('span', { style: { fontSize:8, color:'#475569' } }, 'Télécommande'),
-        h('div', { className: `pn-toggle${remoteOn ? ' on' : ''}` })
+        h('span', { className: 'pn-volt', style: { fontSize: '9px' } }, data.swMode || '—'),
+        h('span', { className: `pn-status${remoteOn ? ' online' : ' offline'}` },
+          h('span', { className: `pn-dot${remoteOn ? '' : ' off'}` }),
+          h('div', { className: `pn-toggle${remoteOn ? ' on' : ''}` })
+        )
       ),
-      h('span', { className: `pn-badge${remoteOn ? ' ok' : ' warn'}` }, remoteOn ? '📡 ON' : 'OFF')
+      h('span', { className: `pn-badge${hasFault ? ' warn' : ' ok'}` }, hasFault ? '⚠ ERR' : '✓ OK')
+    ),
+    h('div', { className: 'pn-bar-row' },
+      h('div', { className: `pn-bar-fill${hasFault ? ' warn' : ' ok'}`, style: { width: '100%' } })
     ),
     h('div', { className: 'pn-ats-sw' },
       h('div', { className: 'pn-sw-card' }, h('span', { className: 'pn-sw-label' }, 'SW1'), h('span', { className: `pn-sw-val${(data.sw1||'').includes('Fermé') ? ' closed' : ' open'}` }, data.sw1 || 'Ouvert')),
@@ -224,7 +230,7 @@ function InverterNode({ data }) {
       h('span', { className: `inv-state-badge ${stateClass}` }, state),
       h('div', { className: 'inv-dot live' })
     ),
-    ignAc != null && h('div', { className: 'inv-ignore-bar' },
+    h('div', { className: 'inv-ignore-bar' },
       h('span', { className: 'inv-ignore-lbl' }, 'AC In Ignore'),
       h('span', { className: `inv-ignore-val ${ignAc ? 'active' : 'normal'}` }, ignAc ? 'ACTIF' : 'Normal')
     ),

--- a/crates/daly-bms-server/templates/viz_nodes_venus.js
+++ b/crates/daly-bms-server/templates/viz_nodes_venus.js
@@ -42,6 +42,7 @@ function MPPTGroupNode({ data }) {
         const pvV   = m.pv_voltage_v ?? null;
         const dcA   = m.dc_current_a ?? null;
         const pw    = m.power_w ?? null;
+        const yld   = m.yield_today_kwh ?? null;
         return h('div', { key: inst, className: 'mg-mppt-row' },
           h('span', { className: 'mg-mppt-name' }, name),
           h('span', { className: `mg-mppt-state ${stateClass(s)}` }, s ?? '—'),
@@ -57,6 +58,10 @@ function MPPTGroupNode({ data }) {
             h('div', { className: 'mg-metric' },
               h('span', { className: 'mg-metric-lbl' }, 'W'),
               h('span', { className: 'mg-metric-val' }, pw != null ? `${Math.round(pw)}` : '—')
+            ),
+            h('div', { className: 'mg-metric' },
+              h('span', { className: 'mg-metric-lbl' }, 'kWh'),
+              h('span', { className: 'mg-metric-val' }, yld != null ? yld.toFixed(2) : '—')
             )
           )
         );


### PR DESCRIPTION
- MPPT: ajoute yield_today_kwh (kWh) dans la ligne de chaque chargeur; réduit le gap mg-mppt-metrics 8px→5px pour tenir les 4 colonnes en 310px
- ATS Main: remplace le bandeau inline-styled par la classe pn-banner identique aux nodes ATS Réseau et ATS Onduleur; badge passe à ✓OK/⚠ERR (défaut) au lieu de 📡ON/OFF (télécommande); barre de progression ajoutée
- Onduleur: inv-ignore-bar toujours affiché quand live=true (supprime la garde ignAc != null) → "Normal" visible même si Node-RED ne renvoie pas encore IgnoreAcIn après redémarrage Docker

Note: l'affichage MPPT-1 au lieu de MPPT-273/MPPT-289 est un problème de donnée (message MQTT retained en format v1 avant rechargement Node-RED). Les flows flux-nodered/ sont corrects dans le dépôt — voir PROCEDURES.md pour la procédure de reimport Node-RED après make reset.

https://claude.ai/code/session_01CXtuvfbD3kEk8q8G5Bp6V2