### PR TITLE
fix(viz): fix 7 display issues on visualization page

### DIFF
--- a/crates/daly-bms-server/src/bridges/influx.rs
+++ b/crates/daly-bms-server/src/bridges/influx.rs
@@ -86,6 +86,12 @@ pub async fn run_influx_bridge(state: AppState, cfg: InfluxConfig) {
                         batch.push(p);
                     }
                 }
+                // Production solaire journalière (total_yield_kwh + solar_total_w).
+                let yield_kwh  = *state.mppt_yield_kwh.read().await;
+                let solar_w    = *state.solar_total_w.read().await;
+                if let Ok(p) = solar_daily_to_point(yield_kwh, solar_w) {
+                    batch.push(p);
+                }
                 if !batch.is_empty() {
                     flush_batch(&client, &cfg.bucket, &mut batch).await;
                 }
@@ -244,12 +250,14 @@ fn venus_mppt_total_to_point(power_w: f32, current_a: f32) -> anyhow::Result<Dat
 fn venus_smartshunt_to_point(s: &VenusSmartShunt) -> anyhow::Result<DataPoint> {
     let ts_ns = s.timestamp.timestamp_nanos_opt().unwrap_or(0);
     let mut b = DataPoint::builder("venus_smartshunt");
-    if let Some(v) = s.voltage_v      { b = b.field("voltage_v",   v as f64); }
-    if let Some(v) = s.current_a      { b = b.field("current_a",   v as f64); }
-    if let Some(v) = s.power_w        { b = b.field("power_w",     v as f64); }
-    if let Some(v) = s.soc_percent    { b = b.field("soc_percent", v as f64); }
-    if let Some(v) = s.energy_in_kwh  { b = b.field("energy_in_kwh",  v as f64); }
-    if let Some(v) = s.energy_out_kwh { b = b.field("energy_out_kwh", v as f64); }
+    if let Some(v) = s.voltage_v           { b = b.field("voltage_v",           v as f64); }
+    if let Some(v) = s.current_a           { b = b.field("current_a",           v as f64); }
+    if let Some(v) = s.power_w             { b = b.field("power_w",             v as f64); }
+    if let Some(v) = s.soc_percent         { b = b.field("soc_percent",         v as f64); }
+    if let Some(v) = s.energy_in_kwh       { b = b.field("energy_in_kwh",       v as f64); }
+    if let Some(v) = s.energy_out_kwh      { b = b.field("energy_out_kwh",      v as f64); }
+    if let Some(v) = s.ah_charged_today    { b = b.field("ah_charged_today",    v as f64); }
+    if let Some(v) = s.ah_discharged_today { b = b.field("ah_discharged_today", v as f64); }
     Ok(b.timestamp(ts_ns).build()?)
 }
 
@@ -293,5 +301,19 @@ fn et112_snapshot_to_point(snap: &Et112Snapshot) -> anyhow::Result<DataPoint> {
         .timestamp(ts_ns)
         .build()?;
 
+    Ok(point)
+}
+
+/// Point InfluxDB production solaire journalière.
+///
+/// Measurement : `solar_daily`
+/// Écrit toutes les 30 s depuis le ticker irradiance.
+fn solar_daily_to_point(yield_kwh: f32, solar_w: f32) -> anyhow::Result<DataPoint> {
+    let ts_ns = Utc::now().timestamp_nanos_opt().unwrap_or(0);
+    let point = DataPoint::builder("solar_daily")
+        .field("total_yield_kwh", yield_kwh as f64)
+        .field("solar_total_w",   solar_w   as f64)
+        .timestamp(ts_ns)
+        .build()?;
     Ok(point)
 }

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -672,6 +672,9 @@ async fn handle_system_topic(state: &AppState, json: &Value) {
             energy_out_kwh: energy_out.map(|e| e / 1000.0),
             state: state_str,
             time_to_go_min,
+            // Calculés dans on_venus_smartshunt par intégration du courant
+            ah_charged_today:    None,
+            ah_discharged_today: None,
             timestamp: Utc::now(),
         };
 

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -55,13 +55,20 @@ async fn collect_snapshot(_state: &AppState) -> MonitorSnapshot {
         status: if daly_status.is_empty() { "active".to_string() } else { daly_status },
     });
 
-    // energy-manager : service indépendant — vérification réelle via systemctl.
-    let em_status = check_systemd_service("energy-manager").await;
-    let em_active = em_status == "active";
+    // energy-manager : vérification via systemctl + fallback sonde TCP :8081.
+    let em_status  = check_systemd_service("energy-manager").await;
+    let em_systemd = em_status == "active";
+    // Si systemd dit inactive, vérifier quand même via TCP (service démarré manuellement).
+    let em_tcp_ok  = if em_systemd { true } else { tcp_probe("127.0.0.1", 8081).await };
+    let em_active  = em_systemd || em_tcp_ok;
     services.push(ServiceStatus {
         name: "energy-manager".to_string(),
         active: em_active,
-        status: if em_status.is_empty() { "unknown".to_string() } else { em_status },
+        status: if em_active {
+            if em_systemd { em_status } else { "active (port 8081)".to_string() }
+        } else {
+            if em_status.is_empty() { "unknown".to_string() } else { em_status }
+        },
     });
 
     // ── Sondes TCP ───────────────────────────────────────────────────────────

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -10,7 +10,7 @@ use crate::irradiance::IrradianceSnapshot;
 use crate::tasmota::TasmotaSnapshot;
 use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Datelike, Utc};
 use serde::Serialize;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
@@ -162,6 +162,10 @@ pub struct VenusSmartShunt {
     pub state: Option<String>,
     /// Temps restant en minutes (None = inconnu ou en charge).
     pub time_to_go_min: Option<f32>,
+    /// Ah chargés depuis minuit (intégration courant × temps).
+    pub ah_charged_today: Option<f32>,
+    /// Ah déchargés depuis minuit (intégration courant × temps).
+    pub ah_discharged_today: Option<f32>,
     pub timestamp: DateTime<Utc>,
 }
 
@@ -354,6 +358,13 @@ pub struct AppState {
     /// Données Venus OS — SmartShunt.
     pub venus_smartshunt: Arc<RwLock<Option<VenusSmartShunt>>>,
 
+    /// Accumulateurs Ah journaliers du SmartShunt (intégration courant, remise à zéro à minuit).
+    pub shunt_ah_charged_today:    Arc<RwLock<f32>>,
+    pub shunt_ah_discharged_today: Arc<RwLock<f32>>,
+    pub shunt_ah_last_ts:          Arc<RwLock<Option<DateTime<Utc>>>>,
+    /// Numéro de jour (days_from_ce) au dernier enregistrement — détecte le passage à minuit.
+    pub shunt_ah_last_day:         Arc<RwLock<i32>>,
+
     /// Données Venus OS — Onduleur/Charger (Victron MultiPlus).
     pub venus_inverter: Arc<RwLock<Option<VenusInverter>>>,
 
@@ -418,6 +429,10 @@ impl AppState {
             house_power_w:  Arc::new(RwLock::new(0.0)),
             venus_mppts: Arc::new(RwLock::new(BTreeMap::new())),
             venus_smartshunt: Arc::new(RwLock::new(None)),
+            shunt_ah_charged_today:    Arc::new(RwLock::new(0.0)),
+            shunt_ah_discharged_today: Arc::new(RwLock::new(0.0)),
+            shunt_ah_last_ts:          Arc::new(RwLock::new(None)),
+            shunt_ah_last_day:         Arc::new(RwLock::new(0)),
             venus_inverter: Arc::new(RwLock::new(None)),
             venus_temperatures: Arc::new(RwLock::new(BTreeMap::new())),
             venus_heatpumps: Arc::new(RwLock::new(BTreeMap::new())),
@@ -615,7 +630,43 @@ impl AppState {
     }
 
     /// Enregistre/met à jour le SmartShunt.
-    pub async fn on_venus_smartshunt(&self, shunt: VenusSmartShunt) {
+    ///
+    /// Intègre le courant pour accumuler les Ah chargés/déchargés depuis minuit.
+    /// L'accumulateur est remis à zéro à chaque changement de jour calendaire.
+    pub async fn on_venus_smartshunt(&self, mut shunt: VenusSmartShunt) {
+        let now     = shunt.timestamp;
+        let day_key = now.date_naive().num_days_from_ce();
+
+        let mut charged    = self.shunt_ah_charged_today.write().await;
+        let mut discharged = self.shunt_ah_discharged_today.write().await;
+        let mut last_ts    = self.shunt_ah_last_ts.write().await;
+        let mut last_day   = self.shunt_ah_last_day.write().await;
+
+        // Remise à zéro à minuit
+        if *last_day != day_key {
+            *charged    = 0.0;
+            *discharged = 0.0;
+            *last_day   = day_key;
+        }
+
+        // Intégration Ah = I × Δt (en heures)
+        if let (Some(prev_ts), Some(current_a)) = (*last_ts, shunt.current_a) {
+            let delta_ms = (now - prev_ts).num_milliseconds();
+            // Ne calculer que si l'intervalle est positif et raisonnable (< 10 min)
+            if delta_ms > 0 && delta_ms < 600_000 {
+                let delta_h = delta_ms as f32 / 3_600_000.0;
+                if current_a > 0.0 {
+                    *charged    += current_a * delta_h;
+                } else if current_a < 0.0 {
+                    *discharged += (-current_a) * delta_h;
+                }
+            }
+        }
+        *last_ts = Some(now);
+
+        shunt.ah_charged_today    = Some(*charged);
+        shunt.ah_discharged_today = Some(*discharged);
+
         *self.venus_smartshunt.write().await = Some(shunt);
     }
 

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -76,6 +76,18 @@
                   border-color 0.25s ease, box-shadow 0.25s ease;
     }
 
+    /* ─── Variantes de bandeau par type d'appareil ────────────── */
+    .bms-hdr-pv      { background: linear-gradient(135deg, #fef9c3 0%, #fef08a 100%); }
+    .bms-hdr-heat    { background: linear-gradient(135deg, #f3e8ff 0%, #e9d5ff 100%); }
+    .bms-hdr-on      { background: linear-gradient(135deg, #dcfce7 0%, #bbf7d0 100%); }
+    .bms-hdr-off     { background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%); }
+    .bms-hdr-offline { background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%); }
+    html.dark .bms-hdr-pv      { background: linear-gradient(135deg, #422006 0%, #78350f 100%); }
+    html.dark .bms-hdr-heat    { background: linear-gradient(135deg, #2e1065 0%, #4c1d95 100%); }
+    html.dark .bms-hdr-on      { background: linear-gradient(135deg, #052e16 0%, #14532d 100%); }
+    html.dark .bms-hdr-off     { background: linear-gradient(135deg, #450a0a 0%, #7f1d1d 100%); }
+    html.dark .bms-hdr-offline { background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%); }
+
     /* ─── Dark mode: BMS card header ─────────────────────────── */
     html.dark .bms-hdr {
       background: linear-gradient(135deg, #1a2f4e 0%, #1e3a5f 100%);

--- a/crates/daly-bms-server/templates/et112_all.html
+++ b/crates/daly-bms-server/templates/et112_all.html
@@ -21,7 +21,7 @@
 <div class="bms-card {% if !d.connected %}" style="opacity:0.7{% endif %}" id="et112-card-{{ d.address }}">
 
   {# Header #}
-  <div class="bms-hdr" style="{% if d.connected %}{% if d.service_type == "pvinverter" %}background:linear-gradient(135deg,#fef9c3 0%,#fef08a 100%){% else if d.service_type == "heatpump" %}background:linear-gradient(135deg,#f3e8ff 0%,#e9d5ff 100%){% else %}background:linear-gradient(135deg,#dbeafe 0%,#bfdbfe 100%){% endif %}{% else %}background:linear-gradient(135deg,#f1f5f9 0%,#e2e8f0 100%){% endif %}">
+  <div class="bms-hdr {% if !d.connected %}bms-hdr-offline{% else if d.service_type == "pvinverter" %}bms-hdr-pv{% else if d.service_type == "heatpump" %}bms-hdr-heat{% endif %}">
     <div class="bms-hdr-left">
       {% if d.connected %}
         <div class="bms-live"><div class="live-dot"></div>LIVE</div>

--- a/crates/daly-bms-server/templates/tasmota_all.html
+++ b/crates/daly-bms-server/templates/tasmota_all.html
@@ -21,7 +21,7 @@
 <div class="bms-card {% if !d.connected %}" style="opacity:0.7{% endif %}" id="tasmota-card-{{ d.id }}">
 
   {# Header #}
-  <div class="bms-hdr" style="{% if d.connected %}{% if d.power_on %}background:linear-gradient(135deg,#dcfce7 0%,#bbf7d0 100%){% else %}background:linear-gradient(135deg,#fee2e2 0%,#fecaca 100%){% endif %}{% else %}background:linear-gradient(135deg,#f1f5f9 0%,#e2e8f0 100%){% endif %}">
+  <div class="bms-hdr {% if !d.connected %}bms-hdr-offline{% else if d.power_on %}bms-hdr-on{% else %}bms-hdr-off{% endif %}">
     <div class="bms-hdr-left">
       {% if d.connected %}
         <div class="bms-live"><div class="live-dot" style="{% if !d.power_on %}background:var(--red);box-shadow:0 0 6px var(--red){% endif %}"></div>{% if d.power_on %}ON{% else %}OFF{% endif %}</div>

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -283,13 +283,16 @@ const atsExecRef = useRef(null);
     setNodes(prev => prev.map(n => {
       switch (n.id) {
         case 'spiral-race': {
-          const mpptYieldSum = mpptList.reduce((s, m) => s + (m.yield_today_kwh ?? 0), 0);
-          const prodKwh = ((et7?.energy_export_wh ?? 0) / 1000) + mpptYieldSum;
-          return { ...n, data: { ...n.data, prodKwh, soc: avgSoc != null ? parseFloat(avgSoc) : 0, irrWm2: irr?.irradiance_wm2 ?? 0 } };
+          const mpptYieldSum  = mpptList.reduce((s, m) => s + (m.yield_today_kwh ?? 0), 0);
+          const localProdKwh  = ((et7?.energy_export_wh ?? 0) / 1000) + mpptYieldSum;
+          const totalYieldKwh = irr?.total_yield_kwh ?? localProdKwh;
+          return { ...n, data: { ...n.data, totalYieldKwh, prodKwh: localProdKwh, soc: avgSoc != null ? parseFloat(avgSoc) : 0, irrWm2: irr?.irradiance_wm2 ?? 0 } };
         }
         case 'sankey': {
-          const loadPwr = tasmotaDevices.reduce((s, d) => s + (d.connected ? (d.power_w ?? 0) : 0), 0);
-          return { ...n, data: { ...n.data, microPwr: et7?.power_w ?? 0, mpptPwr: mpptTotalPowerW, batPwr: Math.max(0, totalPwr), loadPwr } };
+          const loadPwr        = tasmotaDevices.reduce((s, d) => s + (d.connected ? (d.power_w ?? 0) : 0), 0);
+          const batChargePwr   = Math.max(0, totalPwr);
+          const batDischargePwr = Math.max(0, -totalPwr);
+          return { ...n, data: { ...n.data, microPwr: et7?.power_w ?? 0, mpptPwr: mpptTotalPowerW, batChargePwr, batDischargePwr, loadPwr } };
         }
         case 'production':
           return { ...n, data: { ...n.data, value: prodVal, sub: prodSub, dotClass: prodDot } };

--- a/crates/daly-bms-server/templates/viz_nodes_ats.js
+++ b/crates/daly-bms-server/templates/viz_nodes_ats.js
@@ -214,10 +214,10 @@ function InverterNode({ data }) {
     return 'off';
   })();
 
-  const fmtFreq = (f) => f != null ? `${f.toFixed(2)} Hz` : null;
+  const fmtFreq = (f) => f != null ? `${f.toFixed(2)} Hz` : '— Hz';
 
   return h('div', { className: 'inv-card' },
-    acF != null && h('div', { className: 'inv-freq-badge' }, fmtFreq(acF)),
+    h('div', { className: 'inv-freq-badge' }, fmtFreq(acF)),
     mkHandle('target', Position.Top,    'tt'),
     mkHandle('source', Position.Bottom, 'sb'),
     mkHandle('target', Position.Left,   'tl'),

--- a/crates/daly-bms-server/templates/viz_nodes_charts.js
+++ b/crates/daly-bms-server/templates/viz_nodes_charts.js
@@ -7,9 +7,9 @@ const SpiralRaceNode = function SpiralRaceNode({ data }) {
   const chartRef = useRef(null);
   const instRef  = useRef(null);
 
-  const prodKwh = data.prodKwh ?? 0;
-  const soc     = data.soc     ?? 0;
-  const irrWm2  = data.irrWm2  ?? 0;
+  const prodKwh = data.totalYieldKwh ?? data.prodKwh ?? 0;
+  const soc     = data.soc          ?? 0;
+  const irrWm2  = data.irrWm2       ?? 0;
 
   useEffect(function () {
     if (!chartRef.current || !window.echarts) return;
@@ -66,7 +66,7 @@ const SpiralRaceNode = function SpiralRaceNode({ data }) {
     chart.setOption({
       backgroundColor: 'transparent',
       series: [
-        mkGauge('88%',  18,   prodKwh, '#fbbf24', 'Production', 'kWh',  '78%', '90%'),
+        mkGauge('88%',  40,   prodKwh, '#fbbf24', 'Production', 'kWh',  '78%', '90%'),
         mkGauge('65%', 100,   soc,     socCol,    'SOC',        '%',    '48%', '60%'),
         mkGauge('42%', 2000,  irrWm2,  '#38bdf8', 'Irradiance', 'W/m²', '18%', '30%'),
         // Tick marks radiaux fins traversant les 3 anneaux sans atteindre le centre
@@ -90,7 +90,7 @@ const SpiralRaceNode = function SpiralRaceNode({ data }) {
         },
       ]
     }, { notMerge: false, lazyUpdate: false });
-  }, [prodKwh, soc, irrWm2]);
+  }, [prodKwh, soc, irrWm2]); // eslint-disable-line
 
   useEffect(function () {
     return function () {
@@ -117,56 +117,27 @@ const SpiralRaceNode = function SpiralRaceNode({ data }) {
 };
 
 // ── SANKEY NODE ───────────────────────────────────────────────────────────────
-// Sources gauche : Micro-onduleurs, MPPT
-// Puits droite   : Batteries (charge), Maison (Tongou), Export (si positif)
+// Mode production  : Sources = Micro-ond + MPPT  → Batteries(charge) + Maison + Export
+// Mode décharge    : Source  = Batteries(disch.) → Maison + Réseau
 const SankeyNode = function SankeyNode({ data }) {
   const chartRef   = useRef(null);
   const instRef    = useRef(null);
   const prevKeyRef = useRef('');
 
-  const microW  = Math.max(0, data.microPwr  ?? 0);
-  const mpptW   = Math.max(0, data.mpptPwr   ?? 0);
-  const batW    = Math.max(0, data.batPwr    ?? 0);
-  const loadW   = Math.max(0, data.loadPwr   ?? 0);
-  const totalIn = microW + mpptW;
+  const microW        = Math.max(0, data.microPwr        ?? 0);
+  const mpptW         = Math.max(0, data.mpptPwr         ?? 0);
+  const batChargeW    = Math.max(0, data.batChargePwr    ?? data.batPwr ?? 0);
+  const batDischW     = Math.max(0, data.batDischargePwr ?? 0);
+  const loadW         = Math.max(0, data.loadPwr         ?? 0);
+  const totalIn       = microW + mpptW;
+  const isProduction  = totalIn >= 10;
+  const isDischarge   = !isProduction && batDischW >= 10;
 
-  useEffect(function () {
-    if (!chartRef.current || !window.echarts) return;
-    if (!instRef.current) {
-      instRef.current = window.echarts.init(chartRef.current, null, { renderer: 'canvas' });
-    }
-    const chart = instRef.current;
-
-    if (totalIn < 10) {
-      chart.setOption({
-        backgroundColor: 'transparent',
-        series: [],
-        graphic: [{ type: 'text', left: 'center', top: 'middle',
-          style: { text: 'Pas de production', fill: '#64748b', fontSize: 10 } }]
-      }, { notMerge: true });
-      prevKeyRef.current = '';
-      return;
-    }
-
-    const batOut  = Math.min(batW,  totalIn);
-    const loadOut = Math.min(loadW, Math.max(0, totalIn - batOut));
-    const expOut  = Math.max(0, totalIn - batOut - loadOut);
-
-    const srcNodes  = [];
-    const sinkNodes = [];
-    if (microW > 5) srcNodes.push({ name: 'Micro-ond', w: microW, color: '#3b82f6' });
-    if (mpptW  > 5) srcNodes.push({ name: 'MPPT',      w: mpptW,  color: '#f59e0b' });
-    if (batOut > 5) sinkNodes.push({ name: 'Batteries', w: batOut,  color: '#22c55e' });
-    if (loadOut> 5) sinkNodes.push({ name: 'Maison',    w: loadOut, color: '#a855f7' });
-    if (expOut > 5) sinkNodes.push({ name: 'Export',    w: expOut,  color: '#0ea5e9' });
-    if (sinkNodes.length === 0) sinkNodes.push({ name: 'Consomm.', w: totalIn, color: '#64748b' });
-
-    // Clé structurelle : si la liste des nœuds change, notMerge=true pour ré-animer
+  const buildSankey = function(srcNodes, sinkNodes) {
     const structKey = srcNodes.map(n => n.name).join(',') + '|' + sinkNodes.map(n => n.name).join(',');
     const structChanged = structKey !== prevKeyRef.current;
     prevKeyRef.current = structKey;
-
-    const sinkTotal = sinkNodes.reduce((s, n) => s + n.w, 0);
+    const sinkTotal = sinkNodes.reduce((s, n) => s + n.w, 0) || 1;
     const eNodes = [
       ...srcNodes.map(n  => ({ name: n.name, itemStyle: { color: n.color } })),
       ...sinkNodes.map(n => ({ name: n.name, itemStyle: { color: n.color } })),
@@ -178,6 +149,50 @@ const SankeyNode = function SankeyNode({ data }) {
         if (v > 1) eLinks.push({ source: src.name, target: sink.name, value: v });
       });
     });
+    return { eNodes, eLinks, structChanged };
+  };
+
+  useEffect(function () {
+    if (!chartRef.current || !window.echarts) return;
+    if (!instRef.current) {
+      instRef.current = window.echarts.init(chartRef.current, null, { renderer: 'canvas' });
+    }
+    const chart = instRef.current;
+
+    if (!isProduction && !isDischarge) {
+      chart.setOption({
+        backgroundColor: 'transparent',
+        series: [],
+        graphic: [{ type: 'text', left: 'center', top: 'middle',
+          style: { text: 'Pas de production\nni de décharge', fill: '#64748b', fontSize: 10 } }]
+      }, { notMerge: true });
+      prevKeyRef.current = '';
+      return;
+    }
+
+    let srcNodes = [], sinkNodes = [];
+
+    if (isProduction) {
+      // Mode production : PV → batterie/maison/export
+      const batOut  = Math.min(batChargeW, totalIn);
+      const loadOut = Math.min(loadW, Math.max(0, totalIn - batOut));
+      const expOut  = Math.max(0, totalIn - batOut - loadOut);
+      if (microW > 5) srcNodes.push({ name: 'Micro-ond', w: microW, color: '#3b82f6' });
+      if (mpptW  > 5) srcNodes.push({ name: 'MPPT',      w: mpptW,  color: '#f59e0b' });
+      if (batOut > 5) sinkNodes.push({ name: 'Batteries', w: batOut,  color: '#22c55e' });
+      if (loadOut> 5) sinkNodes.push({ name: 'Maison',    w: loadOut, color: '#a855f7' });
+      if (expOut > 5) sinkNodes.push({ name: 'Export',    w: expOut,  color: '#0ea5e9' });
+      if (sinkNodes.length === 0) sinkNodes.push({ name: 'Consomm.', w: totalIn, color: '#64748b' });
+    } else {
+      // Mode décharge : Batteries → maison/réseau
+      srcNodes.push({ name: 'Batteries', w: batDischW, color: '#f97316' });
+      if (loadW > 5)          sinkNodes.push({ name: 'Maison',  w: Math.min(loadW, batDischW), color: '#a855f7' });
+      const reste = batDischW - (sinkNodes[0]?.w ?? 0);
+      if (reste > 5)          sinkNodes.push({ name: 'Réseau',  w: reste, color: '#0ea5e9' });
+      if (sinkNodes.length === 0) sinkNodes.push({ name: 'Consomm.', w: batDischW, color: '#64748b' });
+    }
+
+    const { eNodes, eLinks, structChanged } = buildSankey(srcNodes, sinkNodes);
 
     chart.setOption({
       backgroundColor: 'transparent',
@@ -203,7 +218,7 @@ const SankeyNode = function SankeyNode({ data }) {
         links: eLinks
       }]
     }, { notMerge: structChanged, lazyUpdate: false });
-  }, [microW, mpptW, batW, loadW, totalIn]);
+  }, [microW, mpptW, batChargeW, batDischW, loadW, isProduction, isDischarge]);
 
   useEffect(function () {
     return function () {
@@ -214,15 +229,18 @@ const SankeyNode = function SankeyNode({ data }) {
     };
   }, []);
 
+  const displayW = isProduction ? Math.round(totalIn) : isDischarge ? Math.round(batDischW) : 0;
+  const modeLabel = isDischarge && !isProduction ? '🔋 Décharge' : 'Flux Énergétique';
+
   return h('div', { className: 'sankey-node' },
     mkHandle('target', Position.Top,    'tt'),
     mkHandle('source', Position.Bottom, 'sb'),
     mkHandle('target', Position.Left,   'tl'),
     mkHandle('source', Position.Right,  'sr'),
     h('div', { className: 'sankey-hdr' },
-      h('span', { className: 'sankey-icon' }, '⚡'),
-      h('span', { className: 'sankey-title' }, 'Flux Énergétique'),
-      h('span', { className: 'sankey-total' }, totalIn > 0 ? Math.round(totalIn) + ' W' : '—')
+      h('span', { className: 'sankey-icon' }, isDischarge && !isProduction ? '🔋' : '⚡'),
+      h('span', { className: 'sankey-title' }, modeLabel),
+      h('span', { className: 'sankey-total' }, displayW > 0 ? displayW + ' W' : '—')
     ),
     h('div', { ref: chartRef, className: 'sankey-chart' })
   );

--- a/crates/daly-bms-server/templates/viz_nodes_venus.js
+++ b/crates/daly-bms-server/templates/viz_nodes_venus.js
@@ -1,4 +1,9 @@
 // ── MPPT GROUP NODE ───────────────────────────────────────────────────────────
+// Affiche toujours MPPT-273 et MPPT-289 (instances connues en production).
+// Si les données individuelles sont indisponibles (format v1 agrégé), les lignes
+// restent visibles avec "—" pour les métriques.
+const MPPT_KNOWN_INSTANCES = [273, 289];
+
 function MPPTGroupNode({ data }) {
   const mppts       = data.mppts       ?? [];
   const totalPowerW = data.totalPowerW ?? 0;
@@ -7,10 +12,22 @@ function MPPTGroupNode({ data }) {
   const stateClass = (s) => {
     if (!s) return '';
     const l = s.toLowerCase();
-    if (l === 'off')   return 'off';
-    if (l === 'fault') return 'fault';
+    if (l === 'off')              return 'off';
+    if (l === 'fault')            return 'fault';
+    if (l === 'bulk')             return 'bulk';
+    if (l.includes('absorb'))     return 'bulk';
+    if (l.includes('float') || l.includes('storage')) return 'float';
     return '';
   };
+
+  // Si les données individuelles des instances connues sont présentes, les afficher.
+  // Sinon, toujours montrer les deux lignes connues avec placeholders.
+  const mpptById = {};
+  for (const m of mppts) { mpptById[m.instance] = m; }
+  const hasKnown = MPPT_KNOWN_INSTANCES.some(inst => mpptById[inst]);
+  const displayList = hasKnown
+    ? MPPT_KNOWN_INSTANCES.map(inst => mpptById[inst] || { instance: inst, state: null, pv_voltage_v: null, dc_current_a: null, power_w: null, yield_today_kwh: null })
+    : mppts.length > 0 ? mppts : MPPT_KNOWN_INSTANCES.map(inst => ({ instance: inst, state: null, pv_voltage_v: null, dc_current_a: null, power_w: null, yield_today_kwh: null }));
 
   return h('div', { className: 'mppt-group-card' },
     mkHandle('target', Position.Top,    'tt'),
@@ -22,7 +39,7 @@ function MPPTGroupNode({ data }) {
     h('div', { className: 'mg-header' },
       h('span', { className: 'mg-header-icon' }, '☀️'),
       h('span', { className: 'mg-header-title' }, 'SmartSolar MPPT'),
-      h('span', { style: { fontSize:'0.65rem', opacity:0.8, marginLeft:'auto' } }, `${mppts.length} chargeur${mppts.length > 1 ? 's' : ''}`)
+      h('span', { style: { fontSize:'0.65rem', opacity:0.8, marginLeft:'auto' } }, `${MPPT_KNOWN_INSTANCES.length} chargeurs`)
     ),
     h('div', { className: 'mg-totals' },
       h('div', { className: 'mg-total-chip' },
@@ -34,18 +51,19 @@ function MPPTGroupNode({ data }) {
         h('span', { className: 'mg-total-val' }, `${Math.round(totalDcA)} A`)
       )
     ),
-    mppts.length > 0 ? h('div', { className: 'mg-mppt-list' },
-      mppts.map((m, i) => {
-        const inst  = m.instance ?? i;
-        const name  = inst > 0 ? `MPPT-${inst}` : `MPPT-${i+1}`;
-        const s     = m.state ?? null;
-        const pvV   = m.pv_voltage_v ?? null;
-        const dcA   = m.dc_current_a ?? null;
-        const pw    = m.power_w ?? null;
-        const yld   = m.yield_today_kwh ?? null;
+    h('div', { className: 'mg-mppt-list' },
+      displayList.map(function(m) {
+        const inst = m.instance;
+        const name = `MPPT-${inst}`;
+        const s    = m.state ?? null;
+        const pvV  = m.pv_voltage_v ?? null;
+        const dcA  = m.dc_current_a ?? null;
+        const pw   = m.power_w ?? null;
+        const yld  = m.yield_today_kwh ?? null;
+        const hasData = pvV != null || pw != null;
         return h('div', { key: inst, className: 'mg-mppt-row' },
           h('span', { className: 'mg-mppt-name' }, name),
-          h('span', { className: `mg-mppt-state ${stateClass(s)}` }, s ?? '—'),
+          h('span', { className: `mg-mppt-state ${stateClass(s)}` }, s ?? (hasData ? 'Actif' : '—')),
           h('div', { className: 'mg-mppt-metrics' },
             h('div', { className: 'mg-metric' },
               h('span', { className: 'mg-metric-lbl' }, 'PV'),
@@ -66,21 +84,21 @@ function MPPTGroupNode({ data }) {
           )
         );
       })
-    ) : h('div', { className: 'mg-wait' }, 'En attente des chargeurs…')
+    )
   );
 }
 
 // ── SMARTSHUNT NODE ───────────────────────────────────────────────────────────
 function SmartShuntNode({ data }) {
-  const live    = data.live;
-  const soc     = live?.soc_percent   ?? null;
-  const voltage = live?.voltage_v     ?? null;
-  const current = live?.current_a     ?? null;
-  const power   = live?.power_w       ?? null;
-  const eIn     = live?.energy_in_kwh ?? null;
-  const eOut    = live?.energy_out_kwh ?? null;
-  const state   = live?.state         ?? null;
-  const ttgMin  = live?.time_to_go_min ?? null;
+  const live       = data.live;
+  const soc        = live?.soc_percent        ?? null;
+  const voltage    = live?.voltage_v          ?? null;
+  const current    = live?.current_a          ?? null;
+  const power      = live?.power_w            ?? null;
+  const ahIn       = live?.ah_charged_today   ?? null;
+  const ahOut      = live?.ah_discharged_today ?? null;
+  const state      = live?.state              ?? null;
+  const ttgMin     = live?.time_to_go_min     ?? null;
 
   const stateClass = state === 'Charging' ? 'charging' : state === 'Discharging' ? 'discharging' : 'idle';
 
@@ -133,12 +151,12 @@ function SmartShuntNode({ data }) {
           h('span', { className: 'ss-row-val ttg' }, fmtTtg(ttgMin))
         ),
         h('div', { className: 'ss-row', style: { flex: '1 1 0', minWidth: 0 } },
-          h('span', { className: 'ss-row-lbl' }, '⬆ Chargée'),
-          h('span', { className: 'ss-row-val' }, eIn != null ? `${eIn.toFixed(1)} kWh` : '—')
+          h('span', { className: 'ss-row-lbl' }, '⬆ Chargée (24h)'),
+          h('span', { className: 'ss-row-val pos' }, ahIn  != null ? `${ahIn.toFixed(1)} Ah`  : '—')
         ),
         h('div', { className: 'ss-row', style: { flex: '1 1 0', minWidth: 0 } },
-          h('span', { className: 'ss-row-lbl' }, '⬇ Déchargée'),
-          h('span', { className: 'ss-row-val' }, eOut != null ? `${eOut.toFixed(1)} kWh` : '—')
+          h('span', { className: 'ss-row-lbl' }, '⬇ Déchargée (24h)'),
+          h('span', { className: 'ss-row-val neg' }, ahOut != null ? `${ahOut.toFixed(1)} Ah` : '—')
         )
       )
     ) : h('div', { className: 'ss-wait' }, 'En attente…')


### PR DESCRIPTION
1. EasySolar II freq badge: always visible (shows '— Hz' when data absent)
2. Sankey: add discharge mode (Batteries → Maison/Réseau) when no PV
3. MPPT: always render MPPT-273 and MPPT-289 rows with status badges
4. SmartShunt: track 24h Ah charged/discharged via current integration with midnight reset; update InfluxDB write to include ah_charged/discharged_today
5. Spiral kWh arc: change range from 0-18 to 0-40 kWh; use irr.total_yield_kwh source; add solar_daily measurement to InfluxDB (total_yield_kwh + solar_total_w)
6. Monitor: energy-manager uses TCP probe :8081 as fallback when systemd reports inactive (handles manually-started service)
7. ET112/Tasmota card headers: replace inline gradient styles with CSS classes (bms-hdr-pv, bms-hdr-heat, bms-hdr-on, bms-hdr-off, bms-hdr-offline) defined in base.html with dark-mode support

https://claude.ai/code/session_01P7jZBGJKRH5aHit3pqETL3