### PR TITLE
feat(z8run): installer z8run comme service Pi5 + monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,13 +249,16 @@ check:
 # Installation (systemd)
 # =============================================================================
 
-.PHONY: install uninstall
+.PHONY: install uninstall install-z8run
 
 install: build
 	sudo bash contrib/install-systemd.sh
 
 uninstall:
 	sudo bash contrib/uninstall-systemd.sh
+
+install-z8run:
+	sudo bash contrib/install-z8run.sh
 
 # =============================================================================
 # Cross-compile + déploiement SSH vers le Pi
@@ -379,7 +382,8 @@ help:
 	@echo "  make check           Check + fmt + lint"
 	@echo ""
 	@echo " Déploiement :"
-	@echo "  make install         Installer le service systemd"
+	@echo "  make install         Installer le service systemd daly-bms"
+	@echo "  make install-z8run   Installer z8run (build + service systemd, sur Pi5)"
 	@echo "  make deploy          Déployer sur pi5compute@192.168.1.141 [gnu]"
 	@echo "  make deploy-musl     Déployer binaire statique portable [musl]"
 	@echo "  make install-venus   Déployer dbus-mqtt-venus sur GX (ARM64)"

--- a/contrib/install-z8run.sh
+++ b/contrib/install-z8run.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# =============================================================================
+# install-z8run.sh — Installation de z8run sur Pi5
+#
+# Prérequis :
+#   - Rust 1.91+ (rustup)
+#   - Node.js 22+ (nvm ou apt)
+#   - Source clonée dans ~/z8run
+#
+# Usage (sur le Pi5) :
+#   git clone https://github.com/z8run/z8run.git ~/z8run
+#   sudo bash ~/Daly-BMS-Rust/contrib/install-z8run.sh
+# =============================================================================
+
+set -euo pipefail
+
+Z8RUN_SRC="${HOME}/z8run"
+BINARY_DEST="/usr/local/bin/z8run"
+SERVICE_SRC="$(dirname "$0")/z8run.service"
+SERVICE_DEST="/etc/systemd/system/z8run.service"
+ENV_DIR="/etc/z8run"
+ENV_FILE="${ENV_DIR}/.env"
+DATA_DIR="/var/lib/z8run"
+USER="pi5compute"
+
+# ── Vérifications ─────────────────────────────────────────────────────────────
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Ce script doit être exécuté avec sudo."
+    exit 1
+fi
+
+if [[ ! -d "$Z8RUN_SRC" ]]; then
+    echo "Erreur : sources z8run non trouvées dans $Z8RUN_SRC"
+    echo "  git clone https://github.com/z8run/z8run.git ~/z8run"
+    exit 1
+fi
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+
+echo "→ Build z8run en release (sur Pi5, ~10-20 min première fois)…"
+cd "$Z8RUN_SRC"
+sudo -u "$USER" cargo build --release
+
+BINARY_SRC="${Z8RUN_SRC}/target/release/z8run"
+if [[ ! -f "$BINARY_SRC" ]]; then
+    echo "Erreur : binaire non trouvé après build : $BINARY_SRC"
+    exit 1
+fi
+
+# ── Installation binaire ──────────────────────────────────────────────────────
+
+echo "→ Installation du binaire → $BINARY_DEST"
+install -m 755 -o root -g root "$BINARY_SRC" "$BINARY_DEST"
+
+# ── Répertoires et env ────────────────────────────────────────────────────────
+
+echo "→ Création des répertoires"
+mkdir -p "$DATA_DIR" "$ENV_DIR"
+chown "$USER:$USER" "$DATA_DIR"
+chmod 750 "$DATA_DIR"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "→ Génération du fichier .env"
+    JWT_SECRET=$(openssl rand -hex 32)
+    cat > "$ENV_FILE" <<EOF
+Z8_PORT=7700
+Z8_BIND=0.0.0.0
+Z8_DATA_DIR=${DATA_DIR}
+# SQLite embarqué par défaut — remplacer par postgres:// si besoin
+# Z8_DB_URL=sqlite://${DATA_DIR}/z8run.db
+Z8_JWT_SECRET=${JWT_SECRET}
+EOF
+    chmod 600 "$ENV_FILE"
+    echo "→ .env généré avec JWT_SECRET aléatoire"
+else
+    echo "→ .env existant conservé : $ENV_FILE"
+fi
+
+# ── Service systemd ───────────────────────────────────────────────────────────
+
+echo "→ Installation du service systemd"
+cp "$SERVICE_SRC" "$SERVICE_DEST"
+chmod 644 "$SERVICE_DEST"
+
+systemctl daemon-reload
+systemctl enable z8run
+systemctl restart z8run
+
+sleep 2
+
+# ── Résultat ─────────────────────────────────────────────────────────────────
+
+echo ""
+systemctl status z8run --no-pager -l
+echo ""
+echo "Installation terminée."
+echo "  UI z8run  : http://192.168.1.141:7700"
+echo "  Logs      : journalctl -u z8run -f"
+echo "  Config env: sudo nano $ENV_FILE"

--- a/contrib/z8run.service
+++ b/contrib/z8run.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=z8run — Moteur de workflow visuel (alternative Node-RED)
+Documentation=https://github.com/z8run/z8run
+After=network-online.target mosquitto.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi5compute
+Group=pi5compute
+
+ExecStart=/usr/local/bin/z8run serve
+WorkingDirectory=/var/lib/z8run
+
+Environment=RUST_LOG=info
+EnvironmentFile=-/etc/z8run/.env
+
+Restart=on-failure
+RestartSec=5s
+StartLimitIntervalSec=0
+
+LimitNOFILE=65536
+MemoryMax=256M
+
+[Install]
+WantedBy=multi-user.target

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -21,6 +21,7 @@ use tracing::{info, warn};
 const TCP_SERVICES: &[(&str, &str, u16, Option<&str>)] = &[
     ("mosquitto",      "127.0.0.1",     1883, Some("mosquitto")),
     ("energy-manager", "127.0.0.1",     8081, None),
+    ("z8run",          "127.0.0.1",     7700, None),
     ("venus-mqtt",     "192.168.1.120", 1883, None),
 ];
 
@@ -87,6 +88,18 @@ async fn collect_snapshot(_state: &AppState, net_rx_bps: u64, net_tx_bps: u64) -
         name:   "mosquitto".to_string(),
         active: mosquitto_systemd || tcp_probe("127.0.0.1", 1883).await,
         status: if mosquitto_systemd { "active".to_string() } else { "inactive".to_string() },
+    });
+
+    let z8run_status   = check_systemd_service("z8run").await;
+    let z8run_systemd  = z8run_status == "active";
+    let z8run_tcp_ok   = if z8run_systemd { true } else { tcp_probe("127.0.0.1", 7700).await };
+    let z8run_active   = z8run_systemd || z8run_tcp_ok;
+    services.push(ServiceStatus {
+        name:   "z8run".to_string(),
+        active: z8run_active,
+        status: if z8run_active {
+            if z8run_systemd { z8run_status } else { "active (port 7700)".to_string() }
+        } else if z8run_status.is_empty() { "unknown".to_string() } else { z8run_status },
     });
 
     // ── Sondes TCP ───────────────────────────────────────────────────────────

--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -25,6 +25,34 @@
     </div>
   </div>
 
+  <!-- z8run -->
+  <div class="bms-card" id="card-z8run">
+    <div class="bms-hdr bms-hdr-indigo">
+      <div class="bms-hdr-left"><span class="bms-hdr-name">⚡ z8run — Workflow Engine</span></div>
+      <div class="bms-hdr-right">
+        <span id="z8run-badge" class="bms-badge" style="background:#e2e8f0;color:#64748b">—</span>
+      </div>
+    </div>
+    <div style="padding:0.75rem;">
+      <div style="display:flex;align-items:center;gap:0.6rem;padding:0.4rem 0.1rem;border-bottom:1px solid var(--border);">
+        <span id="z8run-dot" style="width:9px;height:9px;border-radius:50%;flex-shrink:0;background:#94a3b8;"></span>
+        <span style="font-weight:600;font-size:0.8rem;flex:1">Service systemd</span>
+        <span id="z8run-status-text" style="font-size:0.68rem;color:var(--muted2);font-family:monospace">—</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:0.6rem;padding:0.4rem 0.1rem;border-bottom:1px solid var(--border);">
+        <span style="font-size:0.75rem;color:var(--muted2);">Port</span>
+        <span style="font-family:monospace;font-size:0.78rem;flex:1">7700</span>
+        <a id="z8run-link" href="http://192.168.1.141:7700" target="_blank"
+           style="font-size:0.72rem;padding:3px 10px;background:#6366f1;color:#fff;border-radius:4px;text-decoration:none;font-weight:600;">
+          Ouvrir UI →
+        </a>
+      </div>
+      <div style="padding:0.5rem 0.1rem 0.1rem;font-size:0.7rem;color:var(--muted2);">
+        Flow SmartShunt : <code style="font-size:0.68rem;">N/c0619ab9929a/battery/290/#</code>
+      </div>
+    </div>
+  </div>
+
   <!-- NEOHTOP System Overview -->
   <div class="bms-card" id="card-sysmon" style="background:#0f172a;border:1px solid #1e293b;">
     <div style="padding:0.7rem 0.9rem;border-bottom:1px solid #1e293b;display:flex;justify-content:space-between;align-items:center;">
@@ -258,6 +286,18 @@ async function fetchMonitor(){
     if(m.load_avg&&m.load_avg.length>=2){
       document.getElementById('neo-load1').textContent=m.load_avg[0].toFixed(2);
       document.getElementById('neo-load5').textContent=m.load_avg[1].toFixed(2);
+    }
+
+    // z8run card
+    const z8runSvc=(m.services||[]).find(s=>s.name==='z8run');
+    if(z8runSvc){
+      const ok=z8runSvc.active;
+      const dot=document.getElementById('z8run-dot');
+      const badge=document.getElementById('z8run-badge');
+      const txt=document.getElementById('z8run-status-text');
+      if(dot){ dot.style.background=ok?'#16a34a':'#dc2626'; dot.style.boxShadow=ok?'0 0 5px #16a34a66':'none'; }
+      if(badge){ badge.textContent=ok?'active':'inactive'; badge.style.background=ok?'#dcfce7':'#fee2e2'; badge.style.color=ok?'#15803d':'#dc2626'; }
+      if(txt){ txt.textContent=z8runSvc.status||'—'; }
     }
 
     // Services réseau


### PR DESCRIPTION
- contrib/z8run.service : unité systemd z8run (port 7700, user pi5compute)
- contrib/install-z8run.sh : script d'installation (build Rust on-device, génération JWT_SECRET, activation service)
- Makefile : cible `make install-z8run`
- monitor.rs : z8run ajouté dans les services systemd surveillés et dans TCP_SERVICES (sonde port 7700)
- monitor.html : carte z8run avec indicateur live, lien direct vers l'UI, et rappel du topic SmartShunt N/c0619ab9929a/battery/290/#

https://claude.ai/code/session_01MiJxiLkW1MAuXuaFgioCYd