### PR TITLE
feat(tsink): migrate time-series storage from InfluxDB to TsinkDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +461,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -639,6 +654,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +790,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "tsink",
  "uuid",
 ]
 
@@ -1798,6 +1842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1966,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2256,6 +2319,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2478,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
 ]
 
 [[package]]
@@ -3373,6 +3466,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tsink"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4967dd8039e42d4c0789dafb3eb9feb4aa2aadc75cada5d3a8849add7b6a1"
+dependencies = [
+ "async-channel",
+ "bincode",
+ "chrono",
+ "crc32fast",
+ "crossbeam-channel",
+ "libc",
+ "memmap2",
+ "num_cpus",
+ "parking_lot 0.12.5",
+ "rayon",
+ "regex",
+ "regex-syntax",
+ "roaring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,6 +4155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4199,6 +4325,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,9 @@ zvariant      = { version = "4",    default-features = false }
 # ── UUID ───────────────────────────────────────────────────────────────────────
 uuid          = { version = "1",    features = ["v4"] }
 
+# ── Time-series embarqué (remplace InfluxDB) ──────────────────────────────────
+tsink         = "0.10.1"
+
 # ── Misc ───────────────────────────────────────────────────────────────────────
 bytes         = "1"
 futures       = "0.3"

--- a/Config.toml
+++ b/Config.toml
@@ -395,6 +395,33 @@ shelly_id = "shellypro2pm-ec62608840a4"   # IP 192.168.1.136
 name      = "DEYE — Shelly Pro 2PM"
 
 
+# =============================================================================
+# TsinkDB — Stockage time-series embarqué (remplace InfluxDB à terme)
+# =============================================================================
+# Tsink est embarqué dans le binaire : aucune dépendance externe, aucun Docker.
+# Les données sont stockées dans data_path en format compressé (Gorilla + zstd).
+#
+# Migration progressive :
+#   Phase 1 : tsink.enabled = true + influxdb.enabled = true  (dual-write)
+#   Phase 2 : valider les données Tsink via /api/v1/query
+#   Phase 3 : influxdb.enabled = false  (Tsink seul)
+[tsink]
+enabled = true
+
+# Répertoire de stockage local (relatif au répertoire courant ou chemin absolu)
+data_path = "./data/tsink"
+
+# Rétention des données en jours (purge automatique des données anciennes)
+retention_days = 30
+
+# Limite mémoire en Mo pour le cache chaud (données récentes)
+memory_limit_mb = 512
+
+# Limite de cardinalité : nombre maximum de séries distinctes (metric + tags)
+# Dépasse → erreur d'écriture pour les nouvelles séries
+cardinality_limit = 100000
+
+
 [influxdb]
 # true  = activer l'écriture InfluxDB (Docker infra doit être démarré)
 # false = désactiver (pas de Docker, ou test sans InfluxDB)

--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -30,6 +30,7 @@ tower-http     = { workspace = true }
 rumqttc        = { workspace = true }
 influxdb2      = { workspace = true }
 influxdb2-structmap = { workspace = true }
+tsink          = { workspace = true }
 rusqlite       = { workspace = true }
 reqwest        = { workspace = true }
 lettre         = { workspace = true }

--- a/crates/daly-bms-server/src/api/health.rs
+++ b/crates/daly-bms-server/src/api/health.rs
@@ -1,0 +1,58 @@
+//! Endpoint de santé `/health` pour supervision externe.
+
+use axum::{extract::State, Json};
+use serde::Serialize;
+use serde_json::json;
+use std::sync::atomic::Ordering;
+
+use crate::state::AppState;
+
+#[derive(Serialize)]
+#[allow(dead_code)]
+pub struct HealthResponse {
+    pub status: String,
+    pub tsink: TsinkStatus,
+    pub bms_polling: String,
+    pub ws_clients: usize,
+}
+
+#[derive(Serialize)]
+pub struct TsinkStatus {
+    pub enabled: bool,
+    pub memory_used_mb: Option<f64>,
+    pub memory_budget_mb: Option<f64>,
+}
+
+/// `GET /health` — Statut global du serveur.
+pub async fn health_check(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let polling = state.polling_active.load(Ordering::Relaxed);
+    let ws_clients = state.ws_tx.receiver_count();
+
+    let tsink_status = match &state.tsink {
+        None => TsinkStatus {
+            enabled:           false,
+            memory_used_mb:    None,
+            memory_budget_mb:  None,
+        },
+        Some(tsink) => TsinkStatus {
+            enabled:          true,
+            memory_used_mb:   Some(tsink.memory_used_bytes() as f64 / 1_048_576.0),
+            memory_budget_mb: Some(tsink.memory_budget_bytes() as f64 / 1_048_576.0),
+        },
+    };
+
+    let overall = if tsink_status.enabled && polling {
+        "healthy"
+    } else if !polling {
+        "degraded"
+    } else {
+        "ok"
+    };
+
+    Json(json!({
+        "status": overall,
+        "tsink": tsink_status,
+        "bms_polling": if polling { "active" } else { "inactive" },
+        "ws_clients": ws_clients,
+    }))
+}

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -10,6 +10,8 @@ pub mod et112;
 pub mod tasmota;
 pub mod shelly;
 pub mod chart;
+pub mod promql;
+pub mod health;
 
 use crate::dashboard;
 use crate::state::AppState;
@@ -106,6 +108,14 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/shelly",                             get(shelly::list_shelly))
         .route("/api/v1/shelly/:id/status",                  get(shelly::get_shelly_status))
         .route("/api/v1/shelly/:id/channel/:ch/control",     post(shelly::control_shelly_channel))
+        // ── PromQL (historique Tsink) ─────────────────────────────────────────
+        .route("/api/v1/query",          get(promql::query_instant))
+        .route("/api/v1/query_range",    get(promql::query_range))
+        .route("/api/v1/labels",         get(promql::list_metrics))
+
+        // ── Health check ──────────────────────────────────────────────────────
+        .route("/health",                get(health::health_check))
+
         // ── WebSocket ─────────────────────────────────────────────────────────
         .route("/ws/bms/stream",         get(bms::ws_all))
         .route("/ws/bms/:id/stream",     get(bms::ws_single))

--- a/crates/daly-bms-server/src/api/promql.rs
+++ b/crates/daly-bms-server/src/api/promql.rs
@@ -1,0 +1,238 @@
+//! Endpoints PromQL compatibles Prometheus HTTP API.
+//!
+//! Expose l'historique Tsink via :
+//!   GET /api/v1/query        — requête instantanée
+//!   GET /api/v1/query_range  — requête sur plage temporelle
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tracing::warn;
+
+use crate::state::AppState;
+use crate::tsink_db::TsinkError;
+use tsink::promql::{PromqlValue, Sample, Series};
+
+// =============================================================================
+// Paramètres de requête
+// =============================================================================
+
+#[derive(Deserialize)]
+pub struct InstantQueryParams {
+    pub query: String,
+    /// Timestamp d'évaluation en millisecondes (défaut : maintenant)
+    pub time: Option<i64>,
+}
+
+#[derive(Deserialize)]
+pub struct RangeQueryParams {
+    pub query: String,
+    /// Début de plage en millisecondes
+    pub start: i64,
+    /// Fin de plage en millisecondes
+    pub end: i64,
+    /// Pas en millisecondes
+    pub step: i64,
+}
+
+// =============================================================================
+// Réponse d'erreur
+// =============================================================================
+
+#[derive(serde::Serialize)]
+pub struct ApiError {
+    status: String,
+    error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_type: Option<String>,
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (StatusCode::BAD_REQUEST, Json(self)).into_response()
+    }
+}
+
+fn tsink_error_to_api(e: TsinkError) -> ApiError {
+    match e {
+        TsinkError::PromQL(msg) => ApiError {
+            status: "error".into(),
+            error: msg,
+            error_type: Some("bad_data".into()),
+        },
+        other => {
+            warn!("Tsink internal error: {}", other);
+            ApiError {
+                status: "error".into(),
+                error: "internal_error".into(),
+                error_type: Some("internal".into()),
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Conversion PromqlValue → JSON Prometheus
+// =============================================================================
+
+/// Timestamp Tsink (ms) → secondes en f64 (format Prometheus)
+#[inline]
+fn ts_to_secs(ts_ms: i64) -> f64 {
+    ts_ms as f64 / 1000.0
+}
+
+fn sample_to_prometheus(s: &Sample) -> Value {
+    let mut metric = serde_json::Map::new();
+    metric.insert("__name__".into(), Value::String(s.metric.clone()));
+    for label in &s.labels {
+        metric.insert(label.name.clone(), Value::String(label.value.clone()));
+    }
+    json!({
+        "metric": metric,
+        "value": [ts_to_secs(s.timestamp), s.value.to_string()]
+    })
+}
+
+fn series_to_prometheus(s: &Series) -> Value {
+    let mut metric = serde_json::Map::new();
+    metric.insert("__name__".into(), Value::String(s.metric.clone()));
+    for label in &s.labels {
+        metric.insert(label.name.clone(), Value::String(label.value.clone()));
+    }
+    let values: Vec<Value> = s.samples.iter().map(|(ts, v)| {
+        json!([ts_to_secs(*ts), v.to_string()])
+    }).collect();
+    json!({
+        "metric": metric,
+        "values": values
+    })
+}
+
+fn promql_value_to_json(value: PromqlValue) -> Value {
+    match value {
+        PromqlValue::Scalar(v, ts) => json!({
+            "status": "success",
+            "data": {
+                "resultType": "scalar",
+                "result": [ts_to_secs(ts), v.to_string()]
+            }
+        }),
+        PromqlValue::InstantVector(samples) => {
+            let result: Vec<Value> = samples.iter().map(sample_to_prometheus).collect();
+            json!({
+                "status": "success",
+                "data": {
+                    "resultType": "vector",
+                    "result": result
+                }
+            })
+        }
+        PromqlValue::RangeVector(series) => {
+            let result: Vec<Value> = series.iter().map(series_to_prometheus).collect();
+            json!({
+                "status": "success",
+                "data": {
+                    "resultType": "matrix",
+                    "result": result
+                }
+            })
+        }
+        PromqlValue::String(s, ts) => json!({
+            "status": "success",
+            "data": {
+                "resultType": "string",
+                "result": [ts_to_secs(ts), s]
+            }
+        }),
+    }
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+/// `GET /api/v1/query` — Requête PromQL instantanée.
+///
+/// Exemple : `/api/v1/query?query=bms_voltage{bms_id="0x01"}&time=1700000000000`
+pub async fn query_instant(
+    State(state): State<AppState>,
+    Query(params): Query<InstantQueryParams>,
+) -> Result<Json<Value>, ApiError> {
+    let tsink = state.tsink.as_ref().ok_or_else(|| ApiError {
+        status: "error".into(),
+        error: "Tsink storage is not enabled".into(),
+        error_type: Some("unavailable".into()),
+    })?;
+
+    let time_ms = params
+        .time
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+
+    tsink
+        .query_instant(params.query, time_ms)
+        .await
+        .map(|v| Json(promql_value_to_json(v)))
+        .map_err(tsink_error_to_api)
+}
+
+/// `GET /api/v1/query_range` — Requête PromQL sur plage temporelle.
+///
+/// Exemple : `/api/v1/query_range?query=bms_soc{bms_id="0x01"}&start=1700000000000&end=1700086400000&step=60000`
+pub async fn query_range(
+    State(state): State<AppState>,
+    Query(params): Query<RangeQueryParams>,
+) -> Result<Json<Value>, ApiError> {
+    let tsink = state.tsink.as_ref().ok_or_else(|| ApiError {
+        status: "error".into(),
+        error: "Tsink storage is not enabled".into(),
+        error_type: Some("unavailable".into()),
+    })?;
+
+    if params.start > params.end {
+        return Err(ApiError {
+            status: "error".into(),
+            error: "start must be before end".into(),
+            error_type: Some("bad_data".into()),
+        });
+    }
+    if params.step <= 0 {
+        return Err(ApiError {
+            status: "error".into(),
+            error: "step must be positive".into(),
+            error_type: Some("bad_data".into()),
+        });
+    }
+
+    tsink
+        .query_range(params.query, params.start, params.end, params.step)
+        .await
+        .map(|v| Json(promql_value_to_json(v)))
+        .map_err(tsink_error_to_api)
+}
+
+/// `GET /api/v1/labels` — Liste des métriques connues (pour autocomplete frontend).
+pub async fn list_metrics(State(state): State<AppState>) -> Json<Value> {
+    Json(json!({
+        "status": "success",
+        "data": if state.tsink.is_some() {
+            vec![
+                "bms_voltage", "bms_current", "bms_power", "bms_soc",
+                "bms_capacity_ah", "bms_cell_delta_mv", "bms_temp_max", "bms_temp_min",
+                "bms_charge_mos", "bms_discharge_mos", "bms_cell_voltage",
+                "et112_voltage_v", "et112_current_a", "et112_power_w",
+                "et112_energy_import_wh", "et112_energy_export_wh",
+                "irradiance_wm2",
+                "venus_shunt_voltage_v", "venus_shunt_current_a", "venus_shunt_power_w",
+                "venus_shunt_soc_percent", "venus_shunt_ah_charged_today",
+                "venus_inverter_power_w", "venus_inverter_voltage_v",
+            ]
+        } else {
+            vec![]
+        }
+    }))
+}

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -40,6 +40,10 @@ pub struct AppConfig {
     #[serde(default)]
     pub influxdb: InfluxConfig,
 
+    /// Time-series embarqué Tsink (remplace InfluxDB)
+    #[serde(default)]
+    pub tsink: TsinkConfig,
+
     #[serde(default)]
     pub alerts: AlertsConfig,
 
@@ -436,6 +440,33 @@ impl InfluxConfig {
             bucket_downsampled:       "daly_bms_1m".into(),
             batch_size:               50,
             batch_flush_interval_sec: 5.0,
+        }
+    }
+}
+
+/// Configuration du stockage Tsink embarqué.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TsinkConfig {
+    /// Activer le stockage Tsink
+    pub enabled: bool,
+    /// Répertoire de stockage des données
+    pub data_path: String,
+    /// Rétention en jours
+    pub retention_days: u64,
+    /// Limite mémoire en Mo
+    pub memory_limit_mb: usize,
+    /// Limite de cardinalité (nombre de séries max)
+    pub cardinality_limit: usize,
+}
+
+impl Default for TsinkConfig {
+    fn default() -> Self {
+        Self {
+            enabled:           true,
+            data_path:         "./data/tsink".to_string(),
+            retention_days:    30,
+            memory_limit_mb:   512,
+            cardinality_limit: 100_000,
         }
     }
 }

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -22,6 +22,7 @@ mod irradiance;
 mod shelly;
 mod tasmota;
 mod state;
+mod tsink_db;
 mod api;
 mod bridges;
 mod simulator;
@@ -155,12 +156,13 @@ async fn main() -> anyhow::Result<()> {
                 logging:     config::LoggingConfig::default(),
                 mqtt:        config::MqttConfig::default(),
                 influxdb:    config::InfluxConfig::default(),
+                tsink:       config::TsinkConfig::default(),
                 alerts:      config::AlertsConfig::default(),
                 read_only:   config::ReadOnlyConfig::default(),
                 bms:         Vec::new(),
                 et112:       config::Et112Config::default(),
                 irradiance:  None,
-                ats:         None, // Option<AtsConfig> — None = ATS non configuré
+                ats:         None,
                 tasmota:     config::TasmotaConfig::default(),
                 shelly:      config::ShellyConfig::default(),
             }
@@ -207,8 +209,25 @@ async fn main() -> anyhow::Result<()> {
         "DalyBMS Server démarrage"
     );
 
+    // ── Tsink (stockage time-series embarqué) ─────────────────────────────────
+    let tsink_handle = if config.tsink.enabled {
+        match tsink_db::TsinkHandle::new(&config.tsink).await {
+            Ok(h) => {
+                info!("Tsink activé — stockage dans '{}'", config.tsink.data_path);
+                Some(h)
+            }
+            Err(e) => {
+                warn!("Tsink init échoué : {} — stockage désactivé", e);
+                None
+            }
+        }
+    } else {
+        info!("Tsink désactivé (tsink.enabled = false)");
+        None
+    };
+
     // ── État partagé ───────────────────────────────────────────────────────────
-    let state = AppState::new(config.clone(), log_buffer);
+    let state = AppState::new(config.clone(), log_buffer, tsink_handle);
 
     // ── Bridges en arrière-plan ─────────────────────────────────────────────────
 

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -10,6 +10,7 @@ use crate::et112::Et112Snapshot;
 use crate::irradiance::IrradianceSnapshot;
 use crate::shelly::ShellyEmSnapshot;
 use crate::tasmota::TasmotaSnapshot;
+use crate::tsink_db::TsinkHandle;
 use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
 use chrono::{DateTime, Datelike, Utc};
@@ -398,10 +399,13 @@ pub struct AppState {
 
     /// Client MQTT Shelly (pour les commandes de contrôle Switch.Set).
     pub shelly_client: Arc<tokio::sync::Mutex<Option<rumqttc::AsyncClient>>>,
+
+    /// Stockage time-series embarqué Tsink (None si désactivé dans la config).
+    pub tsink: Option<Arc<TsinkHandle>>,
 }
 
 impl AppState {
-    pub fn new(config: AppConfig, log_buffer: LogBuffer) -> Self {
+    pub fn new(config: AppConfig, log_buffer: LogBuffer, tsink: Option<TsinkHandle>) -> Self {
         let (ws_tx, _) = broadcast::channel(WS_BROADCAST_CAPACITY);
         let addresses = config.bms_addresses();
         let ring_size = config.serial.ring_buffer_size;
@@ -455,6 +459,7 @@ impl AppState {
             console_bus: ConsoleBus::new(),
             shelly_latest: Arc::new(RwLock::new(BTreeMap::new())),
             shelly_client: Arc::new(tokio::sync::Mutex::new(None)),
+            tsink: tsink.map(Arc::new),
         }
     }
 
@@ -515,6 +520,16 @@ impl AppState {
         // Broadcast : construire la liste de tous les derniers snapshots
         let latest = self.latest_snapshots().await;
         let _ = self.ws_tx.send(Arc::new(latest));
+
+        // Écriture Tsink en arrière-plan (non-bloquant)
+        if let Some(tsink) = self.tsink.clone() {
+            let rows = TsinkHandle::bms_rows(&snap);
+            tokio::spawn(async move {
+                if let Err(e) = tsink.write_rows(rows).await {
+                    tracing::warn!("Tsink BMS write error: {}", e);
+                }
+            });
+        }
     }
 
     /// Retourne le dernier snapshot de chaque BMS.
@@ -557,11 +572,23 @@ impl AppState {
             "energy_export_kwh": snap.energy_export_kwh(),
         })));
 
-        let mut buffers = self.et112_buffers.write().await;
-        buffers
-            .entry(snap.address)
-            .or_insert_with(|| Et112RingBuffer::new(self.config.et112.ring_buffer_size))
-            .push(snap);
+        {
+            let mut buffers = self.et112_buffers.write().await;
+            buffers
+                .entry(snap.address)
+                .or_insert_with(|| Et112RingBuffer::new(self.config.et112.ring_buffer_size))
+                .push(snap.clone());
+        }
+
+        // Écriture Tsink en arrière-plan
+        if let Some(tsink) = self.tsink.clone() {
+            let rows = TsinkHandle::et112_rows(&snap);
+            tokio::spawn(async move {
+                if let Err(e) = tsink.write_rows(rows).await {
+                    tracing::warn!("Tsink ET112 write error: {}", e);
+                }
+            });
+        }
     }
 
     /// Retourne le dernier snapshot ET112 pour une adresse donnée.
@@ -592,6 +619,14 @@ impl AppState {
             "address": snap.address,
             "irradiance_wm2": snap.irradiance_wm2,
         })));
+        if let Some(tsink) = self.tsink.clone() {
+            let rows = TsinkHandle::irradiance_rows(&snap);
+            tokio::spawn(async move {
+                if let Err(e) = tsink.write_rows(rows).await {
+                    tracing::warn!("Tsink irradiance write error: {}", e);
+                }
+            });
+        }
         *self.irradiance_value.write().await = Some(snap);
     }
 
@@ -707,6 +742,14 @@ impl AppState {
                 "ah_charged_today": shunt.ah_charged_today,
                 "ah_discharged_today": shunt.ah_discharged_today,
             })));
+            if let Some(tsink) = self.tsink.clone() {
+                let rows = TsinkHandle::smartshunt_rows(&shunt);
+                tokio::spawn(async move {
+                    if let Err(e) = tsink.write_rows(rows).await {
+                        tracing::warn!("Tsink SmartShunt write error: {}", e);
+                    }
+                });
+            }
             *self.venus_smartshunt.write().await = Some(shunt);
             return;
         }
@@ -750,6 +793,14 @@ impl AppState {
             "ah_discharged_today": shunt.ah_discharged_today,
         })));
 
+        if let Some(tsink) = self.tsink.clone() {
+            let rows = TsinkHandle::smartshunt_rows(&shunt);
+            tokio::spawn(async move {
+                if let Err(e) = tsink.write_rows(rows).await {
+                    tracing::warn!("Tsink SmartShunt write error: {}", e);
+                }
+            });
+        }
         *self.venus_smartshunt.write().await = Some(shunt);
     }
 
@@ -772,6 +823,14 @@ impl AppState {
 
     /// Enregistre/met à jour les données de l'onduleur Victron (MultiPlus, cgwacs, etc.).
     pub async fn on_venus_inverter(&self, inverter: VenusInverter) {
+        if let Some(tsink) = self.tsink.clone() {
+            let rows = TsinkHandle::inverter_rows(&inverter);
+            tokio::spawn(async move {
+                if let Err(e) = tsink.write_rows(rows).await {
+                    tracing::warn!("Tsink inverter write error: {}", e);
+                }
+            });
+        }
         *self.venus_inverter.write().await = Some(inverter);
     }
 

--- a/crates/daly-bms-server/src/tsink_db.rs
+++ b/crates/daly-bms-server/src/tsink_db.rs
@@ -1,0 +1,266 @@
+//! Wrapper asynchrone pour TsinkDB — stockage time-series embarqué.
+//!
+//! Remplace le bridge InfluxDB par un stockage local sans dépendance externe.
+//! L'API PromQL expose l'historique via `/api/v1/query` et `/api/v1/query_range`.
+
+use std::sync::Arc;
+use std::time::Duration;
+use tsink::{
+    AsyncStorage, AsyncStorageBuilder, DataPoint, Label, Row, TimestampPrecision,
+};
+use tsink::promql::{Engine, PromqlValue};
+use tracing::info;
+
+use crate::config::TsinkConfig;
+use daly_bms_core::types::BmsSnapshot;
+use crate::et112::Et112Snapshot;
+use crate::irradiance::IrradianceSnapshot;
+use crate::state::{VenusSmartShunt, VenusInverter};
+
+// =============================================================================
+// Erreur
+// =============================================================================
+
+#[derive(Debug, thiserror::Error)]
+pub enum TsinkError {
+    #[error("Tsink error: {0}")]
+    Storage(#[from] tsink::TsinkError),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("PromQL query error: {0}")]
+    PromQL(String),
+    #[error("Task join error: {0}")]
+    Join(#[from] tokio::task::JoinError),
+}
+
+pub type Result<T> = std::result::Result<T, TsinkError>;
+
+// =============================================================================
+// TsinkHandle
+// =============================================================================
+
+/// Handle clonable vers le stockage Tsink.
+#[derive(Clone)]
+pub struct TsinkHandle {
+    storage: Arc<AsyncStorage>,
+}
+
+impl TsinkHandle {
+    /// Crée et initialise le stockage Tsink à partir de la configuration.
+    pub async fn new(config: &TsinkConfig) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(&config.data_path)?;
+
+        let storage = AsyncStorageBuilder::new()
+            .with_data_path(&config.data_path)
+            .with_timestamp_precision(TimestampPrecision::Milliseconds)
+            .with_retention(Duration::from_secs(config.retention_days * 24 * 3600))
+            .with_memory_limit(config.memory_limit_mb * 1024 * 1024)
+            .with_cardinality_limit(config.cardinality_limit)
+            .build()?;
+
+        info!(
+            path = %config.data_path,
+            retention_days = config.retention_days,
+            "Tsink initialisé"
+        );
+
+        Ok(Self {
+            storage: Arc::new(storage),
+        })
+    }
+
+    // -------------------------------------------------------------------------
+    // Écriture
+    // -------------------------------------------------------------------------
+
+    /// Écrit un batch de lignes dans Tsink (non-bloquant).
+    pub async fn write_rows(&self, rows: Vec<Row>) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        self.storage
+            .insert_rows(rows)
+            .await
+            .map_err(TsinkError::Storage)
+    }
+
+    // -------------------------------------------------------------------------
+    // Requêtes PromQL
+    // -------------------------------------------------------------------------
+
+    /// Requête PromQL instantanée — `/api/v1/query`
+    pub async fn query_instant(&self, query: String, time_ms: i64) -> Result<PromqlValue> {
+        let sync_storage = self.storage.inner();
+        tokio::task::spawn_blocking(move || {
+            Engine::with_precision(sync_storage, TimestampPrecision::Milliseconds)
+                .instant_query(&query, time_ms)
+                .map_err(|e| TsinkError::PromQL(e.to_string()))
+        })
+        .await
+        .map_err(TsinkError::Join)?
+    }
+
+    /// Requête PromQL sur plage temporelle — `/api/v1/query_range`
+    pub async fn query_range(
+        &self,
+        query: String,
+        start_ms: i64,
+        end_ms: i64,
+        step_ms: i64,
+    ) -> Result<PromqlValue> {
+        let sync_storage = self.storage.inner();
+        tokio::task::spawn_blocking(move || {
+            Engine::with_precision(sync_storage, TimestampPrecision::Milliseconds)
+                .range_query(&query, start_ms, end_ms, step_ms)
+                .map_err(|e| TsinkError::PromQL(e.to_string()))
+        })
+        .await
+        .map_err(TsinkError::Join)?
+    }
+
+    // -------------------------------------------------------------------------
+    // Stats
+    // -------------------------------------------------------------------------
+
+    pub fn memory_used_bytes(&self) -> usize {
+        self.storage.memory_used()
+    }
+
+    pub fn memory_budget_bytes(&self) -> usize {
+        self.storage.memory_budget()
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversions snapshots → Rows
+    // -------------------------------------------------------------------------
+
+    /// Convertit un BmsSnapshot en lignes Tsink.
+    pub fn bms_rows(snap: &BmsSnapshot) -> Vec<Row> {
+        let ts = snap.timestamp.timestamp_millis();
+        let bms_id = format!("{:#04x}", snap.address);
+
+        let mut rows = Vec::with_capacity(10 + snap.voltages.len());
+
+        macro_rules! row {
+            ($metric:expr, $value:expr) => {
+                Row::with_labels(
+                    $metric,
+                    vec![Label::new("bms_id", bms_id.as_str())],
+                    DataPoint::new(ts, $value as f64),
+                )
+            };
+        }
+
+        rows.push(row!("bms_voltage",      snap.dc.voltage));
+        rows.push(row!("bms_current",      snap.dc.current));
+        rows.push(row!("bms_power",        snap.dc.power));
+        rows.push(row!("bms_soc",          snap.soc));
+        rows.push(row!("bms_capacity_ah",  snap.capacity));
+        rows.push(row!("bms_cell_delta_mv",snap.system.cell_delta_mv()));
+        rows.push(row!("bms_temp_max",     snap.system.max_cell_temperature));
+        rows.push(row!("bms_temp_min",     snap.system.min_cell_temperature));
+        rows.push(row!("bms_charge_mos",   snap.io.allow_to_charge));
+        rows.push(row!("bms_discharge_mos",snap.io.allow_to_discharge));
+
+        for (cell_name, &v) in &snap.voltages {
+            rows.push(Row::with_labels(
+                "bms_cell_voltage",
+                vec![
+                    Label::new("bms_id", bms_id.as_str()),
+                    Label::new("cell",   cell_name.as_str()),
+                ],
+                DataPoint::new(ts, v as f64),
+            ));
+        }
+
+        rows
+    }
+
+    /// Convertit un Et112Snapshot en lignes Tsink.
+    pub fn et112_rows(snap: &Et112Snapshot) -> Vec<Row> {
+        let ts  = snap.timestamp.timestamp_millis();
+        let addr = format!("{:#04x}", snap.address);
+
+        macro_rules! row {
+            ($metric:expr, $value:expr) => {
+                Row::with_labels(
+                    $metric,
+                    vec![
+                        Label::new("address", addr.as_str()),
+                        Label::new("name",    snap.name.as_str()),
+                    ],
+                    DataPoint::new(ts, $value as f64),
+                )
+            };
+        }
+
+        vec![
+            row!("et112_voltage_v",         snap.voltage_v),
+            row!("et112_current_a",         snap.current_a),
+            row!("et112_power_w",           snap.power_w),
+            row!("et112_apparent_power_va", snap.apparent_power_va),
+            row!("et112_power_factor",      snap.power_factor),
+            row!("et112_frequency_hz",      snap.frequency_hz),
+            row!("et112_energy_import_wh",  snap.energy_import_wh),
+            row!("et112_energy_export_wh",  snap.energy_export_wh),
+        ]
+    }
+
+    /// Convertit un IrradianceSnapshot en lignes Tsink.
+    pub fn irradiance_rows(snap: &IrradianceSnapshot) -> Vec<Row> {
+        let ts = snap.timestamp.timestamp_millis();
+        vec![Row::with_labels(
+            "irradiance_wm2",
+            vec![Label::new("address", format!("{:#04x}", snap.address).as_str())],
+            DataPoint::new(ts, snap.irradiance_wm2 as f64),
+        )]
+    }
+
+    /// Écrit les données Venus SmartShunt dans Tsink.
+    pub fn smartshunt_rows(shunt: &VenusSmartShunt) -> Vec<Row> {
+        let ts = shunt.timestamp.timestamp_millis();
+
+        let mut rows = Vec::new();
+        macro_rules! push_opt {
+            ($metric:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    rows.push(Row::new($metric, DataPoint::new(ts, v as f64)));
+                }
+            };
+        }
+
+        push_opt!("venus_shunt_voltage_v",          shunt.voltage_v);
+        push_opt!("venus_shunt_current_a",          shunt.current_a);
+        push_opt!("venus_shunt_power_w",            shunt.power_w);
+        push_opt!("venus_shunt_soc_percent",        shunt.soc_percent);
+        push_opt!("venus_shunt_energy_in_kwh",      shunt.energy_in_kwh);
+        push_opt!("venus_shunt_energy_out_kwh",     shunt.energy_out_kwh);
+        push_opt!("venus_shunt_ah_charged_today",   shunt.ah_charged_today);
+        push_opt!("venus_shunt_ah_discharged_today",shunt.ah_discharged_today);
+
+        rows
+    }
+
+    /// Écrit les données Venus Inverter dans Tsink.
+    pub fn inverter_rows(inv: &VenusInverter) -> Vec<Row> {
+        let ts = inv.timestamp.timestamp_millis();
+
+        let mut rows = Vec::new();
+        macro_rules! push_opt {
+            ($metric:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    rows.push(Row::new($metric, DataPoint::new(ts, v as f64)));
+                }
+            };
+        }
+
+        push_opt!("venus_inverter_voltage_v",           inv.voltage_v);
+        push_opt!("venus_inverter_current_a",           inv.current_a);
+        push_opt!("venus_inverter_power_w",             inv.power_w);
+        push_opt!("venus_inverter_ac_output_voltage_v", inv.ac_output_voltage_v);
+        push_opt!("venus_inverter_ac_output_current_a", inv.ac_output_current_a);
+        push_opt!("venus_inverter_ac_output_power_w",   inv.ac_output_power_w);
+
+        rows
+    }
+}


### PR DESCRIPTION
- Add tsink 0.10.1 as embedded time-series database (no external dependency)
- Implement TsinkHandle wrapper (tsink_db.rs) with async write + PromQL query support
- Add TsinkConfig section to AppConfig and Config.toml (dual-write phase: both enabled)
- Update AppState to hold Option<TsinkHandle>, write BMS/ET112/irradiance/Venus data on each snapshot
- Expose Prometheus-compatible PromQL API: GET /api/v1/query, /api/v1/query_range, /api/v1/labels
- Add GET /health endpoint with Tsink memory stats and polling status
- All writes are non-blocking (tokio::spawn) to avoid impacting polling latency

Migration phase: dual-write (influxdb.enabled=true + tsink.enabled=true).
Cut-over: set influxdb.enabled=false after validation via /api/v1/query.

https://claude.ai/code/session_01N5RjL38vMagQLW7Xb7TATJ