### PR TITLE
fix(multi): simplify water_heater rules, fix inverter AC power, smart…

### DIFF
--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -102,6 +102,24 @@
     </div>
   </div>
 
+  <!-- Rules Status -->
+  <div class="bms-card" id="card-rules" style="background:#0f172a;border:1px solid #1e293b;">
+    <div style="padding:0.7rem 0.9rem;border-bottom:1px solid #1e293b;display:flex;justify-content:space-between;align-items:center;">
+      <span style="font-family:monospace;font-weight:700;color:#7dd3fc;font-size:0.85rem;">◈ RÈGLES CHAUFFE-EAU</span>
+      <span id="rules-mode-badge" style="font-family:monospace;font-size:0.72rem;padding:2px 8px;border-radius:4px;background:#1e293b;color:#475569;">—</span>
+    </div>
+    <div style="padding:0.75rem 0.9rem;display:flex;flex-direction:column;gap:0.55rem;">
+
+      <div id="rule-grid" style="display:flex;flex-direction:column;gap:0.5rem;"></div>
+
+      <div style="margin-top:0.4rem;border-top:1px solid #1e293b;padding-top:0.5rem;display:flex;align-items:center;gap:0.5rem;">
+        <span style="font-family:monospace;font-size:0.68rem;color:#475569;">Résultat :</span>
+        <span id="rules-decision" style="font-family:monospace;font-size:0.75rem;font-weight:700;color:#94a3b8;">—</span>
+      </div>
+
+    </div>
+  </div>
+
   <!-- RS485 Health -->
   <div class="bms-card" id="card-rs485" style="grid-column:1/-1">
     <div class="bms-hdr bms-hdr-indigo">
@@ -381,10 +399,79 @@ async function loadLogFile(){
   } catch(e){wrap.innerHTML='<div style="padding:1rem;color:#dc2626">Erreur: '+e.message+'</div>';}
 }
 
+// ── Rules Status (water heater) ──────────────────────────────────────────────
+function ruleRow(label, ok, valueStr, detail) {
+  const dot = `<span style="width:8px;height:8px;border-radius:50%;flex-shrink:0;display:inline-block;background:${ok?'#22c55e':'#ef4444'};${ok?'box-shadow:0 0 5px #22c55e66':''}"></span>`;
+  return `<div style="display:flex;align-items:center;gap:0.55rem;font-family:monospace;font-size:0.73rem;">
+    ${dot}
+    <span style="color:#94a3b8;flex:1;">${label}</span>
+    <span style="color:${ok?'#22c55e':'#ef4444'};font-weight:600;">${valueStr}</span>
+    ${detail?`<span style="color:#475569;font-size:0.65rem;">${detail}</span>`:''}
+  </div>`;
+}
+
+async function fetchRulesStatus() {
+  try {
+    const safe = p => p.catch(() => null);
+    const [bms1r, bms2r, irrR, invR] = await Promise.all([
+      safe(fetch('/api/v1/bms/1/status').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/bms/2/status').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/irradiance/status').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/venus/inverter').then(r => r.ok ? r.json() : null)),
+    ]);
+
+    // SOC — moyenne des BMS disponibles
+    const validBms = [bms1r, bms2r].filter(b => b && b.Soc != null);
+    const avgSoc = validBms.length ? validBms.reduce((s, b) => s + b.Soc, 0) / validBms.length : null;
+    const socOk  = avgSoc != null && avgSoc >= 90;
+
+    // Irradiance
+    const irr    = irrR?.irradiance_wm2 ?? null;
+    const irrOk  = irr != null && irr >= 300;
+
+    // AC IN Ignored (grid disconnected)
+    const inv       = invR?.inverter ?? null;
+    const acIgnore  = inv?.ac_in_ignore ?? null;
+    const gridOffOk = acIgnore === true;
+
+    // Mode actuel (heatpump mqtt_index=1)
+    const hpR = await safe(fetch('/api/v1/venus/heatpumps').then(r => r.ok ? r.json() : null));
+    const hp1 = (hpR?.heatpumps ?? []).find(h => h.mqtt_index === 1) ?? null;
+    const venusState = hp1?.State ?? null;
+    const modeLabel  = venusState === 1 ? 'HEAT_PUMP' : venusState === 0 ? 'VACATION' : '—';
+    const modeOk     = venusState === 1;
+
+    const badge = document.getElementById('rules-mode-badge');
+    if (badge) {
+      badge.textContent = modeLabel;
+      badge.style.background = modeOk ? '#14532d' : '#1c1917';
+      badge.style.color      = modeOk ? '#4ade80' : '#78716c';
+    }
+
+    const grid = document.getElementById('rule-grid');
+    if (grid) {
+      grid.innerHTML = [
+        ruleRow('SOC ≥ 90 %',          socOk,    avgSoc  != null ? `${avgSoc.toFixed(1)} %`   : '—', '(condition remplie si vert)'),
+        ruleRow('Irradiance ≥ 300 W/m²', irrOk,  irr     != null ? `${irr.toFixed(0)} W/m²`  : '—', null),
+        ruleRow('Grid déconnecté (AC IN Ignored)', gridOffOk, acIgnore != null ? (acIgnore ? 'ACTIF' : 'Normal') : '—', null),
+      ].join('');
+    }
+
+    const allOk = socOk && irrOk && gridOffOk;
+    const dec = document.getElementById('rules-decision');
+    if (dec) {
+      dec.textContent = allOk ? '→ HEAT_PUMP activé' : '→ VACATION (en attente des conditions)';
+      dec.style.color = allOk ? '#4ade80' : '#94a3b8';
+    }
+  } catch(e) { console.warn('fetchRulesStatus:', e); }
+}
+
 fetchMonitor();
 fetchRs485Health();
+fetchRulesStatus();
 loadLogList();
 setInterval(fetchMonitor, 10000);
 setInterval(fetchRs485Health, 15000);
+setInterval(fetchRulesStatus, 15000);
 </script>
 {% endblock %}

--- a/crates/daly-bms-server/templates/viz_nodes_venus.js
+++ b/crates/daly-bms-server/templates/viz_nodes_venus.js
@@ -90,15 +90,46 @@ function MPPTGroupNode({ data }) {
 
 // ── SMARTSHUNT NODE ───────────────────────────────────────────────────────────
 function SmartShuntNode({ data }) {
-  const live       = data.live;
-  const soc        = live?.soc_percent        ?? null;
-  const voltage    = live?.voltage_v          ?? null;
-  const current    = live?.current_a          ?? null;
-  const power      = live?.power_w            ?? null;
-  const ahIn       = live?.ah_charged_today   ?? null;
-  const ahOut      = live?.ah_discharged_today ?? null;
-  const state      = live?.state              ?? null;
-  const ttgMin     = live?.time_to_go_min     ?? null;
+  const live    = data.live;
+  const soc     = live?.soc_percent    ?? null;
+  const voltage = live?.voltage_v      ?? null;
+  const current = live?.current_a      ?? null;
+  const power   = live?.power_w        ?? null;
+  const state   = live?.state          ?? null;
+  const ttgMin  = live?.time_to_go_min ?? null;
+
+  const [vmCharge,    setVmCharge]    = useState(null);
+  const [vmDischarge, setVmDischarge] = useState(null);
+
+  useEffect(function() {
+    async function fetchDailyTotals() {
+      const now = new Date();
+      const h = Math.max(1, Math.round(now.getHours() + now.getMinutes() / 60));
+      const win = h + 'h';
+      const qDis = '-avg_over_time(clamp_max(venus_shunt_current_a,0)[' + win + '])*' + h;
+      const qCha = '-avg_over_time(clamp_min(venus_shunt_current_a,0)[' + win + '])*' + h;
+      try {
+        const [rDis, rCha] = await Promise.all([
+          fetch('/api/v1/query?query=' + encodeURIComponent(qDis)).then(r => r.ok ? r.json() : null),
+          fetch('/api/v1/query?query=' + encodeURIComponent(qCha)).then(r => r.ok ? r.json() : null),
+        ]);
+        const parseVm = (resp) => {
+          if (!resp || resp.status !== 'success') return null;
+          const v = resp.data?.result?.[0]?.value?.[1];
+          if (v == null) return null;
+          const n = parseFloat(v);
+          return isNaN(n) ? null : n;
+        };
+        const dis = parseVm(rDis);
+        const cha = parseVm(rCha);
+        setVmDischarge(dis != null ? Math.abs(dis) : null);
+        setVmCharge(cha != null ? Math.abs(cha) : null);
+      } catch (_) {}
+    }
+    fetchDailyTotals();
+    const t = setInterval(fetchDailyTotals, 60000);
+    return () => clearInterval(t);
+  }, []);
 
   const stateClass = state === 'Charging' ? 'charging' : state === 'Discharging' ? 'discharging' : 'idle';
 
@@ -151,12 +182,12 @@ function SmartShuntNode({ data }) {
           h('span', { className: 'ss-row-val ttg' }, fmtTtg(ttgMin))
         ),
         h('div', { className: 'ss-row', style: { flex: '1 1 0', minWidth: 0 } },
-          h('span', { className: 'ss-row-lbl' }, '⬆ Chargée (24h)'),
-          h('span', { className: 'ss-row-val pos' }, ahIn  != null ? `${ahIn.toFixed(1)} Ah`  : '—')
+          h('span', { className: 'ss-row-lbl' }, '⬆ Chargée (auj.)'),
+          h('span', { className: 'ss-row-val pos' }, vmCharge    != null ? `${vmCharge.toFixed(1)} Ah`    : '—')
         ),
         h('div', { className: 'ss-row', style: { flex: '1 1 0', minWidth: 0 } },
-          h('span', { className: 'ss-row-lbl' }, '⬇ Déchargée (24h)'),
-          h('span', { className: 'ss-row-val neg' }, ahOut != null ? `${ahOut.toFixed(1)} Ah` : '—')
+          h('span', { className: 'ss-row-lbl' }, '⬇ Déchargée (auj.)'),
+          h('span', { className: 'ss-row-val neg' }, vmDischarge != null ? `${vmDischarge.toFixed(1)} Ah` : '—')
         )
       )
     ) : h('div', { className: 'ss-wait' }, 'En attente…')

--- a/crates/energy-manager/rules/water_heater.grl
+++ b/crates/energy-manager/rules/water_heater.grl
@@ -2,15 +2,15 @@
 // Decides between HeatPump and Vacation mode based on energy conditions.
 //
 // Input facts (injected from Rust before evaluate):
-//   WH.want_vacation        (bool, initialised to false — set true by any condition rule)
-//   WH.grid_connected       (bool, true = grid on = ac_ignore == 0)
-//   WH.soc_pct              (number, battery SOC %)
-//   WH.discharge_debounced  (bool, pre-computed in Rust: discharging > debounce_secs)
-//   WH.solar_low_debounced  (bool, pre-computed in Rust: solar <= min for > debounce_secs)
-//   WH.irradiance_low       (bool, immediate, no debounce)
+//   WH.want_vacation   (bool, initialised to false — set true by any condition rule)
+//   WH.grid_connected  (bool, true = ac_ignore == 0, grid ON → Vacation)
+//   WH.soc_pct         (number, battery SOC %)
+//   WH.irradiance_low  (bool, true when irradiance < irradiance_min_wm2)
 //
 // Output facts (read from Rust after execute):
-//   WH.target_mode          (string: "HeatPump" | "Vacation")
+//   WH.target_mode     (string: "HeatPump" | "Vacation")
+//
+// HEAT_PUMP requires ALL: SOC >= 90%, irradiance >= 300 W/m², grid disconnected (ac_ignore = 1)
 
 // ── Condition rules (salience 100) ──────────────────────────────────────────
 
@@ -24,20 +24,6 @@ rule "WH_Cond_Grid" salience 100 no-loop {
 rule "WH_Cond_SOC_Low" salience 100 no-loop {
     when
         WH.soc_pct < 90
-    then
-        WH.want_vacation = true;
-}
-
-rule "WH_Cond_Discharge_Long" salience 100 no-loop {
-    when
-        WH.discharge_debounced == true
-    then
-        WH.want_vacation = true;
-}
-
-rule "WH_Cond_Solar_Low" salience 100 no-loop {
-    when
-        WH.solar_low_debounced == true
     then
         WH.want_vacation = true;
 }

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -294,12 +294,13 @@ impl Default for DeyeConfig {
 // Water heater management
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct WaterHeaterConfig {
-    /// Minimum solar production to run water heater (W)
+    /// Kept for TOML compatibility — no longer used in rule evaluation
     #[serde(default = "default_solar_min_w")]
     pub solar_min_w: f64,
-    /// Debounce delay for unstable conditions (seconds)
+    /// Kept for TOML compatibility — no longer used in rule evaluation
     #[serde(default = "default_debounce_secs")]
     pub debounce_secs: u64,
     /// Minimum time between two mode changes (seconds)

--- a/crates/energy-manager/src/logic/inverter/mod.rs
+++ b/crates/energy-manager/src/logic/inverter/mod.rs
@@ -89,6 +89,11 @@ async fn handle(
             state.write().await.ac_frequency_hz = Some(v);
             return true;
         }
+    } else if t.contains("/vebus/") && t.ends_with("/Ac/Out/L1/P") {
+        if let Some(v) = msg.victron_value::<f64>() {
+            state.write().await.ac_out_power_w = Some(v);
+            return true;
+        }
     } else if t.contains("/vebus/") && t.ends_with("/State") {
         if let Some(v) = msg.victron_value::<i64>() {
             state.write().await.vebus_state = Some(v);
@@ -110,23 +115,28 @@ async fn publish_state(
 ) {
     let s = state.read().await;
 
-    let dc_voltage  = s.dc_voltage_v;
-    let dc_current  = s.dc_current_a;
-    let dc_power    = s.dc_power_w;
-    let ac_voltage  = s.ac_out_voltage_v;
-    let ac_current  = s.ac_out_current_a;
-    let ac_freq     = s.ac_frequency_hz;
-    let ac_ignore   = s.ac_ignore;
-    let vebus_state = s.vebus_state;
+    let dc_voltage   = s.dc_voltage_v;
+    let dc_current   = s.dc_current_a;
+    let dc_power     = s.dc_power_w;
+    let ac_voltage   = s.ac_out_voltage_v;
+    let ac_current   = s.ac_out_current_a;
+    let ac_freq      = s.ac_frequency_hz;
+    let ac_ignore    = s.ac_ignore;
+    let vebus_state  = s.vebus_state;
+    let ac_out_power = s.ac_out_power_w;
     drop(s);
 
-    // Rule engine decides whether ac_power can be computed
-    let ac_power = match rule_engine.ac_power_ready(ac_voltage.is_some(), ac_current.is_some()) {
-        Ok(true)  => ac_voltage.zip(ac_current).map(|(v, i)| v * i),
-        Ok(false) => None,
-        Err(e) => {
-            tracing::error!("Inverter rule engine error: {e}");
-            None
+    // Prefer direct power measurement (Ac/Out/L1/P); fall back to V*I when available
+    let ac_power = if ac_out_power.is_some() {
+        ac_out_power
+    } else {
+        match rule_engine.ac_power_ready(ac_voltage.is_some(), ac_current.is_some()) {
+            Ok(true)  => ac_voltage.zip(ac_current).map(|(v, i)| v * i),
+            Ok(false) => None,
+            Err(e) => {
+                tracing::error!("Inverter rule engine error: {e}");
+                None
+            }
         }
     };
 

--- a/crates/energy-manager/src/logic/water_heater/mod.rs
+++ b/crates/energy-manager/src/logic/water_heater/mod.rs
@@ -1,7 +1,8 @@
 /// Automatic management of the LG ThinQ water heater.
-/// Switches between HEAT_PUMP and VACATION based on solar, SOC, grid and battery conditions.
+/// Switches between HEAT_PUMP and VACATION based on SOC, irradiance and grid status.
+/// HEAT_PUMP requires: SOC >= 90%, irradiance >= irradiance_min_wm2, grid disconnected (ac_ignore=1).
 /// Decision logic is handled by rust-rule-engine (rules/water_heater.grl).
-/// Debounce timers and rate limiting remain in Rust (time-based, not rule-based).
+/// Rate limiting remains in Rust (mode_change_min_secs).
 mod rules;
 
 use chrono::{DateTime, Utc};
@@ -83,61 +84,32 @@ async fn control_task(
         }
     };
 
-    // Debounce timestamps — kept in Rust because they track wall-clock duration
-    let mut discharge_since: Option<DateTime<Utc>> = None;
-    let mut low_solar_since: Option<DateTime<Utc>> = None;
-
+    let mut last_change: Option<DateTime<Utc>> = None;
     let mut ticker = interval(Duration::from_secs(30));
 
     loop {
         ticker.tick().await;
         let now = Utc::now();
 
-        let (ac_ignore, soc, batt_current, solar_total, irradiance, current_mode, last_change) = {
+        let (ac_ignore, soc, irradiance, current_mode, stored_last_change) = {
             let s = state.read().await;
             (
                 s.ac_ignore.unwrap_or(0),
                 s.soc_pct.unwrap_or(0.0),
-                s.battery_current_a.unwrap_or(0.0),
-                s.solar_total_w,
                 s.irradiance_wm2,
                 s.water_heater_mode,
                 s.water_heater_last_change,
             )
         };
-
-        // Debounce: track when each condition first appeared
-        let discharging = batt_current < 0.0;
-        if discharging {
-            discharge_since.get_or_insert(now);
-        } else {
-            discharge_since = None;
+        // Sync last_change from persisted state on first tick
+        if last_change.is_none() {
+            last_change = stored_last_change;
         }
-        let discharge_debounced = discharge_since
-            .map(|t| (now - t).num_seconds() as u64 >= cfg.debounce_secs)
-            .unwrap_or(false);
-
-        let solar_low = solar_total <= cfg.solar_min_w;
-        if solar_low {
-            low_solar_since.get_or_insert(now);
-        } else {
-            low_solar_since = None;
-        }
-        let solar_low_debounced = low_solar_since
-            .map(|t| (now - t).num_seconds() as u64 >= cfg.debounce_secs)
-            .unwrap_or(false);
 
         let irradiance_low = irradiance.map(|w| w < cfg.irradiance_min_wm2).unwrap_or(true);
-        let grid_connected  = ac_ignore == 0;
+        let grid_connected = ac_ignore == 0;
 
-        // Rule engine evaluation
-        let target_mode_str = match rule_engine.evaluate(
-            grid_connected,
-            soc,
-            discharge_debounced,
-            solar_low_debounced,
-            irradiance_low,
-        ) {
+        let target_mode_str = match rule_engine.evaluate(grid_connected, soc, irradiance_low) {
             Ok(m) => m,
             Err(e) => {
                 tracing::error!("Water heater rule engine error: {e} — defaulting to Vacation");
@@ -152,11 +124,10 @@ async fn control_task(
 
         debug!(
             "Water heater rule engine: grid={grid_connected} soc={soc:.1}% \
-            discharge_debounced={discharge_debounced} solar_low_debounced={solar_low_debounced} \
             irradiance_low={irradiance_low} → {target_mode_str}"
         );
 
-        // Rate limiting — stays in Rust
+        // Rate limiting
         let can_change = last_change
             .map(|t| (now - t).num_seconds() as u64 >= cfg.mode_change_min_secs)
             .unwrap_or(true);
@@ -172,8 +143,7 @@ async fn control_task(
         }
 
         info!(
-            "Water heater: changing mode {:?} → {:?} (grid={grid_connected}, soc={soc:.1}%, \
-            discharge={discharge_debounced}, solar_low={solar_low_debounced}, irradiance_low={irradiance_low})",
+            "Water heater: changing mode {:?} → {:?} (grid={grid_connected}, soc={soc:.1}%, irradiance_low={irradiance_low})",
             current_mode, target_mode
         );
 
@@ -182,6 +152,7 @@ async fn control_task(
             continue;
         }
 
+        last_change = Some(now);
         {
             let mut s = state.write().await;
             s.water_heater_mode        = target_mode;

--- a/crates/energy-manager/src/logic/water_heater/rules.rs
+++ b/crates/energy-manager/src/logic/water_heater/rules.rs
@@ -17,24 +17,19 @@ impl WaterHeaterRuleEngine {
         })
     }
 
-    /// Evaluates all conditions and returns "HeatPump" or "Vacation".
-    /// Debounce flags are pre-computed in Rust before calling this method.
+    /// Evaluates conditions and returns "HeatPump" or "Vacation".
+    /// HEAT_PUMP requires: SOC >= 90%, irradiance >= threshold, grid disconnected (ac_ignore=1).
     pub fn evaluate(
         &mut self,
         grid_connected: bool,
         soc_pct: f64,
-        discharge_debounced: bool,
-        solar_low_debounced: bool,
         irradiance_low: bool,
     ) -> anyhow::Result<String> {
         let facts = Facts::new();
-        // Initialise to false so WH_Decide_HeatPump fires when no condition is met
-        facts.set("WH.want_vacation",       Value::Boolean(false));
-        facts.set("WH.grid_connected",      Value::Boolean(grid_connected));
-        facts.set("WH.soc_pct",             Value::Number(soc_pct));
-        facts.set("WH.discharge_debounced", Value::Boolean(discharge_debounced));
-        facts.set("WH.solar_low_debounced", Value::Boolean(solar_low_debounced));
-        facts.set("WH.irradiance_low",      Value::Boolean(irradiance_low));
+        facts.set("WH.want_vacation",  Value::Boolean(false));
+        facts.set("WH.grid_connected", Value::Boolean(grid_connected));
+        facts.set("WH.soc_pct",        Value::Number(soc_pct));
+        facts.set("WH.irradiance_low", Value::Boolean(irradiance_low));
 
         self.engine
             .execute(&facts)
@@ -46,7 +41,6 @@ impl WaterHeaterRuleEngine {
                 Value::String(s) => Some(s),
                 _ => None,
             })
-            // Fail-safe: prefer Vacation (less consumption) on any engine error
             .unwrap_or_else(|| "Vacation".to_string());
 
         Ok(mode)


### PR DESCRIPTION
…shunt VM daily totals, monitor rules card

Fix 1 - water_heater: simplify to 3 conditions only (SOC>=90%, irradiance>=300W/m², grid disconnected via ac_ignore=1). Remove solar_low_debounced and discharge_debounced from rule engine.

Fix 2 - inverter: read Ac/Out/L1/P directly from Venus as primary AC power source (falls back to V*I). Populates venus_inverter_ac_output_power_w in VM so edge chart history and W display in InverterNode both work.

Fix 3 - smartshunt: replace static ah_charged/discharged_today with live VictoriaMetrics queries (clamp_max/clamp_min on venus_shunt_current_a) computed since midnight each day.

Fix 4 - monitor: add card-rules after card-sysmon showing water heater rule conditions (SOC, irradiance, AC IN ignore) with live green/red indicators and current decision.

https://claude.ai/code/session_015cjuLwXscae4F31BLwCPsQ