### PR TITLE
refactor(tsink): batch writer dédié — réduit overhead tokio::spawn pa…

### DIFF
--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -32,12 +32,14 @@ mod monitor;
 use crate::bridges::{alerts, influx, mqtt};
 use crate::config::AppConfig;
 use crate::state::{AppState, LogBuffer, LogEntry};
+use crate::tsink_db::Row as TsinkRow;
 use daly_bms_core::bus::{BmsConfig, DalyBusManager, DalyPort};
 use daly_bms_core::poll::{poll_loop, PollConfig, PollErrorKind};
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 use tracing::{error, info, warn};
 use tracing::Subscriber;
 use tracing_subscriber::Layer;
@@ -133,6 +135,54 @@ impl ServerArgs {
 }
 
 // =============================================================================
+// Tsink batch writer
+// =============================================================================
+
+/// Accumule les rows reçues via channel et écrit dans Tsink en batch toutes les
+/// WRITE_INTERVAL secondes. Évite de spawner une task par mesure (source du CPU élevé).
+async fn tsink_batch_writer(
+    tsink: tsink_db::TsinkHandle,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<Vec<TsinkRow>>,
+) {
+    const WRITE_INTERVAL: Duration = Duration::from_secs(10);
+    let mut interval = tokio::time::interval(WRITE_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut pending: Vec<TsinkRow> = Vec::with_capacity(512);
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = interval.tick() => {
+                if !pending.is_empty() {
+                    let rows = std::mem::take(&mut pending);
+                    if let Err(e) = tsink.write_rows(rows).await {
+                        tracing::warn!("Tsink batch write error: {e}");
+                    }
+                }
+            }
+            msg = rx.recv() => {
+                match msg {
+                    Some(rows) => {
+                        pending.extend(rows);
+                        // Drain all immediately available messages for efficient batching
+                        while let Ok(rows) = rx.try_recv() {
+                            pending.extend(rows);
+                        }
+                    }
+                    None => {
+                        // Channel closed — flush remaining rows and exit
+                        if !pending.is_empty() {
+                            let _ = tsink.write_rows(std::mem::take(&mut pending)).await;
+                        }
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
 // Main
 // =============================================================================
 
@@ -210,24 +260,26 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // ── Tsink (stockage time-series embarqué) ─────────────────────────────────
-    let tsink_handle = if config.tsink.enabled {
+    let (tsink_handle, tsink_tx) = if config.tsink.enabled {
         match tsink_db::TsinkHandle::new(&config.tsink).await {
             Ok(h) => {
-                info!("Tsink activé — stockage dans '{}'", config.tsink.data_path);
-                Some(h)
+                info!("Tsink activé — stockage dans '{}' (batch writer 10s)", config.tsink.data_path);
+                let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<TsinkRow>>();
+                tokio::spawn(tsink_batch_writer(h.clone(), rx));
+                (Some(h), Some(tx))
             }
             Err(e) => {
                 warn!("Tsink init échoué : {} — stockage désactivé", e);
-                None
+                (None, None)
             }
         }
     } else {
         info!("Tsink désactivé (tsink.enabled = false)");
-        None
+        (None, None)
     };
 
     // ── État partagé ───────────────────────────────────────────────────────────
-    let state = AppState::new(config.clone(), log_buffer, tsink_handle);
+    let state = AppState::new(config.clone(), log_buffer, tsink_handle, tsink_tx);
 
     // ── Bridges en arrière-plan ─────────────────────────────────────────────────
 

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -10,7 +10,8 @@ use crate::et112::Et112Snapshot;
 use crate::irradiance::IrradianceSnapshot;
 use crate::shelly::ShellyEmSnapshot;
 use crate::tasmota::TasmotaSnapshot;
-use crate::tsink_db::TsinkHandle;
+use crate::tsink_db::{TsinkHandle, Row as TsinkRow};
+use tokio::sync::mpsc;
 use daly_bms_core::bus::DalyPort;
 use daly_bms_core::types::BmsSnapshot;
 use chrono::{DateTime, Datelike, Utc};
@@ -403,10 +404,20 @@ pub struct AppState {
     /// Stockage time-series embarqué Tsink (None si désactivé dans la config).
     pub tsink: Option<Arc<TsinkHandle>>,
 
+    /// Canal d'envoi vers le batch writer Tsink (None si Tsink désactivé).
+    /// Remplace les tokio::spawn par mesure — les rows sont accumulées et
+    /// écrites en un seul appel toutes les 10 secondes.
+    pub tsink_tx: Option<mpsc::UnboundedSender<Vec<TsinkRow>>>,
+
 }
 
 impl AppState {
-    pub fn new(config: AppConfig, log_buffer: LogBuffer, tsink: Option<TsinkHandle>) -> Self {
+    pub fn new(
+        config: AppConfig,
+        log_buffer: LogBuffer,
+        tsink: Option<TsinkHandle>,
+        tsink_tx: Option<mpsc::UnboundedSender<Vec<TsinkRow>>>,
+    ) -> Self {
         let (ws_tx, _) = broadcast::channel(WS_BROADCAST_CAPACITY);
         let addresses = config.bms_addresses();
         let ring_size = config.serial.ring_buffer_size;
@@ -461,6 +472,7 @@ impl AppState {
             shelly_latest: Arc::new(RwLock::new(BTreeMap::new())),
             shelly_client: Arc::new(tokio::sync::Mutex::new(None)),
             tsink: tsink.map(Arc::new),
+            tsink_tx,
         }
     }
 
@@ -522,13 +534,8 @@ impl AppState {
         let latest = self.latest_snapshots().await;
         let _ = self.ws_tx.send(Arc::new(latest));
 
-        if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::bms_rows(&snap);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink BMS write error: {}", e);
-                }
-            });
+        if let Some(tx) = &self.tsink_tx {
+            let _ = tx.send(TsinkHandle::bms_rows(&snap));
         }
     }
 
@@ -580,13 +587,8 @@ impl AppState {
                 .push(snap.clone());
         }
 
-        if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::et112_rows(&snap);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink ET112 write error: {}", e);
-                }
-            });
+        if let Some(tx) = &self.tsink_tx {
+            let _ = tx.send(TsinkHandle::et112_rows(&snap));
         }
     }
 
@@ -618,13 +620,8 @@ impl AppState {
             "address": snap.address,
             "irradiance_wm2": snap.irradiance_wm2,
         })));
-        if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::irradiance_rows(&snap);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink irradiance write error: {}", e);
-                }
-            });
+        if let Some(tx) = &self.tsink_tx {
+            let _ = tx.send(TsinkHandle::irradiance_rows(&snap));
         }
         *self.irradiance_value.write().await = Some(snap);
     }
@@ -741,13 +738,8 @@ impl AppState {
                 "ah_charged_today": shunt.ah_charged_today,
                 "ah_discharged_today": shunt.ah_discharged_today,
             })));
-            if let Some(tsink) = self.tsink.clone() {
-                let rows = TsinkHandle::smartshunt_rows(&shunt);
-                tokio::spawn(async move {
-                    if let Err(e) = tsink.write_rows(rows).await {
-                        tracing::warn!("Tsink SmartShunt write error: {}", e);
-                    }
-                });
+            if let Some(tx) = &self.tsink_tx {
+                let _ = tx.send(TsinkHandle::smartshunt_rows(&shunt));
             }
             *self.venus_smartshunt.write().await = Some(shunt);
             return;
@@ -792,13 +784,8 @@ impl AppState {
             "ah_discharged_today": shunt.ah_discharged_today,
         })));
 
-        if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::smartshunt_rows(&shunt);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink SmartShunt write error: {}", e);
-                }
-            });
+        if let Some(tx) = &self.tsink_tx {
+            let _ = tx.send(TsinkHandle::smartshunt_rows(&shunt));
         }
         *self.venus_smartshunt.write().await = Some(shunt);
     }
@@ -822,13 +809,8 @@ impl AppState {
 
     /// Enregistre/met à jour les données de l'onduleur Victron (MultiPlus, cgwacs, etc.).
     pub async fn on_venus_inverter(&self, inverter: VenusInverter) {
-        if let Some(tsink) = self.tsink.clone() {
-            let rows = TsinkHandle::inverter_rows(&inverter);
-            tokio::spawn(async move {
-                if let Err(e) = tsink.write_rows(rows).await {
-                    tracing::warn!("Tsink inverter write error: {}", e);
-                }
-            });
+        if let Some(tx) = &self.tsink_tx {
+            let _ = tx.send(TsinkHandle::inverter_rows(&inverter));
         }
         *self.venus_inverter.write().await = Some(inverter);
     }

--- a/crates/daly-bms-server/src/tsink_db.rs
+++ b/crates/daly-bms-server/src/tsink_db.rs
@@ -8,6 +8,8 @@ use std::time::Duration;
 use tsink::{
     AsyncStorage, AsyncStorageBuilder, DataPoint, Label, Row, TimestampPrecision, WalSyncMode,
 };
+
+pub use tsink::Row;
 use tsink::promql::{Engine, PromqlValue};
 use tracing::info;
 


### PR DESCRIPTION
…r mesure

Remplace les tokio::spawn(write_rows(...)) par mesure par un canal mpsc::UnboundedSender vers un batch writer qui accumule les rows et écrit dans Tsink en un seul appel toutes les 10 secondes.

Bénéfices :
- Élimine la création d'une task Tokio par snapshot (2 BMS/s + 3 ET112 + Venus)
- Réduit les appels write_rows de ~10/s à 1/10s (moins de lock contention)
- Drain immédiat du channel pour batching efficace des bursts

Note : la root cause profonde (DEFAULT_FLUSH_INTERVAL=250ms hardcodé dans tsink, non configurable via AsyncStorageBuilder) nécessite un profiling sur Pi5 via `top -H -p PID` pour confirmer le thread tsink-flush comme coupable, puis potentiellement un patch tsink ou with_wal_enabled(false).

https://claude.ai/code/session_011QtU3KQPbqh7RJyUYqfxEq