### PR TITLE
fix(energy-manager): remove missed InfluxDB references in lg_thinq + …

### DIFF
--- a/crates/energy-manager/src/http_clients/lg_thinq.rs
+++ b/crates/energy-manager/src/http_clients/lg_thinq.rs
@@ -6,7 +6,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::bus::AppBus;
 use crate::config::LgThinqConfig;
-use crate::types::{InfluxPoint, LiveEvent, WaterHeaterMode};
+use crate::types::{LiveEvent, WaterHeaterMode};
 
 // ---------------------------------------------------------------------------
 // API response types — ThinQ EIC API v2
@@ -226,17 +226,6 @@ pub async fn spawn_poller(
                         s.water_heater_temp_c   = snap.current_temp_c;
                         s.water_heater_target_c = snap.target_temp_c;
                     }
-                    // Write to InfluxDB on every poll
-                    let mut pt = InfluxPoint::new("water_heater_status")
-                        .field_s("mode",  snap.mode.to_lg_str())
-                        .field_i("state", snap.mode.to_venus_state() as i64);
-                    if let Some(t) = snap.current_temp_c {
-                        pt = pt.field_f("temperature_c", t);
-                    }
-                    if let Some(t) = snap.target_temp_c {
-                        pt = pt.field_f("target_c", t);
-                    }
-                    bus2.write_influx(pt).await;
                     bus2.emit_live(LiveEvent::new("water_heater", &snap));
                 }
                 Err(e) => error!("LG ThinQ poll error: {e}"),

--- a/crates/energy-manager/src/logic/solar_power.rs
+++ b/crates/energy-manager/src/logic/solar_power.rs
@@ -154,7 +154,7 @@ async fn writer_task(
             solar_total, house_power,
             m273_w, _m273_v, _m273_i, _m273_yield, _m273_state,
             m289_w, _m289_v, _m289_i, _m289_yield, _m289_state,
-            pvinv_w, pvinv_yield,
+            pvinv_w, _pvinv_yield,
             total_yield,
         ) = {
             let s = state.read().await;


### PR DESCRIPTION
…solar_power

lg_thinq.rs still imported InfluxPoint and called bus.write_influx() — both removed. solar_power.rs had an unused pvinv_yield variable warning fixed by prefixing with underscore.

https://claude.ai/code/session_01KpFj5eZL6UbSnpPcYQwTru