### PR TITLE
feat(deploy): créer /var/lib/daly-bms/tsink et vérifier Tsink au dépl…

### DIFF
--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 info()  { echo -e "${GREEN}[OK]${NC} $*"; }
 step()  { echo -e "${YELLOW}[>>]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[!!]${NC} $*"; }
 error() { echo -e "${RED}[!!]${NC} $*" >&2; exit 1; }
 
 # ── 1. Récupération du code ───────────────────────────────────────────────────
@@ -28,20 +29,37 @@ step "Déploiement Config.toml → /etc/daly-bms/config.toml…"
 sudo cp Config.toml /etc/daly-bms/config.toml
 info "Config.toml déployée"
 
-# ── 4. Déploiement daly-bms-server ───────────────────────────────────────────
+# ── 4. Répertoire Tsink ──────────────────────────────────────────────────────
+TSINK_DIR="/var/lib/daly-bms/tsink"
+step "Vérification répertoire Tsink (${TSINK_DIR})…"
+sudo mkdir -p "${TSINK_DIR}"
+sudo chown "$(whoami):$(id -gn)" "${TSINK_DIR}"
+info "Répertoire Tsink OK"
+
+# ── 5. Déploiement daly-bms-server ───────────────────────────────────────────
 step "Déploiement daly-bms-server…"
 sudo systemctl stop daly-bms
 sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
-sudo cp Config.toml /etc/daly-bms/config.toml
 sudo systemctl start daly-bms
-sleep 2
-if systemctl is-active --quiet daly-bms; then
-    info "daly-bms actif"
-else
+sleep 3
+
+if ! systemctl is-active --quiet daly-bms; then
     error "daly-bms n'a pas démarré — vérifier : journalctl -u daly-bms -n 50"
 fi
+info "daly-bms actif"
 
-# ── 5. Déploiement energy-manager ────────────────────────────────────────────
+# Vérification Tsink
+sleep 2
+TSINK_LOG=$(journalctl -u daly-bms --since "30 seconds ago" 2>/dev/null | grep -i tsink | head -3)
+if echo "${TSINK_LOG}" | grep -q "activé"; then
+    info "Tsink initialisé : ${TSINK_DIR}"
+elif echo "${TSINK_LOG}" | grep -q "échoué\|error\|Error"; then
+    warn "Tsink init a échoué — voir : journalctl -u daly-bms -n 30 | grep -i tsink"
+else
+    warn "Tsink : aucun message de démarrage détecté (vérifier la config)"
+fi
+
+# ── 6. Déploiement energy-manager ────────────────────────────────────────────
 step "Déploiement energy-manager…"
 sudo systemctl stop energy-manager
 sudo cp target/aarch64-unknown-linux-gnu/release/energy-manager /usr/local/bin/
@@ -53,10 +71,15 @@ else
     error "energy-manager n'a pas démarré — vérifier : journalctl -u energy-manager -n 50"
 fi
 
-# ── 6. Résumé ─────────────────────────────────────────────────────────────────
+# ── 7. Résumé ─────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}═══════════════════════════════════════${NC}"
 echo -e "${GREEN}  Déploiement terminé avec succès ✓${NC}"
 echo -e "${GREEN}═══════════════════════════════════════${NC}"
 echo ""
 systemctl status daly-bms energy-manager --no-pager -l | grep -E "Active:|Loaded:" || true
+echo ""
+step "Vérification Tsink via API…"
+sleep 1
+curl -sf 'http://localhost:8080/health' 2>/dev/null | python3 -m json.tool 2>/dev/null || \
+    warn "Endpoint /health non accessible"


### PR DESCRIPTION
…oiement

- Création automatique du répertoire Tsink avec permissions correctes
- Vérification de l'initialisation Tsink dans les logs post-démarrage
- Appel /health en fin de déploiement pour confirmer le statut Tsink
- Ajout fonction warn() pour les avertissements non bloquants

https://claude.ai/code/session_01N5RjL38vMagQLW7Xb7TATJ