### PR TITLE
feat: add Tongou Switch5, remove Node-RED, rename ET112, add InfluxDB…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Pi5 (192.168.1.141, pi5compute)
     ├── Logique solaire, DEYE, chauffe-eau, charge, météo
     ├── WebSocket live events :8081/live
     └── InfluxDB → localhost:8086
-  Docker: mosquitto:1883, influxdb:8086, grafana:3001, nodered:1880
+  Docker: mosquitto:1883, influxdb:8086, grafana:3001
 
 NanoPi (192.168.1.120, root)
   dbus-mqtt-venus (runit /service/dbus-mqtt-venus)
@@ -135,20 +135,25 @@ Bus `/dev/ttyUSB0` :
 | 0x01 | BMS-360Ah | `battery.mqtt_1` | `bms/1/venus` | 151 |
 | 0x02 | BMS-320Ah | `battery.mqtt_2` | `bms/2/venus` | 152 |
 | 0x05 | PRALRAN irradiance | `meteo` | `irradiance/raw` | 40 |
-| 0x07 | ET112 Micro-Onduleurs (SN 119253X) | `pvinverter.mqtt_7` | `pvinverter/7/venus` | 32 |
-| 0x08 | ET112 PAC Chauffe-eau (SN 119215X) | `heatpump.mqtt_8` | `heatpump/8/venus` | 30 |
-| 0x09 | ET112 PAC Climatisation (SN 061077X) | `heatpump.mqtt_9` | `heatpump/9/venus` | 31 |
+| 0x07 | ET112-Micro-Onduleurs (SN 119253X) | `pvinverter.mqtt_7` | `pvinverter/7/venus` | 32 |
+| 0x08 | ET112-Maison (SN 119215X) | `heatpump.mqtt_8` | `heatpump/8/venus` | 30 |
+| 0x09 | ET112-Réseau (SN 061077X) | `heatpump.mqtt_9` | `heatpump/9/venus` | 31 |
 
 Services D-Bus actifs nominaux :
 
 ```
 com.victronenergy.battery.mqtt_1          BMS-360Ah (inst. 151)
 com.victronenergy.battery.mqtt_2          BMS-320Ah (inst. 152)
-com.victronenergy.pvinverter.mqtt_7       ET112 Micro-Onduleurs (inst. 32)
-com.victronenergy.heatpump.mqtt_8         ET112 PAC Chauffe-eau (inst. 30)
-com.victronenergy.heatpump.mqtt_9         ET112 PAC Climatisation (inst. 31)
+com.victronenergy.pvinverter.mqtt_7       ET112-Micro-Onduleurs (inst. 32)
+com.victronenergy.heatpump.mqtt_8         ET112-Maison / Consommation (inst. 30)
+com.victronenergy.heatpump.mqtt_9         ET112-Réseau / Grid (inst. 31)
 com.victronenergy.temperature.mqtt_1      Capteur ext. (type 4, inst. 20)
 com.victronenergy.switch.mqtt_1           ATS CHINT (inst. 60)
+com.victronenergy.switch.mqtt_2           Tongou Switch1 (inst. 61)
+com.victronenergy.switch.mqtt_3           Tongou Switch2 (inst. 62)
+com.victronenergy.switch.mqtt_4           Tongou Switch3 (inst. 63)
+com.victronenergy.switch.mqtt_5           Tongou Switch4 (inst. 64)
+com.victronenergy.switch.mqtt_6           Tongou Switch5 / tongou_3ACC34 (inst. 65)
 com.victronenergy.meteo                   Irradiance PRALRAN + TodaysYield (inst. 40)
 com.victronenergy.pvinverter.cgwacs_ttyUSB0_mb2   Onduleur PV Victron direct
 ```
@@ -201,7 +206,7 @@ Dashboard SSR : `/dashboard/et112/{addr}`
 | ET112 "en attente de données" | Mauvaise adresse Modbus → `sudo systemctl stop daly-bms && mbpoll -m rtu -a 1:15 -b 9600 -t 3:float -r 1 -c 1 /dev/ttyUSB0` |
 | Widget météo "Température: -" | Limitation Venus OS — inévitable, non fixable |
 | `mbpoll` sans réponse | daly-bms monopolise le port — `sudo systemctl stop daly-bms` d'abord |
-| Dashboard affiche cumul brut | Vérifier `pvinv_baseline` dans Node-RED globals |
+| Dashboard affiche cumul brut | Vérifier `pvinv_baseline` retained MQTT (`santuario/persist/pvinv_baseline`) |
 | energy-manager ne démarre pas | `journalctl -u energy-manager -n 50` — souvent TOML manquant ou `.env` absent |
 | `missing field energy_manager` | `sudo cp Config.toml /etc/daly-bms/config.toml` — section `[energy_manager]` absente |
 | energy-manager ne reçoit pas MQTT | Vérifier `portal_id` dans Config.toml et que Mosquitto est accessible sur `mqtt.host` |

--- a/Config.toml
+++ b/Config.toml
@@ -224,7 +224,7 @@ ring_buffer_size = 720
 
 [[et112.devices]]               # SN: 119253X — branché ✅
 address          = "0x07"
-name             = "Micro Onduleurs"
+name             = "ET112-Micro-Onduleurs"
 mqtt_index       = 7           # → santuario/pvinverter/7/venus
 service_type     = "pvinverter"
 device_instance  = 32
@@ -232,7 +232,7 @@ position         = 1
 
 [[et112.devices]]               # SN: 119215X — branché ✅
 address          = "0x08"
-name             = "PAC Chauffe-eau"
+name             = "ET112-Maison"
 mqtt_index       = 8           # → santuario/heatpump/8/venus
 service_type     = "heatpump"
 device_instance  = 30
@@ -240,7 +240,7 @@ position         = 1
 
 [[et112.devices]]               # SN: 061077X — branché ✅
 address          = "0x09"
-name             = "PAC Climatisation"
+name             = "ET112-Réseau"
 mqtt_index       = 9           # → santuario/heatpump/9/venus
 service_type     = "heatpump"
 device_instance  = 31
@@ -360,9 +360,17 @@ device_instance = 63                 # Instance D-Bus Venus OS (60=ATS CHINT, 61
 id              = 4                  # Identifiant interne unique (clé du ring buffer)
 tasmota_id      = "tongou_0A4040"    # Topics : tele/tongou_0A4040/STATE, stat/tongou_0A4040/POWER
 name            = "Tongou Switch4"
-mqtt_index      = 5                 # → forward santuario/switch/2/venus → D-Bus switch.mqtt_5
+mqtt_index      = 5                 # → forward santuario/switch/5/venus → D-Bus switch.mqtt_5
 service_type    = "switch"
-device_instance = 64                 # Instance D-Bus Venus OS (60=ATS CHINT, 61=Tongou)
+device_instance = 64                 # Instance D-Bus Venus OS
+
+[[tasmota.devices]]
+id              = 5                  # Identifiant interne unique (clé du ring buffer)
+tasmota_id      = "tongou_3ACC34"    # 192.168.1.80  tongou-3ACC34
+name            = "Tongou Switch5"
+mqtt_index      = 6                  # → forward santuario/switch/6/venus → D-Bus switch.mqtt_6
+service_type    = "switch"
+device_instance = 65                 # Instance D-Bus Venus OS
 
 # Décommenter et adapter pour chaque prise Tasmota supplémentaire :
 # [[tasmota.devices]]

--- a/Makefile
+++ b/Makefile
@@ -213,22 +213,6 @@ deploy: build-arm
 	@echo "✓ Déployé sur $(PI_HOST)"
 
 # =============================================================================
-# Node-RED — Déploiement des flows depuis git
-# =============================================================================
-
-NODERED_URL ?= http://localhost:1880
-
-.PHONY: deploy-nodered export-nodered
-
-deploy-nodered:
-	@echo "Déploiement des flows Node-RED depuis flux-nodered/ (git → Node-RED) ..."
-	NODERED_URL=$(NODERED_URL) python3 contrib/deploy-nodered-flows.py
-
-export-nodered:
-	@echo "Export des flows Node-RED vers flux-nodered/ (Node-RED → git) ..."
-	NODERED_URL=$(NODERED_URL) python3 contrib/export-nodered-flows.py
-
-# =============================================================================
 # Dashboard (React)
 # =============================================================================
 

--- a/crates/energy-manager/src/logic/deye_command.rs
+++ b/crates/energy-manager/src/logic/deye_command.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use crate::bus::AppBus;
 use crate::config::{DeyeConfig, VictronConfig};
 use crate::mqtt::topics::publish;
-use crate::types::{EnergyState, MqttOutgoing};
+use crate::types::{EnergyState, InfluxPoint, MqttOutgoing};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum DeyeState {
@@ -176,4 +176,10 @@ async fn send_shelly(bus: &AppBus, shelly_id: &str, channel: u8, on: bool) {
     });
     bus.publish(MqttOutgoing::transient(topic, &payload)).await;
     info!("DEYE Shelly: switch {} = {}", channel, if on { "ON" } else { "OFF" });
+
+    let pt = InfluxPoint::new("deye_relay")
+        .tag("host", "pi5")
+        .tag("shelly_id", shelly_id)
+        .field_i("on", if on { 1 } else { 0 });
+    bus.write_influx(pt).await;
 }

--- a/crates/energy-manager/src/logic/switch_ats.rs
+++ b/crates/energy-manager/src/logic/switch_ats.rs
@@ -6,7 +6,7 @@ use tokio::time::{interval, Duration};
 
 use crate::bus::AppBus;
 use crate::mqtt::topics::publish;
-use crate::types::{EnergyState, MqttOutgoing};
+use crate::types::{EnergyState, InfluxPoint, MqttOutgoing};
 
 const KEEPALIVE_SECS: u64 = 60;
 
@@ -38,10 +38,18 @@ pub async fn set_position(
 
 async fn publish_state(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
     let s = state.read().await;
+    let position = s.ats_position;
+    let ats_state = s.ats_state;
     let payload = json!({
-        "Position": s.ats_position,
-        "State":    s.ats_state,
+        "Position": position,
+        "State":    ats_state,
     });
     drop(s);
     bus.publish(MqttOutgoing::retained(publish::SWITCH_VENUS, &payload)).await;
+
+    let pt = InfluxPoint::new("switch_ats")
+        .tag("host", "pi5")
+        .field_i("position", position)
+        .field_i("state", ats_state);
+    bus.write_influx(pt).await;
 }

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -73,40 +73,9 @@ services:
       timeout: 10s
       retries: 5
 
-  nodered:
-    image: nodered/node-red:4.0.2
-    container_name: dalybms-nodered
-    restart: unless-stopped
-    ports:
-      - "1880:1880"
-    environment:
-      - TZ=Europe/Paris
-      - HOSTNAME=pi5
-      # InfluxDB — persistance production solaire (écriture + restore au démarrage +5s)
-      - INFLUX_TOKEN=${INFLUX_TOKEN}
-      - INFLUX_ORG=${INFLUX_ORG:-santuario}
-      - INFLUX_BUCKET=${INFLUX_BUCKET:-daly_bms}
-      # VRM API — restauration authoritative au démarrage +10s (today.totals.kwh)
-      # Créer le token sur vrm.victronenergy.com → Profile → Personal Access Tokens
-      - VRM_TOKEN=${VRM_TOKEN:-}
-      - VRM_INSTALLATION_ID=${VRM_INSTALLATION_ID:-865936}
-    volumes:
-      - nodered-data:/data
-    depends_on:
-      mosquitto:
-        condition: service_started
-      influxdb:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:1880"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-
 volumes:
   mosquitto-data:
   mosquitto-log:
   influxdb-data:
   influxdb-config:
   grafana-data:
-  nodered-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,37 +167,6 @@ services:
     networks:
       - dalybms-net
 
-  # ── Node-RED (automatisation / logique métier) ───────────────────────────────
-  nodered:
-    image: nodered/node-red:4.0.2
-    container_name: dalybms-nodered
-    restart: unless-stopped
-    ports:
-      - "1880:1880"
-    environment:
-      TZ: Europe/Paris
-    volumes:
-      - nodered-data:/data
-    depends_on:
-      mosquitto:
-        condition: service_healthy
-    # Alias pour résoudre dalybms-mosquitto vers le NanoPi broker (192.168.1.120)
-    extra_hosts:
-      - "dalybms-mosquitto:192.168.1.120"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:1880"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 20s
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
-    networks:
-      - dalybms-net
-
   # ── Venus OS keepalive ──────────────────────────────────────────────────────
   # Venus OS exige un publish sur R/<portalId>/keepalive toutes les 60s
   # Sans ce keepalive, Venus OS ne publie aucune donnée sur N/#
@@ -243,7 +212,5 @@ volumes:
     name: dalybms-influxdb-config
   grafana-data:
     name: dalybms-grafana-data
-  nodered-data:
-    name: dalybms-nodered-data
   dalybms-alerts:
     name: dalybms-alerts

--- a/docs/energy-manager-guide.md
+++ b/docs/energy-manager-guide.md
@@ -163,6 +163,26 @@ Nom du measurement configurable : `solar.power_measurement` (défaut : `"solar_p
 
 Nom du measurement configurable : `solar.persist_measurement` (défaut : `"solar_persist"`).
 
+### Measurement `switch_ats`
+
+> Source : `logic/switch_ats.rs` — fréquence : **toutes les 60 secondes** (keepalive)
+
+| Type | Nom | Valeur |
+|------|-----|--------|
+| Tag | `host` | `"pi5"` |
+| Field (i64) | `position` | Position ATS : 0=Réseau, 1=Génératrice |
+| Field (i64) | `state` | État ATS : 0=inactif, 1=actif, 2=alerte |
+
+### Measurement `deye_relay`
+
+> Source : `logic/deye_command.rs` — fréquence : **à chaque changement d'état** (coupure ou réactivation)
+
+| Type | Nom | Valeur |
+|------|-----|--------|
+| Tag | `host` | `"pi5"` |
+| Tag | `shelly_id` | ID du Shelly (ex: `"shellypro2pm-ec62608840a4"`) |
+| Field (i64) | `on` | État relais DEYE : 1=ON, 0=OFF (coupé) |
+
 ---
 
 ## 5. WebSocket live events

--- a/nanoPi/config-nanopi.toml
+++ b/nanoPi/config-nanopi.toml
@@ -169,6 +169,14 @@ command_topic   = "cmnd/tongou_0A4040/Power"
 custom_name     = "Tongou 4"
 group           = "Tongou"
 
+[[switches]]
+mqtt_index      = 6
+name            = "tongou_3ACC34"              # 192.168.1.80
+device_instance = 65
+command_topic   = "cmnd/tongou_3ACC34/Power"
+custom_name     = "Tongou 5"
+group           = "Tongou"
+
 # -----------------------------------------------------------------------------
 # Compteurs réseau / consommation AC
 # Topics : santuario/grid/{mqtt_index}/venus


### PR DESCRIPTION
… writes

1. Config.toml + nanoPi/config-nanopi.toml
   - Add [[tasmota.devices]] tongou_3ACC34 (id=5, mqtt_index=6, instance=65)
   - Add [[switches]] mqtt_index=6 in NanoPi config for Venus OS bridge
   - Rename ET112: 0x07→ET112-Micro-Onduleurs, 0x08→ET112-Maison, 0x09→ET112-Réseau

2. Docker (Node-RED removed)
   - docker-compose.yml: remove dalybms-nodered service + nodered-data volume
   - docker-compose.infra.yml: idem
   - Makefile: remove deploy-nodered / export-nodered targets

3. energy-manager Rust code (cargo check OK)
   - logic/switch_ats.rs: write InfluxDB measurement 'switch_ats' (position+state, 60s)
   - logic/deye_command.rs: write InfluxDB measurement 'deye_relay' (on/off, on change)

4. CLAUDE.md: update architecture, ET112 names, Tongou Switch5, D-Bus inventory, remove nodered:1880, fix Node-RED globals reference

5. docs/energy-manager-guide.md: add switch_ats + deye_relay measurements to InfluxDB inventory

https://claude.ai/code/session_018dAVcXEvnfCY6Lk58cMTqx