### PR TITLE
feat(viz): wire edge history charts to Tsink PromQL (drop InfluxDB)

### DIFF
--- a/crates/daly-bms-server/src/api/chart.rs
+++ b/crates/daly-bms-server/src/api/chart.rs
@@ -21,10 +21,14 @@ pub struct HistoryParams {
 
 #[derive(Deserialize)]
 pub struct EdgeHistoryParams {
-    pub measurement: String,
-    pub field: String,
+    // New direct Tsink interface
+    pub metric: Option<String>,
+    pub bms_id: Option<String>,
     pub address: Option<String>,
     pub minutes: Option<u32>,
+    // Legacy InfluxDB compatibility (kept for backward compat)
+    pub measurement: Option<String>,
+    pub field: Option<String>,
 }
 
 /// GET /api/v1/chart/history?minutes=X
@@ -57,6 +61,29 @@ pub async fn get_chart_history(
     }))
 }
 
+fn normalize_address(addr: &str) -> String {
+    if addr.starts_with("0x") || addr.starts_with("0X") {
+        addr.to_string()
+    } else if let Ok(n) = u32::from_str_radix(addr, 16) {
+        format!("{:#04x}", n)
+    } else if let Ok(n) = addr.parse::<u32>() {
+        format!("{:#04x}", n)
+    } else {
+        addr.to_string()
+    }
+}
+
+fn infer_unit(metric: &str) -> &'static str {
+    if metric.ends_with("_w") || metric.ends_with("_power_w") { return "W"; }
+    if metric.ends_with("_kwh") { return "kWh"; }
+    if metric.ends_with("_a") || metric == "bms_current" { return "A"; }
+    if metric.ends_with("_v") || metric.ends_with("_voltage_v") { return "V"; }
+    if metric.ends_with("_soc") || metric == "bms_soc" { return "%"; }
+    if metric.ends_with("_wm2") { return "W/m²"; }
+    if metric.ends_with("_hz") { return "Hz"; }
+    ""
+}
+
 /// Extracts [{t: "HH:MM", v: f64}] from a PromQL range result.
 fn extract_series_hhmm(result: Option<PromqlValue>) -> Vec<Value> {
     let series_list = match result {
@@ -86,36 +113,52 @@ pub async fn get_edge_history(
         None => return Json(json!({ "ok": false, "series": [], "reason": "tsink_disabled" })),
     };
 
-    // Map old InfluxDB measurement+field names to Tsink metric names
-    let (metric, unit) = match (q.measurement.as_str(), q.field.as_str()) {
-        ("bms_status", "current")          => ("bms_current", "A"),
-        ("bms_status", "soc")              => ("bms_soc", "%"),
-        ("et112_status", "power_w")        => ("et112_power_w", "W"),
-        ("et112_status", "current_a")      => ("et112_current_a", "A"),
-        ("venus_mppt_total", "power_w")    => ("solar_total_w", "W"),
-        ("venus_mppt_total", "current_a")  => ("mppt_power_w", "W"),
-        ("venus_smartshunt", "current_a")  => ("venus_shunt_current_a", "A"),
-        ("venus_smartshunt", "power_w")    => ("venus_shunt_power_w", "W"),
-        ("venus_inverter", "ac_out_power_w") => ("venus_inverter_ac_output_power_w", "W"),
-        ("venus_inverter", "dc_power_w")   => ("venus_inverter_power_w", "W"),
-        ("solar_power", "mppt_power_w")    => ("mppt_power_w", "W"),
-        ("inverter_status", "dc_power_w")  => ("venus_inverter_power_w", "W"),
-        ("inverter_status", "ac_out_power_w") => ("venus_inverter_ac_output_power_w", "W"),
-        _ => return Json(json!({ "ok": false, "series": [], "reason": "unknown_metric" })),
-    };
+    // Resolve metric name and unit.
+    // Priority: direct ?metric= param, then legacy measurement+field mapping.
+    let (metric, unit): (&str, &str);
+    let metric_owned: String;
 
-    // Build label filter if address is given
-    let query = if let Some(addr) = q.address.as_deref().filter(|s| !s.is_empty()) {
-        // Normalize address: "1" → "0x01"
-        let normalized = if addr.starts_with("0x") || addr.starts_with("0X") {
-            addr.to_string()
-        } else if let Ok(n) = u32::from_str_radix(addr, 16) {
-            format!("{:#04x}", n)
-        } else if let Ok(n) = addr.parse::<u32>() {
-            format!("{:#04x}", n)
-        } else {
-            addr.to_string()
+    if let Some(ref m) = q.metric {
+        metric_owned = m.clone();
+        metric = &metric_owned;
+        unit = infer_unit(metric);
+    } else {
+        let measurement = q.measurement.as_deref().unwrap_or("");
+        let field       = q.field.as_deref().unwrap_or("");
+        let mapped = match (measurement, field) {
+            ("bms_status", "current")             => Some(("bms_current", "A")),
+            ("bms_status", "soc")                 => Some(("bms_soc", "%")),
+            ("et112_status", "power_w")           => Some(("et112_power_w", "W")),
+            ("et112_status", "current_a")         => Some(("et112_current_a", "A")),
+            ("venus_mppt_total", "power_w")       => Some(("solar_total_w", "W")),
+            ("venus_mppt_total", "current_a")     => Some(("mppt_power_w", "W")),
+            ("venus_smartshunt", "current_a")     => Some(("venus_shunt_current_a", "A")),
+            ("venus_smartshunt", "power_w")       => Some(("venus_shunt_power_w", "W")),
+            ("venus_inverter", "ac_out_power_w")  => Some(("venus_inverter_ac_output_power_w", "W")),
+            ("venus_inverter", "dc_power_w")      => Some(("venus_inverter_power_w", "W")),
+            ("solar_power", "mppt_power_w")       => Some(("mppt_power_w", "W")),
+            ("inverter_status", "dc_power_w")     => Some(("venus_inverter_power_w", "W")),
+            ("inverter_status", "ac_out_power_w") => Some(("venus_inverter_ac_output_power_w", "W")),
+            _ => None,
         };
+        match mapped {
+            Some((m, u)) => { metric_owned = m.to_string(); metric = &metric_owned; unit = u; }
+            None => return Json(json!({ "ok": false, "series": [], "reason": "unknown_metric" })),
+        }
+    }
+
+    // Build PromQL label filter.
+    // BMS metrics use the `bms_id` label; ET112 metrics use the `address` label.
+    let is_bms = metric.starts_with("bms_");
+    let query = if is_bms {
+        if let Some(bms_id) = q.bms_id.as_deref().filter(|s| !s.is_empty()) {
+            let normalized = normalize_address(bms_id);
+            format!("{}{{bms_id=\"{}\"}}", metric, normalized)
+        } else {
+            metric.to_string()
+        }
+    } else if let Some(addr) = q.address.as_deref().filter(|s| !s.is_empty()) {
+        let normalized = normalize_address(addr);
         format!("{}{{address=\"{}\"}}", metric, normalized)
     } else {
         metric.to_string()

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -90,16 +90,16 @@ function mkEdge(id, src, tgt, color, opts = {}) {
   };
 }
 
-const HIST_ET112_7 = { measurement: 'et112_status',     field: 'current_a',           address: '0x07', label: 'Micro-Onduleurs — I (6h)' };
-const HIST_ET112_8 = { measurement: 'et112_status',     field: 'current_a',           address: '0x08', label: 'Chauffe-eau — I (6h)' };
-const HIST_ET112_9 = { measurement: 'et112_status',     field: 'current_a',           address: '0x09', label: 'Climatisation — I (6h)' };
-const HIST_BMS_1   = { measurement: 'bms_status',       field: 'current',             address: '0x01', label: 'BMS-360Ah — I (6h)' };
-const HIST_BMS_2   = { measurement: 'bms_status',       field: 'current',             address: '0x02', label: 'BMS-320Ah — I (6h)' };
-const HIST_BMS_3   = { measurement: 'bms_status',       field: 'current',             address: '0x03', label: 'BMS-3 — I (6h)' };
-const HIST_MPPT    = { measurement: 'venus_mppt_total', field: 'current_a',        label: 'MPPT total — I DC (6h)' };
-const HIST_INV_DC  = { measurement: 'inverter_status', field: 'dc_current_a',     label: 'Onduleur — I DC (6h)' };
-const HIST_INV_AC  = { measurement: 'inverter_status', field: 'ac_out_current_a', label: 'Onduleur — I AC sortie (6h)' };
-const HIST_SHUNT   = { measurement: 'venus_smartshunt', field: 'current_a',       label: 'SmartShunt — I batterie (6h)' };
+const HIST_ET112_7 = { metric: 'et112_power_w',                    address: '0x07', label: 'Micro-Onduleurs — W (6h)' };
+const HIST_ET112_8 = { metric: 'et112_power_w',                    address: '0x08', label: 'Chauffe-eau — W (6h)' };
+const HIST_ET112_9 = { metric: 'et112_power_w',                    address: '0x09', label: 'Climatisation — W (6h)' };
+const HIST_BMS_1   = { metric: 'bms_current',   bms_id: '0x01',                    label: 'BMS-360Ah — I (6h)' };
+const HIST_BMS_2   = { metric: 'bms_current',   bms_id: '0x02',                    label: 'BMS-320Ah — I (6h)' };
+const HIST_BMS_3   = { metric: 'bms_current',   bms_id: '0x03',                    label: 'BMS-3 — I (6h)' };
+const HIST_MPPT    = { metric: 'solar_total_w',                                     label: 'Solaire total — W (6h)' };
+const HIST_INV_DC  = { metric: 'venus_inverter_power_w',                            label: 'Onduleur — P DC (6h)' };
+const HIST_INV_AC  = { metric: 'venus_inverter_ac_output_power_w',                  label: 'Onduleur — P AC sortie (6h)' };
+const HIST_SHUNT   = { metric: 'venus_shunt_current_a',                             label: 'SmartShunt — I batterie (6h)' };
 
 const EDGES0 = [
   mkEdge('e-ats-maison', 'ats-main', 'et112-maison',   COLOR.ac,  { sourceHandle: 'main-right', targetHandle: 'tl', type: 'customBezier', history: HIST_ET112_8 }),

--- a/crates/daly-bms-server/templates/viz_edges.js
+++ b/crates/daly-bms-server/templates/viz_edges.js
@@ -1,4 +1,4 @@
-// ── EDGE CHART OVERLAY (hover → mini ECharts popup 6h depuis InfluxDB) ────────
+// ── EDGE CHART OVERLAY (hover → mini ECharts popup 6h depuis Tsink PromQL) ────
 function EdgeChartOverlay({ labelX, labelY, history, color }) {
   const [hover, setHover]     = useState(false);
   const [payload, setPayload] = useState(null);
@@ -7,9 +7,9 @@ function EdgeChartOverlay({ labelX, labelY, history, color }) {
   const chartRef    = useRef(null);
   const hideTimer   = useRef(null);
 
-  const measurement = history?.measurement;
-  const field       = history?.field;
-  const addr        = history?.address;
+  const metric = history?.metric;
+  const bmsId  = history?.bms_id;
+  const addr   = history?.address;
 
   function scheduleShow() {
     if (hideTimer.current) { clearTimeout(hideTimer.current); hideTimer.current = null; }
@@ -21,13 +21,12 @@ function EdgeChartOverlay({ labelX, labelY, history, color }) {
   }
 
   useEffect(function () {
-    if (!hover || !measurement) return;
+    if (!hover || !metric) return;
     let cancelled = false;
     setLoading(true);
-    let url = '/api/v1/chart/edge-history?measurement=' + encodeURIComponent(measurement)
-      + '&field=' + encodeURIComponent(field)
-      + '&minutes=360';
-    if (addr) url += '&address=' + encodeURIComponent(addr);
+    let url = '/api/v1/chart/edge-history?metric=' + encodeURIComponent(metric) + '&minutes=360';
+    if (bmsId) url += '&bms_id=' + encodeURIComponent(bmsId);
+    if (addr)  url += '&address=' + encodeURIComponent(addr);
     fetch(url)
       .then(r => r.json())
       .then(j => { if (!cancelled) { setPayload(j); setLoading(false); } })
@@ -36,7 +35,7 @@ function EdgeChartOverlay({ labelX, labelY, history, color }) {
         if (!cancelled) { setLoading(false); setPayload({ ok: false, series: [] }); }
       });
     return function () { cancelled = true; };
-  }, [hover, measurement, field, addr]);
+  }, [hover, metric, bmsId, addr]);
 
   useEffect(function () {
     if (!hover) return;
@@ -133,7 +132,7 @@ function EdgeChartOverlay({ labelX, labelY, history, color }) {
     hoverElements.push(h('div', { key: 'popup', style: popupStyle, onMouseEnter: scheduleShow, onMouseLeave: scheduleHide },
       h('div', { style: headerStyle },
         h('span', null, history.label || 'Courant — 6h'),
-        h('span', { style: { color: '#94a3b8', fontWeight: 400 } }, 'InfluxDB')
+        h('span', { style: { color: '#94a3b8', fontWeight: 400 } }, 'Tsink 6h')
       ),
       h('div', { ref: chartDivRef, style: { flex: 1, width: '100%', minHeight: 0 } }),
       loading && h('div', { style: { position:'absolute', inset:0, display:'flex', alignItems:'center', justifyContent:'center', color:'#64748b', fontSize:11 } }, 'Chargement…'),


### PR DESCRIPTION
Replace InfluxDB measurement/field constants in visualization.html with direct Tsink metric names (et112_power_w, bms_current, solar_total_w, venus_inverter_*, venus_shunt_current_a).

chart.rs get_edge_history now accepts ?metric= directly; BMS queries use bms_id label filter, ET112 queries use address label. Added normalize_address() and infer_unit() helpers. Legacy measurement+field params still accepted for backward compat.

viz_edges.js EdgeChartOverlay builds ?metric=&bms_id=&address= URL and displays "Tsink 6h" instead of "InfluxDB" in the popup header.

https://claude.ai/code/session_01KpFj5eZL6UbSnpPcYQwTru