### PR TITLE
fix(vm): 2 bugs supplémentaires — mismatch clés SmartShunt + throttle…

### DIFF
--- a/crates/daly-bms-server/src/api/system.rs
+++ b/crates/daly-bms-server/src/api/system.rs
@@ -158,13 +158,16 @@ pub async fn set_mppt_yield(
         *state.house_power_w.write().await = hw;
     }
 
-    // Write solar metrics to VictoriaMetrics for history
+    // Write solar metrics to VictoriaMetrics — throttlé à 1 écriture / 5s
+    // (energy-manager appelle cet endpoint toutes les secondes)
     if let Some(vm) = &state.vm {
-        let kwh_val = *state.mppt_yield_kwh.read().await;
-        let pw_val  = *state.mppt_power_w.read().await;
-        let total_w = *state.solar_total_w.read().await;
-        let rows = crate::vm_client::VmClient::solar_rows(total_w, pw_val, kwh_val);
-        let _ = vm.write_rows(rows).await;
+        if state.vm_solar_rate_ok() {
+            let kwh_val = *state.mppt_yield_kwh.read().await;
+            let pw_val  = *state.mppt_power_w.read().await;
+            let total_w = *state.solar_total_w.read().await;
+            let rows = crate::vm_client::VmClient::solar_rows(total_w, pw_val, kwh_val);
+            let _ = vm.write_rows(rows).await;
+        }
     }
 
     let kwh  = *state.mppt_yield_kwh.read().await;

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -692,17 +692,17 @@ async fn handle_temperature_topic(state: &AppState, json: &Value) {
 
 /// Traite le topic `santuario/system/venus`
 ///
-/// Payload v1 : { "Soc": 75.2, "Voltage": 48.32, "Current": 5.5, "Power": 266.0, "EnergyIn": 1000000, "EnergyOut": 500000 }
-/// Payload v2 : { ..., "State": 3, "TimeToGo": 3600 }
-///   State : 0=Idle, 1=Charging, 2=Discharging
-///   TimeToGo : secondes (None si en charge)
+/// Payload energy-manager : { "Soc":75.2, "Voltage":48.3, "Current":5.5, "Power":266.0,
+///   "State":2, "TimeToGo":3600, "ChargedTodayKwh":5.2, "DischargedTodayKwh":2.1,
+///   "AhChargedToday":108.0, "AhDischargedToday":43.0 }
 async fn handle_system_topic(state: &AppState, json: &Value) {
     if let Some(soc) = json.get("Soc").and_then(|v| v.as_f64()).map(|v| v as f32) {
         let voltage    = json.get("Voltage").and_then(|v| v.as_f64()).map(|v| v as f32);
         let current    = json.get("Current").and_then(|v| v.as_f64()).map(|v| v as f32);
         let power      = json.get("Power").and_then(|v| v.as_f64()).map(|v| v as f32);
-        let energy_in  = json.get("EnergyIn").and_then(|v| v.as_f64()).map(|v| v as f32);
-        let energy_out = json.get("EnergyOut").and_then(|v| v.as_f64()).map(|v| v as f32);
+        // ChargedTodayKwh / DischargedTodayKwh — publiés par energy-manager en kWh
+        let energy_in  = json.get("ChargedTodayKwh").and_then(|v| v.as_f64()).map(|v| v as f32);
+        let energy_out = json.get("DischargedTodayKwh").and_then(|v| v.as_f64()).map(|v| v as f32);
 
         // State : entier Victron → libellé
         let state_str = json.get("State").and_then(|v| v.as_u64()).map(|s| match s {
@@ -727,8 +727,8 @@ async fn handle_system_topic(state: &AppState, json: &Value) {
             voltage_v: voltage,
             current_a: current,
             power_w: power,
-            energy_in_kwh: energy_in.map(|e| e / 1000.0),
-            energy_out_kwh: energy_out.map(|e| e / 1000.0),
+            energy_in_kwh: energy_in,   // déjà en kWh
+            energy_out_kwh: energy_out, // déjà en kWh
             state: state_str,
             time_to_go_min,
             ah_charged_today:    ah_charged,

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -445,6 +445,7 @@ pub struct AppState {
     vm_last_bms_write:     Arc<AtomicU64>,
     vm_last_shunt_write:   Arc<AtomicU64>,  // SmartShunt — séparé de l'inverter
     vm_last_inverter_write: Arc<AtomicU64>, // Inverter — séparé du SmartShunt
+    vm_last_solar_write:   Arc<AtomicU64>,  // Solar — POST /api/v1/solar/mppt-yield appelé 1x/s
     vm_last_et112_write:   Arc<AtomicU64>,
     vm_last_irrad_write:   Arc<AtomicU64>,
 }
@@ -508,6 +509,7 @@ impl AppState {
             vm_last_bms_write:      Arc::new(AtomicU64::new(0)),
             vm_last_shunt_write:    Arc::new(AtomicU64::new(0)),
             vm_last_inverter_write: Arc::new(AtomicU64::new(0)),
+            vm_last_solar_write:    Arc::new(AtomicU64::new(0)),
             vm_last_et112_write:    Arc::new(AtomicU64::new(0)),
             vm_last_irrad_write:    Arc::new(AtomicU64::new(0)),
         }
@@ -527,6 +529,12 @@ impl AppState {
         } else {
             false
         }
+    }
+
+    /// Vérifie le throttle pour les writes solaires (interval 5s).
+    /// Utilisé par POST /api/v1/solar/mppt-yield (appelé 1x/s par energy-manager).
+    pub fn vm_solar_rate_ok(&self) -> bool {
+        Self::vm_rate_ok(&self.vm_last_solar_write, 5)
     }
 
     /// Incrémente le compteur de polls réussis pour un appareil RS485.


### PR DESCRIPTION
… solar

Bug 1 — Mismatch clés JSON SmartShunt (handle_system_topic) : energy-manager publie ChargedTodayKwh/DischargedTodayKwh (déjà en kWh) mais le serveur cherchait EnergyIn/EnergyOut (ancien format Wh). Résultat : energy_in_kwh et energy_out_kwh toujours None → venus_shunt_energy_in_kwh et venus_shunt_energy_out_kwh jamais écrits dans VM. Fix : chercher ChargedTodayKwh/DischargedTodayKwh, supprimer la division /1000.

Bug 2 — Writes solaires non throttlés (set_mppt_yield) : energy-manager POST /api/v1/solar/mppt-yield toutes les secondes → VM recevait 3600 writes/heure pour 3 métriques solaires. Fix : vm_solar_rate_ok() (5s) dans AppState + throttle dans set_mppt_yield. Ajout vm_last_solar_write: Arc<AtomicU64> dédié dans AppState.

https://claude.ai/code/session_01LMa5KdjDwzG84AYzTeT1m6