### PR TITLE
chore(z8run): désinstallation complète + retrait du monitoring

### DIFF
--- a/contrib/uninstall-z8run.sh
+++ b/contrib/uninstall-z8run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# =============================================================================
+# uninstall-z8run.sh — Suppression complète de z8run sur Pi5
+#
+# Supprime : service systemd, binaire, config /etc/z8run, config nginx,
+#            données /var/lib/z8run (optionnel).
+#
+# Usage : sudo bash ~/Daly-BMS-Rust/contrib/uninstall-z8run.sh
+# =============================================================================
+
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Ce script doit être exécuté avec sudo."
+    exit 1
+fi
+
+echo "=== Désinstallation de z8run ==="
+
+# ── Service systemd ───────────────────────────────────────────────────────────
+
+if systemctl is-active --quiet z8run 2>/dev/null; then
+    systemctl stop z8run
+    echo "→ Service z8run arrêté"
+fi
+
+if systemctl is-enabled --quiet z8run 2>/dev/null; then
+    systemctl disable z8run
+    echo "→ Service z8run désactivé"
+fi
+
+if [[ -f /etc/systemd/system/z8run.service ]]; then
+    rm -f /etc/systemd/system/z8run.service
+    echo "→ /etc/systemd/system/z8run.service supprimé"
+fi
+
+systemctl daemon-reload
+
+# ── Binaire ───────────────────────────────────────────────────────────────────
+
+if [[ -f /usr/local/bin/z8run ]]; then
+    rm -f /usr/local/bin/z8run
+    echo "→ /usr/local/bin/z8run supprimé"
+fi
+
+# ── Config /etc/z8run ─────────────────────────────────────────────────────────
+
+if [[ -d /etc/z8run ]]; then
+    rm -rf /etc/z8run
+    echo "→ /etc/z8run supprimé"
+fi
+
+# ── Config nginx ──────────────────────────────────────────────────────────────
+
+if [[ -L /etc/nginx/sites-enabled/z8run ]]; then
+    rm -f /etc/nginx/sites-enabled/z8run
+    echo "→ nginx sites-enabled/z8run supprimé"
+fi
+
+if [[ -f /etc/nginx/sites-available/z8run ]]; then
+    rm -f /etc/nginx/sites-available/z8run
+    echo "→ nginx sites-available/z8run supprimé"
+fi
+
+# Rétablir le site nginx default si absent
+if [[ ! -L /etc/nginx/sites-enabled/default ]] && [[ -f /etc/nginx/sites-available/default ]]; then
+    ln -sf /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+    echo "→ Site nginx 'default' rétabli"
+fi
+
+if command -v nginx &>/dev/null; then
+    nginx -t 2>/dev/null && systemctl reload nginx 2>/dev/null || true
+    echo "→ nginx rechargé"
+fi
+
+# ── Données /var/lib/z8run ────────────────────────────────────────────────────
+
+if [[ -d /var/lib/z8run ]]; then
+    read -r -p "Supprimer les données /var/lib/z8run (flows, DB) ? [o/N] " rep
+    if [[ "${rep,,}" == "o" ]]; then
+        rm -rf /var/lib/z8run
+        echo "→ /var/lib/z8run supprimé"
+    else
+        echo "→ /var/lib/z8run conservé"
+    fi
+fi
+
+echo ""
+echo "=== z8run complètement désinstallé ==="
+echo "  Sources ~/z8run conservées (supprimer manuellement si souhaité : rm -rf ~/z8run)"

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -21,7 +21,6 @@ use tracing::{info, warn};
 const TCP_SERVICES: &[(&str, &str, u16, Option<&str>)] = &[
     ("mosquitto",      "127.0.0.1",     1883, Some("mosquitto")),
     ("energy-manager", "127.0.0.1",     8081, None),
-    ("z8run",          "127.0.0.1",     7700, None),
     ("venus-mqtt",     "192.168.1.120", 1883, None),
 ];
 
@@ -88,18 +87,6 @@ async fn collect_snapshot(_state: &AppState, net_rx_bps: u64, net_tx_bps: u64) -
         name:   "mosquitto".to_string(),
         active: mosquitto_systemd || tcp_probe("127.0.0.1", 1883).await,
         status: if mosquitto_systemd { "active".to_string() } else { "inactive".to_string() },
-    });
-
-    let z8run_status   = check_systemd_service("z8run").await;
-    let z8run_systemd  = z8run_status == "active";
-    let z8run_tcp_ok   = if z8run_systemd { true } else { tcp_probe("127.0.0.1", 7700).await };
-    let z8run_active   = z8run_systemd || z8run_tcp_ok;
-    services.push(ServiceStatus {
-        name:   "z8run".to_string(),
-        active: z8run_active,
-        status: if z8run_active {
-            if z8run_systemd { z8run_status } else { "active (port 7700)".to_string() }
-        } else if z8run_status.is_empty() { "unknown".to_string() } else { z8run_status },
     });
 
     // ── Sondes TCP ───────────────────────────────────────────────────────────

--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -25,34 +25,6 @@
     </div>
   </div>
 
-  <!-- z8run -->
-  <div class="bms-card" id="card-z8run">
-    <div class="bms-hdr bms-hdr-indigo">
-      <div class="bms-hdr-left"><span class="bms-hdr-name">⚡ z8run — Workflow Engine</span></div>
-      <div class="bms-hdr-right">
-        <span id="z8run-badge" class="bms-badge" style="background:#e2e8f0;color:#64748b">—</span>
-      </div>
-    </div>
-    <div style="padding:0.75rem;">
-      <div style="display:flex;align-items:center;gap:0.6rem;padding:0.4rem 0.1rem;border-bottom:1px solid var(--border);">
-        <span id="z8run-dot" style="width:9px;height:9px;border-radius:50%;flex-shrink:0;background:#94a3b8;"></span>
-        <span style="font-weight:600;font-size:0.8rem;flex:1">Service systemd</span>
-        <span id="z8run-status-text" style="font-size:0.68rem;color:var(--muted2);font-family:monospace">—</span>
-      </div>
-      <div style="display:flex;align-items:center;gap:0.6rem;padding:0.4rem 0.1rem;border-bottom:1px solid var(--border);">
-        <span style="font-size:0.75rem;color:var(--muted2);">Port</span>
-        <span style="font-family:monospace;font-size:0.78rem;flex:1">7700</span>
-        <a id="z8run-link" href="http://192.168.1.141:7700" target="_blank"
-           style="font-size:0.72rem;padding:3px 10px;background:#6366f1;color:#fff;border-radius:4px;text-decoration:none;font-weight:600;">
-          Ouvrir UI →
-        </a>
-      </div>
-      <div style="padding:0.5rem 0.1rem 0.1rem;font-size:0.7rem;color:var(--muted2);">
-        Flow SmartShunt : <code style="font-size:0.68rem;">N/c0619ab9929a/battery/290/#</code>
-      </div>
-    </div>
-  </div>
-
   <!-- NEOHTOP System Overview -->
   <div class="bms-card" id="card-sysmon" style="background:#0f172a;border:1px solid #1e293b;">
     <div style="padding:0.7rem 0.9rem;border-bottom:1px solid #1e293b;display:flex;justify-content:space-between;align-items:center;">
@@ -286,18 +258,6 @@ async function fetchMonitor(){
     if(m.load_avg&&m.load_avg.length>=2){
       document.getElementById('neo-load1').textContent=m.load_avg[0].toFixed(2);
       document.getElementById('neo-load5').textContent=m.load_avg[1].toFixed(2);
-    }
-
-    // z8run card
-    const z8runSvc=(m.services||[]).find(s=>s.name==='z8run');
-    if(z8runSvc){
-      const ok=z8runSvc.active;
-      const dot=document.getElementById('z8run-dot');
-      const badge=document.getElementById('z8run-badge');
-      const txt=document.getElementById('z8run-status-text');
-      if(dot){ dot.style.background=ok?'#16a34a':'#dc2626'; dot.style.boxShadow=ok?'0 0 5px #16a34a66':'none'; }
-      if(badge){ badge.textContent=ok?'active':'inactive'; badge.style.background=ok?'#dcfce7':'#fee2e2'; badge.style.color=ok?'#15803d':'#dc2626'; }
-      if(txt){ txt.textContent=z8runSvc.status||'—'; }
     }
 
     // Services réseau


### PR DESCRIPTION
- contrib/uninstall-z8run.sh : arrêt service, suppression binaire, /etc/z8run, config nginx, /var/lib/z8run (interactif)
- monitor.rs : suppression z8run des services systemd et TCP_SERVICES
- monitor.html : suppression carte z8run et JS associé

https://claude.ai/code/session_01MiJxiLkW1MAuXuaFgioCYd