### PR TITLE
feat(shelly): integrate Shelly Pro 2PM in Tasmota tab + fix LG ThinQ …

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -381,6 +381,19 @@ device_instance = 65                 # Instance D-Bus Venus OS
 # service_type = "switch"     # "switch" (défaut) ou "acload"
 # device_instance = 500       # Optionnel — instance D-Bus Venus OS
 
+# =============================================================================
+# Shelly Pro 2PM — compteurs d'énergie 2 canaux
+# =============================================================================
+# Topics : {shelly_id}/status/switch:0  et  /status/switch:1
+# Commandes : {shelly_id}/rpc  (Switch.Set via MQTT RPC)
+[shelly]
+ring_buffer_size = 720
+
+[[shelly.devices]]
+id        = 1
+shelly_id = "shellypro2pm-ec62608840a4"   # IP 192.168.1.136
+name      = "DEYE — Shelly Pro 2PM"
+
 
 [influxdb]
 # true  = activer l'écriture InfluxDB (Docker infra doit être démarré)

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -8,6 +8,7 @@ pub mod ats;
 pub mod console;
 pub mod et112;
 pub mod tasmota;
+pub mod shelly;
 pub mod chart;
 
 use crate::dashboard;
@@ -101,6 +102,10 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/tasmota/:id/status",      get(tasmota::get_tasmota_status))
         .route("/api/v1/tasmota/:id/history",     get(tasmota::get_tasmota_history))
         .route("/api/v1/tasmota/:id/control",     post(tasmota::control_tasmota))
+        // ── Shelly ───────────────────────────────────────────────────────────
+        .route("/api/v1/shelly",                             get(shelly::list_shelly))
+        .route("/api/v1/shelly/:id/status",                  get(shelly::get_shelly_status))
+        .route("/api/v1/shelly/:id/channel/:ch/control",     post(shelly::control_shelly_channel))
         // ── WebSocket ─────────────────────────────────────────────────────────
         .route("/ws/bms/stream",         get(bms::ws_all))
         .route("/ws/bms/:id/stream",     get(bms::ws_single))

--- a/crates/daly-bms-server/src/api/shelly.rs
+++ b/crates/daly-bms-server/src/api/shelly.rs
@@ -1,0 +1,108 @@
+//! Endpoints REST pour les compteurs Shelly Pro 2PM.
+//!
+//! Routes :
+//! ```text
+//! GET /api/v1/shelly                           → liste + dernier snapshot
+//! GET /api/v1/shelly/:id/status                → dernier snapshot
+//! POST /api/v1/shelly/:id/channel/:ch/control  → activer / désactiver un canal
+//! ```
+
+use crate::state::AppState;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::Deserialize;
+
+/// GET /api/v1/shelly
+pub async fn list_shelly(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let devices = &state.config.shelly.devices;
+    let mut result = Vec::new();
+    for dev in devices {
+        let snap = state.shelly_latest_for(dev.id).await;
+        result.push(serde_json::json!({
+            "id":       dev.id,
+            "name":     dev.name,
+            "shelly_id": dev.shelly_id,
+            "snapshot": snap,
+        }));
+    }
+    Json(serde_json::json!({ "shelly": result }))
+}
+
+/// GET /api/v1/shelly/:id/status
+pub async fn get_shelly_status(
+    State(state): State<AppState>,
+    Path(id_str): Path<String>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let id   = id_str.trim().parse::<u8>().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let snap = state.shelly_latest_for(id).await.ok_or(StatusCode::NOT_FOUND)?;
+    Ok(Json(serde_json::to_value(&snap).unwrap_or_default()))
+}
+
+#[derive(Deserialize)]
+pub struct ChannelControlPayload {
+    pub state: String, // "on" ou "off"
+}
+
+/// POST /api/v1/shelly/:id/channel/:ch/control
+pub async fn control_shelly_channel(
+    State(state): State<AppState>,
+    Path((id_str, ch_str)): Path<(String, String)>,
+    Json(payload): Json<ChannelControlPayload>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let id: u8 = id_str.trim().parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let ch: u8 = ch_str.trim().parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+    if ch > 1 { return Err(StatusCode::BAD_REQUEST); }
+
+    let device = state
+        .config
+        .shelly
+        .devices
+        .iter()
+        .find(|d| d.id == id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let on = matches!(payload.state.to_lowercase().as_str(), "on" | "1" | "true");
+    let shelly_id = device.shelly_id.clone();
+    let rpc_topic = format!("{}/rpc", shelly_id);
+
+    let rpc_payload = serde_json::json!({
+        "id": 1,
+        "src": "daly-bms",
+        "method": "Switch.Set",
+        "params": { "id": ch, "on": on }
+    });
+
+    let mqtt_cfg = &state.config.mqtt;
+    use rumqttc::{AsyncClient, MqttOptions, QoS};
+    let mut opts = MqttOptions::new(
+        format!("daly-bms-shelly-ctrl-{id}-{ch}"),
+        &mqtt_cfg.host,
+        mqtt_cfg.port,
+    );
+    opts.set_keep_alive(std::time::Duration::from_secs(10));
+    if let (Some(u), Some(p)) = (&mqtt_cfg.username, &mqtt_cfg.password) {
+        opts.set_credentials(u, p);
+    }
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 8);
+    tokio::spawn(async move {
+        loop { if eventloop.poll().await.is_err() { break; } }
+    });
+
+    let payload_str = rpc_payload.to_string();
+    tokio::spawn(async move {
+        let _ = client.publish(&rpc_topic, QoS::AtLeastOnce, false, payload_str.as_bytes()).await;
+    });
+
+    tracing::info!("[Shelly] {} ch{} → {}", shelly_id, ch, if on { "ON" } else { "OFF" });
+
+    Ok(Json(serde_json::json!({
+        "id": id,
+        "channel": ch,
+        "state": on,
+        "command": format!("Switch.Set id={ch} on={on}"),
+    })))
+}

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -23,6 +23,7 @@ use daly_bms_core::types::BmsSnapshot;
 use std::sync::atomic::Ordering;
 use tracing::error;
 use crate::tasmota::TasmotaSnapshot;
+use crate::shelly::ShellyEmSnapshot;
 
 // =============================================================================
 // Filtres Askama pour le formatage des nombres
@@ -530,11 +531,68 @@ pub struct TasmotaDeviceSummary {
     pub service_type:         String,
 }
 
+/// Résumé d'un compteur Shelly Pro 2PM pour la page Tasmota.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ShellyDeviceSummary {
+    pub id:            u8,
+    pub name:          String,
+    pub shelly_id:     String,
+    pub connected:     bool,
+    pub total_power_w: f32,
+    pub ch0_output:    bool,
+    pub ch0_power_w:   f32,
+    pub ch0_voltage_v: f32,
+    pub ch0_current_a: f32,
+    pub ch0_energy_kwh: f32,
+    pub ch1_output:    bool,
+    pub ch1_power_w:   f32,
+    pub ch1_voltage_v: f32,
+    pub ch1_current_a: f32,
+    pub ch1_energy_kwh: f32,
+    pub rssi:          Option<i32>,
+    pub last_ts:       String,
+}
+
+fn summary_from_shelly(id: u8, name: &str, shelly_id: &str, snap_opt: Option<ShellyEmSnapshot>) -> ShellyDeviceSummary {
+    if let Some(s) = snap_opt {
+        ShellyDeviceSummary {
+            id,
+            name:          s.name.clone(),
+            shelly_id:     s.shelly_id.clone(),
+            connected:     true,
+            total_power_w: s.total_power_w,
+            ch0_output:    s.channel_0.output,
+            ch0_power_w:   s.channel_0.power_w,
+            ch0_voltage_v: s.channel_0.voltage_v,
+            ch0_current_a: s.channel_0.current_a,
+            ch0_energy_kwh: (s.channel_0.energy_wh / 1000.0) as f32,
+            ch1_output:    s.channel_1.output,
+            ch1_power_w:   s.channel_1.power_w,
+            ch1_voltage_v: s.channel_1.voltage_v,
+            ch1_current_a: s.channel_1.current_a,
+            ch1_energy_kwh: (s.channel_1.energy_wh / 1000.0) as f32,
+            rssi:          s.rssi,
+            last_ts:       s.timestamp.format("%H:%M:%S").to_string(),
+        }
+    } else {
+        ShellyDeviceSummary {
+            id, name: name.to_string(), shelly_id: shelly_id.to_string(),
+            connected: false, total_power_w: 0.0,
+            ch0_output: false, ch0_power_w: 0.0, ch0_voltage_v: 0.0, ch0_current_a: 0.0, ch0_energy_kwh: 0.0,
+            ch1_output: false, ch1_power_w: 0.0, ch1_voltage_v: 0.0, ch1_current_a: 0.0, ch1_energy_kwh: 0.0,
+            rssi: None, last_ts: "—".to_string(),
+        }
+    }
+}
+
 #[derive(Template)]
 #[template(path = "tasmota_all.html")]
 struct TasmotaAllTemplate {
-    devices:      Vec<TasmotaDeviceSummary>,
-    device_count: usize,
+    devices:        Vec<TasmotaDeviceSummary>,
+    device_count:   usize,
+    shelly_devices: Vec<ShellyDeviceSummary>,
+    shelly_count:   usize,
 }
 
 #[derive(Template)]
@@ -612,8 +670,15 @@ pub async fn dashboard_tasmota_list(State(state): State<AppState>) -> Response {
         devices.push(summary_from_tasmota(cfg, snap_opt));
     }
 
+    let mut shelly_devices: Vec<ShellyDeviceSummary> = Vec::new();
+    for dev in &state.config.shelly.devices {
+        let snap = state.shelly_latest_for(dev.id).await;
+        shelly_devices.push(summary_from_shelly(dev.id, &dev.name, &dev.shelly_id, snap));
+    }
+
     let device_count = devices.len();
-    render(TasmotaAllTemplate { devices, device_count })
+    let shelly_count = shelly_devices.len();
+    render(TasmotaAllTemplate { devices, device_count, shelly_devices, shelly_count })
 }
 
 /// Page de détail d'une prise Tasmota.

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -19,6 +19,7 @@ mod ats;
 mod console;
 mod et112;
 mod irradiance;
+mod shelly;
 mod tasmota;
 mod state;
 mod api;
@@ -262,6 +263,30 @@ async fn main() -> anyhow::Result<()> {
                 move |snap| {
                     let s = state_ta.clone();
                     tokio::spawn(async move { s.on_tasmota_snapshot(snap).await });
+                },
+            )
+            .await;
+        });
+    }
+
+    // ── Shelly Pro 2PM MQTT subscriber ────────────────────────────────────────
+    if !config.shelly.devices.is_empty() {
+        info!(
+            count = config.shelly.devices.len(),
+            "Démarrage Shelly Pro 2PM MQTT subscriber"
+        );
+        let state_sh  = state.clone();
+        let devs_sh   = config.shelly.devices.clone();
+        let mqtt_sh   = config.mqtt.clone();
+        let client_sh = state.shelly_client.clone();
+        tokio::spawn(async move {
+            shelly::run_shelly_mqtt_loop(
+                devs_sh,
+                mqtt_sh,
+                client_sh,
+                move |snap| {
+                    let s = state_sh.clone();
+                    tokio::spawn(async move { s.on_shelly_snapshot(snap).await });
                 },
             )
             .await;

--- a/crates/daly-bms-server/src/shelly/mod.rs
+++ b/crates/daly-bms-server/src/shelly/mod.rs
@@ -6,5 +6,7 @@
 pub mod types;
 pub mod mqtt;
 
-pub use types::{ShellyEmSnapshot, ShellyChannelData};
+pub use types::ShellyEmSnapshot;
+#[allow(unused_imports)]
+pub use types::ShellyChannelData;
 pub use mqtt::run_shelly_mqtt_loop;

--- a/crates/daly-bms-server/src/shelly/mqtt.rs
+++ b/crates/daly-bms-server/src/shelly/mqtt.rs
@@ -1,14 +1,18 @@
-//! Subscriber MQTT Shelly EM — réception des topics natifs Shelly.
+//! Subscriber MQTT Shelly Pro 2PM — réception des topics natifs Shelly Gen3.
 //!
-//! Topics surveillés (wildcards) :
-//!   shellies/+/emeter/0/power           → puissance canal 0 (W)
-//!   shellies/+/emeter/0/reactive_power  → puissance réactive canal 0 (VAr)
-//!   shellies/+/emeter/0/voltage         → tension canal 0 (V)
-//!   shellies/+/emeter/0/pf              → facteur de puissance canal 0
-//!   shellies/+/emeter/0/energy          → énergie cumul canal 0 (Wh)
-//!   shellies/+/emeter/0/returned_energy → retour réseau canal 0 (Wh)
-//!   (idem pour /emeter/1)
-//!   shellies/+/info                     → JSON avec wifi.rssi
+//! Topics surveillés :
+//!   {shelly_id}/status/switch:0   → état + mesures canal 0
+//!   {shelly_id}/status/switch:1   → état + mesures canal 1
+//!
+//! Format JSON (par canal) :
+//! ```json
+//! {
+//!   "id": 0, "source": "timer", "output": true,
+//!   "apower": 250.0, "voltage": 230.0, "current": 1.09, "pf": 0.99,
+//!   "aenergy": { "total": 1234.567 },
+//!   "ret_aenergy": { "total": 0.0 }
+//! }
+//! ```
 
 use crate::config::{MqttConfig, ShellyDeviceConfig};
 use super::types::{ShellyChannelData, ShellyEmSnapshot};
@@ -28,14 +32,14 @@ struct ShellyCache {
     rssi: Option<i32>,
 }
 
-/// Boucle principale d'abonnement MQTT Shelly EM.
+/// Boucle principale d'abonnement MQTT Shelly Pro 2PM.
 ///
-/// Se reconnecte automatiquement après déconnexion (backoff 10 s).
+/// Reconnexion automatique après déconnexion (backoff 10 s).
 /// Appelle `on_snapshot` pour chaque mise à jour reçue.
 pub async fn run_shelly_mqtt_loop<F>(
-    devices:     Vec<ShellyDeviceConfig>,
-    mqtt_cfg:    MqttConfig,
-    client_out:  Arc<Mutex<Option<AsyncClient>>>,
+    devices:         Vec<ShellyDeviceConfig>,
+    mqtt_cfg:        MqttConfig,
+    client_out:      Arc<Mutex<Option<AsyncClient>>>,
     mut on_snapshot: F,
 )
 where
@@ -45,9 +49,8 @@ where
         return;
     }
 
-    info!(count = devices.len(), host = %mqtt_cfg.host, "Démarrage Shelly EM MQTT subscriber");
+    info!(count = devices.len(), host = %mqtt_cfg.host, "Démarrage Shelly Pro 2PM MQTT subscriber");
 
-    // Cache par id de device
     let mut cache: HashMap<u8, ShellyCache> = HashMap::new();
     for dev in &devices {
         cache.insert(dev.id, ShellyCache::default());
@@ -67,26 +70,20 @@ where
 
         let (client, mut eventloop) = AsyncClient::new(opts, 128);
 
-        // Partager le client pour les commandes (non utilisé pour Shelly — read-only)
         {
             let mut guard = client_out.lock().await;
             *guard = Some(client.clone());
         }
 
-        // Abonnement aux wildcards Shelly
-        let _ = client.subscribe("shellies/+/emeter/0/power",           QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/0/reactive_power",  QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/0/voltage",         QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/0/pf",              QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/0/energy",          QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/0/returned_energy", QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/1/power",           QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/1/reactive_power",  QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/1/voltage",         QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/1/pf",              QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/1/energy",          QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/emeter/1/returned_energy", QoS::AtMostOnce).await;
-        let _ = client.subscribe("shellies/+/info",                     QoS::AtMostOnce).await;
+        // Abonnement aux topics status de chaque device configuré
+        for dev in &devices {
+            let t0 = format!("{}/status/switch:0", dev.shelly_id);
+            let t1 = format!("{}/status/switch:1", dev.shelly_id);
+            let ti = format!("{}/info", dev.shelly_id);
+            let _ = client.subscribe(&t0, QoS::AtMostOnce).await;
+            let _ = client.subscribe(&t1, QoS::AtMostOnce).await;
+            let _ = client.subscribe(&ti, QoS::AtMostOnce).await;
+        }
 
         loop {
             match eventloop.poll().await {
@@ -101,41 +98,29 @@ where
                         Err(_) => continue,
                     };
 
-                    // shellies/{device_id}/emeter/{channel}/{metric}
-                    // shellies/{device_id}/info
-                    let parts: Vec<&str> = topic.split('/').collect();
-                    if parts.len() < 3 { continue; }
-                    let device_name = parts[1];
-
-                    // Trouver la config du device par son shelly_id
-                    let dev_cfg = match devices.iter().find(|d| d.shelly_id == device_name) {
+                    // Trouver le device par shelly_id (préfixe du topic)
+                    let dev_cfg = match devices.iter().find(|d| topic.starts_with(&d.shelly_id)) {
                         Some(d) => d,
                         None    => continue,
                     };
                     let id = dev_cfg.id;
-
                     let entry = cache.entry(id).or_default();
 
-                    if parts.len() == 5 && parts[2] == "emeter" {
-                        // parts[3] = "0" ou "1", parts[4] = métrique
-                        let channel: u8 = parts[3].parse().unwrap_or(0);
-                        let metric  = parts[4];
-                        let val_f32: f32 = payload.trim().parse().unwrap_or(0.0);
-                        let val_f64: f64 = payload.trim().parse().unwrap_or(0.0);
+                    // {shelly_id}/status/switch:0 ou /status/switch:1
+                    if topic.ends_with("/status/switch:0") || topic.ends_with("/status/switch:1") {
+                        let channel: u8 = if topic.ends_with(":0") { 0 } else { 1 };
 
-                        let ch = if channel == 0 { &mut entry.ch0 } else { &mut entry.ch1 };
-
-                        match metric {
-                            "power"           => ch.power_w            = val_f32,
-                            "reactive_power"  => ch.reactive_power_var = val_f32,
-                            "voltage"         => ch.voltage_v          = val_f32,
-                            "pf"              => ch.power_factor        = val_f32,
-                            "energy"          => ch.energy_wh           = val_f64,
-                            "returned_energy" => ch.returned_wh         = val_f64,
-                            _ => {}
+                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(payload) {
+                            let ch = if channel == 0 { &mut entry.ch0 } else { &mut entry.ch1 };
+                            ch.output      = json["output"].as_bool().unwrap_or(false);
+                            ch.power_w     = json["apower"].as_f64().unwrap_or(0.0) as f32;
+                            ch.voltage_v   = json["voltage"].as_f64().unwrap_or(0.0) as f32;
+                            ch.current_a   = json["current"].as_f64().unwrap_or(0.0) as f32;
+                            ch.power_factor = json["pf"].as_f64().unwrap_or(0.0) as f32;
+                            ch.energy_wh   = json["aenergy"]["total"].as_f64().unwrap_or(0.0);
+                            ch.returned_wh = json["ret_aenergy"]["total"].as_f64().unwrap_or(0.0);
                         }
 
-                        // Émettre un snapshot à chaque mise à jour
                         let total_power_w = entry.ch0.power_w + entry.ch1.power_w;
                         let snap = ShellyEmSnapshot {
                             id,
@@ -149,10 +134,11 @@ where
                         };
                         on_snapshot(snap);
 
-                    } else if parts.len() == 3 && parts[2] == "info" {
-                        // Payload JSON avec wifi.rssi
+                    } else if topic.ends_with("/info") {
                         if let Ok(json) = serde_json::from_str::<serde_json::Value>(payload) {
-                            entry.rssi = json["wifi"]["rssi"].as_i64().map(|v| v as i32);
+                            entry.rssi = json["wifi"]["rssi"].as_i64()
+                                .or_else(|| json["wifi_sta"]["rssi"].as_i64())
+                                .map(|v| v as i32);
                         }
                     }
                 }
@@ -161,7 +147,7 @@ where
 
                 Err(e) => {
                     warn!("Shelly MQTT erreur : {:?}", e);
-                    break; // sortir pour reconnecter
+                    break;
                 }
             }
         }

--- a/crates/daly-bms-server/src/shelly/types.rs
+++ b/crates/daly-bms-server/src/shelly/types.rs
@@ -1,20 +1,28 @@
-//! Types de données pour les compteurs d'énergie Shelly EM (2 canaux).
+//! Types de données pour les compteurs d'énergie Shelly Pro 2PM (2 canaux).
 
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 
-/// Données d'un canal Shelly EM.
+/// Données d'un canal Shelly Pro 2PM.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ShellyChannelData {
+    /// Relais fermé (ON) ou ouvert (OFF).
+    pub output:             bool,
+    /// Puissance active instantanée (W).
     pub power_w:            f32,
-    pub reactive_power_var: f32,
+    /// Tension secteur (V).
     pub voltage_v:          f32,
+    /// Courant (A).
+    pub current_a:          f32,
+    /// Facteur de puissance.
     pub power_factor:       f32,
+    /// Énergie totale consommée depuis la remise à zéro (Wh).
     pub energy_wh:          f64,
+    /// Énergie retournée au réseau (Wh).
     pub returned_wh:        f64,
 }
 
-/// Snapshot complet d'un Shelly EM (2 canaux).
+/// Snapshot complet d'un Shelly Pro 2PM (2 canaux).
 #[derive(Debug, Clone, Serialize)]
 pub struct ShellyEmSnapshot {
     pub id:           u8,

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -8,6 +8,7 @@ use crate::config::AppConfig;
 use crate::console::{ConsoleBus, ConsoleEvent, EventDevice};
 use crate::et112::Et112Snapshot;
 use crate::irradiance::IrradianceSnapshot;
+use crate::shelly::ShellyEmSnapshot;
 use crate::tasmota::TasmotaSnapshot;
 use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
@@ -391,6 +392,12 @@ pub struct AppState {
 
     /// Canal broadcast pour la console de diagnostic (/ws/console).
     pub console_bus: ConsoleBus,
+
+    /// Derniers snapshots Shelly Pro 2PM (indexés par id device).
+    pub shelly_latest: Arc<RwLock<BTreeMap<u8, ShellyEmSnapshot>>>,
+
+    /// Client MQTT Shelly (pour les commandes de contrôle Switch.Set).
+    pub shelly_client: Arc<tokio::sync::Mutex<Option<rumqttc::AsyncClient>>>,
 }
 
 impl AppState {
@@ -446,6 +453,8 @@ impl AppState {
             ats_bus: Arc::new(RwLock::new(None)),
             rs485_stats: Arc::new(RwLock::new(BTreeMap::new())),
             console_bus: ConsoleBus::new(),
+            shelly_latest: Arc::new(RwLock::new(BTreeMap::new())),
+            shelly_client: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 
@@ -834,5 +843,47 @@ impl AppState {
     /// Enregistre le bus ATS pour les commandes d'écriture.
     pub async fn set_ats_bus(&self, bus: Arc<rs485_bus::SharedBus>) {
         *self.ats_bus.write().await = Some(bus);
+    }
+
+    // ==========================================================================
+    // Méthodes Shelly Pro 2PM
+    // ==========================================================================
+
+    /// Enregistre le dernier snapshot Shelly et émet un événement console.
+    pub async fn on_shelly_snapshot(&self, snap: ShellyEmSnapshot) {
+        self.console_bus.emit(ConsoleEvent::state(
+            EventDevice::Shelly,
+            &format!("Shelly {} — {:.0}W total", snap.name, snap.total_power_w),
+            json!({
+                "id": snap.id,
+                "name": snap.name,
+                "shelly_id": snap.shelly_id,
+                "total_power_w": snap.total_power_w,
+                "ch0": {
+                    "output": snap.channel_0.output,
+                    "power_w": snap.channel_0.power_w,
+                    "voltage_v": snap.channel_0.voltage_v,
+                    "current_a": snap.channel_0.current_a,
+                },
+                "ch1": {
+                    "output": snap.channel_1.output,
+                    "power_w": snap.channel_1.power_w,
+                    "voltage_v": snap.channel_1.voltage_v,
+                    "current_a": snap.channel_1.current_a,
+                },
+            }),
+        ));
+        let mut map = self.shelly_latest.write().await;
+        map.insert(snap.id, snap);
+    }
+
+    /// Retourne le dernier snapshot Shelly pour un id donné.
+    pub async fn shelly_latest_for(&self, id: u8) -> Option<ShellyEmSnapshot> {
+        self.shelly_latest.read().await.get(&id).cloned()
+    }
+
+    /// Retourne tous les derniers snapshots Shelly.
+    pub async fn shelly_latest_all(&self) -> Vec<ShellyEmSnapshot> {
+        self.shelly_latest.read().await.values().cloned().collect()
     }
 }

--- a/crates/daly-bms-server/templates/tasmota_all.html
+++ b/crates/daly-bms-server/templates/tasmota_all.html
@@ -7,9 +7,9 @@
 {% block content %}
 
 <div class="page-hdr">
-  <h1>🔌 Prises Tasmota</h1>
+  <h1>🔌 Prises & Compteurs</h1>
   <div class="page-hdr-meta">
-    <span><strong style="color:var(--text)">{{ device_count }}</strong> appareil(s) configuré(s)</span>
+    <span><strong style="color:var(--text)">{{ device_count }}</strong> Tasmota · <strong style="color:var(--text)">{{ shelly_count }}</strong> Shelly</span>
     <span class="sep">·</span>
     <span>Màj : <span id="tasmota-ts">—</span></span>
   </div>
@@ -19,9 +19,9 @@
 
 {# ── Chauffe-eau LG ThinQ ──────────────────────────────────────────────────── #}
 <div class="bms-card" id="lg-wh-card">
-  <div class="bms-hdr" id="lg-wh-hdr">
+  <div class="bms-hdr bms-hdr-offline" id="lg-wh-hdr">
     <div class="bms-hdr-left">
-      <div class="bms-live"><div class="live-dot" id="lg-wh-dot"></div><span id="lg-wh-mode">—</span></div>
+      <div class="bms-live"><div class="live-dot" id="lg-wh-dot" style="background:var(--muted2);box-shadow:none"></div><span id="lg-wh-mode">—</span></div>
       <span class="bms-hdr-name">🌡️ Chauffe-eau LG ThinQ</span>
     </div>
     <div class="bms-hdr-right">
@@ -50,10 +50,10 @@
   </div>
 </div>
 
+{# ── Prises Tasmota ────────────────────────────────────────────────────────── #}
 {% for d in devices %}
 <div class="bms-card {% if !d.connected %}" style="opacity:0.7{% endif %}" id="tasmota-card-{{ d.id }}">
 
-  {# Header #}
   <div class="bms-hdr {% if !d.connected %}bms-hdr-offline{% else if d.power_on %}bms-hdr-on{% else %}bms-hdr-off{% endif %}">
     <div class="bms-hdr-left">
       {% if d.connected %}
@@ -70,8 +70,6 @@
   </div>
 
   {% if d.connected %}
-
-  {# KPI 4 col #}
   <div class="kpi4">
     <div class="kpi4-cell t-yellow">
       <div class="kpi4-lbl">Puissance</div>
@@ -90,8 +88,6 @@
       <div class="kpi4-val muted" id="pf-{{ d.id }}">{{ d.power_factor|f2 }}</div>
     </div>
   </div>
-
-  {# Énergie #}
   <div class="istrip c3">
     <div class="icell">
       <span class="i-lbl">Aujourd'hui</span>
@@ -106,15 +102,12 @@
       <span class="i-val" id="etot-{{ d.id }}">{{ d.energy_total_kwh|f1 }} kWh</span>
     </div>
   </div>
-
   {% else %}
-
   <div class="empty-state" style="padding:2rem 1rem;">
     <div class="empty-icon" style="font-size:1.5rem">⏳</div>
     <div class="empty-title">En attente de données</div>
     <div class="empty-sub">Topic : <code>tele/{{ d.tasmota_id }}/SENSOR</code></div>
   </div>
-
   {% endif %}
 
   <div style="padding:0.5rem 0.75rem;display:flex;justify-content:space-between;align-items:center;border-top:1px solid var(--border);gap:0.5rem;">
@@ -133,6 +126,95 @@
 </div>
 {% endfor %}
 
+{# ── Compteurs Shelly Pro 2PM ──────────────────────────────────────────────── #}
+{% for s in shelly_devices %}
+<div class="bms-card {% if !s.connected %}" style="opacity:0.7{% endif %}" id="shelly-card-{{ s.id }}">
+
+  <div class="bms-hdr {% if !s.connected %}bms-hdr-offline{% else if s.ch0_output || s.ch1_output %}bms-hdr-on{% else %}bms-hdr-off{% endif %}">
+    <div class="bms-hdr-left">
+      {% if s.connected %}
+        <div class="bms-live">
+          <div class="live-dot" style="{% if !s.ch0_output && !s.ch1_output %}background:var(--red);box-shadow:0 0 6px var(--red){% endif %}"></div>
+          <span id="sh-total-{{ s.id }}">{{ s.total_power_w|f1 }} W</span>
+        </div>
+      {% else %}
+        <span style="font-size:0.62rem;color:var(--muted2)">Hors ligne</span>
+      {% endif %}
+      <span class="bms-hdr-name">⚡ {{ s.name }}</span>
+    </div>
+    <div class="bms-hdr-right">
+      <span class="bms-badge">{{ s.shelly_id }}</span>
+      <span class="bms-ts" id="sh-ts-{{ s.id }}">{{ s.last_ts }}</span>
+    </div>
+  </div>
+
+  {% if s.connected %}
+
+  {# ── Canal 1 ── #}
+  <div style="padding:0.4rem 0.75rem 0.2rem;font-size:0.7rem;font-weight:600;color:var(--muted2);text-transform:uppercase;letter-spacing:0.05em;">Canal 1</div>
+  <div class="kpi4" style="grid-template-columns:repeat(3,1fr);">
+    <div class="kpi4-cell t-yellow">
+      <div class="kpi4-lbl">Puissance</div>
+      <div class="kpi4-val {% if s.ch0_power_w > 0.0 %}chg{% else %}muted{% endif %}" id="sh-p0-{{ s.id }}">{{ s.ch0_power_w|f1 }} W</div>
+    </div>
+    <div class="kpi4-cell t-blue">
+      <div class="kpi4-lbl">Tension</div>
+      <div class="kpi4-val" id="sh-v0-{{ s.id }}">{{ s.ch0_voltage_v|f1 }} V</div>
+    </div>
+    <div class="kpi4-cell t-orange">
+      <div class="kpi4-lbl">Courant</div>
+      <div class="kpi4-val" id="sh-i0-{{ s.id }}">{{ s.ch0_current_a|f2 }} A</div>
+    </div>
+  </div>
+  <div style="padding:0.4rem 0.75rem;display:flex;justify-content:space-between;align-items:center;border-top:1px solid var(--border);gap:0.5rem;">
+    <button
+      id="sh-btn0-{{ s.id }}"
+      onclick="toggleShellyChannel({{ s.id }}, 0)"
+      class="btn {% if s.ch0_output %}btn-danger{% else %}btn-primary{% endif %}"
+      style="font-size:0.72rem;padding:0.3rem 0.9rem;min-width:90px;"
+    >{% if s.ch0_output %}🔴 Éteindre{% else %}🟢 Allumer{% endif %}</button>
+    <span class="i-val muted" style="font-size:0.78rem;" id="sh-e0-{{ s.id }}">{{ s.ch0_energy_kwh|f2 }} kWh</span>
+  </div>
+
+  {# ── Canal 2 ── #}
+  <div style="padding:0.4rem 0.75rem 0.2rem;font-size:0.7rem;font-weight:600;color:var(--muted2);text-transform:uppercase;letter-spacing:0.05em;border-top:1px solid var(--border);">Canal 2</div>
+  <div class="kpi4" style="grid-template-columns:repeat(3,1fr);">
+    <div class="kpi4-cell t-yellow">
+      <div class="kpi4-lbl">Puissance</div>
+      <div class="kpi4-val {% if s.ch1_power_w > 0.0 %}chg{% else %}muted{% endif %}" id="sh-p1-{{ s.id }}">{{ s.ch1_power_w|f1 }} W</div>
+    </div>
+    <div class="kpi4-cell t-blue">
+      <div class="kpi4-lbl">Tension</div>
+      <div class="kpi4-val" id="sh-v1-{{ s.id }}">{{ s.ch1_voltage_v|f1 }} V</div>
+    </div>
+    <div class="kpi4-cell t-orange">
+      <div class="kpi4-lbl">Courant</div>
+      <div class="kpi4-val" id="sh-i1-{{ s.id }}">{{ s.ch1_current_a|f2 }} A</div>
+    </div>
+  </div>
+  <div style="padding:0.4rem 0.75rem;display:flex;justify-content:space-between;align-items:center;border-top:1px solid var(--border);gap:0.5rem;">
+    <button
+      id="sh-btn1-{{ s.id }}"
+      onclick="toggleShellyChannel({{ s.id }}, 1)"
+      class="btn {% if s.ch1_output %}btn-danger{% else %}btn-primary{% endif %}"
+      style="font-size:0.72rem;padding:0.3rem 0.9rem;min-width:90px;"
+    >{% if s.ch1_output %}🔴 Éteindre{% else %}🟢 Allumer{% endif %}</button>
+    <span class="i-val muted" style="font-size:0.78rem;" id="sh-e1-{{ s.id }}">{{ s.ch1_energy_kwh|f2 }} kWh</span>
+  </div>
+
+  {% else %}
+
+  <div class="empty-state" style="padding:2rem 1rem;">
+    <div class="empty-icon" style="font-size:1.5rem">⏳</div>
+    <div class="empty-title">En attente de données</div>
+    <div class="empty-sub">Topics : <code>{{ s.shelly_id }}/status/switch:0,1</code></div>
+  </div>
+
+  {% endif %}
+
+</div>
+{% endfor %}
+
 </div>
 
 {% endblock %}
@@ -140,12 +222,15 @@
 {% block scripts %}
 <script>
 const TASMOTA_IDS = [{% for d in devices %}{{ d.id }}{% if !loop.last %}, {% endif %}{% endfor %}];
+const SHELLY_IDS  = [{% for s in shelly_devices %}{{ s.id }}{% if !loop.last %}, {% endif %}{% endfor %}];
 
 const devicePowerState = {};
-{% for d in devices %}
-devicePowerState[{{ d.id }}] = {{ d.power_on }};
-{% endfor %}
+{% for d in devices %}devicePowerState[{{ d.id }}] = {{ d.power_on }};{% endfor %}
 
+const shellyState = {};
+{% for s in shelly_devices %}shellyState[{{ s.id }}] = { ch0: {{ s.ch0_output }}, ch1: {{ s.ch1_output }} };{% endfor %}
+
+// ── Tasmota toggle helpers ───────────────────────────────────────────────────
 function updateToggleBtn(id, isOn, connected) {
   const btn = document.getElementById(`toggle-btn-${id}`);
   if (!btn) return;
@@ -153,69 +238,51 @@ function updateToggleBtn(id, isOn, connected) {
   if (!connected) { btn.textContent = 'Hors ligne'; btn.className = 'btn btn-outline'; return; }
   btn.textContent = isOn ? '🔴 Éteindre' : '🟢 Allumer';
   btn.className = `btn ${isOn ? 'btn-danger' : 'btn-primary'}`;
-  btn.style.minWidth = '90px';
-  btn.style.fontSize = '0.72rem';
-  btn.style.padding = '0.3rem 0.9rem';
+  btn.style.cssText = 'font-size:0.72rem;padding:0.3rem 0.9rem;min-width:90px;';
 }
 
 async function toggleDevice(id) {
   const btn = document.getElementById(`toggle-btn-${id}`);
   if (!btn || btn.disabled) return;
   const currentOn = devicePowerState[id] ?? false;
-  const cmd = currentOn ? 'off' : 'on';
-
-  btn.disabled = true;
-  btn.textContent = '⏳';
-  btn.style.opacity = '0.7';
-
+  btn.disabled = true; btn.textContent = '⏳'; btn.style.opacity = '0.7';
   try {
     const resp = await fetch(`/api/v1/tasmota/${id}/control`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ state: cmd })
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: currentOn ? 'off' : 'on' })
     });
     if (resp.ok) {
       devicePowerState[id] = !currentOn;
       updateToggleBtn(id, devicePowerState[id], true);
-      updateCardHeader(id, devicePowerState[id]);
-    } else {
-      updateToggleBtn(id, currentOn, true);
-    }
-  } catch(e) {
-    updateToggleBtn(id, currentOn, true);
-  } finally {
-    btn.style.opacity = '';
-  }
+      updateTasmotaHeader(id, devicePowerState[id]);
+    } else { updateToggleBtn(id, currentOn, true); }
+  } catch(e) { updateToggleBtn(id, currentOn, true); }
+  finally { if (document.getElementById(`toggle-btn-${id}`)) document.getElementById(`toggle-btn-${id}`).style.opacity = ''; }
 }
 
-function updateCardHeader(id, isOn) {
+function updateTasmotaHeader(id, isOn) {
   const card = document.getElementById(`tasmota-card-${id}`);
   if (!card) return;
   const hdr = card.querySelector('.bms-hdr');
   if (hdr) {
-    hdr.style.background = isOn
-      ? 'linear-gradient(135deg,#dcfce7 0%,#bbf7d0 100%)'
-      : 'linear-gradient(135deg,#fee2e2 0%,#fecaca 100%)';
+    hdr.classList.remove('bms-hdr-on', 'bms-hdr-off', 'bms-hdr-offline');
+    hdr.classList.add(isOn ? 'bms-hdr-on' : 'bms-hdr-off');
   }
   const liveEl = card.querySelector('.bms-live');
   if (liveEl) {
     const dot = liveEl.querySelector('.live-dot');
-    if (dot) dot.style.background = isOn ? '' : 'var(--red)';
+    if (dot) dot.style.cssText = isOn ? '' : 'background:var(--red);box-shadow:0 0 6px var(--red)';
     liveEl.childNodes.forEach(n => { if (n.nodeType === 3) n.textContent = isOn ? 'ON' : 'OFF'; });
   }
 }
 
 async function updateAll() {
-  const ts = new Date().toLocaleTimeString('fr-FR');
-  const tsEl = document.getElementById('tasmota-ts');
-  if (tsEl) tsEl.textContent = ts;
-
+  document.getElementById('tasmota-ts').textContent = new Date().toLocaleTimeString('fr-FR');
   for (const id of TASMOTA_IDS) {
     try {
       const resp = await fetch(`/api/v1/tasmota/${id}/status`);
       if (!resp.ok) continue;
       const d = await resp.json();
-
       const set = (elId, txt) => { const el = document.getElementById(elId); if (el) el.textContent = txt; };
       set(`p-${id}`,    d.power_w.toFixed(1) + ' W');
       set(`v-${id}`,    d.voltage_v.toFixed(1) + ' V');
@@ -224,16 +291,13 @@ async function updateAll() {
       set(`etd-${id}`,  d.energy_today_kwh.toFixed(2) + ' kWh');
       set(`eyd-${id}`,  d.energy_yesterday_kwh.toFixed(2) + ' kWh');
       set(`etot-${id}`, d.energy_total_kwh.toFixed(1) + ' kWh');
-      set(`ts-${id}`,   ts);
-
+      set(`ts-${id}`,   new Date().toLocaleTimeString('fr-FR'));
       const pw = document.getElementById(`p-${id}`);
       if (pw) pw.className = 'kpi4-val ' + (d.power_w > 0 ? 'chg' : 'muted');
-
-      const prevOn = devicePowerState[id] ?? false;
-      if (prevOn !== d.power_on) {
+      if ((devicePowerState[id] ?? false) !== d.power_on) {
         devicePowerState[id] = d.power_on;
         updateToggleBtn(id, d.power_on, true);
-        updateCardHeader(id, d.power_on);
+        updateTasmotaHeader(id, d.power_on);
       }
     } catch(e) {}
   }
@@ -242,21 +306,90 @@ async function updateAll() {
 updateAll();
 setInterval(updateAll, 5000);
 
-// ── LG ThinQ water heater ────────────────────────────────────────────────────
-// Use same hostname as dashboard so it works regardless of how the page is accessed.
+// ── Shelly Pro 2PM ────────────────────────────────────────────────────────────
+function updateShellyBtn(id, ch, isOn) {
+  const btn = document.getElementById(`sh-btn${ch}-${id}`);
+  if (!btn) return;
+  btn.textContent = isOn ? '🔴 Éteindre' : '🟢 Allumer';
+  btn.className = `btn ${isOn ? 'btn-danger' : 'btn-primary'}`;
+  btn.style.cssText = 'font-size:0.72rem;padding:0.3rem 0.9rem;min-width:90px;';
+}
+
+function updateShellyHeader(id) {
+  const st = shellyState[id] ?? { ch0: false, ch1: false };
+  const card = document.getElementById(`shelly-card-${id}`);
+  if (!card) return;
+  const hdr = card.querySelector('.bms-hdr');
+  if (hdr) {
+    hdr.classList.remove('bms-hdr-on', 'bms-hdr-off', 'bms-hdr-offline');
+    hdr.classList.add(st.ch0 || st.ch1 ? 'bms-hdr-on' : 'bms-hdr-off');
+  }
+  const dot = card.querySelector('.live-dot');
+  if (dot) dot.style.cssText = (st.ch0 || st.ch1) ? '' : 'background:var(--red);box-shadow:0 0 6px var(--red)';
+}
+
+async function toggleShellyChannel(id, ch) {
+  const btn = document.getElementById(`sh-btn${ch}-${id}`);
+  if (!btn || btn.disabled) return;
+  const currentOn = (shellyState[id] ?? {})[`ch${ch}`] ?? false;
+  btn.disabled = true; btn.textContent = '⏳'; btn.style.opacity = '0.7';
+  try {
+    const resp = await fetch(`/api/v1/shelly/${id}/channel/${ch}/control`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: currentOn ? 'off' : 'on' })
+    });
+    if (resp.ok) {
+      if (!shellyState[id]) shellyState[id] = { ch0: false, ch1: false };
+      shellyState[id][`ch${ch}`] = !currentOn;
+      updateShellyBtn(id, ch, !currentOn);
+      updateShellyHeader(id);
+    } else { updateShellyBtn(id, ch, currentOn); }
+  } catch(e) { updateShellyBtn(id, ch, currentOn); }
+  finally { if (btn) btn.style.opacity = ''; }
+}
+
+async function updateShellyAll() {
+  for (const id of SHELLY_IDS) {
+    try {
+      const resp = await fetch(`/api/v1/shelly/${id}/status`);
+      if (!resp.ok) continue;
+      const d = await resp.json();
+      const set = (elId, txt) => { const el = document.getElementById(elId); if (el) el.textContent = txt; };
+      set(`sh-total-${id}`, d.total_power_w.toFixed(1) + ' W');
+      set(`sh-ts-${id}`,    new Date().toLocaleTimeString('fr-FR'));
+      // Canal 0
+      set(`sh-p0-${id}`, d.channel_0.power_w.toFixed(1) + ' W');
+      set(`sh-v0-${id}`, d.channel_0.voltage_v.toFixed(1) + ' V');
+      set(`sh-i0-${id}`, d.channel_0.current_a.toFixed(2) + ' A');
+      set(`sh-e0-${id}`, (d.channel_0.energy_wh / 1000).toFixed(2) + ' kWh');
+      const p0 = document.getElementById(`sh-p0-${id}`);
+      if (p0) p0.className = 'kpi4-val ' + (d.channel_0.power_w > 0 ? 'chg' : 'muted');
+      // Canal 1
+      set(`sh-p1-${id}`, d.channel_1.power_w.toFixed(1) + ' W');
+      set(`sh-v1-${id}`, d.channel_1.voltage_v.toFixed(1) + ' V');
+      set(`sh-i1-${id}`, d.channel_1.current_a.toFixed(2) + ' A');
+      set(`sh-e1-${id}`, (d.channel_1.energy_wh / 1000).toFixed(2) + ' kWh');
+      const p1 = document.getElementById(`sh-p1-${id}`);
+      if (p1) p1.className = 'kpi4-val ' + (d.channel_1.power_w > 0 ? 'chg' : 'muted');
+      // Sync state + header if changed
+      const prev = shellyState[id] ?? { ch0: false, ch1: false };
+      if (prev.ch0 !== d.channel_0.output || prev.ch1 !== d.channel_1.output) {
+        shellyState[id] = { ch0: d.channel_0.output, ch1: d.channel_1.output };
+        updateShellyBtn(id, 0, d.channel_0.output);
+        updateShellyBtn(id, 1, d.channel_1.output);
+        updateShellyHeader(id);
+      }
+    } catch(e) {}
+  }
+}
+
+if (SHELLY_IDS.length > 0) {
+  updateShellyAll();
+  setInterval(updateShellyAll, 5000);
+}
+
+// ── LG ThinQ ─────────────────────────────────────────────────────────────────
 const LG_API = window.location.protocol + '//' + window.location.hostname + ':8081';
-
-const LG_MODE_COLORS = {
-  HEAT_PUMP: 'linear-gradient(135deg,#fef3c7 0%,#fde68a 100%)',
-  TURBO:     'linear-gradient(135deg,#fee2e2 0%,#fca5a5 100%)',
-  VACATION:  'linear-gradient(135deg,#e0f2fe 0%,#bae6fd 100%)',
-};
-
-const LG_MODE_DOT = {
-  HEAT_PUMP: '',   // default green pulse
-  TURBO:     'background:var(--orange);box-shadow:0 0 6px var(--orange)',
-  VACATION:  'background:var(--blue);box-shadow:0 0 6px var(--blue)',
-};
 
 async function lgFetchStatus() {
   try {
@@ -271,25 +404,33 @@ async function lgFetchStatus() {
     document.getElementById('lg-wh-target').textContent = d.target_temp_c  != null ? d.target_temp_c.toFixed(1)  + ' °C' : '—';
     document.getElementById('lg-wh-ts').textContent     = new Date().toLocaleTimeString('fr-FR');
 
-    // Highlight active mode button — same pattern as toggle buttons
+    // Highlight active mode button
     const btnMap = { HEAT_PUMP: 'btn-heatpump', TURBO: 'btn-turbo', VACATION: 'btn-vacation' };
     Object.entries(btnMap).forEach(([m, btnId]) => {
       const btn = document.getElementById(btnId);
       if (!btn) return;
       btn.className = (mode === m) ? 'btn btn-primary' : 'btn btn-outline';
-      btn.style.fontSize = '0.72rem';
-      btn.style.padding  = '0.3rem 0.9rem';
+      btn.style.fontSize = '0.72rem'; btn.style.padding = '0.3rem 0.9rem';
     });
 
-    // Header color + dot — same mechanism as updateCardHeader()
+    // Header CSS class — same pattern as Tasmota cards
     const hdr = document.getElementById('lg-wh-hdr');
-    if (hdr) hdr.style.background = LG_MODE_COLORS[mode] || LG_MODE_COLORS.VACATION;
+    if (hdr) {
+      hdr.classList.remove('bms-hdr-on', 'bms-hdr-off', 'bms-hdr-offline');
+      hdr.classList.add(mode === 'HEAT_PUMP' || mode === 'TURBO' ? 'bms-hdr-on' : 'bms-hdr-off');
+    }
     const dot = document.getElementById('lg-wh-dot');
-    if (dot) dot.style.cssText = LG_MODE_DOT[mode] ?? '';
+    if (dot) {
+      if (mode === 'TURBO')     dot.style.cssText = 'background:var(--orange);box-shadow:0 0 6px var(--orange)';
+      else if (mode === 'HEAT_PUMP') dot.style.cssText = '';
+      else                      dot.style.cssText = 'background:var(--blue);box-shadow:0 0 6px var(--blue)';
+    }
 
-    if (!d.lg_enabled) lgSetError('LG ThinQ désactivé (LG_DEVICE_ID / LG_BEARER_TOKEN manquants)');
+    if (!d.lg_enabled) lgSetError('LG ThinQ désactivé (credentials manquants)');
   } catch(e) {
     lgSetError('energy-manager inaccessible (:8081)');
+    const hdr = document.getElementById('lg-wh-hdr');
+    if (hdr) { hdr.classList.remove('bms-hdr-on','bms-hdr-off'); hdr.classList.add('bms-hdr-offline'); }
   }
 }
 
@@ -297,15 +438,12 @@ async function lgSetMode(mode) {
   lgSetError('');
   try {
     const resp = await fetch(`${LG_API}/api/water-heater/mode`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ mode })
     });
     if (!resp.ok) lgSetError(await resp.text());
     else await lgFetchStatus();
-  } catch(e) {
-    lgSetError('Erreur: ' + e.message);
-  }
+  } catch(e) { lgSetError('Erreur: ' + e.message); }
 }
 
 function lgSetError(msg) {

--- a/crates/energy-manager/src/http_clients/lg_thinq.rs
+++ b/crates/energy-manager/src/http_clients/lg_thinq.rs
@@ -13,13 +13,30 @@ use crate::types::{LiveEvent, WaterHeaterMode};
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct LgStateResponse {
-    result: Option<LgStateResult>,
+    response: LgStateResponseData,
 }
 
 #[derive(Debug, Deserialize)]
-struct LgStateResult {
-    data: Option<serde_json::Value>,
+#[serde(rename_all = "camelCase")]
+struct LgStateResponseData {
+    water_heater_job_mode: Option<WaterHeaterJobMode>,
+    temperature: Option<TemperatureData>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WaterHeaterJobMode {
+    current_job_mode: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TemperatureData {
+    current_temperature: f64,
+    target_temperature: f64,
+    // unit: String, // non utilisé, supprimé pour éviter warning dead_code
 }
 
 // ---------------------------------------------------------------------------
@@ -77,7 +94,6 @@ impl LgThinqClient {
             h.insert("x-client-id",
                 HeaderValue::from_str(&self.cfg.client_id).unwrap());
         }
-        // x-message-id: unique per request (simple counter via timestamp)
         let msg_id = format!("{:x}", std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -100,25 +116,22 @@ impl LgThinqClient {
             .context("LG ThinQ GET state HTTP error")?;
 
         let body: LgStateResponse = resp.json().await.context("LG ThinQ parse state")?;
-        let data = body.result.and_then(|r| r.data).unwrap_or(serde_json::Value::Null);
 
-        // ThinQ EIC API: data.waterHeaterJobMode.currentJobMode
-        let mode_str = data
-            .get("waterHeaterJobMode")
-            .and_then(|v| v.get("currentJobMode"))
-            .and_then(|v| v.as_str())
+        let mode_str = body.response
+            .water_heater_job_mode
+            .as_ref()
+            .map(|m| m.current_job_mode.as_str())
             .unwrap_or_default()
             .to_string();
 
-        // temperature: data.temperature.currentTemperature / targetTemperature
-        let current_temp_c = data
-            .get("temperature")
-            .and_then(|v| v.get("currentTemperature"))
-            .and_then(|v| v.as_f64());
-        let target_temp_c = data
-            .get("temperature")
-            .and_then(|v| v.get("targetTemperature"))
-            .and_then(|v| v.as_f64());
+        let current_temp_c = body.response
+            .temperature
+            .as_ref()
+            .map(|t| t.current_temperature);
+        let target_temp_c = body.response
+            .temperature
+            .as_ref()
+            .map(|t| t.target_temperature);
 
         debug!("LG ThinQ state: mode={mode_str} temp={current_temp_c:?} target={target_temp_c:?}");
         Ok(LgSnapshot {
@@ -129,7 +142,6 @@ impl LgThinqClient {
     }
 
     pub async fn set_mode(&self, mode: WaterHeaterMode) -> Result<()> {
-        // ThinQ EIC API control payload format (from Node-RED reference implementation)
         let payload = json!({
             "waterHeaterJobMode": {
                 "currentJobMode": mode.to_lg_str()
@@ -175,7 +187,7 @@ impl LgThinqClient {
 }
 
 // ---------------------------------------------------------------------------
-// Polling task (read state every N minutes)
+// Polling task
 // ---------------------------------------------------------------------------
 
 pub async fn spawn_poller(


### PR DESCRIPTION
…temperatures

- Shelly Pro 2PM: rewrite mqtt.rs for Gen3 topics ({id}/status/switch:0,1), add output/current_a fields to ShellyChannelData, wire on_shelly_snapshot into AppState, start loop in main.rs, add REST API (list/status/control), add Shelly card with two-channel design (same as Tongou) to tasmota_all.html
- Config.toml: add [shelly] + [[shelly.devices]] for shellypro2pm-ec62608840a4
- LG ThinQ: apply real API response structure fix (response.waterHeaterJobMode not result.data.*) so temperatures are no longer null
- LG card: use bms-hdr CSS classes (same as Tasmota cards) instead of inline background styles; offline state shown on initial render

https://claude.ai/code/session_01WkTcchAa2HTezHGnxwDPUQ