### PR TITLE
fix(deploy): service user est dalybms, pas pi5compute

### DIFF
--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -33,7 +33,7 @@ info "Config.toml déployée"
 TSINK_DIR="/var/lib/daly-bms/tsink"
 # Récupère l'utilisateur qui exécute le service (ExecStart user, pas root)
 SERVICE_USER=$(systemctl show daly-bms --property=User --value 2>/dev/null)
-SERVICE_USER="${SERVICE_USER:-$(logname 2>/dev/null || echo pi5compute)}"
+SERVICE_USER="${SERVICE_USER:-dalybms}"
 step "Vérification répertoire Tsink (${TSINK_DIR}) → owner=${SERVICE_USER}…"
 sudo mkdir -p "${TSINK_DIR}"
 sudo chown "${SERVICE_USER}:${SERVICE_USER}" "${TSINK_DIR}"


### PR DESCRIPTION
Le service tourne sous User=dalybms (contrib/daly-bms.service). Tous les chown pi5compute étaient sans effet → Permission denied persistant. Fallback explicite sur dalybms si systemctl show ne retourne rien.

https://claude.ai/code/session_01N5RjL38vMagQLW7Xb7TATJ