### PR TITLE
feat(console): add real-time diagnostic console at /dashboard/console

### DIFF
--- a/crates/daly-bms-server/src/api/console.rs
+++ b/crates/daly-bms-server/src/api/console.rs
@@ -1,0 +1,113 @@
+//! WebSocket console — streams ConsoleEvent to the browser in real-time.
+//!
+//! GET /ws/console
+//!
+//! Optional query parameters (comma-separated lists):
+//!   devices = bms1,bms2,et112,smartshunt,ats,energy_manager,venus,system
+//!   kinds   = mqtt_in,mqtt_out,rs485,state,error,system
+
+use crate::console::{EventDevice, EventKind};
+use crate::state::AppState;
+use axum::{
+    extract::{Query, State, WebSocketUpgrade},
+    response::IntoResponse,
+};
+use axum::extract::ws::{Message, WebSocket};
+use futures::{SinkExt, StreamExt};
+use serde::Deserialize;
+use std::collections::HashSet;
+
+#[derive(Debug, Deserialize)]
+pub struct ConsoleQuery {
+    pub devices: Option<String>,
+    pub kinds:   Option<String>,
+}
+
+/// GET /ws/console
+pub async fn ws_console(
+    ws:    WebSocketUpgrade,
+    Query(q): Query<ConsoleQuery>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_ws_console(socket, state, q))
+}
+
+async fn handle_ws_console(socket: WebSocket, state: AppState, q: ConsoleQuery) {
+    let device_filter: Option<HashSet<String>> = q.devices.as_deref().map(|s| {
+        s.split(',').map(|p| p.trim().to_lowercase()).filter(|s| !s.is_empty()).collect()
+    });
+    let kind_filter: Option<HashSet<String>> = q.kinds.as_deref().map(|s| {
+        s.split(',').map(|p| p.trim().to_lowercase()).filter(|s| !s.is_empty()).collect()
+    });
+
+    let mut rx = state.console_bus.subscribe();
+    let (mut sender, mut receiver) = socket.split();
+
+    // Welcome message
+    let welcome = serde_json::json!({
+        "type": "connected",
+        "message": "Console diagnostique connectée",
+        "filters": {
+            "devices": q.devices.as_deref().unwrap_or("all"),
+            "kinds":   q.kinds.as_deref().unwrap_or("all"),
+        }
+    });
+    let _ = sender.send(Message::Text(welcome.to_string())).await;
+
+    loop {
+        tokio::select! {
+            Ok(ev) = rx.recv() => {
+                // Apply device filter
+                if let Some(ref df) = device_filter {
+                    let dev_str = device_to_str(&ev.device);
+                    if !df.contains(dev_str) {
+                        continue;
+                    }
+                }
+                // Apply kind filter
+                if let Some(ref kf) = kind_filter {
+                    let kind_str = kind_to_str(&ev.kind);
+                    if !kf.contains(kind_str) {
+                        continue;
+                    }
+                }
+
+                if let Ok(json) = serde_json::to_string(&*ev) {
+                    if sender.send(Message::Text(json)).await.is_err() {
+                        break;
+                    }
+                }
+            }
+            Some(msg) = receiver.next() => {
+                match msg {
+                    Ok(Message::Close(_)) | Err(_) => break,
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn device_to_str(d: &EventDevice) -> &'static str {
+    match d {
+        EventDevice::Bms1         => "bms1",
+        EventDevice::Bms2         => "bms2",
+        EventDevice::Et112        => "et112",
+        EventDevice::SmartShunt   => "smartshunt",
+        EventDevice::Ats          => "ats",
+        EventDevice::EnergyManager => "energy_manager",
+        EventDevice::Venus        => "venus",
+        EventDevice::System       => "system",
+    }
+}
+
+fn kind_to_str(k: &EventKind) -> &'static str {
+    match k {
+        EventKind::MqttIn  => "mqtt_in",
+        EventKind::MqttOut => "mqtt_out",
+        EventKind::Rs485   => "rs485",
+        EventKind::State   => "state",
+        EventKind::Error   => "error",
+        EventKind::System  => "system",
+    }
+}

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -5,6 +5,7 @@
 pub mod system;
 pub mod bms;
 pub mod ats;
+pub mod console;
 pub mod et112;
 pub mod tasmota;
 pub mod chart;
@@ -104,6 +105,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/ws/bms/stream",         get(bms::ws_all))
         .route("/ws/bms/:id/stream",     get(bms::ws_single))
         .route("/ws/venus/stream",       get(bms::ws_venus))
+        .route("/ws/console",            get(console::ws_console))
 
         // ── Middlewares ───────────────────────────────────────────────────────
         .layer(cors)

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -15,6 +15,7 @@
 
 use crate::ats::AtsSnapshot;
 use crate::config::MqttConfig;
+use crate::console::{ConsoleEvent, EventDevice};
 use crate::et112::Et112Snapshot;
 use crate::state::{AppState, VenusHeatpump, VenusMppt, VenusSmartShunt, VenusTemperature};
 use crate::tasmota::TasmotaSnapshot;
@@ -85,6 +86,13 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
                 .get(&snap.address)
                 .cloned()
                 .unwrap_or_else(|| snap.address.to_string());
+            let topic = format!("{}/bms/{}/venus", cfg.topic_prefix.trim_end_matches('/').rsplit_once('/').map(|(p,_)| p).unwrap_or("santuario"), topic_id);
+            let device = if snap.address == 1 { EventDevice::Bms1 } else { EventDevice::Bms2 };
+            state.console_bus.emit(ConsoleEvent::mqtt_out(device, &topic, json!({
+                "Soc": snap.soc,
+                "Voltage": snap.dc.voltage,
+                "Current": snap.dc.current,
+            })));
             if let Err(e) = publish_snapshot(&client, &cfg, snap, &topic_id).await {
                 error!("MQTT publish BMS erreur : {:?}", e);
             }
@@ -508,6 +516,18 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
 
                 // Parser le payload JSON
                 if let Ok(json) = serde_json::from_str::<Value>(payload) {
+                    // Console diagnostic events
+                    let ev_device = if topic.contains("/meteo/") || topic.contains("/inverter/") {
+                        EventDevice::Venus
+                    } else if topic.contains("/system/") {
+                        EventDevice::SmartShunt
+                    } else if topic.contains("/heat/") || topic.contains("/heatpump/") {
+                        EventDevice::EnergyManager
+                    } else {
+                        EventDevice::Venus
+                    };
+                    state.console_bus.emit(ConsoleEvent::mqtt_in(ev_device, topic, json.clone()));
+
                     if topic == "santuario/meteo/venus" {
                         handle_meteo_topic(&state, &json).await;
                     } else if topic.starts_with("santuario/heat/") && topic.ends_with("/venus") {

--- a/crates/daly-bms-server/src/console.rs
+++ b/crates/daly-bms-server/src/console.rs
@@ -1,0 +1,161 @@
+//! Diagnostic console — broadcast channel for real-time event streaming.
+//!
+//! Each significant event (MQTT in/out, RS485 state changes, system messages)
+//! is wrapped in a [`ConsoleEvent`] and sent on the [`ConsoleBus`].
+//! The `/ws/console` WebSocket handler subscribes and forwards events to the browser.
+
+use chrono::Utc;
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+pub const CONSOLE_CAPACITY: usize = 512;
+
+// ---------------------------------------------------------------------------
+// Event classification
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    MqttIn,
+    MqttOut,
+    Rs485,
+    State,
+    Error,
+    System,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EventDevice {
+    Bms1,
+    Bms2,
+    Et112,
+    SmartShunt,
+    Ats,
+    EnergyManager,
+    Venus,
+    System,
+}
+
+// ---------------------------------------------------------------------------
+// ConsoleEvent
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ConsoleEvent {
+    pub ts:      String,
+    pub kind:    EventKind,
+    pub device:  EventDevice,
+    pub label:   String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topic:   Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text:    Option<String>,
+}
+
+impl ConsoleEvent {
+    fn now() -> String {
+        Utc::now().format("%H:%M:%S%.3f").to_string()
+    }
+
+    pub fn mqtt_in(device: EventDevice, topic: &str, payload: serde_json::Value) -> Self {
+        Self {
+            ts:      Self::now(),
+            kind:    EventKind::MqttIn,
+            device,
+            label:   format!("MQTT ← {topic}"),
+            topic:   Some(topic.to_string()),
+            payload: Some(payload),
+            text:    None,
+        }
+    }
+
+    pub fn mqtt_out(device: EventDevice, topic: &str, payload: serde_json::Value) -> Self {
+        Self {
+            ts:      Self::now(),
+            kind:    EventKind::MqttOut,
+            device,
+            label:   format!("MQTT → {topic}"),
+            topic:   Some(topic.to_string()),
+            payload: Some(payload),
+            text:    None,
+        }
+    }
+
+    pub fn rs485(device: EventDevice, label: &str, payload: serde_json::Value) -> Self {
+        Self {
+            ts:      Self::now(),
+            kind:    EventKind::Rs485,
+            device,
+            label:   label.to_string(),
+            topic:   None,
+            payload: Some(payload),
+            text:    None,
+        }
+    }
+
+    pub fn state(device: EventDevice, label: &str, payload: serde_json::Value) -> Self {
+        Self {
+            ts:      Self::now(),
+            kind:    EventKind::State,
+            device,
+            label:   label.to_string(),
+            topic:   None,
+            payload: Some(payload),
+            text:    None,
+        }
+    }
+
+    pub fn error(device: EventDevice, label: &str, msg: &str) -> Self {
+        Self {
+            ts:      Self::now(),
+            kind:    EventKind::Error,
+            device,
+            label:   label.to_string(),
+            topic:   None,
+            payload: None,
+            text:    Some(msg.to_string()),
+        }
+    }
+
+    pub fn system(label: &str, msg: &str) -> Self {
+        Self {
+            ts:      Self::now(),
+            kind:    EventKind::System,
+            device:  EventDevice::System,
+            label:   label.to_string(),
+            topic:   None,
+            payload: None,
+            text:    Some(msg.to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ConsoleBus
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct ConsoleBus {
+    tx: broadcast::Sender<Arc<ConsoleEvent>>,
+}
+
+impl ConsoleBus {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(CONSOLE_CAPACITY);
+        Self { tx }
+    }
+
+    /// Emit an event. Non-blocking — silently drops if no subscribers.
+    pub fn emit(&self, ev: ConsoleEvent) {
+        let _ = self.tx.send(Arc::new(ev));
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<ConsoleEvent>> {
+        self.tx.subscribe()
+    }
+}

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -700,6 +700,15 @@ pub async fn dashboard_monitor() -> Response {
     render(MonitorTemplate {})
 }
 
+#[derive(Template)]
+#[template(path = "console.html")]
+struct ConsoleTemplate {}
+
+/// Console de diagnostic — streaming WebSocket temps réel.
+pub async fn dashboard_console() -> Response {
+    render(ConsoleTemplate {})
+}
+
 /// Construit le routeur du dashboard (à fusionner dans le routeur principal).
 pub fn build_dashboard_router() -> Router<AppState> {
     Router::new()
@@ -714,6 +723,7 @@ pub fn build_dashboard_router() -> Router<AppState> {
         .route("/dashboard/tasmota/:id",       get(dashboard_tasmota))
         .route("/dashboard/ats",               get(dashboard_ats))
         .route("/dashboard/monitor",           get(dashboard_monitor))
+        .route("/dashboard/console",           get(dashboard_console))
         .route("/dashboard/visualization",     get(dashboard_visualization))
         .route("/visualization",               get(dashboard_visualization))
 }

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -16,6 +16,7 @@
 mod autodetect;
 mod config;
 mod ats;
+mod console;
 mod et112;
 mod irradiance;
 mod tasmota;

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -5,6 +5,7 @@
 
 use crate::ats::AtsSnapshot;
 use crate::config::AppConfig;
+use crate::console::{ConsoleBus, ConsoleEvent, EventDevice};
 use crate::et112::Et112Snapshot;
 use crate::irradiance::IrradianceSnapshot;
 use crate::tasmota::TasmotaSnapshot;
@@ -12,6 +13,7 @@ use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
 use chrono::{DateTime, Datelike, Utc};
 use serde::Serialize;
+use serde_json::json;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{broadcast, RwLock};
@@ -386,6 +388,9 @@ pub struct AppState {
     /// Compteurs de santé par appareil RS485 (indexés par adresse).
     /// Alimenté par les boucles de polling BMS / ET112 / irradiance / ATS.
     pub rs485_stats: Arc<RwLock<BTreeMap<u8, Rs485DeviceStats>>>,
+
+    /// Canal broadcast pour la console de diagnostic (/ws/console).
+    pub console_bus: ConsoleBus,
 }
 
 impl AppState {
@@ -440,6 +445,7 @@ impl AppState {
             ats_snapshot: Arc::new(RwLock::new(None)),
             ats_bus: Arc::new(RwLock::new(None)),
             rs485_stats: Arc::new(RwLock::new(BTreeMap::new())),
+            console_bus: ConsoleBus::new(),
         }
     }
 
@@ -476,6 +482,20 @@ impl AppState {
 
     /// Enregistre un nouveau snapshot dans le ring buffer et broadcast WebSocket.
     pub async fn on_snapshot(&self, snap: BmsSnapshot) {
+        // Console diagnostic event
+        let device = if snap.address == 1 { EventDevice::Bms1 } else { EventDevice::Bms2 };
+        self.console_bus.emit(ConsoleEvent::rs485(device, &format!("BMS-{} snapshot", snap.address), json!({
+            "address": snap.address,
+            "soc": snap.soc,
+            "voltage": snap.dc.voltage,
+            "current": snap.dc.current,
+            "power": snap.dc.power,
+            "temp_max": snap.system.max_cell_temperature,
+            "cell_delta_mv": snap.system.cell_delta_mv(),
+            "charge_ok": snap.io.allow_to_charge != 0,
+            "discharge_ok": snap.io.allow_to_discharge != 0,
+        })));
+
         {
             let mut buffers = self.buffers.write().await;
             buffers
@@ -519,6 +539,15 @@ impl AppState {
 
     /// Enregistre un snapshot ET112 dans le ring buffer correspondant.
     pub async fn on_et112_snapshot(&self, snap: Et112Snapshot) {
+        self.console_bus.emit(ConsoleEvent::rs485(EventDevice::Et112, &format!("ET112-{:#04x} snapshot", snap.address), json!({
+            "address": snap.address,
+            "power_w": snap.power_w,
+            "voltage_v": snap.voltage_v,
+            "current_a": snap.current_a,
+            "energy_import_kwh": snap.energy_import_kwh(),
+            "energy_export_kwh": snap.energy_export_kwh(),
+        })));
+
         let mut buffers = self.et112_buffers.write().await;
         buffers
             .entry(snap.address)
@@ -647,6 +676,15 @@ impl AppState {
             *last_ts  = Some(now);
             if let Some(v) = shunt.ah_charged_today    { *charged    = v; }
             if let Some(v) = shunt.ah_discharged_today { *discharged = v; }
+            self.console_bus.emit(ConsoleEvent::state(EventDevice::SmartShunt, "SmartShunt update", json!({
+                "soc_pct": shunt.soc_percent,
+                "voltage_v": shunt.voltage_v,
+                "current_a": shunt.current_a,
+                "power_w": shunt.power_w,
+                "state": shunt.state,
+                "ah_charged_today": shunt.ah_charged_today,
+                "ah_discharged_today": shunt.ah_discharged_today,
+            })));
             *self.venus_smartshunt.write().await = Some(shunt);
             return;
         }
@@ -678,6 +716,17 @@ impl AppState {
 
         shunt.ah_charged_today    = Some(*charged);
         shunt.ah_discharged_today = Some(*discharged);
+
+        // Console event (after values are updated)
+        self.console_bus.emit(ConsoleEvent::state(EventDevice::SmartShunt, "SmartShunt update", json!({
+            "soc_pct": shunt.soc_percent,
+            "voltage_v": shunt.voltage_v,
+            "current_a": shunt.current_a,
+            "power_w": shunt.power_w,
+            "state": shunt.state,
+            "ah_charged_today": shunt.ah_charged_today,
+            "ah_discharged_today": shunt.ah_discharged_today,
+        })));
 
         *self.venus_smartshunt.write().await = Some(shunt);
     }

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -823,6 +823,9 @@
     <a href="/dashboard/monitor" class="nav-link {% block nav_monitor %}{% endblock %}">
       <span class="nav-icon">🖥</span> Monitoring
     </a>
+    <a href="/dashboard/console" class="nav-link {% block nav_console %}{% endblock %}">
+      <span class="nav-icon">🔬</span> Console
+    </a>
     <a href="/dashboard/settings" class="nav-link {% block nav_settings %}{% endblock %}">
       <span class="nav-icon">⚙</span> Paramètres
     </a>

--- a/crates/daly-bms-server/templates/console.html
+++ b/crates/daly-bms-server/templates/console.html
@@ -1,0 +1,659 @@
+{% extends "base.html" %}
+
+{% block title %}Console Diagnostique — ESS Monitor{% endblock %}
+{% block page_title %}Console Diagnostique{% endblock %}
+{% block nav_console %}active{% endblock %}
+
+{% block content %}
+<style>
+/* ── Console layout ──────────────────────────────────────────────────── */
+.console-wrap {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 3.5rem);
+  overflow: hidden;
+  padding: 0;
+}
+
+/* ── Toolbar ─────────────────────────────────────────────────────────── */
+.con-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 0.6rem 0.75rem;
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.con-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.con-toolbar-sep { width: 1px; height: 1.2rem; background: var(--border); margin: 0 0.2rem; }
+
+/* Status pill */
+.con-status {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 99px;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  margin-left: auto;
+}
+.con-status-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--muted2);
+  transition: background 0.3s;
+}
+.con-status-dot.connected    { background: var(--green); box-shadow: 0 0 6px var(--green); }
+.con-status-dot.disconnected { background: var(--red); }
+
+/* Stats bar */
+.con-stats {
+  display: flex;
+  gap: 1rem;
+  padding: 0.35rem 0.75rem;
+  background: var(--bg2);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  color: var(--muted2);
+  flex-wrap: wrap;
+}
+.con-stat { display: flex; gap: 0.3rem; align-items: center; }
+.con-stat-val { color: var(--text); font-weight: 600; }
+.con-stat-val.c-green { color: var(--green); }
+.con-stat-val.c-blue  { color: var(--blue); }
+.con-stat-val.c-orange{ color: var(--orange); }
+.con-stat-val.c-red   { color: var(--red); }
+
+/* ── Body: sidebar + stream ──────────────────────────────────────────── */
+.con-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* ── Filter sidebar ──────────────────────────────────────────────────── */
+.con-sidebar {
+  width: 190px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: 0.75rem;
+  border-right: 1px solid var(--border);
+  background: var(--card);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+.con-filter-grp { display: flex; flex-direction: column; gap: 0.3rem; }
+.con-filter-title {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted2);
+  margin-bottom: 0.15rem;
+}
+.con-check {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0.15rem 0;
+  user-select: none;
+}
+.con-check input[type=checkbox] {
+  width: 13px; height: 13px;
+  accent-color: var(--blue);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.con-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ── Log stream ──────────────────────────────────────────────────────── */
+.con-stream {
+  flex: 1;
+  overflow-y: auto;
+  background: #0d1117;
+  font-family: 'Consolas', 'Fira Code', 'Menlo', monospace;
+  font-size: 0.78rem;
+  padding: 0.4rem 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Search bar ──────────────────────────────────────────────────────── */
+.con-search {
+  position: relative;
+}
+.con-search input {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 0.78rem;
+  padding: 0.25rem 0.5rem 0.25rem 1.6rem;
+  width: 180px;
+  outline: none;
+}
+.con-search input:focus { border-color: var(--blue); }
+.con-search::before {
+  content: '🔍';
+  position: absolute;
+  left: 0.4rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.7rem;
+  pointer-events: none;
+}
+
+/* ── Event row ───────────────────────────────────────────────────────── */
+.ev-row {
+  display: flex;
+  flex-direction: column;
+  padding: 0.2rem 0.75rem;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.ev-row:hover { background: rgba(255,255,255,0.04); }
+.ev-row.highlighted { background: rgba(255,200,0,0.08); }
+
+.ev-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.ev-ts {
+  color: #6e7681;
+  font-size: 0.72rem;
+  flex-shrink: 0;
+  width: 10ch;
+}
+.ev-badge {
+  font-size: 0.62rem;
+  padding: 0.05rem 0.45rem;
+  border-radius: 3px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+.ev-device {
+  font-size: 0.68rem;
+  color: #8b949e;
+  flex-shrink: 0;
+}
+.ev-label {
+  color: #e6edf3;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.75rem;
+}
+.ev-label mark {
+  background: rgba(255,200,0,0.35);
+  color: inherit;
+  border-radius: 2px;
+}
+
+/* Badge colours */
+.badge-mqtt_in   { background: #1a3a5c; color: #58a6ff; }
+.badge-mqtt_out  { background: #1a3a2a; color: #56d364; }
+.badge-rs485     { background: #3a2a1a; color: #d29922; }
+.badge-state     { background: #1a1a3a; color: #a371f7; }
+.badge-error     { background: #3a1a1a; color: #f85149; }
+.badge-system    { background: #1c2128; color: #8b949e; }
+
+/* Device dot colours */
+.dev-bms1         { background: #58a6ff; }
+.dev-bms2         { background: #56d364; }
+.dev-et112        { background: #d29922; }
+.dev-smartshunt   { background: #a371f7; }
+.dev-ats          { background: #f0883e; }
+.dev-energy_manager { background: #39d353; }
+.dev-venus        { background: #79c0ff; }
+.dev-system       { background: #8b949e; }
+
+/* ── Expandable payload ──────────────────────────────────────────────── */
+.ev-payload {
+  display: none;
+  margin-top: 0.3rem;
+  padding: 0.4rem 0.6rem;
+  background: rgba(255,255,255,0.04);
+  border-left: 2px solid rgba(255,255,255,0.12);
+  border-radius: 0 4px 4px 0;
+  overflow-x: auto;
+}
+.ev-payload.open { display: block; }
+.ev-payload pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: #e6edf3;
+  font-size: 0.74rem;
+  line-height: 1.5;
+}
+
+/* ── Empty state ─────────────────────────────────────────────────────── */
+.con-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: #6e7681;
+  gap: 0.5rem;
+  padding: 2rem;
+}
+.con-empty-icon { font-size: 2rem; }
+.con-empty-msg  { font-size: 0.85rem; }
+
+/* ── Responsive ──────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .con-sidebar { width: 150px; }
+  .con-search input { width: 140px; }
+}
+</style>
+
+<div class="console-wrap">
+
+  <!-- Toolbar -->
+  <div class="con-toolbar">
+    <div class="con-toolbar-group">
+      <button class="btn btn-primary" id="btn-connect" onclick="consoleConnect()" style="font-size:0.72rem;padding:0.3rem 0.8rem;">▶ Connecter</button>
+      <button class="btn btn-danger"  id="btn-pause"   onclick="consolePause()"  style="font-size:0.72rem;padding:0.3rem 0.8rem;display:none;">⏸ Pause</button>
+      <button class="btn btn-outline" id="btn-resume"  onclick="consoleResume()" style="font-size:0.72rem;padding:0.3rem 0.8rem;display:none;">▶ Reprendre</button>
+    </div>
+    <div class="con-toolbar-sep"></div>
+    <div class="con-toolbar-group">
+      <button class="btn btn-outline" onclick="consoleClear()"    style="font-size:0.72rem;padding:0.3rem 0.7rem;" title="Vider la console">🗑 Effacer</button>
+      <button class="btn btn-outline" onclick="consoleDownload()" style="font-size:0.72rem;padding:0.3rem 0.7rem;" title="Télécharger les logs">⬇ Exporter</button>
+    </div>
+    <div class="con-toolbar-sep"></div>
+    <div class="con-search">
+      <input type="text" id="con-search" placeholder="Rechercher…" oninput="consoleSearch(this.value)" />
+    </div>
+    <div class="con-toolbar-sep"></div>
+    <label class="con-check" title="Défiler vers le bas automatiquement">
+      <input type="checkbox" id="chk-autoscroll" checked /> Auto-scroll
+    </label>
+    <div class="con-status">
+      <div class="con-status-dot disconnected" id="con-dot"></div>
+      <span id="con-status-lbl">Déconnecté</span>
+    </div>
+  </div>
+
+  <!-- Stats bar -->
+  <div class="con-stats">
+    <div class="con-stat">Total : <span class="con-stat-val" id="stat-total">0</span></div>
+    <div class="con-stat">Affiché : <span class="con-stat-val c-blue" id="stat-shown">0</span></div>
+    <div class="con-stat">MQTT↓ : <span class="con-stat-val c-green" id="stat-mqtt-in">0</span></div>
+    <div class="con-stat">MQTT↑ : <span class="con-stat-val c-green" id="stat-mqtt-out">0</span></div>
+    <div class="con-stat">RS485 : <span class="con-stat-val c-orange" id="stat-rs485">0</span></div>
+    <div class="con-stat">Erreurs : <span class="con-stat-val c-red" id="stat-errors">0</span></div>
+    <div class="con-stat" style="margin-left:auto;">Evt/min : <span class="con-stat-val" id="stat-rate">0</span></div>
+  </div>
+
+  <!-- Body -->
+  <div class="con-body">
+
+    <!-- Filter sidebar -->
+    <div class="con-sidebar">
+
+      <div class="con-filter-grp">
+        <div class="con-filter-title">Appareils</div>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="bms1"          checked onchange="applyFilters()"><span class="con-dot dev-bms1"></span> BMS-1</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="bms2"          checked onchange="applyFilters()"><span class="con-dot dev-bms2"></span> BMS-2</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="et112"         checked onchange="applyFilters()"><span class="con-dot dev-et112"></span> ET112</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="smartshunt"    checked onchange="applyFilters()"><span class="con-dot dev-smartshunt"></span> SmartShunt</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="ats"           checked onchange="applyFilters()"><span class="con-dot dev-ats"></span> ATS</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="energy_manager" checked onchange="applyFilters()"><span class="con-dot dev-energy_manager"></span> Energy-Mgr</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="venus"         checked onchange="applyFilters()"><span class="con-dot dev-venus"></span> Venus OS</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="system"        checked onchange="applyFilters()"><span class="con-dot dev-system"></span> Système</label>
+      </div>
+
+      <div class="con-filter-grp">
+        <div class="con-filter-title">Types</div>
+        <label class="con-check"><input type="checkbox" class="kind-filter" value="mqtt_in"  checked onchange="applyFilters()"><span class="ev-badge badge-mqtt_in"  style="font-size:0.58rem;">MQTT↓</span></label>
+        <label class="con-check"><input type="checkbox" class="kind-filter" value="mqtt_out" checked onchange="applyFilters()"><span class="ev-badge badge-mqtt_out" style="font-size:0.58rem;">MQTT↑</span></label>
+        <label class="con-check"><input type="checkbox" class="kind-filter" value="rs485"    checked onchange="applyFilters()"><span class="ev-badge badge-rs485"    style="font-size:0.58rem;">RS485</span></label>
+        <label class="con-check"><input type="checkbox" class="kind-filter" value="state"    checked onchange="applyFilters()"><span class="ev-badge badge-state"    style="font-size:0.58rem;">STATE</span></label>
+        <label class="con-check"><input type="checkbox" class="kind-filter" value="error"    checked onchange="applyFilters()"><span class="ev-badge badge-error"    style="font-size:0.58rem;">ERROR</span></label>
+        <label class="con-check"><input type="checkbox" class="kind-filter" value="system"   checked onchange="applyFilters()"><span class="ev-badge badge-system"   style="font-size:0.58rem;">SYS</span></label>
+      </div>
+
+      <div class="con-filter-grp" style="margin-top:auto;">
+        <div class="con-filter-title">Limite</div>
+        <select id="sel-limit" onchange="applyFilters()" style="background:var(--bg2);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:0.2rem 0.4rem;font-size:0.75rem;width:100%;">
+          <option value="200">200 lignes</option>
+          <option value="500" selected>500 lignes</option>
+          <option value="1000">1000 lignes</option>
+          <option value="0">Illimitée</option>
+        </select>
+      </div>
+
+    </div>
+
+    <!-- Log stream -->
+    <div class="con-stream" id="con-stream">
+      <div class="con-empty" id="con-empty">
+        <div class="con-empty-icon">📡</div>
+        <div class="con-empty-msg">Cliquez sur <strong>Connecter</strong> pour démarrer le streaming</div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+// ── State ──────────────────────────────────────────────────────────────
+let ws = null;
+let paused = false;
+let searchTerm = '';
+let events = [];      // raw event objects
+let stats = { total: 0, mqtt_in: 0, mqtt_out: 0, rs485: 0, state: 0, error: 0, system: 0 };
+let rateWindow = [];  // timestamps for events/min calculation
+
+const MAX_DOM_ROWS = 1000;  // hard limit on rendered rows to prevent DOM bloat
+
+// ── Connect / disconnect ───────────────────────────────────────────────
+function consoleConnect() {
+  if (ws) { ws.close(); ws = null; }
+
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  const url   = `${proto}://${location.host}/ws/console`;
+
+  setStatus('connecting', 'Connexion…');
+  ws = new WebSocket(url);
+
+  ws.onopen = () => {
+    setStatus('connected', 'Connecté');
+    document.getElementById('btn-connect').style.display = 'none';
+    document.getElementById('btn-pause').style.display   = '';
+    document.getElementById('btn-resume').style.display  = 'none';
+    appendSystem('Connexion WebSocket établie');
+  };
+
+  ws.onclose = () => {
+    setStatus('disconnected', 'Déconnecté');
+    document.getElementById('btn-connect').style.display = '';
+    document.getElementById('btn-pause').style.display   = 'none';
+    document.getElementById('btn-resume').style.display  = 'none';
+    appendSystem('Connexion WebSocket fermée');
+  };
+
+  ws.onerror = () => {
+    appendSystem('Erreur WebSocket');
+  };
+
+  ws.onmessage = (e) => {
+    try {
+      const msg = JSON.parse(e.data);
+      if (msg.type === 'connected') { return; }  // welcome message
+      handleEvent(msg);
+    } catch(_) {}
+  };
+}
+
+function consolePause() {
+  paused = true;
+  document.getElementById('btn-pause').style.display  = 'none';
+  document.getElementById('btn-resume').style.display = '';
+}
+function consoleResume() {
+  paused = false;
+  document.getElementById('btn-pause').style.display  = '';
+  document.getElementById('btn-resume').style.display = 'none';
+  rerender();
+}
+
+// ── Event handling ─────────────────────────────────────────────────────
+function handleEvent(ev) {
+  const now = Date.now();
+  rateWindow.push(now);
+  // Keep only last 60s for rate calculation
+  rateWindow = rateWindow.filter(t => now - t < 60000);
+
+  stats.total++;
+  stats[ev.kind] = (stats[ev.kind] || 0) + 1;
+
+  events.push(ev);
+  // Trim raw buffer
+  const limit = parseInt(document.getElementById('sel-limit').value) || 500;
+  if (limit > 0 && events.length > limit * 2) {
+    events = events.slice(-limit);
+  }
+
+  if (!paused) {
+    if (passesFilter(ev)) {
+      appendRow(ev);
+      trimDomRows();
+    }
+    updateStats();
+  }
+}
+
+// ── Filter logic ───────────────────────────────────────────────────────
+function getActiveDevices() {
+  return new Set([...document.querySelectorAll('.dev-filter:checked')].map(c => c.value));
+}
+function getActiveKinds() {
+  return new Set([...document.querySelectorAll('.kind-filter:checked')].map(c => c.value));
+}
+function passesFilter(ev) {
+  const devs  = getActiveDevices();
+  const kinds = getActiveKinds();
+  if (!devs.has(ev.device))  return false;
+  if (!kinds.has(ev.kind))   return false;
+  if (searchTerm) {
+    const haystack = (ev.label + ' ' + (ev.topic || '') + ' ' + JSON.stringify(ev.payload || '') + (ev.text || '')).toLowerCase();
+    if (!haystack.includes(searchTerm)) return false;
+  }
+  return true;
+}
+
+function applyFilters() {
+  rerender();
+}
+
+function consoleSearch(val) {
+  searchTerm = val.trim().toLowerCase();
+  rerender();
+}
+
+function rerender() {
+  const stream = document.getElementById('con-stream');
+  stream.innerHTML = '';
+  const limit = parseInt(document.getElementById('sel-limit').value) || 500;
+  const filtered = (limit > 0 ? events.slice(-limit) : events).filter(passesFilter);
+
+  if (filtered.length === 0) {
+    stream.innerHTML = `<div class="con-empty"><div class="con-empty-icon">🔍</div><div class="con-empty-msg">Aucun événement ne correspond aux filtres actuels</div></div>`;
+  } else {
+    for (const ev of filtered) {
+      stream.appendChild(buildRow(ev));
+    }
+  }
+  updateStats();
+  maybeScroll();
+}
+
+// ── DOM row construction ───────────────────────────────────────────────
+function appendRow(ev) {
+  const stream = document.getElementById('con-stream');
+  // Remove empty placeholder
+  const empty = document.getElementById('con-empty');
+  if (empty) empty.remove();
+
+  stream.appendChild(buildRow(ev));
+  maybeScroll();
+}
+
+function buildRow(ev) {
+  const row = document.createElement('div');
+  row.className = 'ev-row' + (searchTerm && rowMatchesSearch(ev) ? ' highlighted' : '');
+  row.dataset.kind   = ev.kind;
+  row.dataset.device = ev.device;
+
+  const hasPayload = ev.payload !== undefined && ev.payload !== null;
+  if (hasPayload) row.title = 'Cliquer pour développer';
+
+  // Header
+  const hdr = document.createElement('div');
+  hdr.className = 'ev-header';
+
+  const ts     = mkEl('span', 'ev-ts',     ev.ts);
+  const badge  = mkEl('span', `ev-badge badge-${ev.kind}`, kindLabel(ev.kind));
+  const device = mkEl('span', 'ev-device', `[${deviceLabel(ev.device)}]`);
+  const label  = document.createElement('span');
+  label.className = 'ev-label';
+  label.innerHTML = searchTerm ? highlightSearch(escHtml(ev.label)) : escHtml(ev.label);
+
+  hdr.append(ts, badge, device, label);
+  row.appendChild(hdr);
+
+  // Payload (expandable)
+  if (hasPayload || ev.text) {
+    const pay = document.createElement('div');
+    pay.className = 'ev-payload';
+    const pre = document.createElement('pre');
+    if (ev.payload) {
+      pre.textContent = JSON.stringify(ev.payload, null, 2);
+    } else {
+      pre.textContent = ev.text || '';
+    }
+    pay.appendChild(pre);
+    row.appendChild(pay);
+
+    row.addEventListener('click', () => {
+      pay.classList.toggle('open');
+    });
+  }
+
+  return row;
+}
+
+function rowMatchesSearch(ev) {
+  if (!searchTerm) return false;
+  const haystack = (ev.label + ' ' + (ev.topic || '') + ' ' + JSON.stringify(ev.payload || '') + (ev.text || '')).toLowerCase();
+  return haystack.includes(searchTerm);
+}
+
+function highlightSearch(html) {
+  if (!searchTerm) return html;
+  const re = new RegExp(escRegex(searchTerm), 'gi');
+  return html.replace(re, m => `<mark>${m}</mark>`);
+}
+
+function trimDomRows() {
+  const stream = document.getElementById('con-stream');
+  const rows = stream.querySelectorAll('.ev-row');
+  if (rows.length > MAX_DOM_ROWS) {
+    for (let i = 0; i < rows.length - MAX_DOM_ROWS; i++) rows[i].remove();
+  }
+}
+
+// ── Scroll ─────────────────────────────────────────────────────────────
+function maybeScroll() {
+  if (!document.getElementById('chk-autoscroll').checked) return;
+  const stream = document.getElementById('con-stream');
+  stream.scrollTop = stream.scrollHeight;
+}
+
+// ── Stats ──────────────────────────────────────────────────────────────
+function updateStats() {
+  const stream  = document.getElementById('con-stream');
+  const shown   = stream.querySelectorAll('.ev-row').length;
+  document.getElementById('stat-total').textContent    = stats.total;
+  document.getElementById('stat-shown').textContent    = shown;
+  document.getElementById('stat-mqtt-in').textContent  = stats.mqtt_in  || 0;
+  document.getElementById('stat-mqtt-out').textContent = stats.mqtt_out || 0;
+  document.getElementById('stat-rs485').textContent    = stats.rs485    || 0;
+  document.getElementById('stat-errors').textContent   = stats.error    || 0;
+  document.getElementById('stat-rate').textContent     = rateWindow.length;
+}
+
+// ── Actions ────────────────────────────────────────────────────────────
+function consoleClear() {
+  events = [];
+  stats  = { total: 0, mqtt_in: 0, mqtt_out: 0, rs485: 0, state: 0, error: 0, system: 0 };
+  rateWindow = [];
+  const stream = document.getElementById('con-stream');
+  stream.innerHTML = `<div class="con-empty" id="con-empty"><div class="con-empty-icon">📡</div><div class="con-empty-msg">Console vidée</div></div>`;
+  updateStats();
+}
+
+function consoleDownload() {
+  const lines = events.map(ev => {
+    const base = `[${ev.ts}] [${ev.kind.toUpperCase().padEnd(8)}] [${ev.device.padEnd(14)}] ${ev.label}`;
+    const detail = ev.payload ? '\n' + JSON.stringify(ev.payload, null, 2) : (ev.text ? '\n' + ev.text : '');
+    return base + detail;
+  }).join('\n---\n');
+
+  const blob = new Blob([lines], { type: 'text/plain' });
+  const url  = URL.createObjectURL(blob);
+  const a    = document.createElement('a');
+  a.href     = url;
+  a.download = `console-${new Date().toISOString().slice(0,19).replace(/:/g,'-')}.txt`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ── System message helper ──────────────────────────────────────────────
+function appendSystem(msg) {
+  const ev = { ts: new Date().toLocaleTimeString('fr-FR', {hour12:false}) + '.000',
+               kind: 'system', device: 'system', label: msg, text: msg };
+  handleEvent(ev);
+}
+
+// ── Status helpers ─────────────────────────────────────────────────────
+function setStatus(cls, lbl) {
+  const dot = document.getElementById('con-dot');
+  const lbl_el = document.getElementById('con-status-lbl');
+  dot.className = `con-status-dot ${cls}`;
+  lbl_el.textContent = lbl;
+}
+
+// ── Label maps ─────────────────────────────────────────────────────────
+function kindLabel(k) {
+  return { mqtt_in:'MQTT↓', mqtt_out:'MQTT↑', rs485:'RS485', state:'STATE', error:'ERROR', system:'SYS' }[k] || k.toUpperCase();
+}
+function deviceLabel(d) {
+  return { bms1:'BMS-1', bms2:'BMS-2', et112:'ET112', smartshunt:'SmartShunt',
+           ats:'ATS', energy_manager:'EnergyMgr', venus:'Venus', system:'System' }[d] || d;
+}
+
+// ── Utilities ──────────────────────────────────────────────────────────
+function mkEl(tag, cls, text) {
+  const el = document.createElement(tag);
+  el.className = cls;
+  if (text !== undefined) el.textContent = text;
+  return el;
+}
+function escHtml(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+function escRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g,'\\$&');
+}
+
+// Rate ticker
+setInterval(updateStats, 5000);
+</script>
+{% endblock %}


### PR DESCRIPTION
WebSocket stream of MQTT IN/OUT, RS485, state-change and error events. Filter sidebar by device (BMS-1/2, ET112, SmartShunt, ATS, Venus…) and event kind; dark terminal UI with expandable JSON payloads, search/ highlight, auto-scroll, stats bar, pause/resume, and log export.

Instrumented: on_snapshot, on_et112_snapshot, on_venus_smartshunt, run_mqtt_bridge (MQTT OUT) and start_venus_mqtt_subscriber (MQTT IN).

https://claude.ai/code/session_01WkTcchAa2HTezHGnxwDPUQ