### PR TITLE
fix(tsink): résoudre CPU 100% et crash WAL + robustesse energy-manager

### DIFF
--- a/contrib/energy-manager.service
+++ b/contrib/energy-manager.service
@@ -20,8 +20,8 @@ Environment=ENERGY_CONFIG=/etc/daly-bms/config.toml
 
 Restart=on-failure
 RestartSec=5s
-StartLimitIntervalSec=60
-StartLimitBurst=5
+# Allow unlimited restarts — the service manages its own reconnection logic.
+StartLimitIntervalSec=0
 
 # Resource limits
 LimitNOFILE=65536

--- a/crates/daly-bms-server/src/tsink_db.rs
+++ b/crates/daly-bms-server/src/tsink_db.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 use tsink::{
-    AsyncStorage, AsyncStorageBuilder, DataPoint, Label, Row, TimestampPrecision,
+    AsyncStorage, AsyncStorageBuilder, DataPoint, Label, Row, TimestampPrecision, WalSyncMode,
 };
 use tsink::promql::{Engine, PromqlValue};
 use tracing::info;
@@ -56,6 +56,13 @@ impl TsinkHandle {
             .with_retention(Duration::from_secs(config.retention_days * 24 * 3600))
             .with_memory_limit(config.memory_limit_mb * 1024 * 1024)
             .with_cardinality_limit(config.cardinality_limit)
+            // Batch fsyncs every 5s instead of per-append: eliminates IO-bound CPU spike.
+            .with_wal_sync_mode(WalSyncMode::Periodic(Duration::from_secs(5)))
+            // WAL directory race during segment rotation → tolerate background errors
+            // instead of shutting down the entire storage engine.
+            .with_background_fail_fast(false)
+            // One read worker is sufficient for our query load; prevents runaway thread spawns.
+            .with_read_workers(1)
             .build()?;
 
         info!(

--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -56,8 +56,16 @@ pub async fn serve(
     let addr: SocketAddr = bind.parse().unwrap_or_else(|_| "0.0.0.0:8081".parse().unwrap());
     info!("Energy-manager HTTP server listening on {addr}");
 
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("Cannot bind {addr}: {e}");
+            return;
+        }
+    };
+    if let Err(e) = axum::serve(listener, app).await {
+        tracing::error!("HTTP server error: {e}");
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**CPU 100% (root cause) — tsink_db.rs**
WalSyncMode::PerAppend (défaut) appelait fsync() + sync_dir() sur chaque écriture → IO-bound CPU spike. Remplacé par Periodic(5s) : fsync groupé.

**Storage shutdown (root cause) — tsink_db.rs**
write_published_highwater_marker ouvre wal.published.tmp dans le dossier WAL ; la rotation de segments peut supprimer ce dossier entre les deux opérations → ENOENT → "Storage is shutting down" via background_fail_fast=true (défaut). Correctifs : with_wal_sync_mode(Periodic) + with_background_fail_fast(false). with_read_workers(1) limite les threads de lecture (suffisant pour notre charge).

**energy-manager ne redémarre pas — live_ws/server.rs + .service**
- TcpListener::bind().unwrap() + axum::serve().unwrap() combinés à panic=abort abortaient le processus si le port 8081 était occupé ; remplacé par error log.
- StartLimitBurst=5 faisait abandonner systemd après 5 crash rapides ; remplacé par StartLimitIntervalSec=0 (redémarrages illimités).

https://claude.ai/code/session_01N5RjL38vMagQLW7Xb7TATJ