### PR TITLE
fix(tsink): throttle writes + TSINK_MAX_CPUS=1 + watchdog sans sudo

### DIFF
--- a/contrib/daly-bms.service
+++ b/contrib/daly-bms.service
@@ -15,6 +15,9 @@ Environment=DALY_CONFIG=/etc/daly-bms/config.toml
 # Niveau de log (trace, debug, info, warn, error)
 Environment=RUST_LOG=info
 
+# Limite les threads background Tsink (WAL/flush/compaction) — évite 100% CPU
+Environment=TSINK_MAX_CPUS=1
+
 ExecStart=/usr/local/bin/daly-bms-server
 
 # Redémarrage automatique en cas de crash

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -265,7 +265,9 @@ async fn read_uptime_secs() -> u64 {
 /// Services à surveiller : (label, host, port, commande_systemd).
 /// Si la commande est None le service n'est pas redémarré automatiquement.
 const WATCHDOG_SERVICES: &[(&str, &str, u16, Option<&str>)] = &[
-    ("energy-manager", "127.0.0.1", 8081, Some("energy-manager")),
+    // None = pas de restart automatique : NoNewPrivileges=true empêche sudo,
+    // systemd gère le restart via Restart=on-failure dans energy-manager.service.
+    ("energy-manager", "127.0.0.1", 8081, None),
 ];
 
 /// Intervalle de vérification du watchdog.

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -17,7 +17,8 @@ use chrono::{DateTime, Datelike, Utc};
 use serde::Serialize;
 use serde_json::json;
 use std::collections::{BTreeMap, VecDeque};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, atomic::{AtomicU64, Ordering}};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, RwLock};
 
 // =============================================================================
@@ -402,6 +403,13 @@ pub struct AppState {
 
     /// Stockage time-series embarqué Tsink (None si désactivé dans la config).
     pub tsink: Option<Arc<TsinkHandle>>,
+
+    /// Timestamps de la dernière écriture Tsink par catégorie (epoch secondes).
+    /// Permet de throttler le débit d'écriture et d'éviter la saturation du WAL.
+    tsink_last_bms_write:   Arc<AtomicU64>,
+    tsink_last_venus_write: Arc<AtomicU64>,
+    tsink_last_et112_write: Arc<AtomicU64>,
+    tsink_last_irrad_write: Arc<AtomicU64>,
 }
 
 impl AppState {
@@ -460,6 +468,26 @@ impl AppState {
             shelly_latest: Arc::new(RwLock::new(BTreeMap::new())),
             shelly_client: Arc::new(tokio::sync::Mutex::new(None)),
             tsink: tsink.map(Arc::new),
+            tsink_last_bms_write:   Arc::new(AtomicU64::new(0)),
+            tsink_last_venus_write: Arc::new(AtomicU64::new(0)),
+            tsink_last_et112_write: Arc::new(AtomicU64::new(0)),
+            tsink_last_irrad_write: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Vérifie si l'intervalle minimum est écoulé depuis le dernier write Tsink.
+    /// Thread-safe via AtomicU64. Retourne true ET met à jour le timestamp si ok.
+    fn tsink_rate_ok(last: &AtomicU64, interval_secs: u64) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let prev = last.load(Ordering::Relaxed);
+        if now.saturating_sub(prev) >= interval_secs {
+            last.store(now, Ordering::Relaxed);
+            true
+        } else {
+            false
         }
     }
 
@@ -521,14 +549,16 @@ impl AppState {
         let latest = self.latest_snapshots().await;
         let _ = self.ws_tx.send(Arc::new(latest));
 
-        // Écriture Tsink en arrière-plan (non-bloquant)
+        // Écriture Tsink — throttlée à 1 écriture / 10s pour ne pas saturer le WAL
         if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::bms_rows(&snap);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink BMS write error: {}", e);
-                }
-            });
+            if Self::tsink_rate_ok(&self.tsink_last_bms_write, 10) {
+                let rows = TsinkHandle::bms_rows(&snap);
+                tokio::spawn(async move {
+                    if let Err(e) = tsink.write_rows(rows).await {
+                        tracing::warn!("Tsink BMS write error: {}", e);
+                    }
+                });
+            }
         }
     }
 
@@ -580,14 +610,16 @@ impl AppState {
                 .push(snap.clone());
         }
 
-        // Écriture Tsink en arrière-plan
+        // Écriture Tsink — throttlée à 1 écriture / 30s
         if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::et112_rows(&snap);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink ET112 write error: {}", e);
-                }
-            });
+            if Self::tsink_rate_ok(&self.tsink_last_et112_write, 30) {
+                let rows = TsinkHandle::et112_rows(&snap);
+                tokio::spawn(async move {
+                    if let Err(e) = tsink.write_rows(rows).await {
+                        tracing::warn!("Tsink ET112 write error: {}", e);
+                    }
+                });
+            }
         }
     }
 
@@ -620,12 +652,14 @@ impl AppState {
             "irradiance_wm2": snap.irradiance_wm2,
         })));
         if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::irradiance_rows(&snap);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink irradiance write error: {}", e);
-                }
-            });
+            if Self::tsink_rate_ok(&self.tsink_last_irrad_write, 60) {
+                let rows = TsinkHandle::irradiance_rows(&snap);
+                tokio::spawn(async move {
+                    if let Err(e) = tsink.write_rows(rows).await {
+                        tracing::warn!("Tsink irradiance write error: {}", e);
+                    }
+                });
+            }
         }
         *self.irradiance_value.write().await = Some(snap);
     }
@@ -743,12 +777,14 @@ impl AppState {
                 "ah_discharged_today": shunt.ah_discharged_today,
             })));
             if let Some(tsink) = self.tsink.clone() {
-                let rows = TsinkHandle::smartshunt_rows(&shunt);
-                tokio::spawn(async move {
-                    if let Err(e) = tsink.write_rows(rows).await {
-                        tracing::warn!("Tsink SmartShunt write error: {}", e);
-                    }
-                });
+                if Self::tsink_rate_ok(&self.tsink_last_venus_write, 10) {
+                    let rows = TsinkHandle::smartshunt_rows(&shunt);
+                    tokio::spawn(async move {
+                        if let Err(e) = tsink.write_rows(rows).await {
+                            tracing::warn!("Tsink SmartShunt write error: {}", e);
+                        }
+                    });
+                }
             }
             *self.venus_smartshunt.write().await = Some(shunt);
             return;
@@ -794,12 +830,14 @@ impl AppState {
         })));
 
         if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::smartshunt_rows(&shunt);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink SmartShunt write error: {}", e);
-                }
-            });
+            if Self::tsink_rate_ok(&self.tsink_last_venus_write, 10) {
+                let rows = TsinkHandle::smartshunt_rows(&shunt);
+                tokio::spawn(async move {
+                    if let Err(e) = tsink.write_rows(rows).await {
+                        tracing::warn!("Tsink SmartShunt write error: {}", e);
+                    }
+                });
+            }
         }
         *self.venus_smartshunt.write().await = Some(shunt);
     }
@@ -824,12 +862,14 @@ impl AppState {
     /// Enregistre/met à jour les données de l'onduleur Victron (MultiPlus, cgwacs, etc.).
     pub async fn on_venus_inverter(&self, inverter: VenusInverter) {
         if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::inverter_rows(&inverter);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink inverter write error: {}", e);
-                }
-            });
+            if Self::tsink_rate_ok(&self.tsink_last_venus_write, 10) {
+                let rows = TsinkHandle::inverter_rows(&inverter);
+                tokio::spawn(async move {
+                    if let Err(e) = tsink.write_rows(rows).await {
+                        tracing::warn!("Tsink inverter write error: {}", e);
+                    }
+                });
+            }
         }
         *self.venus_inverter.write().await = Some(inverter);
     }


### PR DESCRIPTION
Problèmes résolus :
1. WAL "No such file or directory" + Storage shutting down → Venus OS publie SmartShunt/Inverter à 1-5Hz, Tsink était saturé (~127 rows/s) → Rate-limit par catégorie : BMS 10s, ET112 30s, Irradiance 60s, Venus 10s → Débit effectif réduit à ~20 rows/s maximum
2. 100% CPU des workers Tsink → TSINK_MAX_CPUS=1 dans contrib/daly-bms.service
3. Watchdog sudo échoue (NoNewPrivileges=true) → energy-manager passe à None (pas de restart automatique) → systemd gère le restart via Restart=on-failure dans energy-manager.service

https://claude.ai/code/session_01N5RjL38vMagQLW7Xb7TATJ