### PR TITLE
fix(monitor): remplace nodered par energy-manager, ajoute Switch5 à l…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -335,7 +335,7 @@ ring_buffer_size = 720
 [[tasmota.devices]]
 id              = 1                  # Identifiant interne unique (clé du ring buffer)
 tasmota_id      = "tongou_3BC764"    # Topics : tele/tongou_3BC764/STATE, stat/tongou_3BC764/POWER
-name            = "Tongou Switch"
+name            = "Tongou Switch1"
 mqtt_index      = 2                  # → forward santuario/switch/2/venus → D-Bus switch.mqtt_2
 service_type    = "switch"
 device_instance = 61                 # Instance D-Bus Venus OS (60=ATS CHINT, 61=Tongou)

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -1,8 +1,8 @@
 //! Agent de monitoring autonome — surveille l'ensemble du système Pi5.
 //!
 //! Vérifie toutes les 30 secondes :
-//! - Service systemd daly-bms (via systemctl)
-//! - Services réseau via sonde TCP : mosquitto, influxdb, grafana, nodered, venus MQTT
+//! - Services systemd daly-bms + energy-manager (via systemctl)
+//! - Services réseau via sonde TCP : mosquitto, influxdb, grafana, energy-manager, venus MQTT
 //! - Port série RS485 (/dev/ttyUSB0)
 //! - CPU, RAM, disque, charge système, uptime
 //!
@@ -18,11 +18,11 @@ use tracing::{info, warn};
 
 /// Services réseau à sonder : (label, host, port, conteneur_docker_pour_restart).
 const TCP_SERVICES: &[(&str, &str, u16, Option<&str>)] = &[
-    ("mosquitto",  "127.0.0.1",     1883, Some("mosquitto")),
-    ("influxdb",   "127.0.0.1",     8086, Some("influxdb")),
-    ("grafana",    "127.0.0.1",     3001, Some("grafana")),
-    ("nodered",    "127.0.0.1",     1880, Some("nodered")),
-    ("venus-mqtt", "192.168.1.120", 1883, None),
+    ("mosquitto",      "127.0.0.1",     1883, Some("mosquitto")),
+    ("influxdb",       "127.0.0.1",     8086, Some("influxdb")),
+    ("grafana",        "127.0.0.1",     3001, Some("grafana")),
+    ("energy-manager", "127.0.0.1",     8081, None),
+    ("venus-mqtt",     "192.168.1.120", 1883, None),
 ];
 
 /// Port série RS485.
@@ -46,14 +46,22 @@ async fn collect_snapshot(_state: &AppState) -> MonitorSnapshot {
     let mut network_services = Vec::new();
     let mut auto_actions = Vec::new();
 
-    // ── Service systemd daly-bms ──────────────────────────────────────────────
-    // Nous sommes le processus en cours — on force active:true pour signaler
-    // que le service tourne (le systemd peut retourner "activating" au démarrage).
+    // ── Services systemd ──────────────────────────────────────────────────────
+    // daly-bms : nous sommes le processus en cours — on force active:true.
     let daly_status = check_systemd_service("daly-bms").await;
     services.push(ServiceStatus {
         name: "daly-bms".to_string(),
         active: true,
         status: if daly_status.is_empty() { "active".to_string() } else { daly_status },
+    });
+
+    // energy-manager : service indépendant — vérification réelle via systemctl.
+    let em_status = check_systemd_service("energy-manager").await;
+    let em_active = em_status == "active";
+    services.push(ServiceStatus {
+        name: "energy-manager".to_string(),
+        active: em_active,
+        status: if em_status.is_empty() { "unknown".to_string() } else { em_status },
     });
 
     // ── Sondes TCP ───────────────────────────────────────────────────────────

--- a/crates/daly-bms-server/templates/viz_nodes_devices.js
+++ b/crates/daly-bms-server/templates/viz_nodes_devices.js
@@ -1,5 +1,5 @@
 // ── TONGOU GROUP NODE ─────────────────────────────────────────────────────────
-const TASMOTA_IDS = [1, 2, 3, 4];
+const TASMOTA_IDS = [1, 2, 3, 4, 5];
 
 const TongouGroupNode = memo(function TongouGroupNode({ data }) {
   const switches = (data.switches && data.switches.length > 0)


### PR DESCRIPTION
…a viz

- monitor.rs: remplace la sonde TCP nodered:1880 par energy-manager:8081
- monitor.rs: ajoute le service systemd energy-manager dans les checks systemd
- viz_nodes_devices.js: ajoute id=5 dans TASMOTA_IDS pour Switch5
- Config.toml: renomme "Tongou Switch" → "Tongou Switch1" (évite confusion avec Switch5)

https://claude.ai/code/session_018dAVcXEvnfCY6Lk58cMTqx