### PR TITLE
fix(tsink): use absolute path /var/lib/daly-bms/tsink

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -409,7 +409,7 @@ name      = "DEYE — Shelly Pro 2PM"
 enabled = true
 
 # Répertoire de stockage local (relatif au répertoire courant ou chemin absolu)
-data_path = "./data/tsink"
+data_path = "/var/lib/daly-bms/tsink"
 
 # Rétention des données en jours (purge automatique des données anciennes)
 retention_days = 30

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -463,7 +463,7 @@ impl Default for TsinkConfig {
     fn default() -> Self {
         Self {
             enabled:           true,
-            data_path:         "./data/tsink".to_string(),
+            data_path:         "/var/lib/daly-bms/tsink".to_string(),
             retention_days:    30,
             memory_limit_mb:   512,
             cardinality_limit: 100_000,


### PR DESCRIPTION
systemd runs without WorkingDirectory, so relative paths resolve to / which requires root. Absolute path avoids permission denied at startup.

https://claude.ai/code/session_01N5RjL38vMagQLW7Xb7TATJ