### PR TITLE
fix: edge charts, data staleness and deploy script

### DIFF
--- a/crates/daly-bms-server/src/api/chart.rs
+++ b/crates/daly-bms-server/src/api/chart.rs
@@ -194,6 +194,11 @@ pub async fn get_edge_history(
     let (measurement, address_required) = match q.measurement.as_str() {
         "bms_status"        => ("bms_status",        true),
         "et112_status"      => ("et112_status",      true),
+        // energy-manager real measurement names
+        "battery_status"    => ("battery_status",    false),
+        "inverter_status"   => ("inverter_status",   false),
+        "solar_power"       => ("solar_power",       false),
+        // legacy aliases (kept for backward compat — never written, return empty series)
         "venus_mppt_total"  => ("venus_mppt_total",  false),
         "venus_smartshunt"  => ("venus_smartshunt",  false),
         "venus_inverter"    => ("venus_inverter",    false),
@@ -202,6 +207,14 @@ pub async fn get_edge_history(
     let field = match q.field.as_str() {
         "current"              => "current",
         "current_a"            => "current_a",
+        // inverter_status field names (energy-manager)
+        "dc_current_a"         => "dc_current_a",
+        "ac_out_current_a"     => "ac_out_current_a",
+        "dc_power_w"           => "dc_power_w",
+        "ac_out_power_w"       => "ac_out_power_w",
+        // solar_power field names (energy-manager)
+        "mppt_power_w"         => "mppt_power_w",
+        // legacy / generic
         "ac_output_current_a"  => "ac_output_current_a",
         "power_w"              => "power_w",
         _ => return Json(json!({ "ok": false, "series": [], "reason": "bad_field" })),
@@ -254,8 +267,8 @@ pub async fn get_edge_history(
     };
 
     let unit = match field {
-        "current" | "current_a" | "ac_output_current_a" => "A",
-        "power_w" => "W",
+        "current" | "current_a" | "dc_current_a" | "ac_out_current_a" | "ac_output_current_a" => "A",
+        "power_w" | "mppt_power_w" | "dc_power_w" | "ac_out_power_w" => "W",
         _ => "",
     };
 

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -96,10 +96,10 @@ const HIST_ET112_9 = { measurement: 'et112_status',     field: 'current_a',     
 const HIST_BMS_1   = { measurement: 'bms_status',       field: 'current',             address: '0x01', label: 'BMS-360Ah — I (6h)' };
 const HIST_BMS_2   = { measurement: 'bms_status',       field: 'current',             address: '0x02', label: 'BMS-320Ah — I (6h)' };
 const HIST_BMS_3   = { measurement: 'bms_status',       field: 'current',             address: '0x03', label: 'BMS-3 — I (6h)' };
-const HIST_MPPT    = { measurement: 'venus_mppt_total', field: 'current_a',           label: 'MPPT total — I DC (6h)' };
-const HIST_INV_DC  = { measurement: 'venus_inverter',   field: 'current_a',           label: 'Onduleur — I DC (6h)' };
-const HIST_INV_AC  = { measurement: 'venus_inverter',   field: 'ac_output_current_a', label: 'Onduleur — I AC sortie (6h)' };
-const HIST_SHUNT   = { measurement: 'venus_smartshunt', field: 'current_a',           label: 'SmartShunt — I batterie (6h)' };
+const HIST_MPPT    = { measurement: 'solar_power',     field: 'mppt_power_w',     label: 'MPPT total — Puissance DC (6h)' };
+const HIST_INV_DC  = { measurement: 'inverter_status', field: 'dc_current_a',     label: 'Onduleur — I DC (6h)' };
+const HIST_INV_AC  = { measurement: 'inverter_status', field: 'ac_out_current_a', label: 'Onduleur — I AC sortie (6h)' };
+const HIST_SHUNT   = { measurement: 'battery_status',  field: 'current_a',        label: 'SmartShunt — I batterie (6h)' };
 
 const EDGES0 = [
   mkEdge('e-ats-maison', 'ats-main', 'et112-maison',   COLOR.ac,  { sourceHandle: 'main-right', targetHandle: 'tl', type: 'customBezier', history: HIST_ET112_8 }),
@@ -122,6 +122,8 @@ function ESSFlow() {
   const [nodes, setNodes, onNodesChange] = useNodesState(NODES0);
   const [edges, setEdges, onEdgesChange] = useEdgesState(EDGES0);
   const [lastUpdate, setLastUpdate] = useState('—');
+  const [dataAge, setDataAge]       = useState(0);
+  const lastUpdateTsRef = useRef(null);
   const [atsProcessing, setAtsProcessing] = useState(false);
   const [atsRev, setAtsRev] = useState(0);
 const atsExecRef = useRef(null);
@@ -352,6 +354,8 @@ const atsExecRef = useRef(null);
     }));
 
     setLastUpdate(new Date().toLocaleTimeString('fr-FR'));
+    lastUpdateTsRef.current = Date.now();
+    setDataAge(0);
   }, [atsProcessing, atsRev, handleAtsReseauForce, handleAtsOnduleurForce, handleAtsToggleRemote, handleAtsForceOff]);
 
   useEffect(function() {
@@ -409,7 +413,25 @@ const atsExecRef = useRef(null);
     }
     fetchAll();
     const timer = setInterval(fetchAll, 2000);
-    return function() { clearInterval(timer); };
+
+    // Re-fetch immediately when tab becomes visible (browser throttles setInterval in background)
+    function onVisibility() {
+      if (!document.hidden) fetchAll();
+    }
+    document.addEventListener('visibilitychange', onVisibility);
+
+    // Age counter — ticks every second to show data staleness
+    const ageTick = setInterval(function() {
+      if (lastUpdateTsRef.current) {
+        setDataAge(Math.floor((Date.now() - lastUpdateTsRef.current) / 1000));
+      }
+    }, 1000);
+
+    return function() {
+      clearInterval(timer);
+      clearInterval(ageTick);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
   }, [applyData]);
 
   const legend = [
@@ -434,7 +456,15 @@ const atsExecRef = useRef(null);
       )
     ),
     h(Panel, { position: 'bottom-right' },
-      h('div', { className: 'viz-panel' }, `Màj : ${lastUpdate}`)
+      h('div', { className: 'viz-panel', style: { display: 'flex', alignItems: 'center', gap: '6px' } },
+        h('span', { style: {
+          width: '8px', height: '8px', borderRadius: '50%', display: 'inline-block', flexShrink: 0,
+          background: dataAge < 5 ? '#22c55e' : dataAge < 15 ? '#f59e0b' : '#ef4444'
+        }}),
+        dataAge < 5
+          ? `Màj : ${lastUpdate}`
+          : `Màj : ${lastUpdate} (${dataAge}s)`
+      )
     ),
   );
 }

--- a/crates/energy-manager/src/logic/mod.rs
+++ b/crates/energy-manager/src/logic/mod.rs
@@ -8,4 +8,5 @@ pub mod smartshunt;
 pub mod solar_power;
 pub mod switch_ats;
 pub mod tasmota;
+pub mod victron_keepalive;
 pub mod water_heater;

--- a/crates/energy-manager/src/logic/solar_power.rs
+++ b/crates/energy-manager/src/logic/solar_power.rs
@@ -179,9 +179,10 @@ async fn writer_task(
 
         // POST to daly-bms-server
         let body = json!({
-            "solar_total_w": solar_total,
-            "mppt_power_w":  mppt_power,
-            "house_power_w": house_power,
+            "solar_total_w":   solar_total,
+            "mppt_power_w":    mppt_power,
+            "total_yield_kwh": total_yield,
+            "house_power_w":   house_power,
         });
         if let Err(e) = http_client
             .post(&api_url)

--- a/crates/energy-manager/src/logic/victron_keepalive.rs
+++ b/crates/energy-manager/src/logic/victron_keepalive.rs
@@ -1,0 +1,24 @@
+/// Sends a periodic keepalive to the Victron GX MQTT broker.
+///
+/// Venus OS stops publishing N/ topics after ~60s if no client publishes
+/// an R/ keepalive.  We publish `R/{portal_id}/keepalive` every 30s so the
+/// GX keeps streaming live data.
+use tokio::time::{interval, Duration};
+use tracing::debug;
+
+use crate::bus::AppBus;
+use crate::types::MqttOutgoing;
+
+pub async fn spawn(portal_id: String, bus: AppBus) {
+    tokio::spawn(run(portal_id, bus));
+}
+
+async fn run(portal_id: String, bus: AppBus) {
+    let topic = format!("R/{portal_id}/keepalive");
+    let mut ticker = interval(Duration::from_secs(30));
+    loop {
+        ticker.tick().await;
+        debug!("Sending Victron keepalive → {topic}");
+        bus.publish(MqttOutgoing::raw(&topic, "", false)).await;
+    }
+}

--- a/crates/energy-manager/src/main.rs
+++ b/crates/energy-manager/src/main.rs
@@ -88,6 +88,7 @@ async fn main() -> anyhow::Result<()> {
     logic::deye_command::spawn(vic.clone(), cfg.deye.clone(), bus.clone(), state.clone()).await;
     logic::water_heater::spawn(cfg.water_heater.clone(), lg_arc, bus.clone(), state.clone()).await;
     logic::meteo::spawn(cfg.solar.clone(), bus.clone(), state.clone()).await;
+    logic::victron_keepalive::spawn(cfg.victron.portal_id.clone(), bus.clone()).await;
 
     // --- Live WebSocket server ---
     let bind    = cfg.api.bind.clone();

--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -23,7 +23,12 @@ step "Compilation energy-manager (aarch64)…"
 make build-energy-arm || error "make build-energy-arm a échoué"
 info "energy-manager compilé"
 
-# ── 3. Déploiement daly-bms-server ───────────────────────────────────────────
+# ── 3. Mise à jour de la configuration ──────────────────────────────────────
+step "Déploiement Config.toml → /etc/daly-bms/config.toml…"
+sudo cp Config.toml /etc/daly-bms/config.toml
+info "Config.toml déployée"
+
+# ── 4. Déploiement daly-bms-server ───────────────────────────────────────────
 step "Déploiement daly-bms-server…"
 sudo systemctl stop daly-bms
 sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
@@ -35,7 +40,7 @@ else
     error "daly-bms n'a pas démarré — vérifier : journalctl -u daly-bms -n 50"
 fi
 
-# ── 4. Déploiement energy-manager ────────────────────────────────────────────
+# ── 5. Déploiement energy-manager ────────────────────────────────────────────
 step "Déploiement energy-manager…"
 sudo systemctl stop energy-manager
 sudo cp target/aarch64-unknown-linux-gnu/release/energy-manager /usr/local/bin/
@@ -47,7 +52,7 @@ else
     error "energy-manager n'a pas démarré — vérifier : journalctl -u energy-manager -n 50"
 fi
 
-# ── 5. Résumé ─────────────────────────────────────────────────────────────────
+# ── 6. Résumé ─────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}═══════════════════════════════════════${NC}"
 echo -e "${GREEN}  Déploiement terminé avec succès ✓${NC}"


### PR DESCRIPTION
- chart.rs: add battery_status/inverter_status/solar_power to measurement whitelist; add dc_current_a/ac_out_current_a/mppt_power_w to field whitelist; extend unit map to cover all new fields
- visualization.html: correct HIST_MPPT/INV_DC/INV_AC/SHUNT to use actual InfluxDB measurement names written by energy-manager
- visualization.html: Page Visibility API re-fetches on tab focus; age counter dot turns amber at 5s / red at 15s to expose stale data
- energy-manager: add victron_keepalive module — publishes R/{portal_id}/ keepalive every 30s so Venus OS never stops streaming N/ topics
- solar_power.rs: include total_yield_kwh in POST to daly-bms-server so spiral kWh counter updates correctly
- deploy-pi5.sh: copy Config.toml to /etc/daly-bms/ before restart

https://claude.ai/code/session_01P7jZBGJKRH5aHit3pqETL3