### PR TITLE
fix: correct 6 reported issues after deployment

### DIFF
--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -781,9 +781,11 @@ async fn handle_heatpump_topic(state: &AppState, topic: &str, json: &Value) {
 
     debug!(index = idx, state = hp_state, "Heatpump MQTT reçu");
     let mode_lbl = match hp_state { 0 => "Vacances", 1 => "HEAT_PUMP", 2 => "TURBO", _ => "Inconnu" };
-    state.console_bus.emit(ConsoleEvent::state(EventDevice::WaterHeater, &format!("Chauffe-eau idx={idx} — {mode_lbl}"), json!({
+    let temp_str = temperature.map(|t| format!(" | {:.1}°C", t)).unwrap_or_default();
+    let tgt_str  = target_temp.map(|t| format!(" → {:.1}°C", t)).unwrap_or_default();
+    state.console_bus.emit(ConsoleEvent::state(EventDevice::WaterHeater, &format!("Chauffe-eau idx={idx} — {mode_lbl}{temp_str}{tgt_str}"), json!({
         "idx": idx, "state": hp_state, "mode": mode_lbl,
-        "temperature": temperature, "target": target_temp,
+        "temperature_c": temperature, "target_c": target_temp,
         "power_w": ac_power, "energy_kwh": ac_energy,
     })));
     state.on_venus_heatpump(hp).await;

--- a/crates/daly-bms-server/src/shelly/mqtt.rs
+++ b/crates/daly-bms-server/src/shelly/mqtt.rs
@@ -1,18 +1,12 @@
 //! Subscriber MQTT Shelly Pro 2PM — réception des topics natifs Shelly Gen3.
 //!
 //! Topics surveillés :
-//!   {shelly_id}/status/switch:0   → état + mesures canal 0
-//!   {shelly_id}/status/switch:1   → état + mesures canal 1
+//!   {shelly_id}/status/switch:0   → état + mesures canal 0 (publié sur changement)
+//!   {shelly_id}/status/switch:1   → état + mesures canal 1 (publié sur changement)
+//!   daly-bms-shelly/rpc           → réponses aux RPC GetStatus demandées par ce client
 //!
-//! Format JSON (par canal) :
-//! ```json
-//! {
-//!   "id": 0, "source": "timer", "output": true,
-//!   "apower": 250.0, "voltage": 230.0, "current": 1.09, "pf": 0.99,
-//!   "aenergy": { "total": 1234.567 },
-//!   "ret_aenergy": { "total": 0.0 }
-//! }
-//! ```
+//! Interrogation active toutes les 30 s via RPC Switch.GetStatus pour obtenir l'état
+//! initial et combler les absences de publication (aucun changement d'état).
 
 use crate::config::{MqttConfig, ShellyDeviceConfig};
 use super::types::{ShellyChannelData, ShellyEmSnapshot};
@@ -23,6 +17,9 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 use chrono::Local;
+
+/// Client ID de ce subscriber — utilisé comme topic de réponse RPC.
+const RPC_SRC: &str = "daly-bms-shelly";
 
 /// Cache intermédiaire pour assembler les mesures multi-topics.
 #[derive(Default)]
@@ -58,7 +55,7 @@ where
 
     loop {
         let mut opts = MqttOptions::new(
-            format!("daly-bms-shelly-{}", uuid::Uuid::new_v4()),
+            format!("{}-{}", RPC_SRC, uuid::Uuid::new_v4()),
             &mqtt_cfg.host,
             mqtt_cfg.port,
         );
@@ -75,7 +72,9 @@ where
             *guard = Some(client.clone());
         }
 
-        // Abonnement aux topics status de chaque device configuré
+        // Abonnement aux topics status de chaque device configuré + réponses RPC
+        let rpc_response_topic = format!("{}/rpc", RPC_SRC);
+        let _ = client.subscribe(&rpc_response_topic, QoS::AtMostOnce).await;
         for dev in &devices {
             let t0 = format!("{}/status/switch:0", dev.shelly_id);
             let t1 = format!("{}/status/switch:1", dev.shelly_id);
@@ -85,10 +84,56 @@ where
             let _ = client.subscribe(&ti, QoS::AtMostOnce).await;
         }
 
+        // Tâche de polling périodique (30 s) via RPC Switch.GetStatus.
+        // Permet d'obtenir l'état initial et de rafraîchir même sans changement d'état.
+        let poll_client  = client.clone();
+        let poll_devices = devices.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(Duration::from_secs(30));
+            loop {
+                ticker.tick().await;
+                for (req_id, dev) in poll_devices.iter().enumerate() {
+                    for ch in 0u8..2 {
+                        let payload = serde_json::json!({
+                            "id":     req_id * 2 + ch as usize,
+                            "src":    RPC_SRC,
+                            "method": "Switch.GetStatus",
+                            "params": { "id": ch }
+                        });
+                        let topic = format!("{}/rpc", dev.shelly_id);
+                        let _ = poll_client.publish(
+                            &topic,
+                            QoS::AtMostOnce,
+                            false,
+                            payload.to_string().as_bytes(),
+                        ).await;
+                    }
+                }
+            }
+        });
+
         loop {
             match eventloop.poll().await {
                 Ok(Event::Incoming(Incoming::ConnAck(_))) => {
                     info!("Shelly MQTT connecté (broker {}:{})", mqtt_cfg.host, mqtt_cfg.port);
+                    // Demande immédiate de l'état courant via RPC
+                    for (req_id, dev) in devices.iter().enumerate() {
+                        for ch in 0u8..2 {
+                            let payload = serde_json::json!({
+                                "id":     req_id * 2 + ch as usize + 100,
+                                "src":    RPC_SRC,
+                                "method": "Switch.GetStatus",
+                                "params": { "id": ch }
+                            });
+                            let topic = format!("{}/rpc", dev.shelly_id);
+                            let _ = client.publish(
+                                &topic,
+                                QoS::AtMostOnce,
+                                false,
+                                payload.to_string().as_bytes(),
+                            ).await;
+                        }
+                    }
                 }
 
                 Ok(Event::Incoming(Incoming::Publish(msg))) => {
@@ -97,6 +142,44 @@ where
                         Ok(s) => s,
                         Err(_) => continue,
                     };
+
+                    // Réponse RPC : daly-bms-shelly/rpc
+                    if topic == rpc_response_topic {
+                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(payload) {
+                            // { "id":..., "src": "{shelly_id}", ..., "result": { "id": 0|1, "output": ..., ... } }
+                            let result = match json.get("result") { Some(r) => r, None => continue };
+                            let src_id = json["src"].as_str().unwrap_or("");
+                            let dev_cfg = match devices.iter().find(|d| d.shelly_id == src_id) {
+                                Some(d) => d,
+                                None    => continue,
+                            };
+                            let channel = result["id"].as_u64().unwrap_or(0) as u8;
+                            let id = dev_cfg.id;
+                            let entry = cache.entry(id).or_default();
+                            let ch = if channel == 0 { &mut entry.ch0 } else { &mut entry.ch1 };
+                            ch.output      = result["output"].as_bool().unwrap_or(false);
+                            ch.power_w     = result["apower"].as_f64().unwrap_or(0.0) as f32;
+                            ch.voltage_v   = result["voltage"].as_f64().unwrap_or(0.0) as f32;
+                            ch.current_a   = result["current"].as_f64().unwrap_or(0.0) as f32;
+                            ch.power_factor = result["pf"].as_f64().unwrap_or(0.0) as f32;
+                            ch.energy_wh   = result["aenergy"]["total"].as_f64().unwrap_or(0.0);
+                            ch.returned_wh = result["ret_aenergy"]["total"].as_f64().unwrap_or(0.0);
+
+                            let total_power_w = entry.ch0.power_w + entry.ch1.power_w;
+                            let snap = ShellyEmSnapshot {
+                                id,
+                                name:         dev_cfg.name.clone(),
+                                shelly_id:    dev_cfg.shelly_id.clone(),
+                                timestamp:    Local::now(),
+                                channel_0:    entry.ch0.clone(),
+                                channel_1:    entry.ch1.clone(),
+                                rssi:         entry.rssi,
+                                total_power_w,
+                            };
+                            on_snapshot(snap);
+                        }
+                        continue;
+                    }
 
                     // Trouver le device par shelly_id (préfixe du topic)
                     let dev_cfg = match devices.iter().find(|d| topic.starts_with(&d.shelly_id)) {

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -96,10 +96,10 @@ const HIST_ET112_9 = { measurement: 'et112_status',     field: 'current_a',     
 const HIST_BMS_1   = { measurement: 'bms_status',       field: 'current',             address: '0x01', label: 'BMS-360Ah — I (6h)' };
 const HIST_BMS_2   = { measurement: 'bms_status',       field: 'current',             address: '0x02', label: 'BMS-320Ah — I (6h)' };
 const HIST_BMS_3   = { measurement: 'bms_status',       field: 'current',             address: '0x03', label: 'BMS-3 — I (6h)' };
-const HIST_MPPT    = { measurement: 'solar_power',     field: 'mppt_power_w',     label: 'MPPT total — Puissance DC (6h)' };
+const HIST_MPPT    = { measurement: 'venus_mppt_total', field: 'current_a',        label: 'MPPT total — I DC (6h)' };
 const HIST_INV_DC  = { measurement: 'inverter_status', field: 'dc_current_a',     label: 'Onduleur — I DC (6h)' };
 const HIST_INV_AC  = { measurement: 'inverter_status', field: 'ac_out_current_a', label: 'Onduleur — I AC sortie (6h)' };
-const HIST_SHUNT   = { measurement: 'battery_status',  field: 'current_a',        label: 'SmartShunt — I batterie (6h)' };
+const HIST_SHUNT   = { measurement: 'venus_smartshunt', field: 'current_a',       label: 'SmartShunt — I batterie (6h)' };
 
 const EDGES0 = [
   mkEdge('e-ats-maison', 'ats-main', 'et112-maison',   COLOR.ac,  { sourceHandle: 'main-right', targetHandle: 'tl', type: 'customBezier', history: HIST_ET112_8 }),

--- a/crates/energy-manager/src/http_clients/lg_thinq.rs
+++ b/crates/energy-manager/src/http_clients/lg_thinq.rs
@@ -6,7 +6,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::bus::AppBus;
 use crate::config::LgThinqConfig;
-use crate::types::{LiveEvent, WaterHeaterMode};
+use crate::types::{InfluxPoint, LiveEvent, WaterHeaterMode};
 
 // ---------------------------------------------------------------------------
 // API response types — ThinQ EIC API v2
@@ -226,6 +226,17 @@ pub async fn spawn_poller(
                         s.water_heater_temp_c   = snap.current_temp_c;
                         s.water_heater_target_c = snap.target_temp_c;
                     }
+                    // Write to InfluxDB on every poll
+                    let mut pt = InfluxPoint::new("water_heater_status")
+                        .field_s("mode",  snap.mode.to_lg_str())
+                        .field_i("state", snap.mode.to_venus_state() as i64);
+                    if let Some(t) = snap.current_temp_c {
+                        pt = pt.field_f("temperature_c", t);
+                    }
+                    if let Some(t) = snap.target_temp_c {
+                        pt = pt.field_f("target_c", t);
+                    }
+                    bus2.write_influx(pt).await;
                     bus2.emit_live(LiveEvent::new("water_heater", &snap));
                 }
                 Err(e) => error!("LG ThinQ poll error: {e}"),

--- a/crates/energy-manager/src/logic/water_heater.rs
+++ b/crates/energy-manager/src/logic/water_heater.rs
@@ -6,13 +6,13 @@ use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::{interval, sleep, Duration};
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::bus::AppBus;
 use crate::config::WaterHeaterConfig;
 use crate::http_clients::lg_thinq::LgThinqClient;
 use crate::mqtt::topics::publish;
-use crate::types::{EnergyState, LiveEvent, MqttOutgoing, WaterHeaterMode};
+use crate::types::{EnergyState, InfluxPoint, LiveEvent, MqttOutgoing, WaterHeaterMode};
 
 pub async fn spawn(
     cfg: WaterHeaterConfig,
@@ -133,17 +133,32 @@ async fn control_task(
         let want_vacation = grid_on || soc_low || discharge_too_long || solar_too_low || irradiance_low;
         let target_mode = if want_vacation { WaterHeaterMode::Vacation } else { WaterHeaterMode::HeatPump };
 
+        debug!(
+            "Water heater conditions: grid_on={grid_on} soc={soc:.1}% soc_low={soc_low} \
+            batt_current={batt_current:.1}A discharge_too_long={discharge_too_long} \
+            solar_total={solar_total:.0}W solar_too_low={solar_too_low} \
+            irradiance={:?}W/m² irradiance_low={irradiance_low} \
+            → want_vacation={want_vacation} current={current_mode:?}",
+            irradiance
+        );
+
         // --- Rate limiting ---
         let can_change = last_change.map(|t| {
             (now - t).num_seconds() as u64 >= cfg.mode_change_min_secs
         }).unwrap_or(true);
 
         if target_mode == current_mode || !can_change {
+            if target_mode != current_mode && !can_change {
+                let wait = cfg.mode_change_min_secs.saturating_sub(
+                    last_change.map(|t| (now - t).num_seconds() as u64).unwrap_or(0)
+                );
+                debug!("Water heater: mode change blocked — rate limit, {wait}s remaining");
+            }
             continue;
         }
 
         info!("Water heater: changing mode {:?} → {:?} (grid={grid_on}, soc={soc:.1}%, \
-            discharge={discharge_too_long}, solar_low={solar_too_low}, irradiance_low={irradiance_low})",
+            discharge={discharge_too_long}, solar={solar_total:.0}W solar_low={solar_too_low}, irradiance_low={irradiance_low})",
             current_mode, target_mode);
 
         // --- Apply change ---
@@ -157,6 +172,12 @@ async fn control_task(
             s.water_heater_mode        = target_mode;
             s.water_heater_last_change = Some(now);
         }
+
+        // Write mode change to InfluxDB
+        let pt = InfluxPoint::new("water_heater_status")
+            .field_s("mode",  target_mode.to_lg_str())
+            .field_i("state", target_mode.to_venus_state() as i64);
+        bus.write_influx(pt).await;
 
         publish_to_venus(&bus, &state).await;
 


### PR DESCRIPTION
- visualization: HIST_MPPT measurement changed solar_power/mppt_power_w → venus_mppt_total/current_a (DC current, not power)
- visualization: HIST_SHUNT measurement changed battery_status → venus_smartshunt (correct measurement name)
- console: water heater label now includes temperature and target (e.g. "Vacances | 52.3°C → 55.0°C"), payload fields renamed temperature_c/target_c
- energy-manager: LG ThinQ poller writes water_heater_status measurement to InfluxDB on every poll (temperature_c, target_c, mode, state fields)
- energy-manager: water heater mode changes also write to InfluxDB
- water_heater: add debug logging each cycle showing all conditions (grid_on, soc, discharge, solar_total, irradiance) to help diagnose VACATION stuck issue
- shelly mqtt: add RPC Switch.GetStatus polling every 30s + on connect to obtain initial switch state without waiting for a state change event

https://claude.ai/code/session_01WkTcchAa2HTezHGnxwDPUQ