### PR TITLE
fix(console): instrument missing devices, add sub-menus and device dots

### DIFF
--- a/crates/daly-bms-server/src/api/console.rs
+++ b/crates/daly-bms-server/src/api/console.rs
@@ -90,14 +90,17 @@ async fn handle_ws_console(socket: WebSocket, state: AppState, q: ConsoleQuery) 
 
 fn device_to_str(d: &EventDevice) -> &'static str {
     match d {
-        EventDevice::Bms1         => "bms1",
-        EventDevice::Bms2         => "bms2",
-        EventDevice::Et112        => "et112",
-        EventDevice::SmartShunt   => "smartshunt",
-        EventDevice::Ats          => "ats",
-        EventDevice::EnergyManager => "energy_manager",
-        EventDevice::Venus        => "venus",
-        EventDevice::System       => "system",
+        EventDevice::Bms1        => "bms1",
+        EventDevice::Bms2        => "bms2",
+        EventDevice::Et112       => "et112",
+        EventDevice::Ats         => "ats",
+        EventDevice::SmartShunt  => "smartshunt",
+        EventDevice::Tasmota     => "tasmota",
+        EventDevice::WaterHeater => "water_heater",
+        EventDevice::Solar       => "solar",
+        EventDevice::Inverter    => "inverter",
+        EventDevice::Venus       => "venus",
+        EventDevice::System      => "system",
     }
 }
 

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -500,8 +500,8 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
     loop {
         match eventloop.poll().await {
             Ok(rumqttc::Event::Incoming(rumqttc::Packet::ConnAck(_))) => {
-                // Reconnexion détectée — réabonnement obligatoire (clean_session=true)
                 info!("MQTT Venus connecté/reconnecté — réabonnement aux topics");
+                state.console_bus.emit(ConsoleEvent::system("MQTT Venus", "Connecté/reconnecté — réabonnement aux topics"));
                 for (topic, qos) in &topics {
                     if let Err(e) = client.subscribe(*topic, *qos).await {
                         warn!("MQTT re-subscribe erreur pour {}: {:?}", topic, e);
@@ -516,13 +516,17 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
 
                 // Parser le payload JSON
                 if let Ok(json) = serde_json::from_str::<Value>(payload) {
-                    // Console diagnostic events
-                    let ev_device = if topic.contains("/meteo/") || topic.contains("/inverter/") {
-                        EventDevice::Venus
+                    // Console MQTT IN — device inferred from topic
+                    let ev_device = if topic.contains("/meteo/") {
+                        EventDevice::Solar
+                    } else if topic.contains("/inverter/") {
+                        EventDevice::Inverter
                     } else if topic.contains("/system/") {
                         EventDevice::SmartShunt
-                    } else if topic.contains("/heat/") || topic.contains("/heatpump/") {
-                        EventDevice::EnergyManager
+                    } else if topic.contains("/heatpump/") {
+                        EventDevice::WaterHeater
+                    } else if topic.contains("/heat/") {
+                        EventDevice::Venus
                     } else {
                         EventDevice::Venus
                     };
@@ -564,6 +568,11 @@ async fn handle_meteo_topic(state: &AppState, json: &Value) {
     let irradiance = json.get("Irradiance").and_then(|v| v.as_f64()).map(|v| v as f32).unwrap_or(0.0);
     let yield_kwh  = json.get("TodaysYield").and_then(|v| v.as_f64()).map(|v| v as f32);
     let mppt_power = json.get("MpptPower").and_then(|v| v.as_f64()).map(|v| v as f32);
+    state.console_bus.emit(ConsoleEvent::state(EventDevice::Solar, "Solaire/MPPT update", json!({
+        "irradiance_wm2": irradiance,
+        "yield_today_kwh": yield_kwh,
+        "mppt_power_w": mppt_power,
+    })));
 
     // Format v2 : tableau Mppts avec données individuelles par chargeur.
     // On remplace toute la map en une seule opération pour purger les entrées
@@ -771,6 +780,12 @@ async fn handle_heatpump_topic(state: &AppState, topic: &str, json: &Value) {
     };
 
     debug!(index = idx, state = hp_state, "Heatpump MQTT reçu");
+    let mode_lbl = match hp_state { 0 => "Vacances", 1 => "HEAT_PUMP", 2 => "TURBO", _ => "Inconnu" };
+    state.console_bus.emit(ConsoleEvent::state(EventDevice::WaterHeater, &format!("Chauffe-eau idx={idx} — {mode_lbl}"), json!({
+        "idx": idx, "state": hp_state, "mode": mode_lbl,
+        "temperature": temperature, "target": target_temp,
+        "power_w": ac_power, "energy_kwh": ac_energy,
+    })));
     state.on_venus_heatpump(hp).await;
 }
 

--- a/crates/daly-bms-server/src/console.rs
+++ b/crates/daly-bms-server/src/console.rs
@@ -34,10 +34,13 @@ pub enum EventDevice {
     Bms1,
     Bms2,
     Et112,
-    SmartShunt,
     Ats,
-    EnergyManager,
-    Venus,
+    SmartShunt,
+    Tasmota,
+    WaterHeater,  // LG ThinQ / heatpump
+    Solar,        // MPPT / pvinverter (energy-manager)
+    Inverter,     // Venus OS onduleur
+    Venus,        // températures et autres données Venus OS
     System,
 }
 

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -589,6 +589,15 @@ impl AppState {
 
     /// Enregistre un snapshot Tasmota dans le ring buffer correspondant.
     pub async fn on_tasmota_snapshot(&self, snap: TasmotaSnapshot) {
+        self.console_bus.emit(ConsoleEvent::state(EventDevice::Tasmota, &format!("Tasmota {} — {}", snap.name, if snap.power_on { "ON" } else { "OFF" }), json!({
+            "id": snap.id,
+            "name": snap.name,
+            "power_on": snap.power_on,
+            "power_w": snap.power_w,
+            "voltage_v": snap.voltage_v,
+            "current_a": snap.current_a,
+            "energy_today_kwh": snap.energy_today_kwh,
+        })));
         let mut buffers = self.tasmota_buffers.write().await;
         buffers
             .entry(snap.id)
@@ -801,6 +810,15 @@ impl AppState {
 
     /// Enregistre le dernier snapshot ATS.
     pub async fn on_ats_snapshot(&self, snap: AtsSnapshot) {
+        self.console_bus.emit(ConsoleEvent::rs485(EventDevice::Ats, &format!("ATS CHINT — {}", snap.active_source.label()), json!({
+            "source": snap.active_source.label(),
+            "v1a": snap.v1a, "v1b": snap.v1b, "v1c": snap.v1c,
+            "v2a": snap.v2a, "v2b": snap.v2b, "v2c": snap.v2c,
+            "freq1_hz": snap.freq1_hz, "freq2_hz": snap.freq2_hz,
+            "sw1_closed": snap.sw1_closed, "sw2_closed": snap.sw2_closed,
+            "fault": snap.fault.label(),
+            "sw_mode": if snap.sw_mode { "Auto" } else { "Manuel" },
+        })));
         *self.ats_snapshot.write().await = Some(snap);
     }
 

--- a/crates/daly-bms-server/templates/console.html
+++ b/crates/daly-bms-server/templates/console.html
@@ -221,11 +221,39 @@
 .dev-bms1         { background: #58a6ff; }
 .dev-bms2         { background: #56d364; }
 .dev-et112        { background: #d29922; }
-.dev-smartshunt   { background: #a371f7; }
 .dev-ats          { background: #f0883e; }
-.dev-energy_manager { background: #39d353; }
+.dev-smartshunt   { background: #a371f7; }
+.dev-tasmota      { background: #e3b341; }
+.dev-water_heater { background: #ff7b72; }
+.dev-solar        { background: #ffa657; }
+.dev-inverter     { background: #3fb950; }
 .dev-venus        { background: #79c0ff; }
 .dev-system       { background: #8b949e; }
+
+/* Sub-group (Energy Manager / Venus OS) */
+.con-subgrp {
+  padding-left: 0.6rem;
+  border-left: 2px solid rgba(255,255,255,0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: 0.1rem;
+}
+.con-grp-hdr {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--muted2);
+  cursor: pointer;
+  padding: 0.15rem 0;
+  user-select: none;
+}
+.con-grp-hdr:hover { color: var(--text); }
+.con-grp-arrow { font-size: 0.6rem; transition: transform 0.15s; }
+.con-grp-arrow.open { transform: rotate(90deg); }
+.con-grp-body { display: flex; flex-direction: column; gap: 0.3rem; }
 
 /* ── Expandable payload ──────────────────────────────────────────────── */
 .ev-payload {
@@ -313,16 +341,47 @@
     <!-- Filter sidebar -->
     <div class="con-sidebar">
 
+      <!-- RS485 -->
       <div class="con-filter-grp">
-        <div class="con-filter-title">Appareils</div>
-        <label class="con-check"><input type="checkbox" class="dev-filter" value="bms1"          checked onchange="applyFilters()"><span class="con-dot dev-bms1"></span> BMS-1</label>
-        <label class="con-check"><input type="checkbox" class="dev-filter" value="bms2"          checked onchange="applyFilters()"><span class="con-dot dev-bms2"></span> BMS-2</label>
-        <label class="con-check"><input type="checkbox" class="dev-filter" value="et112"         checked onchange="applyFilters()"><span class="con-dot dev-et112"></span> ET112</label>
-        <label class="con-check"><input type="checkbox" class="dev-filter" value="smartshunt"    checked onchange="applyFilters()"><span class="con-dot dev-smartshunt"></span> SmartShunt</label>
-        <label class="con-check"><input type="checkbox" class="dev-filter" value="ats"           checked onchange="applyFilters()"><span class="con-dot dev-ats"></span> ATS</label>
-        <label class="con-check"><input type="checkbox" class="dev-filter" value="energy_manager" checked onchange="applyFilters()"><span class="con-dot dev-energy_manager"></span> Energy-Mgr</label>
-        <label class="con-check"><input type="checkbox" class="dev-filter" value="venus"         checked onchange="applyFilters()"><span class="con-dot dev-venus"></span> Venus OS</label>
-        <label class="con-check"><input type="checkbox" class="dev-filter" value="system"        checked onchange="applyFilters()"><span class="con-dot dev-system"></span> Système</label>
+        <div class="con-filter-title">RS485</div>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="bms1"  checked onchange="applyFilters()"><span class="con-dot dev-bms1"></span> BMS-1</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="bms2"  checked onchange="applyFilters()"><span class="con-dot dev-bms2"></span> BMS-2</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="et112" checked onchange="applyFilters()"><span class="con-dot dev-et112"></span> ET112</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="ats"   checked onchange="applyFilters()"><span class="con-dot dev-ats"></span> ATS CHINT</label>
+      </div>
+
+      <!-- Energy Manager (collapsible) -->
+      <div class="con-filter-grp">
+        <div class="con-grp-hdr" onclick="toggleGrp('grp-em')">
+          <span class="con-grp-arrow open" id="arr-grp-em">▶</span> Energy Manager
+        </div>
+        <div class="con-grp-body" id="grp-em">
+          <div class="con-subgrp">
+            <label class="con-check"><input type="checkbox" class="dev-filter" value="smartshunt"  checked onchange="applyFilters()"><span class="con-dot dev-smartshunt"></span> SmartShunt</label>
+            <label class="con-check"><input type="checkbox" class="dev-filter" value="water_heater" checked onchange="applyFilters()"><span class="con-dot dev-water_heater"></span> Chauffe-eau LG</label>
+            <label class="con-check"><input type="checkbox" class="dev-filter" value="solar"       checked onchange="applyFilters()"><span class="con-dot dev-solar"></span> Solaire/MPPT</label>
+          </div>
+        </div>
+      </div>
+
+      <!-- Venus OS (collapsible) -->
+      <div class="con-filter-grp">
+        <div class="con-grp-hdr" onclick="toggleGrp('grp-venus')">
+          <span class="con-grp-arrow open" id="arr-grp-venus">▶</span> Venus OS
+        </div>
+        <div class="con-grp-body" id="grp-venus">
+          <div class="con-subgrp">
+            <label class="con-check"><input type="checkbox" class="dev-filter" value="inverter" checked onchange="applyFilters()"><span class="con-dot dev-inverter"></span> Onduleur</label>
+            <label class="con-check"><input type="checkbox" class="dev-filter" value="venus"    checked onchange="applyFilters()"><span class="con-dot dev-venus"></span> Températures</label>
+          </div>
+        </div>
+      </div>
+
+      <!-- Prises & Système -->
+      <div class="con-filter-grp">
+        <div class="con-filter-title">Prises / Système</div>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="tasmota" checked onchange="applyFilters()"><span class="con-dot dev-tasmota"></span> Tasmota</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="system"  checked onchange="applyFilters()"><span class="con-dot dev-system"></span> Système</label>
       </div>
 
       <div class="con-filter-grp">
@@ -518,14 +577,16 @@ function buildRow(ev) {
   const hdr = document.createElement('div');
   hdr.className = 'ev-header';
 
-  const ts     = mkEl('span', 'ev-ts',     ev.ts);
+  const ts     = mkEl('span', 'ev-ts', ev.ts);
   const badge  = mkEl('span', `ev-badge badge-${ev.kind}`, kindLabel(ev.kind));
-  const device = mkEl('span', 'ev-device', `[${deviceLabel(ev.device)}]`);
+  const dot    = mkEl('span', `con-dot dev-${ev.device}`, '');
+  dot.style.cssText = 'display:inline-block;width:7px;height:7px;border-radius:50%;flex-shrink:0;';
+  const device = mkEl('span', 'ev-device', deviceLabel(ev.device));
   const label  = document.createElement('span');
   label.className = 'ev-label';
   label.innerHTML = searchTerm ? highlightSearch(escHtml(ev.label)) : escHtml(ev.label);
 
-  hdr.append(ts, badge, device, label);
+  hdr.append(ts, badge, dot, device, label);
   row.appendChild(hdr);
 
   // Payload (expandable)
@@ -635,8 +696,21 @@ function kindLabel(k) {
   return { mqtt_in:'MQTT↓', mqtt_out:'MQTT↑', rs485:'RS485', state:'STATE', error:'ERROR', system:'SYS' }[k] || k.toUpperCase();
 }
 function deviceLabel(d) {
-  return { bms1:'BMS-1', bms2:'BMS-2', et112:'ET112', smartshunt:'SmartShunt',
-           ats:'ATS', energy_manager:'EnergyMgr', venus:'Venus', system:'System' }[d] || d;
+  return {
+    bms1:'BMS-1', bms2:'BMS-2', et112:'ET112', ats:'ATS',
+    smartshunt:'SmartShunt', tasmota:'Tasmota',
+    water_heater:'ChauffEau', solar:'Solaire',
+    inverter:'Onduleur', venus:'Venus', system:'Système'
+  }[d] || d;
+}
+
+function toggleGrp(id) {
+  const body = document.getElementById(id);
+  const arr  = document.getElementById('arr-' + id);
+  if (!body) return;
+  const isOpen = body.style.display !== 'none';
+  body.style.display = isOpen ? 'none' : '';
+  if (arr) arr.classList.toggle('open', !isOpen);
 }
 
 // ── Utilities ──────────────────────────────────────────────────────────


### PR DESCRIPTION
- ATS: RS485 event in on_ats_snapshot() with v1/v2 voltages + fault
- Tasmota: STATE event in on_tasmota_snapshot() with power/energy
- WaterHeater: STATE event in handle_heatpump_topic() with mode/temp/power
- Solar: STATE event in handle_meteo_topic() with irradiance/yield/power
- System: startup event emitted on MQTT Venus ConnAck
- Fix MQTT IN device classification: meteo→solar, inverter→inverter, system→smartshunt, heatpump→water_heater
- New EventDevice variants: Tasmota, WaterHeater, Solar, Inverter (replaces overly broad EnergyManager)
- Filter sidebar: RS485 group, Energy Manager sub-menu (SmartShunt / Chauffe-eau LG / Solaire), Venus OS sub-menu (Onduleur / Températures), Tasmota+Système row; collapsible groups with toggle arrow
- Device dot shown inline in each event row for instant color identification

https://claude.ai/code/session_01WkTcchAa2HTezHGnxwDPUQ