### PR TITLE
fix(energy): correct 3 regressions — solar baseline day reset, SmartS…

### DIFF
--- a/crates/daly-bms-server/templates/tasmota_all.html
+++ b/crates/daly-bms-server/templates/tasmota_all.html
@@ -15,11 +15,16 @@
   </div>
 </div>
 
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1.25rem;">
+
 {# ── Chauffe-eau LG ThinQ ──────────────────────────────────────────────────── #}
-<div class="bms-card" id="lg-wh-card" style="margin-bottom:1.25rem;">
-  <div class="bms-hdr bms-hdr-on" id="lg-wh-hdr">
+<div class="bms-card" id="lg-wh-card">
+  <div class="bms-hdr bms-hdr-off" id="lg-wh-hdr">
     <div class="bms-hdr-left">
-      <div class="bms-live"><div class="live-dot" id="lg-wh-dot"></div><span id="lg-wh-mode">—</span></div>
+      <div class="bms-live">
+        <div class="live-dot" id="lg-wh-dot" style="background:var(--muted2);box-shadow:none;"></div>
+        <span id="lg-wh-mode">—</span>
+      </div>
       <span class="bms-hdr-name">🌡️ Chauffe-eau LG ThinQ</span>
     </div>
     <div class="bms-hdr-right">
@@ -38,15 +43,15 @@
     </div>
   </div>
 
-  <div style="padding:0.6rem 0.75rem;display:flex;gap:0.5rem;flex-wrap:wrap;border-top:1px solid var(--border);">
-    <button onclick="lgSetMode('HEAT_PUMP')" id="btn-hp"       class="btn btn-primary"  style="font-size:0.72rem;padding:0.3rem 0.9rem;">♨️ HEAT_PUMP</button>
-    <button onclick="lgSetMode('TURBO')"     id="btn-turbo"    class="btn btn-outline"   style="font-size:0.72rem;padding:0.3rem 0.9rem;">⚡ TURBO</button>
-    <button onclick="lgSetMode('VACATION')"  id="btn-vacation" class="btn btn-danger"    style="font-size:0.72rem;padding:0.3rem 0.9rem;">❄️ VACATION</button>
+  <div style="padding:0.5rem 0.75rem;display:flex;justify-content:space-between;align-items:center;border-top:1px solid var(--border);gap:0.5rem;flex-wrap:wrap;">
+    <div style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+      <button onclick="lgSetMode('HEAT_PUMP')" id="btn-heatpump" class="btn btn-outline" style="font-size:0.72rem;padding:0.3rem 0.9rem;">♨️ HEAT_PUMP</button>
+      <button onclick="lgSetMode('TURBO')"     id="btn-turbo"    class="btn btn-outline" style="font-size:0.72rem;padding:0.3rem 0.9rem;">⚡ TURBO</button>
+      <button onclick="lgSetMode('VACATION')"  id="btn-vacation" class="btn btn-outline" style="font-size:0.72rem;padding:0.3rem 0.9rem;">❄️ VACATION</button>
+    </div>
     <span id="lg-wh-err" style="font-size:0.72rem;color:var(--red);align-self:center;"></span>
   </div>
 </div>
-
-<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1.25rem;">
 
 {% for d in devices %}
 <div class="bms-card {% if !d.connected %}" style="opacity:0.7{% endif %}" id="tasmota-card-{{ d.id }}">
@@ -241,7 +246,20 @@ updateAll();
 setInterval(updateAll, 5000);
 
 // ── LG ThinQ water heater ────────────────────────────────────────────────────
-const LG_API = 'http://192.168.1.141:8081';
+// Use same hostname as dashboard so it works regardless of how the page is accessed.
+const LG_API = window.location.protocol + '//' + window.location.hostname + ':8081';
+
+const LG_MODE_COLORS = {
+  HEAT_PUMP: 'linear-gradient(135deg,#fef3c7 0%,#fde68a 100%)',
+  TURBO:     'linear-gradient(135deg,#fee2e2 0%,#fca5a5 100%)',
+  VACATION:  'linear-gradient(135deg,#e0f2fe 0%,#bae6fd 100%)',
+};
+
+const LG_MODE_DOT = {
+  HEAT_PUMP: '',   // default green pulse
+  TURBO:     'background:var(--orange);box-shadow:0 0 6px var(--orange)',
+  VACATION:  'background:var(--blue);box-shadow:0 0 6px var(--blue)',
+};
 
 async function lgFetchStatus() {
   try {
@@ -249,25 +267,30 @@ async function lgFetchStatus() {
     if (!resp.ok) { lgSetError('Erreur HTTP ' + resp.status); return; }
     const d = await resp.json();
     lgSetError('');
-    document.getElementById('lg-wh-mode').textContent   = d.mode || '—';
+
+    const mode = d.mode || 'VACATION';
+    document.getElementById('lg-wh-mode').textContent   = mode;
     document.getElementById('lg-wh-temp').textContent   = d.current_temp_c != null ? d.current_temp_c.toFixed(1) + ' °C' : '—';
     document.getElementById('lg-wh-target').textContent = d.target_temp_c  != null ? d.target_temp_c.toFixed(1)  + ' °C' : '—';
     document.getElementById('lg-wh-ts').textContent     = new Date().toLocaleTimeString('fr-FR');
 
-    // Highlight active mode button
-    ['HEAT_PUMP','TURBO','VACATION'].forEach(m => {
-      const btn = document.getElementById('btn-' + m.toLowerCase().replace('_',''));
+    // Highlight active mode button — same pattern as toggle buttons
+    const btnMap = { HEAT_PUMP: 'btn-heatpump', TURBO: 'btn-turbo', VACATION: 'btn-vacation' };
+    Object.entries(btnMap).forEach(([m, btnId]) => {
+      const btn = document.getElementById(btnId);
       if (!btn) return;
-      btn.className = (d.mode === m) ? 'btn btn-primary' : 'btn btn-outline';
+      btn.className = (mode === m) ? 'btn btn-primary' : 'btn btn-outline';
+      btn.style.fontSize = '0.72rem';
+      btn.style.padding  = '0.3rem 0.9rem';
     });
-    // header color
+
+    // Header color + dot — same mechanism as updateCardHeader()
     const hdr = document.getElementById('lg-wh-hdr');
-    if (hdr) {
-      hdr.style.background = d.mode === 'HEAT_PUMP' ? 'linear-gradient(135deg,#fef3c7 0%,#fde68a 100%)'
-                           : d.mode === 'TURBO'     ? 'linear-gradient(135deg,#fee2e2 0%,#fca5a5 100%)'
-                           : 'linear-gradient(135deg,#e0f2fe 0%,#bae6fd 100%)';
-    }
-    if (!d.lg_enabled) lgSetError('LG ThinQ désactivé (voir Config.toml)');
+    if (hdr) hdr.style.background = LG_MODE_COLORS[mode] || LG_MODE_COLORS.VACATION;
+    const dot = document.getElementById('lg-wh-dot');
+    if (dot) dot.style.cssText = LG_MODE_DOT[mode] ?? '';
+
+    if (!d.lg_enabled) lgSetError('LG ThinQ désactivé (LG_DEVICE_ID / LG_BEARER_TOKEN manquants)');
   } catch(e) {
     lgSetError('energy-manager inaccessible (:8081)');
   }

--- a/crates/energy-manager/src/logic/smartshunt.rs
+++ b/crates/energy-manager/src/logic/smartshunt.rs
@@ -36,9 +36,6 @@ async fn run(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState
     let t_soc        = format!("N/{pid}/battery/{shunt}/Soc");
     let t_ttg        = format!("N/{pid}/battery/{shunt}/TimeToGo");
     let t_state      = format!("N/{pid}/battery/{shunt}/State");
-    let t_charged    = format!("N/{pid}/battery/{shunt}/History/ChargedEnergy");
-    let t_discharged = format!("N/{pid}/battery/{shunt}/History/DischargedEnergy");
-
     let mut rx = bus.subscribe_mqtt();
     loop {
         let msg = match rx.recv().await {
@@ -47,7 +44,7 @@ async fn run(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState
         };
 
         if let Some(dirty) = handle(&msg, &state, &t_voltage, &t_current, &t_power,
-                                    &t_soc, &t_ttg, &t_state, &t_charged, &t_discharged).await {
+                                    &t_soc, &t_ttg, &t_state).await {
             if dirty {
                 publish_state(&bus, &state).await;
             }
@@ -58,7 +55,6 @@ async fn run(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState
 /// Returns Some(true) if state was updated (caller should publish),
 /// Some(false) if topic matched but no value changed,
 /// None if topic was not ours.
-#[allow(clippy::too_many_arguments)]
 async fn handle(
     msg: &MqttIncoming,
     state: &Arc<RwLock<EnergyState>>,
@@ -68,8 +64,6 @@ async fn handle(
     t_soc:     &str,
     t_ttg:     &str,
     t_state:   &str,
-    t_charged: &str,
-    t_discharged: &str,
 ) -> Option<bool> {
     let t = &msg.topic;
 
@@ -82,9 +76,13 @@ async fn handle(
     let is_vebus_pw    = t.ends_with("/Dc/0/Power")      && t.contains("/vebus/");
 
     // --- Direct SmartShunt topics ---
+    // History/ChargedEnergy and DischargedEnergy use wildcard subscription
+    // (battery/+/...) so we match by suffix instead of exact topic.
+    let is_charged    = t.ends_with("/History/ChargedEnergy")    && t.contains("/battery/");
+    let is_discharged = t.ends_with("/History/DischargedEnergy") && t.contains("/battery/");
     let is_shunt = t == t_voltage || t == t_current || t == t_power
         || t == t_soc || t == t_ttg || t == t_state
-        || t == t_charged || t == t_discharged;
+        || is_charged || is_discharged;
 
     if !is_shunt && !is_sys_soc && !is_sys_current && !is_sys_state
         && !is_sys_ttg && !is_vebus_v && !is_vebus_pw {
@@ -119,7 +117,7 @@ async fn handle(
         if let Some(v) = msg.victron_value::<i64>() {
             s.battery_state = Some(v);
         }
-    } else if t == t_charged {
+    } else if is_charged {
         if let Some(kwh) = msg.victron_value::<f64>() {
             let day_key = now.date_naive().num_days_from_ce();
             if s.shunt_charged_day != day_key || s.shunt_charged_baseline_kwh.is_none() {
@@ -132,7 +130,7 @@ async fn handle(
             s.shunt_charged_today_kwh = (kwh - baseline).max(0.0);
             debug!("SmartShunt ChargedEnergy: raw={kwh:.3} baseline={baseline:.3} today={:.3}", s.shunt_charged_today_kwh);
         }
-    } else if t == t_discharged {
+    } else if is_discharged {
         if let Some(kwh) = msg.victron_value::<f64>() {
             let day_key = now.date_naive().num_days_from_ce();
             if s.shunt_discharged_day != day_key || s.shunt_discharged_baseline_kwh.is_none() {

--- a/crates/energy-manager/src/logic/solar_power.rs
+++ b/crates/energy-manager/src/logic/solar_power.rs
@@ -1,3 +1,4 @@
+use chrono::Datelike;
 use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -6,7 +7,8 @@ use tracing::debug;
 
 use crate::bus::AppBus;
 use crate::config::{SolarConfig, VictronConfig};
-use crate::types::{EnergyState, InfluxPoint, LiveEvent};
+use crate::mqtt::topics::publish;
+use crate::types::{EnergyState, InfluxPoint, LiveEvent, MqttOutgoing};
 
 pub async fn spawn(
     vic: Arc<VictronConfig>,
@@ -59,7 +61,8 @@ async fn mqtt_task(
 
         // Track whether a new baseline was just established (must be published
         // *after* releasing the write lock to avoid deadlocking the bus).
-        let mut publish_baseline: Option<f64> = None;
+        // Tuple: (ordinal_day, kwh) so we can encode the day in the retained message.
+        let mut publish_baseline: Option<(i32, f64)> = None;
 
         {
             let mut s = state.write().await;
@@ -74,9 +77,15 @@ async fn mqtt_task(
                 s.pvinverter_power_w = msg.victron_value::<f64>();
             } else if *t == t_pv_energy {
                 if let Some(kwh) = msg.victron_value::<f64>() {
+                    let today = chrono::Utc::now().date_naive().num_days_from_ce();
+                    // Midnight reset: new day → discard yesterday's baseline
+                    if s.pvinv_baseline_day != today {
+                        s.pvinv_baseline_kwh = None;
+                        s.pvinv_baseline_day = today;
+                    }
                     if s.pvinv_baseline_kwh.is_none() {
                         s.pvinv_baseline_kwh = Some(kwh);
-                        publish_baseline = Some(kwh);
+                        publish_baseline = Some((today, kwh));
                     }
                     let baseline = s.pvinv_baseline_kwh.unwrap_or(kwh);
                     s.pvinv_yield_today_kwh = (kwh - baseline).max(0.0);
@@ -117,15 +126,14 @@ async fn mqtt_task(
 
         // Outside the lock: publish baseline as retained so restarts within the
         // same day pick up the correct start-of-day ET112 counter value.
-        if let Some(kwh) = publish_baseline {
-            use crate::mqtt::topics::publish;
-            use crate::types::MqttOutgoing;
+        // Format: "{ordinal_day}:{kwh}" — day is checked on restore to reject stale values.
+        if let Some((day, kwh)) = publish_baseline {
             bus.publish(MqttOutgoing::raw(
                 publish::PVINV_BASELINE,
-                format!("{kwh:.3}"),
+                format!("{day}:{kwh:.3}"),
                 true,
             )).await;
-            debug!("pvinv_baseline published as retained: {kwh:.3} kWh");
+            debug!("pvinv_baseline published as retained: day={day} kwh={kwh:.3}");
         }
     }
 }

--- a/crates/energy-manager/src/mqtt/topics.rs
+++ b/crates/energy-manager/src/mqtt/topics.rs
@@ -45,8 +45,10 @@ pub fn all_subscriptions(portal_id: &str, vebus: u32, mppt1: u32, mppt2: u32, pv
         n(pid, &format!("battery/{shunt}/Soc")),
         n(pid, &format!("battery/{shunt}/TimeToGo")),
         n(pid, &format!("battery/{shunt}/State")),
-        n(pid, &format!("battery/{shunt}/History/ChargedEnergy")),
-        n(pid, &format!("battery/{shunt}/History/DischargedEnergy")),
+        // Wildcards: match any battery instance so we don't need to know the
+        // exact SmartShunt instance number (varies per installation).
+        n(pid, "battery/+/History/ChargedEnergy"),
+        n(pid, "battery/+/History/DischargedEnergy"),
 
         // --- MPPT 1 ---
         n(pid, &format!("solarcharger/{mppt1}/Yield/Power")),

--- a/crates/energy-manager/src/persist/baseline.rs
+++ b/crates/energy-manager/src/persist/baseline.rs
@@ -1,6 +1,7 @@
 /// Restores solar baselines and production counters at startup.
 /// Primary source: MQTT retained topics (pvinv_baseline, yield_yesterday).
 /// InfluxDB writes (during runtime and midnight reset) ensure persistence across restarts.
+use chrono::Datelike;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::info;
@@ -23,17 +24,35 @@ pub async fn restore(
     // See on_retained_baseline() and on_retained_yield_yesterday() below.
 }
 
-/// Called when MQTT retained baseline arrives (santuario/persist/pvinv_baseline)
+/// Called when MQTT retained baseline arrives (santuario/persist/pvinv_baseline).
+/// Format: "{ordinal_day}:{kwh:.3}"  (e.g. "738976:17.123")
+/// The day is checked against today to reject stale baselines from previous days.
 pub async fn on_retained_baseline(payload: &str, state: &Arc<RwLock<EnergyState>>) {
     if payload.is_empty() {
-        return; // cleared at midnight
+        return;
     }
-    if let Ok(v) = payload.trim().parse::<f64>() {
-        let mut s = state.write().await;
-        if s.pvinv_baseline_kwh.is_none() {
-            s.pvinv_baseline_kwh = Some(v);
-            info!("Baseline restored from MQTT retained: pvinv_baseline = {v:.3} kWh");
-        }
+    let today = chrono::Utc::now().date_naive().num_days_from_ce();
+
+    let (day, kwh) = if let Some((d_str, kwh_str)) = payload.trim().split_once(':') {
+        let Ok(d)   = d_str.parse::<i32>()  else { return };
+        let Ok(v)   = kwh_str.parse::<f64>() else { return };
+        (d, v)
+    } else {
+        // Legacy format (plain kWh, no day) — ignore to avoid stale value
+        info!("pvinv_baseline retained: legacy format without day, ignoring to prevent stale baseline");
+        return;
+    };
+
+    if day != today {
+        info!("pvinv_baseline retained: from day {day}, today is {today} — ignoring stale baseline");
+        return;
+    }
+
+    let mut s = state.write().await;
+    if s.pvinv_baseline_kwh.is_none() {
+        s.pvinv_baseline_kwh = Some(kwh);
+        s.pvinv_baseline_day = today;
+        info!("Baseline restored from MQTT retained: pvinv_baseline = {kwh:.3} kWh (day={day})");
     }
 }
 

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -219,7 +219,8 @@ pub struct EnergyState {
     // --- Solar production counters ---
     pub mppt_yield_today_kwh: f64,
     pub pvinv_yield_today_kwh: f64,
-    pub pvinv_baseline_kwh: Option<f64>,   // absolute energy at start of day
+    pub pvinv_baseline_kwh: Option<f64>,   // ET112 cumulative counter at start of day
+    pub pvinv_baseline_day: i32,           // day ordinal when baseline was set (reset at midnight)
     pub total_yield_today_kwh: f64,
     pub yield_yesterday_kwh: f64,
 


### PR DESCRIPTION
…hunt wildcard, LG style

Fix #1 (solar baseline) — pvinv_baseline now resets at midnight via pvinv_baseline_day tracking in EnergyState. Retained MQTT format changed to "{day}:{kwh}" so on_retained_baseline rejects stale values from previous days (was: plain kWh with no day info → stale baseline cumulated over multiple days).

Fix #2 (SmartShunt kWh) — subscribe to battery/+/History/ChargedEnergy and battery/+/History/DischargedEnergy using MQTT wildcards. Match by ends_with() in handle() so the instance number in Config.toml is no longer required for energy counters (was: hardcoded instance 290 which may not match the actual SmartShunt).

Fix #3 (LG widget style + URL) — LG water heater card moved inside the Tasmota grid, uses identical card/header/kpi4/button structure as Tasmota device cards. LG_API URL now derived from window.location.hostname instead of hardcoded 192.168.1.141 so it works regardless of the IP used to access the dashboard. Mode buttons use btn-primary for active mode, btn-outline otherwise (same pattern as toggle buttons).

https://claude.ai/code/session_01WkTcchAa2HTezHGnxwDPUQ