### PR TITLE
chore(ui): remplacer les références Tsink par VictoriaMetrics dans l'UI

### DIFF
--- a/crates/daly-bms-server/templates/history.html
+++ b/crates/daly-bms-server/templates/history.html
@@ -163,7 +163,7 @@
     </div>
     <div class="chart-wrap">
       <div id="chart-kwh" style="width:100%;height:100%"></div>
-      <div class="no-data-overlay" id="nd-kwh"><span>📊</span><span>Aucune donnée Tsink</span></div>
+      <div class="no-data-overlay" id="nd-kwh"><span>📊</span><span>Aucune donnée VictoriaMetrics</span></div>
     </div>
   </div>
 
@@ -175,7 +175,7 @@
     </div>
     <div class="chart-wrap">
       <div id="chart-w" style="width:100%;height:100%"></div>
-      <div class="no-data-overlay" id="nd-w"><span>📊</span><span>Aucune donnée Tsink</span></div>
+      <div class="no-data-overlay" id="nd-w"><span>📊</span><span>Aucune donnée VictoriaMetrics</span></div>
     </div>
   </div>
 
@@ -187,7 +187,7 @@
     </div>
     <div class="chart-wrap">
       <div id="chart-ah" style="width:100%;height:100%"></div>
-      <div class="no-data-overlay" id="nd-ah"><span>📊</span><span>Aucune donnée Tsink</span></div>
+      <div class="no-data-overlay" id="nd-ah"><span>📊</span><span>Aucune donnée VictoriaMetrics</span></div>
     </div>
   </div>
 
@@ -416,7 +416,7 @@ async function loadHistory(period) {
     if (!resp.ok) throw new Error('HTTP ' + resp.status);
     const data = await resp.json();
     if (!data.ok) {
-      document.getElementById('period-label').textContent = 'Tsink désactivé';
+      document.getElementById('period-label').textContent = 'VictoriaMetrics désactivé';
       return;
     }
     renderCharts(data);

--- a/crates/daly-bms-server/templates/viz_edges.js
+++ b/crates/daly-bms-server/templates/viz_edges.js
@@ -1,4 +1,4 @@
-// ── EDGE CHART OVERLAY (hover → mini ECharts popup 6h depuis Tsink PromQL) ────
+// ── EDGE CHART OVERLAY (hover → mini ECharts popup 6h depuis VictoriaMetrics) ────
 function EdgeChartOverlay({ labelX, labelY, history, color }) {
   const [hover, setHover]     = useState(false);
   const [payload, setPayload] = useState(null);
@@ -132,7 +132,7 @@ function EdgeChartOverlay({ labelX, labelY, history, color }) {
     hoverElements.push(h('div', { key: 'popup', style: popupStyle, onMouseEnter: scheduleShow, onMouseLeave: scheduleHide },
       h('div', { style: headerStyle },
         h('span', null, history.label || 'Courant — 6h'),
-        h('span', { style: { color: '#94a3b8', fontWeight: 400 } }, 'Tsink 6h')
+        h('span', { style: { color: '#94a3b8', fontWeight: 400 } }, 'VM 6h')
       ),
       h('div', { ref: chartDivRef, style: { flex: 1, width: '100%', minHeight: 0 } }),
       loading && h('div', { style: { position:'absolute', inset:0, display:'flex', alignItems:'center', justifyContent:'center', color:'#64748b', fontSize:11 } }, 'Chargement…'),


### PR DESCRIPTION
- viz_edges.js : en-tête popup edge "Tsink 6h" → "VM 6h"
- history.html : "Aucune donnée Tsink" → "Aucune donnée VictoriaMetrics" (×3)
- history.html : "Tsink désactivé" → "VictoriaMetrics désactivé"

https://claude.ai/code/session_01LMa5KdjDwzG84AYzTeT1m6