### PR TITLE
feat(alerts): étendre AlertEngine — for: duration, SmartShunt, pack O…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -414,9 +414,9 @@ timeout_secs = 10
 
 
 [alerts]
-# Chemin de la base SQLite pour journal des alertes
-# Laisser vide pour désactiver les alertes (pas de base SQLite requise)
-db_path = ""
+# Chemin de la base SQLite pour journal des alertes.
+# Laisser vide pour désactiver complètement les alertes.
+db_path = "/var/lib/daly-bms/alerts.db"
 
 # Intervalle d'évaluation des règles (secondes)
 check_interval_sec = 1.0
@@ -433,15 +433,25 @@ smtp_password = ""
 smtp_from = "dalybms@santuario.local"
 smtp_to = "admin@santuario.local"
 
+# Durées minimales "for:" avant déclenchement (secondes).
+# 0 = déclencher immédiatement (comportement legacy).
+soc_critical_for_secs = 180   # 3 minutes
+soc_low_for_secs      = 300   # 5 minutes
+temp_high_for_secs    = 180   # 3 minutes
+current_high_for_secs = 120   # 2 minutes
+voltage_for_secs      = 60    # 1 minute
+
 # Seuils d'alertes logicielles (indépendants des seuils hardware BMS)
 [alerts.thresholds]
-cell_ovp_v          = 3.60
-cell_uvp_v          = 2.90
-cell_delta_mv       = 100
-soc_low_percent     = 20.0
-soc_critical_percent= 10.0
-temp_high_c         = 45.0
-current_high_a      = 80.0
+cell_ovp_v           = 3.60
+cell_uvp_v           = 2.90
+cell_delta_mv        = 100
+soc_low_percent      = 20.0
+soc_critical_percent = 15.0   # SOC critique ESS (était 10, aligné avec vmalert plan)
+temp_high_c          = 45.0
+current_high_a       = 100.0  # Courant décharge max via SmartShunt (était 80A BMS seul)
+pack_ovp_v           = 57.0   # Tension pack trop haute (V)
+pack_uvp_v           = 44.0   # Tension pack trop basse (V)
 
 
 [read_only]

--- a/crates/daly-bms-server/src/api/alerts.rs
+++ b/crates/daly-bms-server/src/api/alerts.rs
@@ -1,0 +1,106 @@
+//! Endpoints REST pour le journal d'alertes (lecture depuis SQLite via AlertEngine).
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use tokio::task::spawn_blocking;
+
+use crate::state::AppState;
+use crate::bridges::alerts::{AlertEventRow, AlertStats};
+
+// =============================================================================
+// Types de réponse
+// =============================================================================
+
+#[derive(Serialize)]
+pub struct AlertListResponse {
+    pub total:  i64,
+    pub events: Vec<AlertEventRow>,
+}
+
+// =============================================================================
+// Paramètres de requête
+// =============================================================================
+
+#[derive(Deserialize)]
+pub struct AlertListQuery {
+    /// Nombre max d'événements (défaut 100, max 500).
+    limit:    Option<usize>,
+    /// Décalage pour la pagination.
+    offset:   Option<usize>,
+    /// Filtrer par sévérité : "critical" | "warning".
+    severity: Option<String>,
+    /// Si `true`, ne retourner que les événements "triggered" (non effacés).
+    active:   Option<bool>,
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+/// Liste les événements d'alerte avec pagination et filtres optionnels.
+///
+/// `GET /api/v1/alerts/list?limit=50&offset=0&severity=critical&active=true`
+pub async fn list_alerts(
+    State(state): State<AppState>,
+    Query(q): Query<AlertListQuery>,
+) -> Result<Json<AlertListResponse>, StatusCode> {
+    let engine = state.alert_engine.as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?
+        .clone();
+
+    let limit      = q.limit.unwrap_or(100).min(500);
+    let offset     = q.offset.unwrap_or(0);
+    let only_active = q.active.unwrap_or(false);
+    let severity   = q.severity;
+
+    let result = spawn_blocking(move || {
+        engine.query_events(limit, offset, only_active, severity)
+    })
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let (total, events) = result;
+    Ok(Json(AlertListResponse { total, events }))
+}
+
+/// Retourne les compteurs agrégés.
+///
+/// `GET /api/v1/alerts/stats`
+pub async fn get_stats(
+    State(state): State<AppState>,
+) -> Result<Json<AlertStats>, StatusCode> {
+    let engine = state.alert_engine.as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?
+        .clone();
+
+    let stats = spawn_blocking(move || engine.count_stats())
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(stats))
+}
+
+/// Acquitte une alerte par son ID.
+///
+/// `POST /api/v1/alerts/:id/acknowledge`
+pub async fn acknowledge_alert(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<StatusCode, StatusCode> {
+    let engine = state.alert_engine.as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?
+        .clone();
+
+    let found = spawn_blocking(move || engine.acknowledge(id))
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if found { Ok(StatusCode::OK) } else { Err(StatusCode::NOT_FOUND) }
+}

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -5,6 +5,7 @@
 pub mod system;
 pub mod bms;
 pub mod ats;
+pub mod alerts;
 pub mod console;
 pub mod et112;
 pub mod tasmota;
@@ -116,6 +117,11 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/query",          get(promql::query_instant))
         .route("/api/v1/query_range",    get(promql::query_range))
         .route("/api/v1/labels",         get(promql::list_metrics))
+
+        // ── Alertes (journal SQLite) ──────────────────────────────────────────
+        .route("/api/v1/alerts/list",              get(alerts::list_alerts))
+        .route("/api/v1/alerts/stats",             get(alerts::get_stats))
+        .route("/api/v1/alerts/:id/acknowledge",   post(alerts::acknowledge_alert))
 
         // ── Health check ──────────────────────────────────────────────────────
         .route("/health",                get(health::health_check))

--- a/crates/daly-bms-server/src/bridges/alerts.rs
+++ b/crates/daly-bms-server/src/bridges/alerts.rs
@@ -1,20 +1,54 @@
-//! Moteur d'alertes avec hysteresis, journal SQLite, notifications Telegram/SMTP.
+//! Moteur d'alertes avec hysteresis, durée minimale ("for:"), journal SQLite,
+//! notifications Telegram/SMTP.
 //!
 //! ## Architecture
 //!
 //! - [`AlertEngine`] évalue chaque snapshot contre les règles configurées.
 //! - Chaque règle a un seuil de déclenchement et un seuil d'effacement (hysteresis).
-//! - Les événements sont journalisés dans SQLite.
-//! - Les notifications sont envoyées par Telegram et/ou SMTP avec cooldown.
+//! - `min_duration` : la condition doit rester vraie pendant X secondes avant de déclencher.
+//! - Les événements sont journalisés dans SQLite (table `alert_events`).
+//! - Les notifications sont envoyées par Telegram avec cooldown.
+//! - Les méthodes `query_events`, `count_stats`, `acknowledge` permettent l'accès API.
 
 use crate::config::AlertsConfig;
 use crate::state::AppState;
 use daly_bms_core::types::BmsSnapshot;
 use rusqlite::{Connection, params};
+use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tracing::{error, info, warn};
+
+// =============================================================================
+// Types publics pour l'API REST
+// =============================================================================
+
+/// Un événement d'alerte journalisé dans SQLite.
+#[derive(Debug, Clone, Serialize)]
+pub struct AlertEventRow {
+    pub id:              i64,
+    pub bms_address:     u8,
+    pub rule_id:         String,
+    pub description:     String,
+    pub severity:        String,
+    pub event:           String,
+    pub value:           f64,
+    pub timestamp:       String,
+    pub acknowledged:    bool,
+    pub acknowledged_at: Option<String>,
+}
+
+/// Compteurs agrégés pour le dashboard.
+#[derive(Debug, Clone, Serialize)]
+pub struct AlertStats {
+    pub total:           i64,
+    pub triggered:       i64,
+    pub cleared:         i64,
+    pub critical:        i64,
+    pub warning:         i64,
+    pub unacknowledged:  i64,
+}
 
 // =============================================================================
 // Règles d'alerte
@@ -28,41 +62,54 @@ pub enum Severity {
 }
 
 impl Severity {
-    #[allow(dead_code)]
-    fn icon(&self) -> &'static str {
+    fn as_str(&self) -> &'static str {
         match self {
-            Self::Warning  => "⚠️",
-            Self::Critical => "🔴",
+            Self::Warning  => "warning",
+            Self::Critical => "critical",
         }
     }
 }
 
-/// État d'une règle pour un BMS donné.
+/// État d'une règle pour une clé (adresse BMS, rule_id).
 #[derive(Debug, Clone)]
 struct RuleState {
-    active: bool,
-    last_notified: Option<Instant>,
+    /// Règle actuellement déclenchée (notification envoyée).
+    active:         bool,
+    /// Dernière notification envoyée (pour cooldown).
+    last_notified:  Option<Instant>,
+    /// Instant où la condition a commencé à être vraie (pour `min_duration`).
+    pending_since:  Option<Instant>,
 }
 
 impl Default for RuleState {
-    fn default() -> Self { Self { active: false, last_notified: None } }
+    fn default() -> Self {
+        Self {
+            active:        false,
+            last_notified: None,
+            pending_since: None,
+        }
+    }
 }
 
-/// Contexte d'évaluation d'une règle.
+/// Contexte d'évaluation passé à chaque règle.
 pub struct AlertContext<'a> {
-    pub snap: &'a BmsSnapshot,
-    pub cfg:  &'a AlertsConfig,
+    pub snap:             &'a BmsSnapshot,
+    pub cfg:              &'a AlertsConfig,
+    /// Courant SmartShunt (A) — positif = charge, négatif = décharge.
+    pub shunt_current_a:  Option<f32>,
 }
 
 /// Définition d'une règle d'alerte.
 pub struct AlertRule {
-    pub id:          &'static str,
-    pub description: &'static str,
-    #[allow(dead_code)]
-    pub severity:    Severity,
-    pub cooldown:    Duration,
-    pub trigger:     Box<dyn Fn(&AlertContext) -> Option<f32> + Send + Sync>,
-    pub clear:       Box<dyn Fn(&AlertContext) -> bool + Send + Sync>,
+    pub id:           &'static str,
+    pub description:  &'static str,
+    pub severity:     Severity,
+    pub cooldown:     Duration,
+    /// Durée minimale pendant laquelle la condition doit rester vraie avant de déclencher.
+    /// `None` = déclencher immédiatement (comportement legacy).
+    pub min_duration: Option<Duration>,
+    pub trigger:      Box<dyn Fn(&AlertContext) -> Option<f32> + Send + Sync>,
+    pub clear:        Box<dyn Fn(&AlertContext) -> bool + Send + Sync>,
 }
 
 // =============================================================================
@@ -73,7 +120,7 @@ pub struct AlertEngine {
     rules:  Vec<AlertRule>,
     states: Mutex<HashMap<(u8, &'static str), RuleState>>,
     db:     Mutex<Connection>,
-    cfg:    AlertsConfig,
+    pub cfg: AlertsConfig,
 }
 
 impl AlertEngine {
@@ -83,7 +130,7 @@ impl AlertEngine {
         init_db(&db)?;
 
         let engine = Arc::new(Self {
-            rules:  build_rules(),
+            rules:  build_rules(&cfg),
             states: Mutex::new(HashMap::new()),
             db:     Mutex::new(db),
             cfg,
@@ -93,47 +140,71 @@ impl AlertEngine {
 
     /// Évalue toutes les règles sur un snapshot et envoie les notifications.
     ///
-    /// Le Mutex est relâché avant chaque appel async (pas de MutexGuard across await).
-    pub async fn evaluate(&self, snap: &BmsSnapshot) {
-        let ctx = AlertContext { snap, cfg: &self.cfg };
+    /// `shunt_current_a` : courant SmartShunt courant (None si non disponible).
+    pub async fn evaluate(&self, snap: &BmsSnapshot, shunt_current_a: Option<f32>) {
+        let ctx = AlertContext { snap, cfg: &self.cfg, shunt_current_a };
 
-        // Collecter les actions à effectuer (sans tenir le lock pendant les await)
-        let mut notifications: Vec<(u8, &'static str, &'static str, f32, bool)> = Vec::new();
+        // Collecter les actions (sans tenir le Mutex pendant les await)
+        let mut notifications: Vec<(u8, &'static str, &'static str, &'static str, f32, bool)> = Vec::new();
 
         {
             let mut states = self.states.lock().unwrap();
             for rule in &self.rules {
-                let key = (snap.address, rule.id);
+                let key   = (snap.address, rule.id);
                 let state = states.entry(key).or_default();
 
                 if !state.active {
                     if let Some(value) = (rule.trigger)(&ctx) {
-                        state.active = true;
-                        let should_notify = state.last_notified
-                            .map(|t| t.elapsed() >= rule.cooldown)
-                            .unwrap_or(true);
-                        if should_notify {
-                            state.last_notified = Some(Instant::now());
-                            notifications.push((snap.address, rule.id, rule.description, value, true));
+                        if let Some(min_dur) = rule.min_duration {
+                            // Condition vraie — démarrer ou continuer le timer pending
+                            let ps = state.pending_since.get_or_insert_with(Instant::now);
+                            if ps.elapsed() >= min_dur {
+                                // Durée atteinte → déclencher
+                                state.active        = true;
+                                state.pending_since = None;
+                                let should_notify = state.last_notified
+                                    .map(|t| t.elapsed() >= rule.cooldown)
+                                    .unwrap_or(true);
+                                if should_notify {
+                                    state.last_notified = Some(Instant::now());
+                                    notifications.push((snap.address, rule.id, rule.description, rule.severity.as_str(), value, true));
+                                }
+                            }
+                            // Sinon : toujours en attente, pas encore déclenché
+                        } else {
+                            // Pas de durée minimale → déclencher immédiatement
+                            state.active        = true;
+                            state.pending_since = None;
+                            let should_notify = state.last_notified
+                                .map(|t| t.elapsed() >= rule.cooldown)
+                                .unwrap_or(true);
+                            if should_notify {
+                                state.last_notified = Some(Instant::now());
+                                notifications.push((snap.address, rule.id, rule.description, rule.severity.as_str(), value, true));
+                            }
                         }
+                    } else {
+                        // Condition non vraie → réinitialiser le timer pending
+                        state.pending_since = None;
                     }
                 } else if (rule.clear)(&ctx) {
-                    state.active = false;
-                    notifications.push((snap.address, rule.id, rule.description, 0.0, false));
+                    state.active        = false;
+                    state.pending_since = None;
+                    notifications.push((snap.address, rule.id, rule.description, rule.severity.as_str(), 0.0, false));
                 }
             }
         } // Mutex relâché ici
 
-        // Envoyer les notifications hors du lock
-        for (addr, rule_id, description, value, triggered) in notifications {
+        // Envoyer notifications hors du lock
+        for (addr, rule_id, description, severity, value, triggered) in notifications {
             let event = if triggered { "triggered" } else { "cleared" };
-            self.log_event(addr, rule_id, event, value);
+            self.log_event(addr, rule_id, description, severity, event, value);
 
-            let icon = if triggered { "🔴" } else { "✅" };
+            let icon   = if triggered { "🔴" } else { "✅" };
             let action = if triggered { "DÉCLENCHÉE" } else { "EFFACÉE" };
             let msg = format!(
-                "{} Alerte {} — BMS {:#04x}\nRègle : {}\nValeur : {:.2}\nÉtat : {}",
-                icon, action, addr, description, value, action
+                "{} Alerte {} — BMS {:#04x}\nRègle : {}\nValeur : {:.2}\nSévérité : {}",
+                icon, action, addr, description, value, severity
             );
             info!("{}", msg);
             if !self.cfg.telegram_token.is_empty() && !self.cfg.telegram_chat_id.is_empty() {
@@ -144,14 +215,106 @@ impl AlertEngine {
         }
     }
 
-    fn log_event(&self, addr: u8, rule_id: &str, event: &str, value: f32) {
+    fn log_event(&self, addr: u8, rule_id: &str, description: &str, severity: &str, event: &str, value: f32) {
         if let Ok(db) = self.db.lock() {
             let _ = db.execute(
-                "INSERT INTO alert_events (bms_address, rule_id, event, value, timestamp) \
-                 VALUES (?1, ?2, ?3, ?4, datetime('now'))",
-                params![addr, rule_id, event, value],
+                "INSERT INTO alert_events \
+                 (bms_address, rule_id, description, severity, event, value, timestamp) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))",
+                params![addr, rule_id, description, severity, event, value],
             );
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Méthodes publiques pour l'API REST
+    // -------------------------------------------------------------------------
+
+    /// Liste les événements avec pagination et filtres optionnels.
+    /// Retourne (total_count, events).
+    pub fn query_events(
+        &self,
+        limit:         usize,
+        offset:        usize,
+        only_active:   bool,
+        severity_filter: Option<String>,
+    ) -> rusqlite::Result<(i64, Vec<AlertEventRow>)> {
+        let db = self.db.lock().unwrap();
+
+        let mut where_parts: Vec<String> = Vec::new();
+        if only_active {
+            where_parts.push("event = 'triggered'".to_string());
+        }
+        if let Some(ref sev) = severity_filter {
+            where_parts.push(format!("severity = '{}'", sev.replace('\'', "''")));
+        }
+        let where_clause = if where_parts.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", where_parts.join(" AND "))
+        };
+
+        let count: i64 = db.query_row(
+            &format!("SELECT COUNT(*) FROM alert_events {}", where_clause),
+            [],
+            |r| r.get(0),
+        )?;
+
+        let mut stmt = db.prepare(&format!(
+            "SELECT id, bms_address, rule_id, description, severity, event, value, \
+                    timestamp, acknowledged, acknowledged_at \
+             FROM alert_events {} \
+             ORDER BY timestamp DESC \
+             LIMIT {} OFFSET {}",
+            where_clause, limit, offset
+        ))?;
+
+        let rows = stmt.query_map([], |row| {
+            Ok(AlertEventRow {
+                id:              row.get(0)?,
+                bms_address:     row.get::<_, i64>(1)? as u8,
+                rule_id:         row.get(2)?,
+                description:     row.get(3)?,
+                severity:        row.get(4)?,
+                event:           row.get(5)?,
+                value:           row.get(6)?,
+                timestamp:       row.get(7)?,
+                acknowledged:    row.get::<_, i64>(8)? != 0,
+                acknowledged_at: row.get(9)?,
+            })
+        })?.collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok((count, rows))
+    }
+
+    /// Compteurs agrégés pour le dashboard.
+    pub fn count_stats(&self) -> rusqlite::Result<AlertStats> {
+        let db = self.db.lock().unwrap();
+
+        let q = |sql: &str| -> rusqlite::Result<i64> {
+            db.query_row(sql, [], |r| r.get(0))
+        };
+
+        Ok(AlertStats {
+            total:          q("SELECT COUNT(*) FROM alert_events")?,
+            triggered:      q("SELECT COUNT(*) FROM alert_events WHERE event = 'triggered'")?,
+            cleared:        q("SELECT COUNT(*) FROM alert_events WHERE event = 'cleared'")?,
+            critical:       q("SELECT COUNT(*) FROM alert_events WHERE severity = 'critical'")?,
+            warning:        q("SELECT COUNT(*) FROM alert_events WHERE severity = 'warning'")?,
+            unacknowledged: q("SELECT COUNT(*) FROM alert_events WHERE acknowledged = 0 AND event = 'triggered'")?,
+        })
+    }
+
+    /// Marque une alerte comme acquittée. Retourne `true` si l'enregistrement existe.
+    pub fn acknowledge(&self, id: i64) -> rusqlite::Result<bool> {
+        let db = self.db.lock().unwrap();
+        let n = db.execute(
+            "UPDATE alert_events \
+             SET acknowledged = 1, acknowledged_at = datetime('now') \
+             WHERE id = ?1",
+            [id],
+        )?;
+        Ok(n > 0)
     }
 }
 
@@ -159,26 +322,35 @@ impl AlertEngine {
 // Règles par défaut
 // =============================================================================
 
-fn build_rules() -> Vec<AlertRule> {
+fn dur_opt(secs: u64) -> Option<Duration> {
+    if secs > 0 { Some(Duration::from_secs(secs)) } else { None }
+}
+
+fn build_rules(cfg: &AlertsConfig) -> Vec<AlertRule> {
+    let t = cfg.thresholds.clone();
+
     vec![
+        // ── Règles cellule BMS ────────────────────────────────────────────────
         AlertRule {
-            id: "cell_ovp",
-            description: "Sur-tension cellule",
-            severity: Severity::Critical,
-            cooldown: Duration::from_secs(300),
-            trigger: Box::new(|ctx| {
+            id:           "cell_ovp",
+            description:  "Sur-tension cellule",
+            severity:     Severity::Critical,
+            cooldown:     Duration::from_secs(300),
+            min_duration: None,
+            trigger: Box::new(move |ctx| {
                 let v = ctx.snap.system.max_cell_voltage;
                 if v > ctx.cfg.thresholds.cell_ovp_v { Some(v) } else { None }
             }),
-            clear: Box::new(|ctx| {
-                ctx.snap.system.max_cell_voltage < ctx.cfg.thresholds.cell_ovp_v - 0.05
+            clear: Box::new(move |ctx| {
+                ctx.snap.system.max_cell_voltage < t.cell_ovp_v - 0.05
             }),
         },
         AlertRule {
-            id: "cell_uvp",
-            description: "Sous-tension cellule",
-            severity: Severity::Critical,
-            cooldown: Duration::from_secs(300),
+            id:           "cell_uvp",
+            description:  "Sous-tension cellule",
+            severity:     Severity::Critical,
+            cooldown:     Duration::from_secs(300),
+            min_duration: None,
             trigger: Box::new(|ctx| {
                 let v = ctx.snap.system.min_cell_voltage;
                 if v < ctx.cfg.thresholds.cell_uvp_v { Some(v) } else { None }
@@ -188,10 +360,11 @@ fn build_rules() -> Vec<AlertRule> {
             }),
         },
         AlertRule {
-            id: "cell_imbalance",
-            description: "Déséquilibre cellules",
-            severity: Severity::Warning,
-            cooldown: Duration::from_secs(600),
+            id:           "cell_imbalance",
+            description:  "Déséquilibre cellules",
+            severity:     Severity::Warning,
+            cooldown:     Duration::from_secs(600),
+            min_duration: None,
             trigger: Box::new(|ctx| {
                 let d = ctx.snap.system.cell_delta_mv();
                 if d > ctx.cfg.thresholds.cell_delta_mv { Some(d) } else { None }
@@ -200,11 +373,14 @@ fn build_rules() -> Vec<AlertRule> {
                 ctx.snap.system.cell_delta_mv() < ctx.cfg.thresholds.cell_delta_mv - 10.0
             }),
         },
+
+        // ── Règles ESS niveau pack ────────────────────────────────────────────
         AlertRule {
-            id: "soc_low",
-            description: "SOC bas",
-            severity: Severity::Warning,
-            cooldown: Duration::from_secs(900),
+            id:           "soc_low",
+            description:  "SOC bas",
+            severity:     Severity::Warning,
+            cooldown:     Duration::from_secs(900),
+            min_duration: dur_opt(cfg.soc_low_for_secs),
             trigger: Box::new(|ctx| {
                 let s = ctx.snap.soc;
                 if s < ctx.cfg.thresholds.soc_low_percent { Some(s) } else { None }
@@ -214,10 +390,11 @@ fn build_rules() -> Vec<AlertRule> {
             }),
         },
         AlertRule {
-            id: "soc_critical",
-            description: "SOC critique",
-            severity: Severity::Critical,
-            cooldown: Duration::from_secs(300),
+            id:           "soc_critical",
+            description:  "SOC critique",
+            severity:     Severity::Critical,
+            cooldown:     Duration::from_secs(300),
+            min_duration: dur_opt(cfg.soc_critical_for_secs),
             trigger: Box::new(|ctx| {
                 let s = ctx.snap.soc;
                 if s < ctx.cfg.thresholds.soc_critical_percent { Some(s) } else { None }
@@ -227,10 +404,11 @@ fn build_rules() -> Vec<AlertRule> {
             }),
         },
         AlertRule {
-            id: "temp_high",
-            description: "Sur-température",
-            severity: Severity::Critical,
-            cooldown: Duration::from_secs(300),
+            id:           "temp_high",
+            description:  "Sur-température batterie",
+            severity:     Severity::Critical,
+            cooldown:     Duration::from_secs(300),
+            min_duration: dur_opt(cfg.temp_high_for_secs),
             trigger: Box::new(|ctx| {
                 let t = ctx.snap.system.max_cell_temperature;
                 if t > ctx.cfg.thresholds.temp_high_c { Some(t) } else { None }
@@ -240,16 +418,51 @@ fn build_rules() -> Vec<AlertRule> {
             }),
         },
         AlertRule {
-            id: "high_current",
-            description: "Sur-courant",
-            severity: Severity::Warning,
-            cooldown: Duration::from_secs(60),
+            id:           "high_current",
+            description:  "Sur-courant décharge",
+            severity:     Severity::Warning,
+            cooldown:     Duration::from_secs(60),
+            min_duration: dur_opt(cfg.current_high_for_secs),
             trigger: Box::new(|ctx| {
-                let c = ctx.snap.dc.current.abs();
+                // Priorité SmartShunt ; fallback courant BMS
+                let c = ctx.shunt_current_a
+                    .map(|v| v.abs())
+                    .unwrap_or_else(|| ctx.snap.dc.current.abs());
                 if c > ctx.cfg.thresholds.current_high_a { Some(c) } else { None }
             }),
             clear: Box::new(|ctx| {
-                ctx.snap.dc.current.abs() < ctx.cfg.thresholds.current_high_a - 5.0
+                let c = ctx.shunt_current_a
+                    .map(|v| v.abs())
+                    .unwrap_or_else(|| ctx.snap.dc.current.abs());
+                c < ctx.cfg.thresholds.current_high_a - 5.0
+            }),
+        },
+        AlertRule {
+            id:           "pack_ovp",
+            description:  "Tension pack trop haute",
+            severity:     Severity::Critical,
+            cooldown:     Duration::from_secs(300),
+            min_duration: dur_opt(cfg.voltage_for_secs),
+            trigger: Box::new(|ctx| {
+                let v = ctx.snap.dc.voltage;
+                if v > ctx.cfg.thresholds.pack_ovp_v { Some(v) } else { None }
+            }),
+            clear: Box::new(|ctx| {
+                ctx.snap.dc.voltage < ctx.cfg.thresholds.pack_ovp_v - 0.5
+            }),
+        },
+        AlertRule {
+            id:           "pack_uvp",
+            description:  "Tension pack trop basse",
+            severity:     Severity::Critical,
+            cooldown:     Duration::from_secs(300),
+            min_duration: dur_opt(cfg.voltage_for_secs),
+            trigger: Box::new(|ctx| {
+                let v = ctx.snap.dc.voltage;
+                if v < ctx.cfg.thresholds.pack_uvp_v { Some(v) } else { None }
+            }),
+            clear: Box::new(|ctx| {
+                ctx.snap.dc.voltage > ctx.cfg.thresholds.pack_uvp_v + 0.5
             }),
         },
     ]
@@ -265,8 +478,8 @@ async fn send_telegram(token: &str, chat_id: &str, message: &str) -> anyhow::Res
     client
         .post(&url)
         .json(&serde_json::json!({
-            "chat_id": chat_id,
-            "text":    message,
+            "chat_id":    chat_id,
+            "text":       message,
             "parse_mode": "HTML",
         }))
         .send()
@@ -282,47 +495,55 @@ async fn send_telegram(token: &str, chat_id: &str, message: &str) -> anyhow::Res
 fn init_db(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch("
         CREATE TABLE IF NOT EXISTS alert_events (
-            id          INTEGER PRIMARY KEY AUTOINCREMENT,
-            bms_address INTEGER NOT NULL,
-            rule_id     TEXT NOT NULL,
-            event       TEXT NOT NULL,
-            value       REAL NOT NULL,
-            timestamp   TEXT NOT NULL
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            bms_address     INTEGER NOT NULL,
+            rule_id         TEXT    NOT NULL,
+            description     TEXT    NOT NULL DEFAULT '',
+            severity        TEXT    NOT NULL DEFAULT 'warning',
+            event           TEXT    NOT NULL,
+            value           REAL    NOT NULL,
+            timestamp       TEXT    NOT NULL,
+            acknowledged    INTEGER NOT NULL DEFAULT 0,
+            acknowledged_at TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_alert_ts
             ON alert_events(timestamp);
         CREATE INDEX IF NOT EXISTS idx_alert_bms_rule
             ON alert_events(bms_address, rule_id);
-    ")
+        CREATE INDEX IF NOT EXISTS idx_alert_event
+            ON alert_events(event);
+        CREATE INDEX IF NOT EXISTS idx_alert_ack
+            ON alert_events(acknowledged);
+    ")?;
+
+    // Migration pour les bases existantes (ADD COLUMN échoue silencieusement si déjà là)
+    let _ = conn.execute("ALTER TABLE alert_events ADD COLUMN description TEXT NOT NULL DEFAULT ''", []);
+    let _ = conn.execute("ALTER TABLE alert_events ADD COLUMN severity TEXT NOT NULL DEFAULT 'warning'", []);
+    let _ = conn.execute("ALTER TABLE alert_events ADD COLUMN acknowledged INTEGER NOT NULL DEFAULT 0", []);
+    let _ = conn.execute("ALTER TABLE alert_events ADD COLUMN acknowledged_at TEXT", []);
+
+    Ok(())
 }
 
 // =============================================================================
 // Tâche principale
 // =============================================================================
 
-/// Démarre le moteur d'alertes en arrière-plan.
-pub async fn run_alert_engine(state: AppState, cfg: AlertsConfig) {
-    if cfg.db_path.is_empty() {
-        info!("AlertEngine : db_path vide, alertes désactivées");
-        return;
-    }
-
-    let engine = match AlertEngine::new(cfg.clone()) {
-        Ok(e) => e,
-        Err(e) => {
-            error!("AlertEngine init erreur : {:?}", e);
-            return;
-        }
-    };
-
-    info!(db = %cfg.db_path, "AlertEngine démarré");
+/// Démarre la boucle d'évaluation en arrière-plan.
+/// Accepte un `Arc<AlertEngine>` déjà créé (partagé avec l'API REST via AppState).
+pub async fn run_alert_engine(state: AppState, engine: Arc<AlertEngine>) {
+    info!(db = %engine.cfg.db_path, "AlertEngine démarré");
 
     let mut rx = state.subscribe_ws();
     loop {
         match rx.recv().await {
             Ok(snaps) => {
+                // Lire le courant SmartShunt une seule fois pour tous les BMS
+                let shunt_current_a = state.venus_smartshunt_get().await
+                    .and_then(|s| s.current_a);
+
                 for snap in snaps.iter() {
-                    engine.evaluate(snap).await;
+                    engine.evaluate(snap, shunt_current_a).await;
                 }
             }
             Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -448,6 +448,17 @@ pub struct AlertsConfig {
     pub smtp_to: String,
     #[serde(default)]
     pub thresholds: AlertThresholds,
+    /// Durée minimale avant déclenchement (secondes). 0 = immédiat (comportement legacy).
+    #[serde(default)]
+    pub soc_critical_for_secs: u64,
+    #[serde(default)]
+    pub soc_low_for_secs: u64,
+    #[serde(default)]
+    pub temp_high_for_secs: u64,
+    #[serde(default)]
+    pub current_high_for_secs: u64,
+    #[serde(default)]
+    pub voltage_for_secs: u64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -459,6 +470,12 @@ pub struct AlertThresholds {
     pub soc_critical_percent: f32,
     pub temp_high_c: f32,
     pub current_high_a: f32,
+    /// Tension de pack trop haute (V) — règle ESS pack_ovp.
+    #[serde(default = "default_pack_ovp_v")]
+    pub pack_ovp_v: f32,
+    /// Tension de pack trop basse (V) — règle ESS pack_uvp.
+    #[serde(default = "default_pack_uvp_v")]
+    pub pack_uvp_v: f32,
 }
 
 // Seuils d'alerte par défaut — valeurs de production (voir CLAUDE.md §5).
@@ -470,6 +487,11 @@ const DEFAULT_SOC_LOW_PERCENT:      f32 = 20.0;
 const DEFAULT_SOC_CRITICAL_PERCENT: f32 = 10.0;
 const DEFAULT_TEMP_HIGH_C:          f32 = 45.0;
 const DEFAULT_CURRENT_HIGH_A:       f32 = 80.0;
+const DEFAULT_PACK_OVP_V:           f32 = 57.0;
+const DEFAULT_PACK_UVP_V:           f32 = 44.0;
+
+fn default_pack_ovp_v() -> f32 { DEFAULT_PACK_OVP_V }
+fn default_pack_uvp_v() -> f32 { DEFAULT_PACK_UVP_V }
 
 impl Default for AlertThresholds {
     fn default() -> Self {
@@ -481,6 +503,8 @@ impl Default for AlertThresholds {
             soc_critical_percent:  DEFAULT_SOC_CRITICAL_PERCENT,
             temp_high_c:           DEFAULT_TEMP_HIGH_C,
             current_high_a:        DEFAULT_CURRENT_HIGH_A,
+            pack_ovp_v:            DEFAULT_PACK_OVP_V,
+            pack_uvp_v:            DEFAULT_PACK_UVP_V,
         }
     }
 }
@@ -668,6 +692,8 @@ mod tests {
         assert_eq!(t.soc_critical_percent, 10.0);
         assert_eq!(t.temp_high_c, 45.0);
         assert_eq!(t.current_high_a, 80.0);
+        assert_eq!(t.pack_ovp_v, 57.0);
+        assert_eq!(t.pack_uvp_v, 44.0);
     }
 }
 

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -787,6 +787,22 @@ pub async fn dashboard_history() -> Response {
     render(HistoryTemplate {})
 }
 
+// =============================================================================
+// Dashboard Alertes
+// =============================================================================
+
+#[derive(Template)]
+#[template(path = "alerts.html")]
+struct AlertsTemplate {
+    alerts_enabled: bool,
+}
+
+/// Page journal des alertes.
+pub async fn dashboard_alerts(State(state): State<AppState>) -> Response {
+    let alerts_enabled = state.alert_engine.is_some();
+    render(AlertsTemplate { alerts_enabled })
+}
+
 /// Construit le routeur du dashboard (à fusionner dans le routeur principal).
 pub fn build_dashboard_router() -> Router<AppState> {
     Router::new()
@@ -805,4 +821,5 @@ pub fn build_dashboard_router() -> Router<AppState> {
         .route("/dashboard/visualization",     get(dashboard_visualization))
         .route("/visualization",               get(dashboard_visualization))
         .route("/dashboard/history",           get(dashboard_history))
+        .route("/dashboard/alerts",            get(dashboard_alerts))
 }

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -273,6 +273,27 @@ async fn main() -> anyhow::Result<()> {
         "DalyBMS Server démarrage"
     );
 
+    // ── AlertEngine (SQLite + règles ESS) ─────────────────────────────────────
+    let alert_engine = if !config.alerts.db_path.is_empty() {
+        // Créer le répertoire parent si nécessaire
+        if let Some(parent) = std::path::Path::new(&config.alerts.db_path).parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match alerts::AlertEngine::new(config.alerts.clone()) {
+            Ok(e) => {
+                info!(db = %config.alerts.db_path, "AlertEngine initialisé");
+                Some(e)
+            }
+            Err(e) => {
+                warn!("AlertEngine init échoué : {} — alertes désactivées", e);
+                None
+            }
+        }
+    } else {
+        info!("AlertEngine désactivé (alerts.db_path vide)");
+        None
+    };
+
     // ── VictoriaMetrics (client HTTP stockage time-series) ────────────────────
     let vm_handle = if config.victoriametrics.enabled {
         match vm_client::VmClient::new(&config.victoriametrics) {
@@ -291,7 +312,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // ── État partagé ───────────────────────────────────────────────────────────
-    let state = AppState::new(config.clone(), log_buffer, vm_handle);
+    let state = AppState::new(config.clone(), log_buffer, vm_handle, alert_engine.clone());
 
     // ── Bridges en arrière-plan ─────────────────────────────────────────────────
 
@@ -311,10 +332,12 @@ async fn main() -> anyhow::Result<()> {
         let (s, c, m) = (state.clone(), config.mqtt.clone(), mqtt_addr_map);
         async move { mqtt::run_mqtt_bridge(s, c, m).await }
     });
-    tokio::spawn({
-        let (s, c) = (state.clone(), config.alerts.clone());
-        async move { alerts::run_alert_engine(s, c).await }
-    });
+    if let Some(ref engine) = alert_engine {
+        tokio::spawn({
+            let (s, e) = (state.clone(), engine.clone());
+            async move { alerts::run_alert_engine(s, e).await }
+        });
+    }
 
     // ── Venus OS MQTT subscriber (données D-Bus) ───────────────────────────────
     if config.mqtt.enabled {

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -4,6 +4,7 @@
 //! et les handlers Axum.
 
 use crate::ats::AtsSnapshot;
+use crate::bridges::alerts::AlertEngine;
 use crate::config::AppConfig;
 use crate::console::{ConsoleBus, ConsoleEvent, EventDevice};
 use crate::et112::Et112Snapshot;
@@ -436,6 +437,9 @@ pub struct AppState {
     /// Client MQTT Shelly (pour les commandes de contrôle Switch.Set).
     pub shelly_client: Arc<tokio::sync::Mutex<Option<rumqttc::AsyncClient>>>,
 
+    /// Moteur d'alertes (None si alerts.db_path vide dans la config).
+    pub alert_engine: Option<Arc<AlertEngine>>,
+
     /// Client VictoriaMetrics (None si désactivé dans la config).
     pub vm: Option<Arc<VmClient>>,
 
@@ -457,7 +461,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(config: AppConfig, log_buffer: LogBuffer, vm: Option<VmClient>) -> Self {
+    pub fn new(config: AppConfig, log_buffer: LogBuffer, vm: Option<VmClient>, alert_engine: Option<Arc<AlertEngine>>) -> Self {
         let (ws_tx, _) = broadcast::channel(WS_BROADCAST_CAPACITY);
         let addresses = config.bms_addresses();
         let ring_size = config.serial.ring_buffer_size;
@@ -511,6 +515,7 @@ impl AppState {
             console_bus: ConsoleBus::new(),
             shelly_latest: Arc::new(RwLock::new(BTreeMap::new())),
             shelly_client: Arc::new(tokio::sync::Mutex::new(None)),
+            alert_engine,
             vm: vm.map(Arc::new),
             vm_last_bms_write:      Arc::new(AtomicU64::new(0)),
             vm_last_shunt_write:    Arc::new(AtomicU64::new(0)),

--- a/crates/daly-bms-server/templates/alerts.html
+++ b/crates/daly-bms-server/templates/alerts.html
@@ -1,0 +1,214 @@
+{% extends "base.html" %}
+{% block title %}Alertes — ESS Monitor{% endblock %}
+{% block page_title %}Alertes{% endblock %}
+{% block nav_alerts %}active{% endblock %}
+
+{% block content %}
+<div class="page-hdr">
+  <h1>🔔 Alertes</h1>
+  <div class="page-hdr-meta">
+    <span>Màj : <span id="alert-ts">—</span></span>
+    <span class="sep">·</span>
+    <span id="alert-status-badge" class="bms-badge" style="background:#e2e8f0;color:#64748b">Chargement…</span>
+    <button onclick="loadAlerts()" style="margin-left:0.5rem;padding:0.25rem 0.75rem;border-radius:6px;border:1px solid #cbd5e1;background:#f8fafc;cursor:pointer;font-size:0.8rem;">↻ Rafraîchir</button>
+  </div>
+</div>
+
+{% if !alerts_enabled %}
+<div class="bms-card" style="padding:2rem;text-align:center;color:#64748b;">
+  <div style="font-size:2rem;margin-bottom:0.5rem;">⚠️</div>
+  <div style="font-weight:600;margin-bottom:0.25rem;">AlertEngine désactivé</div>
+  <div style="font-size:0.85rem;">Activez <code>alerts.db_path</code> dans <code>Config.toml</code> pour utiliser le journal d'alertes.</div>
+</div>
+{% else %}
+
+<!-- Stats bar -->
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:1rem;margin-bottom:1.25rem;">
+  <div class="bms-card" style="padding:1rem;text-align:center;">
+    <div style="font-size:1.6rem;font-weight:700;color:#ef4444;" id="stat-triggered">—</div>
+    <div style="font-size:0.75rem;color:#64748b;margin-top:0.2rem;">Actives</div>
+  </div>
+  <div class="bms-card" style="padding:1rem;text-align:center;">
+    <div style="font-size:1.6rem;font-weight:700;color:#f59e0b;" id="stat-unack">—</div>
+    <div style="font-size:0.75rem;color:#64748b;margin-top:0.2rem;">Non acquittées</div>
+  </div>
+  <div class="bms-card" style="padding:1rem;text-align:center;">
+    <div style="font-size:1.6rem;font-weight:700;color:#dc2626;" id="stat-critical">—</div>
+    <div style="font-size:0.75rem;color:#64748b;margin-top:0.2rem;">Critiques (total)</div>
+  </div>
+  <div class="bms-card" style="padding:1rem;text-align:center;">
+    <div style="font-size:1.6rem;font-weight:700;color:#475569;" id="stat-total">—</div>
+    <div style="font-size:0.75rem;color:#64748b;margin-top:0.2rem;">Total journalisés</div>
+  </div>
+</div>
+
+<!-- Filtres -->
+<div class="bms-card" style="padding:0.75rem 1rem;margin-bottom:1.25rem;display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center;">
+  <label style="font-size:0.8rem;color:#64748b;font-weight:500;">Sévérité :</label>
+  <select id="filter-severity" onchange="loadAlerts()" style="padding:0.25rem 0.5rem;border-radius:6px;border:1px solid #cbd5e1;font-size:0.8rem;">
+    <option value="">Toutes</option>
+    <option value="critical">Critique</option>
+    <option value="warning">Warning</option>
+  </select>
+  <label style="font-size:0.8rem;color:#64748b;font-weight:500;">Statut :</label>
+  <select id="filter-active" onchange="loadAlerts()" style="padding:0.25rem 0.5rem;border-radius:6px;border:1px solid #cbd5e1;font-size:0.8rem;">
+    <option value="">Tous</option>
+    <option value="true">Actives seulement</option>
+  </select>
+  <button onclick="resetFilters()" style="padding:0.25rem 0.6rem;border-radius:6px;border:1px solid #cbd5e1;background:#f1f5f9;cursor:pointer;font-size:0.8rem;color:#64748b;">Réinitialiser</button>
+</div>
+
+<!-- Liste des événements -->
+<div class="bms-card">
+  <div class="bms-hdr bms-hdr-sky">
+    <div class="bms-hdr-left"><span class="bms-hdr-name">📋 Journal d'alertes</span></div>
+    <div id="alert-count-label" style="font-size:0.75rem;color:#94a3b8;margin-right:0.75rem;"></div>
+  </div>
+  <div id="alerts-list" style="padding:0.5rem;">
+    <div class="empty-state"><div class="empty-icon">⏳</div><div class="empty-title">Chargement…</div></div>
+  </div>
+  <!-- Pagination simple -->
+  <div id="pagination" style="display:none;padding:0.75rem 1rem;border-top:1px solid #e2e8f0;display:flex;gap:0.5rem;align-items:center;font-size:0.8rem;color:#64748b;">
+    <button id="btn-prev" onclick="prevPage()" style="padding:0.2rem 0.6rem;border-radius:6px;border:1px solid #cbd5e1;cursor:pointer;background:#f8fafc;">‹ Préc.</button>
+    <span id="page-info">Page 1</span>
+    <button id="btn-next" onclick="nextPage()" style="padding:0.2rem 0.6rem;border-radius:6px;border:1px solid #cbd5e1;cursor:pointer;background:#f8fafc;">Suiv. ›</button>
+  </div>
+</div>
+
+{% endif %}
+
+<script>
+const PAGE_SIZE = 50;
+let currentPage = 0;
+let totalEvents = 0;
+
+function severityColor(sev) {
+  return sev === 'critical' ? '#dc2626' : '#f59e0b';
+}
+function severityBg(sev) {
+  return sev === 'critical' ? '#fef2f2' : '#fffbeb';
+}
+function severityBorder(sev) {
+  return sev === 'critical' ? '#fca5a5' : '#fde68a';
+}
+function eventIcon(ev) {
+  return ev === 'triggered' ? '🔴' : '✅';
+}
+
+async function loadStats() {
+  try {
+    const r = await fetch('/api/v1/alerts/stats');
+    if (!r.ok) return;
+    const s = await r.json();
+    document.getElementById('stat-triggered').textContent  = s.triggered;
+    document.getElementById('stat-unack').textContent      = s.unacknowledged;
+    document.getElementById('stat-critical').textContent   = s.critical;
+    document.getElementById('stat-total').textContent      = s.total;
+
+    const badge = document.getElementById('alert-status-badge');
+    if (s.triggered > 0) {
+      badge.style.background = '#fef2f2';
+      badge.style.color      = '#dc2626';
+      badge.textContent      = s.triggered + ' alerte(s) active(s)';
+    } else {
+      badge.style.background = '#f0fdf4';
+      badge.style.color      = '#16a34a';
+      badge.textContent      = 'Aucune alerte active';
+    }
+    document.getElementById('alert-ts').textContent = new Date().toLocaleTimeString('fr-FR');
+  } catch(e) { /* silencieux */ }
+}
+
+async function loadAlerts() {
+  const severity = document.getElementById('filter-severity').value;
+  const active   = document.getElementById('filter-active').value;
+  const offset   = currentPage * PAGE_SIZE;
+
+  let url = `/api/v1/alerts/list?limit=${PAGE_SIZE}&offset=${offset}`;
+  if (severity) url += `&severity=${severity}`;
+  if (active)   url += `&active=${active}`;
+
+  const list = document.getElementById('alerts-list');
+  list.innerHTML = '<div class="empty-state"><div class="empty-icon">⏳</div><div class="empty-title">Chargement…</div></div>';
+
+  try {
+    const r = await fetch(url);
+    if (!r.ok) { list.innerHTML = '<div class="empty-state"><div class="empty-icon">❌</div><div class="empty-title">Erreur chargement</div></div>'; return; }
+    const data = await r.json();
+    totalEvents = data.total;
+
+    document.getElementById('alert-count-label').textContent = `${data.total} événement(s)`;
+    updatePagination();
+    renderAlerts(data.events);
+    loadStats();
+  } catch(e) {
+    list.innerHTML = '<div class="empty-state"><div class="empty-icon">❌</div><div class="empty-title">Erreur réseau</div></div>';
+  }
+}
+
+function renderAlerts(events) {
+  const list = document.getElementById('alerts-list');
+  if (!events || events.length === 0) {
+    list.innerHTML = '<div class="empty-state"><div class="empty-icon">✅</div><div class="empty-title">Aucun événement</div></div>';
+    return;
+  }
+
+  list.innerHTML = events.map(ev => {
+    const bg     = ev.event === 'triggered' ? severityBg(ev.severity)     : '#f8fafc';
+    const border = ev.event === 'triggered' ? severityBorder(ev.severity) : '#e2e8f0';
+    const col    = ev.event === 'triggered' ? severityColor(ev.severity)  : '#64748b';
+    const ackBtn = (ev.event === 'triggered' && !ev.acknowledged)
+      ? `<button onclick="ackAlert(${ev.id})" style="padding:0.2rem 0.6rem;border-radius:6px;border:1px solid ${border};background:white;cursor:pointer;font-size:0.75rem;color:${col};white-space:nowrap;">Acquitter</button>`
+      : (ev.acknowledged ? '<span style="font-size:0.7rem;color:#16a34a;white-space:nowrap;">✓ Acquittée</span>' : '');
+
+    return `<div style="padding:0.6rem 0.75rem;margin:0.3rem 0;border-radius:8px;border:1px solid ${border};background:${bg};display:flex;justify-content:space-between;align-items:flex-start;gap:0.5rem;">
+      <div style="flex:1;min-width:0;">
+        <div style="display:flex;align-items:center;gap:0.4rem;flex-wrap:wrap;margin-bottom:0.15rem;">
+          <span>${eventIcon(ev.event)}</span>
+          <span style="font-weight:600;font-size:0.85rem;color:${col};">${ev.description}</span>
+          <span style="font-size:0.7rem;padding:0.1rem 0.4rem;border-radius:4px;background:${border};color:${col};">${ev.severity}</span>
+          <span style="font-size:0.7rem;color:#94a3b8;">${ev.rule_id}</span>
+          <span style="font-size:0.7rem;color:#94a3b8;">BMS ${ev.bms_address}</span>
+        </div>
+        <div style="font-size:0.75rem;color:#475569;">
+          Valeur : <strong>${ev.value.toFixed(2)}</strong>
+          &nbsp;·&nbsp;${ev.timestamp}
+          ${ev.acknowledged_at ? `&nbsp;·&nbsp;Ack : ${ev.acknowledged_at}` : ''}
+        </div>
+      </div>
+      <div style="flex-shrink:0;">${ackBtn}</div>
+    </div>`;
+  }).join('');
+}
+
+async function ackAlert(id) {
+  try {
+    const r = await fetch(`/api/v1/alerts/${id}/acknowledge`, { method: 'POST' });
+    if (r.ok) loadAlerts();
+  } catch(e) { /* silencieux */ }
+}
+
+function updatePagination() {
+  const totalPages = Math.ceil(totalEvents / PAGE_SIZE);
+  const pag = document.getElementById('pagination');
+  if (totalEvents <= PAGE_SIZE) { pag.style.display = 'none'; return; }
+  pag.style.display = 'flex';
+  document.getElementById('page-info').textContent = `Page ${currentPage + 1} / ${totalPages}`;
+  document.getElementById('btn-prev').disabled = currentPage === 0;
+  document.getElementById('btn-next').disabled = currentPage >= totalPages - 1;
+}
+
+function prevPage() { if (currentPage > 0) { currentPage--; loadAlerts(); } }
+function nextPage() { currentPage++; loadAlerts(); }
+function resetFilters() {
+  document.getElementById('filter-severity').value = '';
+  document.getElementById('filter-active').value   = '';
+  currentPage = 0;
+  loadAlerts();
+}
+
+// Chargement initial + auto-refresh 30s
+loadAlerts();
+setInterval(loadAlerts, 30000);
+</script>
+{% endblock %}


### PR DESCRIPTION
…VP/UVP, API REST + dashboard

- bridges/alerts.rs : ajout min_duration ("for:") par règle avec pending_since timer, contexte shunt_current_a (SmartShunt prioritaire sur BMS), 2 nouvelles règles ESS (pack_ovp / pack_uvp), méthodes publiques query_events / count_stats / acknowledge, schéma SQLite enrichi (description, severity, acknowledged, acknowledged_at), migration backward-compat via ALTER TABLE silencieux
- config.rs : AlertThresholds += pack_ovp_v + pack_uvp_v ; AlertsConfig += durées for: (soc_critical_for_secs, soc_low_for_secs, temp_high_for_secs, etc.)
- state.rs : AppState += alert_engine: Option<Arc<AlertEngine>>
- main.rs : AlertEngine créé avant AppState, partagé via Arc avec API et boucle
- api/alerts.rs : GET /api/v1/alerts/list|stats, POST /:id/acknowledge (spawn_blocking)
- api/mod.rs : câblage des nouvelles routes alerts
- dashboard/mod.rs : page /dashboard/alerts + AlertsTemplate Askama
- templates/alerts.html : journal temps réel, stats, filtres, pagination, acquittement
- Config.toml : db_path activé, durées for: configurées, seuils ESS ajustés

https://claude.ai/code/session_01SDUf7iGztfgwh2mXjDvb6D