### PR TITLE
feat(vm): remontée complète de toutes les métriques vers VictoriaMetrics

### DIFF
--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -442,12 +442,18 @@ pub struct AppState {
     /// Timestamps de la dernière écriture VM par catégorie (epoch secondes).
     /// Throttle le débit d'écriture pour éviter de surcharger VM.
     /// Chaque source a son propre timer — ne jamais partager entre sources différentes.
-    vm_last_bms_write:     Arc<AtomicU64>,
-    vm_last_shunt_write:   Arc<AtomicU64>,  // SmartShunt — séparé de l'inverter
-    vm_last_inverter_write: Arc<AtomicU64>, // Inverter — séparé du SmartShunt
-    vm_last_solar_write:   Arc<AtomicU64>,  // Solar — POST /api/v1/solar/mppt-yield appelé 1x/s
-    vm_last_et112_write:   Arc<AtomicU64>,
-    vm_last_irrad_write:   Arc<AtomicU64>,
+    vm_last_bms_write:      Arc<AtomicU64>,
+    vm_last_shunt_write:    Arc<AtomicU64>,
+    vm_last_inverter_write: Arc<AtomicU64>,
+    vm_last_solar_write:    Arc<AtomicU64>,
+    vm_last_et112_write:    Arc<AtomicU64>,
+    vm_last_irrad_write:    Arc<AtomicU64>,
+    vm_last_mppt_write:     Arc<AtomicU64>,
+    vm_last_temp_write:     Arc<AtomicU64>,
+    vm_last_heat_write:     Arc<AtomicU64>,
+    vm_last_ats_write:      Arc<AtomicU64>,
+    vm_last_tasmota_write:  Arc<AtomicU64>,
+    vm_last_shelly_write:   Arc<AtomicU64>,
 }
 
 impl AppState {
@@ -512,6 +518,12 @@ impl AppState {
             vm_last_solar_write:    Arc::new(AtomicU64::new(0)),
             vm_last_et112_write:    Arc::new(AtomicU64::new(0)),
             vm_last_irrad_write:    Arc::new(AtomicU64::new(0)),
+            vm_last_mppt_write:     Arc::new(AtomicU64::new(0)),
+            vm_last_temp_write:     Arc::new(AtomicU64::new(0)),
+            vm_last_heat_write:     Arc::new(AtomicU64::new(0)),
+            vm_last_ats_write:      Arc::new(AtomicU64::new(0)),
+            vm_last_tasmota_write:  Arc::new(AtomicU64::new(0)),
+            vm_last_shelly_write:   Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -712,6 +724,15 @@ impl AppState {
 
     /// Enregistre un snapshot Tasmota dans le ring buffer correspondant.
     pub async fn on_tasmota_snapshot(&self, snap: TasmotaSnapshot) {
+        // Écriture VM — throttlée à 1/10s (partagée entre tous les Tasmota)
+        if let Some(vm) = self.vm.clone() {
+            if Self::vm_rate_ok(&self.vm_last_tasmota_write, 10) {
+                let rows = VmClient::tasmota_rows(&snap);
+                if let Err(e) = vm.write_rows(rows).await {
+                    tracing::warn!("VM Tasmota write error: {}", e);
+                }
+            }
+        }
         self.console_bus.emit(ConsoleEvent::state(EventDevice::Tasmota, &format!("Tasmota {} — {}", snap.name, if snap.power_on { "ON" } else { "OFF" }), json!({
             "id": snap.id,
             "name": snap.name,
@@ -756,6 +777,15 @@ impl AppState {
 
     /// Enregistre/met à jour un snapshot MPPT unique (format v1 legacy).
     pub async fn on_venus_mppt(&self, mppt: VenusMppt) {
+        // Écriture VM — throttlée à 1/10s par instance
+        if let Some(vm) = self.vm.clone() {
+            if Self::vm_rate_ok(&self.vm_last_mppt_write, 10) {
+                let rows = VmClient::mppt_rows(&mppt);
+                if let Err(e) = vm.write_rows(rows).await {
+                    tracing::warn!("VM MPPT write error: {}", e);
+                }
+            }
+        }
         let mut mppts = self.venus_mppts.write().await;
         mppts.insert(mppt.instance, mppt);
     }
@@ -765,6 +795,15 @@ impl AppState {
     /// Utilisé quand Venus OS publie un snapshot complet de tous les chargeurs.
     /// Les entrées orphelines (MPPT déconnecté) sont ainsi purgées automatiquement.
     pub async fn on_venus_mppts_replace(&self, mppts: Vec<VenusMppt>) {
+        // Écriture VM — throttlée à 1/10s (toutes instances en un batch)
+        if let Some(vm) = self.vm.clone() {
+            if Self::vm_rate_ok(&self.vm_last_mppt_write, 10) {
+                let rows: Vec<_> = mppts.iter().flat_map(VmClient::mppt_rows).collect();
+                if let Err(e) = vm.write_rows(rows).await {
+                    tracing::warn!("VM MPPT replace write error: {}", e);
+                }
+            }
+        }
         let mut map = self.venus_mppts.write().await;
         map.clear();
         for mppt in mppts {
@@ -888,6 +927,15 @@ impl AppState {
 
     /// Enregistre/met à jour un capteur de température.
     pub async fn on_venus_temperature(&self, temp: VenusTemperature) {
+        // Écriture VM — throttlée à 1/60s (temp/humidité varient lentement)
+        if let Some(vm) = self.vm.clone() {
+            if Self::vm_rate_ok(&self.vm_last_temp_write, 60) {
+                let rows = VmClient::temperature_rows(&temp);
+                if let Err(e) = vm.write_rows(rows).await {
+                    tracing::warn!("VM temperature write error: {}", e);
+                }
+            }
+        }
         let mut temps = self.venus_temperatures.write().await;
         temps.insert(temp.instance, temp);
     }
@@ -923,6 +971,15 @@ impl AppState {
 
     /// Enregistre/met à jour un snapshot heatpump.
     pub async fn on_venus_heatpump(&self, hp: VenusHeatpump) {
+        // Écriture VM — throttlée à 1/10s
+        if let Some(vm) = self.vm.clone() {
+            if Self::vm_rate_ok(&self.vm_last_heat_write, 10) {
+                let rows = VmClient::heatpump_rows(&hp);
+                if let Err(e) = vm.write_rows(rows).await {
+                    tracing::warn!("VM heatpump write error: {}", e);
+                }
+            }
+        }
         let mut hps = self.venus_heatpumps.write().await;
         hps.insert(hp.mqtt_index, hp);
     }
@@ -960,6 +1017,15 @@ impl AppState {
 
     /// Enregistre le dernier snapshot ATS.
     pub async fn on_ats_snapshot(&self, snap: AtsSnapshot) {
+        // Écriture VM — throttlée à 1/5s
+        if let Some(vm) = self.vm.clone() {
+            if Self::vm_rate_ok(&self.vm_last_ats_write, 5) {
+                let rows = VmClient::ats_rows(&snap);
+                if let Err(e) = vm.write_rows(rows).await {
+                    tracing::warn!("VM ATS write error: {}", e);
+                }
+            }
+        }
         self.console_bus.emit(ConsoleEvent::rs485(EventDevice::Ats, &format!("ATS CHINT — {}", snap.active_source.label()), json!({
             "source": snap.active_source.label(),
             "v1a": snap.v1a, "v1b": snap.v1b, "v1c": snap.v1c,
@@ -988,6 +1054,15 @@ impl AppState {
 
     /// Enregistre le dernier snapshot Shelly et émet un événement console.
     pub async fn on_shelly_snapshot(&self, snap: ShellyEmSnapshot) {
+        // Écriture VM — throttlée à 1/10s
+        if let Some(vm) = self.vm.clone() {
+            if Self::vm_rate_ok(&self.vm_last_shelly_write, 10) {
+                let rows = VmClient::shelly_rows(&snap);
+                if let Err(e) = vm.write_rows(rows).await {
+                    tracing::warn!("VM Shelly write error: {}", e);
+                }
+            }
+        }
         self.console_bus.emit(ConsoleEvent::state(
             EventDevice::Shelly,
             &format!("Shelly {} — {:.0}W total", snap.name, snap.total_power_w),

--- a/crates/daly-bms-server/src/vm_client.rs
+++ b/crates/daly-bms-server/src/vm_client.rs
@@ -12,7 +12,10 @@ use crate::config::VmConfig;
 use daly_bms_core::types::BmsSnapshot;
 use crate::et112::Et112Snapshot;
 use crate::irradiance::IrradianceSnapshot;
-use crate::state::{VenusSmartShunt, VenusInverter};
+use crate::ats::AtsSnapshot;
+use crate::tasmota::TasmotaSnapshot;
+use crate::shelly::ShellyEmSnapshot;
+use crate::state::{VenusMppt, VenusSmartShunt, VenusInverter, VenusTemperature, VenusHeatpump};
 
 // =============================================================================
 // VmRow — métrique en format Prometheus text
@@ -147,7 +150,7 @@ impl VmClient {
     }
 
     // -------------------------------------------------------------------------
-    // Conversions snapshots → VmRow (mêmes métriques qu'avec Tsink)
+    // Conversions snapshots → VmRow
     // -------------------------------------------------------------------------
 
     pub fn bms_rows(snap: &BmsSnapshot) -> Vec<VmRow> {
@@ -275,6 +278,201 @@ impl VmClient {
         push_opt!("venus_inverter_ac_output_voltage_v", inv.ac_output_voltage_v);
         push_opt!("venus_inverter_ac_output_current_a", inv.ac_output_current_a);
         push_opt!("venus_inverter_ac_output_power_w",   inv.ac_output_power_w);
+        push_opt!("venus_inverter_ac_freq_hz",          inv.ac_out_frequency_hz);
+        if let Some(ignore) = inv.ac_in_ignore {
+            rows.push(VmRow::new("venus_inverter_ac_in_ignore", if ignore { 1.0 } else { 0.0 }, ts));
+        }
+
+        rows
+    }
+
+    /// Métriques par MPPT Victron (SmartSolar).
+    /// Label `instance` = numéro d'instance Venus OS (ex: "273", "289").
+    pub fn mppt_rows(mppt: &VenusMppt) -> Vec<VmRow> {
+        let ts       = mppt.timestamp.timestamp_millis();
+        let instance = mppt.instance.to_string();
+        let inst     = instance.as_str();
+        let mut rows = Vec::new();
+
+        macro_rules! push_opt {
+            ($metric:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    rows.push(VmRow::with_labels(
+                        $metric, vec![("instance", inst), ("name", mppt.name.as_str())],
+                        v as f64, ts,
+                    ));
+                }
+            };
+        }
+
+        push_opt!("venus_mppt_power_w",         mppt.power_w);
+        push_opt!("venus_mppt_pv_voltage_v",    mppt.pv_voltage_v);
+        push_opt!("venus_mppt_dc_current_a",    mppt.dc_current_a);
+        push_opt!("venus_mppt_yield_today_kwh", mppt.yield_today_kwh);
+        push_opt!("venus_mppt_max_power_today_w", mppt.max_power_today_w);
+
+        rows
+    }
+
+    /// Métriques capteur température/humidité (Venus OS temperature.mqtt_*).
+    /// Label `instance` = DeviceInstance Venus OS (ex: "20").
+    pub fn temperature_rows(temp: &VenusTemperature) -> Vec<VmRow> {
+        let ts       = temp.timestamp.timestamp_millis();
+        let instance = temp.instance.to_string();
+        let inst     = instance.as_str();
+        let mut rows = Vec::new();
+
+        if let Some(t) = temp.temp_c {
+            rows.push(VmRow::with_labels(
+                "venus_temp_c",
+                vec![("instance", inst), ("name", temp.name.as_str()), ("type", temp.temp_type.as_str())],
+                t as f64, ts,
+            ));
+        }
+        if let Some(h) = temp.humidity_percent {
+            rows.push(VmRow::with_labels(
+                "venus_humidity_percent",
+                vec![("instance", inst), ("name", temp.name.as_str())],
+                h as f64, ts,
+            ));
+        }
+
+        rows
+    }
+
+    /// Métriques chauffe-eau / PAC (heatpump MQTT).
+    /// Label `idx` = mqtt_index (ex: "8" pour ET112 PAC Chauffe-eau).
+    pub fn heatpump_rows(hp: &VenusHeatpump) -> Vec<VmRow> {
+        let ts  = hp.timestamp.timestamp_millis();
+        let idx = hp.mqtt_index.to_string();
+        let i   = idx.as_str();
+        let mut rows = Vec::new();
+
+        rows.push(VmRow::with_labels(
+            "venus_heatpump_state",
+            vec![("idx", i)],
+            hp.state as f64, ts,
+        ));
+        rows.push(VmRow::with_labels(
+            "venus_heatpump_power_w",
+            vec![("idx", i)],
+            hp.ac_power as f64, ts,
+        ));
+        rows.push(VmRow::with_labels(
+            "venus_heatpump_energy_kwh",
+            vec![("idx", i)],
+            hp.ac_energy_forward as f64, ts,
+        ));
+        if let Some(t) = hp.temperature {
+            rows.push(VmRow::with_labels(
+                "venus_heatpump_temp_c",
+                vec![("idx", i)],
+                t as f64, ts,
+            ));
+        }
+        if let Some(t) = hp.target_temperature {
+            rows.push(VmRow::with_labels(
+                "venus_heatpump_target_temp_c",
+                vec![("idx", i)],
+                t as f64, ts,
+            ));
+        }
+
+        rows
+    }
+
+    /// Métriques ATS CHINT NXZB/NXZBN.
+    /// Pas de label (un seul ATS dans l'installation).
+    pub fn ats_rows(snap: &AtsSnapshot) -> Vec<VmRow> {
+        let ts = snap.timestamp.timestamp_millis();
+
+        // active_source : 0=Onduleur(src1) 1=Réseau(src2) 2=Neutre
+        let src_val = snap.active_source.venus_position() as f64;
+
+        let mut rows = vec![
+            VmRow::new("ats_sw1_closed",    if snap.sw1_closed { 1.0 } else { 0.0 }, ts),
+            VmRow::new("ats_sw2_closed",    if snap.sw2_closed { 1.0 } else { 0.0 }, ts),
+            VmRow::new("ats_active_source", src_val,                                  ts),
+        ];
+
+        // Tensions Source 1 (Onduleur) par phase
+        for (phase, v) in [("a", snap.v1a), ("b", snap.v1b), ("c", snap.v1c)] {
+            rows.push(VmRow::with_labels(
+                "ats_voltage_v",
+                vec![("source", "1"), ("phase", phase)],
+                v as f64, ts,
+            ));
+        }
+        // Tensions Source 2 (Réseau) par phase
+        for (phase, v) in [("a", snap.v2a), ("b", snap.v2b), ("c", snap.v2c)] {
+            rows.push(VmRow::with_labels(
+                "ats_voltage_v",
+                vec![("source", "2"), ("phase", phase)],
+                v as f64, ts,
+            ));
+        }
+        // Fréquences (MN uniquement)
+        if let Some(f) = snap.freq1_hz {
+            rows.push(VmRow::with_labels("ats_freq_hz", vec![("source", "1")], f as f64, ts));
+        }
+        if let Some(f) = snap.freq2_hz {
+            rows.push(VmRow::with_labels("ats_freq_hz", vec![("source", "2")], f as f64, ts));
+        }
+
+        rows
+    }
+
+    /// Métriques prise Tasmota Tongou.
+    /// Labels `id` + `name` identifient l'appareil.
+    pub fn tasmota_rows(snap: &TasmotaSnapshot) -> Vec<VmRow> {
+        let ts   = snap.timestamp.timestamp_millis();
+        let id   = snap.id.to_string();
+        let id_s = id.as_str();
+
+        macro_rules! row {
+            ($metric:expr, $value:expr) => {
+                VmRow::with_labels(
+                    $metric,
+                    vec![("id", id_s), ("name", snap.name.as_str())],
+                    $value as f64, ts,
+                )
+            };
+        }
+
+        vec![
+            row!("tasmota_power_on",         if snap.power_on { 1.0_f32 } else { 0.0_f32 }),
+            row!("tasmota_power_w",          snap.power_w),
+            row!("tasmota_voltage_v",        snap.voltage_v),
+            row!("tasmota_current_a",        snap.current_a),
+            row!("tasmota_energy_today_kwh", snap.energy_today_kwh),
+        ]
+    }
+
+    /// Métriques Shelly Pro 2PM (2 canaux).
+    /// Label `ch` = "0" ou "1".
+    pub fn shelly_rows(snap: &ShellyEmSnapshot) -> Vec<VmRow> {
+        let ts   = snap.timestamp.timestamp_millis();
+        let id   = snap.id.to_string();
+        let id_s = id.as_str();
+
+        let mut rows = Vec::new();
+
+        for (ch_str, ch) in [("0", &snap.channel_0), ("1", &snap.channel_1)] {
+            macro_rules! row {
+                ($metric:expr, $value:expr) => {
+                    VmRow::with_labels(
+                        $metric,
+                        vec![("id", id_s), ("name", snap.name.as_str()), ("ch", ch_str)],
+                        $value as f64, ts,
+                    )
+                };
+            }
+            rows.push(row!("shelly_output",     if ch.output { 1.0_f32 } else { 0.0_f32 }));
+            rows.push(row!("shelly_power_w",    ch.power_w));
+            rows.push(row!("shelly_voltage_v",  ch.voltage_v));
+            rows.push(row!("shelly_current_a",  ch.current_a));
+            rows.push(row!("shelly_energy_wh",  ch.energy_wh as f32));
+        }
 
         rows
     }

--- a/docs/victoriametrics-queries.md
+++ b/docs/victoriametrics-queries.md
@@ -1,0 +1,477 @@
+# VictoriaMetrics — Référence des métriques et requêtes PromQL
+
+> URL VMUI : `http://192.168.1.141:8428/vmui/`
+> URL API  : `http://192.168.1.141:8428/api/v1/query?query=<PROMQL>`
+
+---
+
+## Récapitulatif des métriques par appareil
+
+| Appareil | Métriques | Séries |
+|----------|-----------|--------|
+| BMS ×2 | bms_voltage, bms_current, bms_power, bms_soc, bms_capacity_ah, bms_cell_delta_mv, bms_temp_max, bms_temp_min, bms_charge_mos, bms_discharge_mos, bms_cell_voltage×16 | ~54 |
+| ET112 ×3 | et112_voltage_v, et112_current_a, et112_power_w, et112_apparent_power_va, et112_power_factor, et112_frequency_hz, et112_energy_import_wh, et112_energy_export_wh | 24 |
+| Irradiance | irradiance_wm2 | 1 |
+| SmartShunt | venus_shunt_voltage_v, venus_shunt_current_a, venus_shunt_power_w, venus_shunt_soc_percent, venus_shunt_energy_in_kwh, venus_shunt_energy_out_kwh, venus_shunt_ah_charged_today, venus_shunt_ah_discharged_today | 8 |
+| Solar agrégé | solar_total_w, mppt_power_w, solar_yield_kwh | 3 |
+| Inverter (EasySolar II GX) | venus_inverter_voltage_v, venus_inverter_current_a, venus_inverter_power_w, venus_inverter_ac_output_voltage_v, venus_inverter_ac_output_current_a, venus_inverter_ac_output_power_w, venus_inverter_ac_freq_hz, venus_inverter_ac_in_ignore | 8 |
+| MPPT ×2 | venus_mppt_power_w, venus_mppt_pv_voltage_v, venus_mppt_dc_current_a, venus_mppt_yield_today_kwh, venus_mppt_max_power_today_w | 10 |
+| Température/Humidité | venus_temp_c, venus_humidity_percent | 2 |
+| Heatpump ×2 (PAC/chauffe-eau) | venus_heatpump_state, venus_heatpump_power_w, venus_heatpump_energy_kwh, venus_heatpump_temp_c, venus_heatpump_target_temp_c | 10 |
+| ATS CHINT | ats_sw1_closed, ats_sw2_closed, ats_active_source, ats_voltage_v×6, ats_freq_hz×2 | 11 |
+| Tasmota ×6 | tasmota_power_on, tasmota_power_w, tasmota_voltage_v, tasmota_current_a, tasmota_energy_today_kwh | 30 |
+| Shelly Pro 2PM | shelly_output×2, shelly_power_w×2, shelly_voltage_v×2, shelly_current_a×2, shelly_energy_wh×2 | 10 |
+| **Total** | | **~171** |
+
+---
+
+## Labels utilisés
+
+| Label | Valeurs exemples | Métriques concernées |
+|-------|-----------------|----------------------|
+| `bms_id` | `"0x01"`, `"0x02"` | bms_* |
+| `cell` | `"C01"` … `"C16"` | bms_cell_voltage |
+| `address` | `"0x05"`, `"0x07"`, `"0x08"`, `"0x09"` | et112_*, irradiance_wm2 |
+| `name` | `"ET112-Micro-Onduleurs"`, `"Tongou Switch1"` … | et112_*, tasmota_*, shelly_* |
+| `instance` | `"273"`, `"289"` | venus_mppt_* |
+| `idx` | `"8"`, `"9"` | venus_heatpump_* |
+| `source` | `"1"` (Onduleur), `"2"` (Réseau) | ats_voltage_v, ats_freq_hz |
+| `phase` | `"a"`, `"b"`, `"c"` | ats_voltage_v |
+| `id` | `"1"` … `"6"` (Tasmota), `"1"` (Shelly) | tasmota_*, shelly_* |
+| `ch` | `"0"`, `"1"` | shelly_* |
+
+---
+
+## 1. BMS Daly (2 × 16 cellules)
+
+```promql
+# Tension totale BMS-1
+bms_voltage{bms_id="0x01"}
+
+# Courant instantané BMS-2
+bms_current{bms_id="0x02"}
+
+# SOC des deux BMS (instant)
+bms_soc
+
+# SOC moyen des deux BMS
+avg(bms_soc)
+
+# Delta cellule max (mV) — surveillance équilibrage
+bms_cell_delta_mv
+
+# Tension cellule C07 du BMS-1
+bms_cell_voltage{bms_id="0x01", cell="C07"}
+
+# Toutes les tensions de cellules du BMS-1 — heatmap
+bms_cell_voltage{bms_id="0x01"}
+
+# Température max BMS-1 sur 6h
+bms_temp_max{bms_id="0x01"}[6h]
+
+# État MOS charge BMS-1 (1=autorisé, 0=bloqué)
+bms_charge_mos{bms_id="0x01"}
+
+# Puissance totale des deux BMS
+sum(bms_power)
+
+# Énergie totale sur 24h (Wh = intégrale de la puissance)
+# NB : nécessite des données continues
+increase(bms_capacity_ah[24h])
+```
+
+---
+
+## 2. ET112 Carlo Gavazzi (3 compteurs)
+
+```promql
+# Puissance active de chaque ET112
+et112_power_w
+
+# Puissance Micro-onduleurs uniquement
+et112_power_w{address="0x07"}
+
+# Puissance Maison (PAC Chauffe-eau)
+et112_power_w{address="0x08"}
+
+# Puissance Réseau (import = positif, export = négatif)
+et112_power_w{address="0x09"}
+
+# Tension réseau (ET112 Réseau)
+et112_voltage_v{address="0x09"}
+
+# Courant instantané tous ET112
+et112_current_a
+
+# Énergie importée totale ET112 Réseau (Wh cumulatif)
+et112_energy_import_wh{address="0x09"}
+
+# Énergie exportée ET112 Micro-onduleurs (Wh cumulatif)
+et112_energy_export_wh{address="0x07"}
+
+# Énergie importée sur les dernières 24h (delta)
+increase(et112_energy_import_wh{address="0x09"}[24h])
+
+# Facteur de puissance ET112 Réseau
+et112_power_factor{address="0x09"}
+
+# Fréquence réseau
+et112_frequency_hz{address="0x09"}
+
+# Puissance apparente
+et112_apparent_power_va
+```
+
+---
+
+## 3. Capteur Irradiance PRALRAN (RS485)
+
+```promql
+# Irradiance instantanée (W/m²)
+irradiance_wm2
+
+# Irradiance sur 6h (graphe temporel)
+irradiance_wm2[6h]
+
+# Moyenne irradiance sur 1h
+avg_over_time(irradiance_wm2[1h])
+
+# Irradiance max aujourd'hui
+max_over_time(irradiance_wm2[24h])
+```
+
+---
+
+## 4. SmartShunt Victron
+
+```promql
+# Courant batterie instantané (A — négatif = décharge)
+venus_shunt_current_a
+
+# Tension batterie (V)
+venus_shunt_voltage_v
+
+# Puissance batterie (W — négatif = décharge)
+venus_shunt_power_w
+
+# SOC batterie (%)
+venus_shunt_soc_percent
+
+# Énergie chargée aujourd'hui (kWh)
+venus_shunt_energy_in_kwh
+
+# Énergie déchargée aujourd'hui (kWh)
+venus_shunt_energy_out_kwh
+
+# Ah chargés aujourd'hui
+venus_shunt_ah_charged_today
+
+# Ah déchargés aujourd'hui
+venus_shunt_ah_discharged_today
+
+# Historique courant sur 6h
+venus_shunt_current_a[6h]
+
+# Bilan énergétique du jour (kWh)
+venus_shunt_energy_in_kwh - venus_shunt_energy_out_kwh
+```
+
+---
+
+## 5. Solar / MPPT agrégé
+
+```promql
+# Production solaire totale (MPPT1 + MPPT2 + Micro-onduleurs)
+solar_total_w
+
+# Puissance MPPT uniquement (sans micro-onduleurs)
+mppt_power_w
+
+# Production totale du jour (kWh)
+solar_yield_kwh
+
+# Historique production sur 24h
+solar_total_w[24h]
+
+# Production max instantanée sur la journée
+max_over_time(solar_total_w[24h])
+```
+
+---
+
+## 6. MPPT Victron SmartSolar (2 chargeurs)
+
+> Instances : **273** (MPPT1) et **289** (MPPT2)
+
+```promql
+# Puissance de chaque MPPT
+venus_mppt_power_w
+
+# Puissance MPPT1 uniquement
+venus_mppt_power_w{instance="273"}
+
+# Puissance MPPT2 uniquement
+venus_mppt_power_w{instance="289"}
+
+# Tension panneau PV par MPPT
+venus_mppt_pv_voltage_v
+
+# Courant DC sortie chargeur (vers batterie)
+venus_mppt_dc_current_a
+
+# Production du jour par MPPT (kWh)
+venus_mppt_yield_today_kwh
+
+# Puissance max du jour par MPPT (W)
+venus_mppt_max_power_today_w
+
+# Puissance totale des 2 MPPT
+sum(venus_mppt_power_w)
+
+# Comparaison MPPT1 vs MPPT2
+venus_mppt_power_w{instance=~"273|289"}
+```
+
+---
+
+## 7. Inverter / EasySolar II GX
+
+```promql
+# Tension DC entrée onduleur (= tension batterie côté onduleur)
+venus_inverter_voltage_v
+
+# Courant DC entrée
+venus_inverter_current_a
+
+# Puissance DC totale consommée par l'onduleur
+venus_inverter_power_w
+
+# Tension AC sortie (V)
+venus_inverter_ac_output_voltage_v
+
+# Courant AC sortie (A)
+venus_inverter_ac_output_current_a
+
+# Puissance AC sortie (W)
+venus_inverter_ac_output_power_w
+
+# Fréquence AC sortie (Hz)
+venus_inverter_ac_freq_hz
+
+# Mode îlotage actif (1=AC input ignoré, 0=normal)
+venus_inverter_ac_in_ignore
+
+# Efficacité onduleur (%) — approximation
+(venus_inverter_ac_output_power_w / venus_inverter_power_w) * 100
+
+# Historique puissance AC sortie sur 6h
+venus_inverter_ac_output_power_w[6h]
+```
+
+---
+
+## 8. Capteur Température / Humidité
+
+> Instance **20** — Température extérieure (Outdoor)
+
+```promql
+# Température extérieure (°C)
+venus_temp_c{instance="20"}
+
+# Humidité extérieure (%)
+venus_humidity_percent{instance="20"}
+
+# Température sur 24h
+venus_temp_c[24h]
+
+# Température min/max du jour
+min_over_time(venus_temp_c[24h])
+max_over_time(venus_temp_c[24h])
+```
+
+---
+
+## 9. Heatpump / PAC (chauffe-eau ET112)
+
+> Index MQTT : **8** (PAC Chauffe-eau), **9** (PAC Climatisation)
+> State : 0=Off/Vacances, 1=Pompe chaleur, 2=Turbo
+
+```promql
+# État PAC Chauffe-eau (0=Off, 1=HEAT_PUMP, 2=Turbo)
+venus_heatpump_state{idx="8"}
+
+# Température eau courante (°C)
+venus_heatpump_temp_c{idx="8"}
+
+# Température eau cible (°C)
+venus_heatpump_target_temp_c{idx="8"}
+
+# Puissance consommée (W)
+venus_heatpump_power_w{idx="8"}
+
+# Énergie totale consommée (kWh cumulatif)
+venus_heatpump_energy_kwh{idx="8"}
+
+# Énergie consommée aujourd'hui (delta)
+increase(venus_heatpump_energy_kwh{idx="8"}[24h])
+
+# Puissance totale PAC + Climatisation
+sum(venus_heatpump_power_w)
+```
+
+---
+
+## 10. ATS CHINT NXZB
+
+> active_source : 0=Onduleur (Source1 / AC2), 1=Réseau (Source2 / AC1), 2=Neutre
+
+```promql
+# Source active (0=Onduleur, 1=Réseau, 2=Neutre)
+ats_active_source
+
+# SW1 fermé = Onduleur alimenté (0/1)
+ats_sw1_closed
+
+# SW2 fermé = Réseau alimenté (0/1)
+ats_sw2_closed
+
+# Tension Source 1 (Onduleur) phase A
+ats_voltage_v{source="1", phase="a"}
+
+# Tension Source 2 (Réseau) phase A
+ats_voltage_v{source="2", phase="a"}
+
+# Toutes les tensions ATS
+ats_voltage_v
+
+# Fréquence Source 1 (Hz) — MN uniquement
+ats_freq_hz{source="1"}
+
+# Nombre de commutations Source1→Source2 sur 24h
+increase(ats_active_source[24h])
+
+# Historique source active sur 6h
+ats_active_source[6h]
+```
+
+---
+
+## 11. Tasmota Tongou (6 switchs)
+
+> IDs : 1=Tongou Switch1, 2=Switch2, 3=Switch3, 4=Switch4, 5=Switch5, 6=Switch6 (tongou_3ACC34)
+
+```promql
+# État de tous les switchs (1=ON, 0=OFF)
+tasmota_power_on
+
+# État Tongou Switch1
+tasmota_power_on{id="1"}
+
+# Puissance consommée par switch
+tasmota_power_w
+
+# Puissance totale tous switchs
+sum(tasmota_power_w)
+
+# Tension alimentation (V)
+tasmota_voltage_v
+
+# Courant (A)
+tasmota_current_a
+
+# Énergie consommée aujourd'hui (kWh)
+tasmota_energy_today_kwh
+
+# Énergie totale tous switchs aujourd'hui
+sum(tasmota_energy_today_kwh)
+
+# Historique puissance Switch1 sur 24h
+tasmota_power_w{id="1"}[24h]
+
+# Switchs allumés en ce moment
+tasmota_power_on == 1
+```
+
+---
+
+## 12. Shelly Pro 2PM (DEYE)
+
+> ID **1** — 2 canaux : ch=0 (canal 1), ch=1 (canal 2)
+
+```promql
+# État relais canal 0 (1=ON, 0=OFF)
+shelly_output{id="1", ch="0"}
+
+# État relais canal 1
+shelly_output{id="1", ch="1"}
+
+# Puissance canal 0 (W)
+shelly_power_w{id="1", ch="0"}
+
+# Puissance canal 1 (W)
+shelly_power_w{id="1", ch="1"}
+
+# Puissance totale Shelly (2 canaux)
+sum(shelly_power_w{id="1"})
+
+# Tension (V)
+shelly_voltage_v{id="1", ch="0"}
+
+# Courant (A)
+shelly_current_a{id="1", ch="0"}
+
+# Énergie totale canal 0 (Wh cumulatif)
+shelly_energy_wh{id="1", ch="0"}
+
+# Énergie canal 0 aujourd'hui (delta)
+increase(shelly_energy_wh{id="1", ch="0"}[24h])
+```
+
+---
+
+## Requêtes d'analyse globale
+
+```promql
+# Bilan énergétique instantané (W)
+# Production totale
+solar_total_w
+
+# Consommation maison
+et112_power_w{address="0x08"}
+
+# Puissance réseau (+ = import, - = export)
+et112_power_w{address="0x09"}
+
+# État batterie global
+venus_shunt_soc_percent
+
+# Puissance batterie (+ = charge, - = décharge)
+venus_shunt_power_w
+
+
+# Vérification cardinality — toutes les métriques présentes
+# VMUI → Explore → Cardinality
+# ou : curl http://192.168.1.141:8428/api/v1/label/__name__/values | jq '.data | length'
+
+# Dernier point de chaque métrique (vérification fraîcheur)
+{__name__=~"bms_soc|venus_shunt_soc_percent|solar_total_w|ats_active_source|tasmota_power_on"}
+```
+
+---
+
+## Throttles d'écriture VM
+
+| Source | Intervalle écriture | Fréquence données source |
+|--------|--------------------|--------------------------| 
+| BMS | 5 s | 1 s (RS485) |
+| ET112 | 5 s | 2 s (RS485) |
+| Irradiance | 30 s | 5 s (RS485) |
+| SmartShunt | 5 s | push MQTT (energy-manager) |
+| Inverter | 5 s | push MQTT |
+| MPPT | 10 s | push MQTT |
+| Solar agrégé | 5 s | 1 s (POST energy-manager) |
+| Température | 60 s | push MQTT |
+| Heatpump | 10 s | push MQTT |
+| ATS | 5 s | 2 s (RS485) |
+| Tasmota | 10 s | push MQTT |
+| Shelly | 10 s | push MQTT |


### PR DESCRIPTION
- vm_client.rs: 6 nouvelles fonctions row builder (mppt_rows, temperature_rows, heatpump_rows, ats_rows, tasmota_rows, shelly_rows); inverter_rows enrichi (freq + ac_in_ignore); fix timestamp ms (suppression /1000); ajout Content-Type: text/plain sur write_rows; imports AtsSnapshot, TasmotaSnapshot, ShellyEmSnapshot, VenusMppt, VenusTemperature, VenusHeatpump
- state.rs: 6 nouveaux timers AtomicU64 (mppt, temp, heat, ats, tasmota, shelly); VM writes ajoutés dans on_venus_mppt (10s), on_venus_mppts_replace (10s), on_venus_temperature (60s), on_venus_heatpump (10s), on_ats_snapshot (5s), on_tasmota_snapshot (10s), on_shelly_snapshot (10s)
- docs/victoriametrics-queries.md: référence complète avec toutes les métriques, labels et exemples PromQL pour les 12 catégories d'appareils

https://claude.ai/code/session_01LMa5KdjDwzG84AYzTeT1m6