### PR TITLE
fix(z8run): WorkingDirectory=/home/pi5compute/z8run — frontend servi …

### DIFF
--- a/contrib/install-z8run.sh
+++ b/contrib/install-z8run.sh
@@ -2,14 +2,12 @@
 # =============================================================================
 # install-z8run.sh — Installation de z8run sur Pi5
 #
-# Architecture :
-#   nginx :7700 (public)  → sert frontend/dist/ + proxifie vers z8run :7701
-#   z8run :7701 (interne) → API REST/WS uniquement
+# Le binaire z8run sert le frontend React depuis frontend/dist/ au runtime
+# (lecture depuis le WorkingDirectory du service). Pas de nginx nécessaire.
 #
 # Prérequis :
 #   - Rust 1.91+ (rustup)
 #   - Node.js 22+ (installé automatiquement si absent)
-#   - nginx (sudo apt install nginx)
 #   - Source clonée dans ~/z8run
 #
 # Usage (sur le Pi5) :
@@ -19,7 +17,6 @@
 
 set -euo pipefail
 
-# Résoudre le home de l'utilisateur réel même sous sudo
 REAL_USER="${SUDO_USER:-${USER}}"
 REAL_HOME=$(getent passwd "$REAL_USER" | cut -d: -f6)
 
@@ -27,11 +24,8 @@ Z8RUN_SRC="${REAL_HOME}/z8run"
 BINARY_DEST="/usr/local/bin/z8run"
 SERVICE_SRC="$(dirname "$0")/z8run.service"
 SERVICE_DEST="/etc/systemd/system/z8run.service"
-NGINX_CONF_SRC="$(dirname "$0")/nginx-z8run.conf"
-NGINX_CONF_DEST="/etc/nginx/sites-available/z8run"
 ENV_DIR="/etc/z8run"
 ENV_FILE="${ENV_DIR}/.env"
-DATA_DIR="/var/lib/z8run"
 
 # ── Vérifications ─────────────────────────────────────────────────────────────
 
@@ -46,6 +40,18 @@ if [[ ! -d "$Z8RUN_SRC" ]]; then
     exit 1
 fi
 
+# ── Désactiver nginx pour z8run si configuré (nettoyage ancienne install) ─────
+
+if [[ -L /etc/nginx/sites-enabled/z8run ]]; then
+    rm -f /etc/nginx/sites-enabled/z8run
+    # Rétablir le site default si absent
+    if [[ ! -L /etc/nginx/sites-enabled/default ]] && [[ -f /etc/nginx/sites-available/default ]]; then
+        ln -sf /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+    fi
+    systemctl reload nginx 2>/dev/null || true
+    echo "→ Config nginx z8run désactivée (plus nécessaire)"
+fi
+
 # ── Node.js 22+ ───────────────────────────────────────────────────────────────
 
 NODE_MAJOR=$(node --version 2>/dev/null | sed 's/v\([0-9]*\).*/\1/' || echo 0)
@@ -58,26 +64,25 @@ else
     echo "→ Node.js $(node --version) OK"
 fi
 
-# ── nginx ─────────────────────────────────────────────────────────────────────
-
-if ! command -v nginx &>/dev/null; then
-    echo "→ Installation de nginx…"
-    apt-get install -y nginx
-fi
-
 # ── Build frontend React ──────────────────────────────────────────────────────
 
 echo "→ Build frontend React (npm install + npm run build)…"
 sudo -u "$REAL_USER" bash -l -c "cd '$Z8RUN_SRC/frontend' && npm install && npm run build"
 
+if [[ ! -d "$Z8RUN_SRC/frontend/dist" ]]; then
+    echo "Erreur : frontend/dist/ absent après npm run build"
+    exit 1
+fi
+echo "→ frontend/dist/ OK ($(find "$Z8RUN_SRC/frontend/dist" -type f | wc -l) fichiers)"
+
 # ── Build Rust ────────────────────────────────────────────────────────────────
 
-echo "→ Build z8run backend en release…"
-sudo -u "$REAL_USER" bash -l -c "touch '$Z8RUN_SRC/build.rs' 2>/dev/null; cd '$Z8RUN_SRC' && cargo build --release"
+echo "→ Build z8run en release…"
+sudo -u "$REAL_USER" bash -l -c "cd '$Z8RUN_SRC' && cargo build --release"
 
 BINARY_SRC="${Z8RUN_SRC}/target/release/z8run"
 if [[ ! -f "$BINARY_SRC" ]]; then
-    echo "Erreur : binaire non trouvé après build : $BINARY_SRC"
+    echo "Erreur : binaire non trouvé après build"
     exit 1
 fi
 
@@ -86,70 +91,44 @@ fi
 echo "→ Installation du binaire → $BINARY_DEST"
 install -m 755 -o root -g root "$BINARY_SRC" "$BINARY_DEST"
 
-# ── Répertoires et env ────────────────────────────────────────────────────────
+# ── Env ───────────────────────────────────────────────────────────────────────
 
-echo "→ Création des répertoires"
-mkdir -p "$DATA_DIR" "$ENV_DIR"
-chown "$REAL_USER:$REAL_USER" "$DATA_DIR"
-chmod 750 "$DATA_DIR"
+mkdir -p "$ENV_DIR"
 
 if [[ ! -f "$ENV_FILE" ]]; then
-    echo "→ Génération du fichier .env"
     JWT_SECRET=$(openssl rand -hex 32)
     cat > "$ENV_FILE" <<EOF
-# z8run écoute sur 7701 (interne) — nginx proxifie sur 7700 (public)
-Z8_PORT=7701
-Z8_BIND=127.0.0.1
-Z8_DATA_DIR=${DATA_DIR}
+Z8_PORT=7700
+Z8_BIND=0.0.0.0
 Z8_JWT_SECRET=${JWT_SECRET}
 EOF
     chmod 600 "$ENV_FILE"
     echo "→ .env généré"
 else
-    # Mettre à jour le port si nécessaire
-    sed -i 's/^Z8_PORT=7700/Z8_PORT=7701/' "$ENV_FILE"
-    sed -i 's/^Z8_BIND=0\.0\.0\.0/Z8_BIND=127.0.0.1/' "$ENV_FILE"
-    echo "→ .env existant mis à jour (port 7701, bind 127.0.0.1)"
+    # Corriger port/bind si ancienne config
+    sed -i 's/^Z8_PORT=7701/Z8_PORT=7700/' "$ENV_FILE"
+    sed -i 's/^Z8_BIND=127\.0\.0\.1/Z8_BIND=0.0.0.0/' "$ENV_FILE"
+    echo "→ .env mis à jour"
 fi
 
-# ── Service systemd z8run ─────────────────────────────────────────────────────
+# ── Service systemd ───────────────────────────────────────────────────────────
 
-echo "→ Installation du service systemd z8run"
+echo "→ Installation du service systemd"
 cp "$SERVICE_SRC" "$SERVICE_DEST"
 chmod 644 "$SERVICE_DEST"
 systemctl daemon-reload
 systemctl enable z8run
 systemctl restart z8run
 
-# ── Config nginx ──────────────────────────────────────────────────────────────
-
-echo "→ Installation de la config nginx"
-cp "$NGINX_CONF_SRC" "$NGINX_CONF_DEST"
-ln -sf "$NGINX_CONF_DEST" /etc/nginx/sites-enabled/z8run
-
-# Désactiver le site default si présent (évite conflit de port)
-if [[ -L /etc/nginx/sites-enabled/default ]]; then
-    rm -f /etc/nginx/sites-enabled/default
-    echo "→ Site nginx 'default' désactivé"
-fi
-
-nginx -t
-systemctl enable nginx
-systemctl restart nginx
+sleep 2
 
 # ── Résultat ─────────────────────────────────────────────────────────────────
 
-sleep 2
 echo ""
-echo "=== z8run backend ==="
 systemctl status z8run --no-pager -l | head -20
-echo ""
-echo "=== nginx ==="
-systemctl status nginx --no-pager -l | head -10
 echo ""
 echo "Installation terminée."
 echo "  UI z8run  : http://192.168.1.141:7700"
-echo "  API santé : curl http://localhost:7701/api/v1/health"
-echo "  Logs z8run: journalctl -u z8run -f"
-echo "  Logs nginx: tail -f /var/log/nginx/z8run_error.log"
-echo "  Config env: sudo nano $ENV_FILE"
+echo "  Santé API : curl http://localhost:7700/api/v1/health"
+echo "  Logs      : journalctl -u z8run -f"
+echo "  Config    : sudo nano $ENV_FILE"

--- a/contrib/z8run.service
+++ b/contrib/z8run.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=z8run — Moteur de workflow visuel (alternative Node-RED)
 Documentation=https://github.com/z8run/z8run
-After=network-online.target mosquitto.service nginx.service
+After=network-online.target mosquitto.service
 Wants=network-online.target
 
 [Service]
@@ -10,7 +10,8 @@ User=pi5compute
 Group=pi5compute
 
 ExecStart=/usr/local/bin/z8run serve
-WorkingDirectory=/var/lib/z8run
+# Le binaire sert frontend/dist/ depuis ce répertoire au runtime
+WorkingDirectory=/home/pi5compute/z8run
 
 Environment=RUST_LOG=info
 EnvironmentFile=-/etc/z8run/.env

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -21,7 +21,7 @@ use tracing::{info, warn};
 const TCP_SERVICES: &[(&str, &str, u16, Option<&str>)] = &[
     ("mosquitto",      "127.0.0.1",     1883, Some("mosquitto")),
     ("energy-manager", "127.0.0.1",     8081, None),
-    ("z8run",          "127.0.0.1",     7701, None),
+    ("z8run",          "127.0.0.1",     7700, None),
     ("venus-mqtt",     "192.168.1.120", 1883, None),
 ];
 


### PR DESCRIPTION
…depuis le CWD

Root cause réelle : z8run sert frontend/dist/ au runtime depuis son répertoire de travail. WorkingDirectory=/var/lib/z8run → fichiers introuvables → 404.

- z8run.service : WorkingDirectory=/home/pi5compute/z8run
- install-z8run.sh : port 7700 direct (nginx non nécessaire), nettoyage de l'ancienne config nginx, vérification que frontend/dist/ existe après npm build
- monitor.rs : sonde TCP retour sur port 7700

https://claude.ai/code/session_01MiJxiLkW1MAuXuaFgioCYd