### PR TITLE
fix(all): resolve 6 display/functionality issues (freq, MPPT, Ah, wat…

### DIFF
--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -553,7 +553,28 @@ async fn handle_meteo_topic(state: &AppState, json: &Value) {
         for item in arr {
             let instance = item.get("Instance").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
             let name     = format!("MPPT-{}", instance);
-            let state_str = item.get("State").and_then(|v| v.as_str()).map(|s| s.to_string());
+            // State comes as integer from energy-manager; fall back to string for legacy sources.
+            let state_str = item.get("State").and_then(|v| {
+                if let Some(i) = v.as_i64() {
+                    Some(match i {
+                        0  => "Off".to_string(),
+                        1  => "Low power".to_string(),
+                        2  => "Fault".to_string(),
+                        3  => "Bulk".to_string(),
+                        4  => "Absorption".to_string(),
+                        5  => "Float".to_string(),
+                        6  => "Storage".to_string(),
+                        7  => "Equalize".to_string(),
+                        8  => "Passthru".to_string(),
+                        9  => "Inverting".to_string(),
+                        10 => "Power assist".to_string(),
+                        11 => "Power supply".to_string(),
+                        _  => format!("State {}", i),
+                    })
+                } else {
+                    v.as_str().map(|s| s.to_string())
+                }
+            });
             let pv_v     = item.get("PvVoltage").and_then(|v| v.as_f64()).map(|v| v as f32);
             let dc_i     = item.get("DcCurrent").and_then(|v| v.as_f64()).map(|v| v as f32);
             let power    = item.get("Power").and_then(|v| v.as_f64()).map(|v| v as f32);
@@ -571,7 +592,12 @@ async fn handle_meteo_topic(state: &AppState, json: &Value) {
                 timestamp: Utc::now(),
             });
         }
+        // Sync mppt_yield_kwh with the sum from all chargers.
+        let total_yield: f32 = new_mppts.iter().filter_map(|m| m.yield_today_kwh).sum();
         state.on_venus_mppts_replace(new_mppts).await;
+        if total_yield > 0.0 {
+            *state.mppt_yield_kwh.write().await = total_yield;
+        }
         return; // format v2 traité, pas de fallback nécessaire
     }
 
@@ -663,6 +689,10 @@ async fn handle_system_topic(state: &AppState, json: &Value) {
             .map(|secs| secs as f32 / 60.0)
             .filter(|&m| m < 14400.0); // > 10 jours → ignorer (= en charge)
 
+        // Ah values computed by energy-manager; fall back to local integration when absent.
+        let ah_charged    = json.get("AhChargedToday").and_then(|v| v.as_f64()).map(|v| v as f32);
+        let ah_discharged = json.get("AhDischargedToday").and_then(|v| v.as_f64()).map(|v| v as f32);
+
         let shunt = VenusSmartShunt {
             soc_percent: Some(soc),
             voltage_v: voltage,
@@ -672,9 +702,8 @@ async fn handle_system_topic(state: &AppState, json: &Value) {
             energy_out_kwh: energy_out.map(|e| e / 1000.0),
             state: state_str,
             time_to_go_min,
-            // Calculés dans on_venus_smartshunt par intégration du courant
-            ah_charged_today:    None,
-            ah_discharged_today: None,
+            ah_charged_today:    ah_charged,
+            ah_discharged_today: ah_discharged,
             timestamp: Utc::now(),
         };
 

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -325,10 +325,10 @@ pub async fn run_watchdog_agent(_state: AppState) {
     }
 }
 
-/// Redémarre un service systemd via `systemctl restart <name>`.
+/// Redémarre un service systemd via `sudo systemctl restart <name>`.
 async fn restart_systemd_service(name: &str) -> bool {
-    match Command::new("systemctl")
-        .args(["restart", name])
+    match Command::new("sudo")
+        .args(["systemctl", "restart", name])
         .output()
         .await
     {

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -631,28 +631,40 @@ impl AppState {
 
     /// Enregistre/met à jour le SmartShunt.
     ///
-    /// Intègre le courant pour accumuler les Ah chargés/déchargés depuis minuit.
-    /// L'accumulateur est remis à zéro à chaque changement de jour calendaire.
+    /// Si energy-manager fournit les Ah (AhChargedToday/AhDischargedToday) dans le payload,
+    /// on les utilise directement. Sinon on intègre le courant localement (fallback).
     pub async fn on_venus_smartshunt(&self, mut shunt: VenusSmartShunt) {
         let now     = shunt.timestamp;
         let day_key = now.date_naive().num_days_from_ce();
 
+        // energy-manager calcule déjà les Ah → utiliser ces valeurs directement.
+        if shunt.ah_charged_today.is_some() || shunt.ah_discharged_today.is_some() {
+            let mut charged    = self.shunt_ah_charged_today.write().await;
+            let mut discharged = self.shunt_ah_discharged_today.write().await;
+            let mut last_ts    = self.shunt_ah_last_ts.write().await;
+            let mut last_day   = self.shunt_ah_last_day.write().await;
+            *last_day = day_key;
+            *last_ts  = Some(now);
+            if let Some(v) = shunt.ah_charged_today    { *charged    = v; }
+            if let Some(v) = shunt.ah_discharged_today { *discharged = v; }
+            *self.venus_smartshunt.write().await = Some(shunt);
+            return;
+        }
+
+        // Fallback : intégration locale Ah = I × Δt (en heures).
         let mut charged    = self.shunt_ah_charged_today.write().await;
         let mut discharged = self.shunt_ah_discharged_today.write().await;
         let mut last_ts    = self.shunt_ah_last_ts.write().await;
         let mut last_day   = self.shunt_ah_last_day.write().await;
 
-        // Remise à zéro à minuit
         if *last_day != day_key {
             *charged    = 0.0;
             *discharged = 0.0;
             *last_day   = day_key;
         }
 
-        // Intégration Ah = I × Δt (en heures)
         if let (Some(prev_ts), Some(current_a)) = (*last_ts, shunt.current_a) {
             let delta_ms = (now - prev_ts).num_milliseconds();
-            // Ne calculer que si l'intervalle est positif et raisonnable (< 10 min)
             if delta_ms > 0 && delta_ms < 600_000 {
                 let delta_h = delta_ms as f32 / 3_600_000.0;
                 if current_a > 0.0 {

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -82,11 +82,17 @@
     .bms-hdr-on      { background: linear-gradient(135deg, #dcfce7 0%, #bbf7d0 100%); }
     .bms-hdr-off     { background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%); }
     .bms-hdr-offline { background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%); }
+    .bms-hdr-sky     { background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%); }
+    .bms-hdr-indigo  { background: linear-gradient(135deg, #eef2ff 0%, #e0e7ff 100%); }
+    .bms-hdr-amber   { background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%); }
     html.dark .bms-hdr-pv      { background: linear-gradient(135deg, #422006 0%, #78350f 100%); }
     html.dark .bms-hdr-heat    { background: linear-gradient(135deg, #2e1065 0%, #4c1d95 100%); }
     html.dark .bms-hdr-on      { background: linear-gradient(135deg, #052e16 0%, #14532d 100%); }
     html.dark .bms-hdr-off     { background: linear-gradient(135deg, #450a0a 0%, #7f1d1d 100%); }
     html.dark .bms-hdr-offline { background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%); }
+    html.dark .bms-hdr-sky     { background: linear-gradient(135deg, #0c2340 0%, #0e3a5f 100%); }
+    html.dark .bms-hdr-indigo  { background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%); }
+    html.dark .bms-hdr-amber   { background: linear-gradient(135deg, #451a03 0%, #78350f 100%); }
 
     /* ─── Dark mode: BMS card header ─────────────────────────── */
     html.dark .bms-hdr {

--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -19,7 +19,7 @@
 
   <!-- ── Services systemd ───────────────────────────────────── -->
   <div class="bms-card" id="card-systemd">
-    <div class="bms-hdr" style="background:linear-gradient(135deg,#f0f9ff 0%,#e0f2fe 100%)">
+    <div class="bms-hdr bms-hdr-sky">
       <div class="bms-hdr-left">
         <span class="bms-hdr-name">⚙ Services Systemd</span>
       </div>
@@ -31,7 +31,7 @@
 
   <!-- ── Services réseau (TCP) ─────────────────────────────── -->
   <div class="bms-card" id="card-network">
-    <div class="bms-hdr" style="background:linear-gradient(135deg,#fdf4ff 0%,#fae8ff 100%)">
+    <div class="bms-hdr bms-hdr-heat">
       <div class="bms-hdr-left">
         <span class="bms-hdr-name">🌐 Services Réseau</span>
       </div>
@@ -43,7 +43,7 @@
 
   <!-- ── Métriques système ──────────────────────────────────── -->
   <div class="bms-card" id="card-system">
-    <div class="bms-hdr" style="background:linear-gradient(135deg,#f0fdf4 0%,#dcfce7 100%)">
+    <div class="bms-hdr bms-hdr-on">
       <div class="bms-hdr-left">
         <span class="bms-hdr-name">📊 Métriques Système</span>
       </div>
@@ -106,7 +106,7 @@
 
   <!-- ── Santé bus RS485 (timeouts/CRC par appareil) ─────────── -->
   <div class="bms-card" id="card-rs485" style="grid-column:1/-1">
-    <div class="bms-hdr" style="background:linear-gradient(135deg,#eef2ff 0%,#e0e7ff 100%)">
+    <div class="bms-hdr bms-hdr-indigo">
       <div class="bms-hdr-left">
         <span class="bms-hdr-name">🔌 Santé bus RS485</span>
       </div>
@@ -121,7 +121,7 @@
 
   <!-- ── Journal des actions automatiques ──────────────────── -->
   <div class="bms-card" id="card-actions">
-    <div class="bms-hdr" style="background:linear-gradient(135deg,#fffbeb 0%,#fef3c7 100%)">
+    <div class="bms-hdr bms-hdr-amber">
       <div class="bms-hdr-left">
         <span class="bms-hdr-name">📋 Actions Automatiques</span>
       </div>

--- a/crates/energy-manager/src/logic/inverter.rs
+++ b/crates/energy-manager/src/logic/inverter.rs
@@ -73,6 +73,11 @@ async fn handle(
             state.write().await.ac_out_current_a = Some(v);
             return true;
         }
+    } else if t.contains("/vebus/") && t.ends_with("/Ac/Out/L1/F") {
+        if let Some(v) = msg.victron_value::<f64>() {
+            state.write().await.ac_frequency_hz = Some(v);
+            return true;
+        }
     } else if t.contains("/vebus/") && t.ends_with("/State") {
         if let Some(v) = msg.victron_value::<i64>() {
             state.write().await.vebus_state = Some(v);

--- a/crates/energy-manager/src/logic/meteo.rs
+++ b/crates/energy-manager/src/logic/meteo.rs
@@ -54,6 +54,7 @@ pub async fn publish_all(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
     });
 
     // santuario/meteo/venus — irradiance + solar + wind
+    // Key "Mppts" matches daly-bms-server handle_meteo_topic (was "MpptList" — mismatch fixed)
     let meteo_payload = json!({
         "Irradiance":    s.irradiance_wm2,
         "TodaysYield":   s.total_yield_today_kwh,
@@ -61,7 +62,7 @@ pub async fn publish_all(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
         "WindSpeed":     s.wind_speed_ms,
         "MpptPower":     s.mppt_273.power_w.unwrap_or(0.0) + s.mppt_289.power_w.unwrap_or(0.0),
         "SolarTotal":    s.solar_total_w,
-        "MpptList": [
+        "Mppts": [
             {
                 "Instance": 273u32,
                 "State":    s.mppt_273.state,

--- a/crates/energy-manager/src/logic/smartshunt.rs
+++ b/crates/energy-manager/src/logic/smartshunt.rs
@@ -1,4 +1,6 @@
 /// Aggregates SmartShunt (battery system) topics → santuario/system/venus (retained).
+/// Computes daily Ah charged/discharged by integrating current over time.
+use chrono::{Datelike, Utc};
 use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -40,6 +42,31 @@ async fn handle(msg: &MqttIncoming, state: &Arc<RwLock<EnergyState>>) -> bool {
             }
         } else if t.ends_with("Battery/Current") {
             if let Some(v) = msg.victron_value::<f64>() {
+                // --- Ah integration ---
+                let now = Utc::now();
+                let day_key = now.date_naive().num_days_from_ce();
+
+                // Midnight reset
+                if s.ah_last_day != day_key {
+                    s.ah_charged_today   = 0.0;
+                    s.ah_discharged_today = 0.0;
+                    s.ah_last_day        = day_key;
+                }
+
+                if let Some(prev_ts) = s.ah_last_ts {
+                    let delta_ms = (now - prev_ts).num_milliseconds();
+                    // Only integrate if interval is positive and < 10 minutes
+                    if delta_ms > 0 && delta_ms < 600_000 {
+                        let delta_h = delta_ms as f64 / 3_600_000.0;
+                        if v > 0.0 {
+                            s.ah_charged_today   += v * delta_h;
+                        } else if v < 0.0 {
+                            s.ah_discharged_today += (-v) * delta_h;
+                        }
+                    }
+                }
+                s.ah_last_ts = Some(now);
+
                 s.battery_current_a = Some(v);
                 updated = true;
             }
@@ -70,31 +97,39 @@ async fn handle(msg: &MqttIncoming, state: &Arc<RwLock<EnergyState>>) -> bool {
 
 async fn publish_state(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
     let s = state.read().await;
-    let soc      = s.soc_pct;
-    let voltage  = s.battery_voltage_v;
-    let current  = s.battery_current_a;
-    let power    = s.battery_power_w;
+    let soc        = s.soc_pct;
+    let voltage    = s.battery_voltage_v;
+    let current    = s.battery_current_a;
+    let power      = s.battery_power_w;
     let batt_state = s.battery_state;
-    let ttg      = s.time_to_go_sec;
+    let ttg        = s.time_to_go_sec;
+    let ah_charged    = s.ah_charged_today;
+    let ah_discharged = s.ah_discharged_today;
+
     let payload = json!({
-        "Soc":      soc,
-        "Voltage":  voltage,
-        "Current":  current,
-        "Power":    power,
-        "State":    batt_state,
-        "TimeToGo": ttg,
+        "Soc":               soc,
+        "Voltage":           voltage,
+        "Current":           current,
+        "Power":             power,
+        "State":             batt_state,
+        "TimeToGo":          ttg,
+        "AhChargedToday":    ah_charged,
+        "AhDischargedToday": ah_discharged,
     });
     drop(s);
+
     bus.publish(MqttOutgoing::retained(publish::SYSTEM_VENUS, &payload)).await;
     bus.emit_live(LiveEvent::new("battery", &payload));
 
     let pt = InfluxPoint::new("battery_status")
         .tag("host", "pi5")
-        .field_f("soc_pct",        soc.unwrap_or(0.0))
-        .field_f("voltage_v",      voltage.unwrap_or(0.0))
-        .field_f("current_a",      current.unwrap_or(0.0))
-        .field_f("power_w",        power.unwrap_or(0.0))
-        .field_i("state",          batt_state.unwrap_or(0))
-        .field_i("time_to_go_sec", ttg.unwrap_or(0));
+        .field_f("soc_pct",            soc.unwrap_or(0.0))
+        .field_f("voltage_v",          voltage.unwrap_or(0.0))
+        .field_f("current_a",          current.unwrap_or(0.0))
+        .field_f("power_w",            power.unwrap_or(0.0))
+        .field_i("state",              batt_state.unwrap_or(0))
+        .field_i("time_to_go_sec",     ttg.unwrap_or(0))
+        .field_f("ah_charged_today",   ah_charged)
+        .field_f("ah_discharged_today", ah_discharged);
     bus.write_influx(pt).await;
 }

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -238,6 +238,12 @@ pub struct EnergyState {
     // --- Charge current (last published) ---
     pub last_charge_current_a: Option<f64>,
     pub last_power_assist: Option<i64>,
+
+    // --- SmartShunt Ah accumulators (reset at midnight) ---
+    pub ah_charged_today: f64,
+    pub ah_discharged_today: f64,
+    pub ah_last_ts: Option<DateTime<Utc>>,
+    pub ah_last_day: i32,
 }
 
 #[derive(Debug, Default, Clone, Serialize)]


### PR DESCRIPTION
…chdog, CSS)

- energy-manager/inverter.rs: add missing AC frequency handler for /Ac/Out/L1/F
- energy-manager/meteo.rs: fix MpptList → Mppts key mismatch (MPPT data now parsed)
- energy-manager/types.rs: add ah_charged_today/discharged/last_ts/last_day fields
- energy-manager/smartshunt.rs: Ah integration with midnight reset; publish Ah in MQTT+InfluxDB
- daly-bms-server/mqtt.rs: parse MPPT state integer→string; sync mppt_yield_kwh from Mppts array; read AhChargedToday/AhDischargedToday from system/venus payload
- daly-bms-server/state.rs: prefer energy-manager Ah values when present (skip local integration)
- daly-bms-server/monitor.rs: use sudo systemctl restart for watchdog
- templates/base.html: add bms-hdr-sky, bms-hdr-indigo, bms-hdr-amber CSS classes + dark variants
- templates/monitor.html: replace inline gradient styles with CSS classes

https://claude.ai/code/session_01P7jZBGJKRH5aHit3pqETL3