### PR TITLE
fix: résolution définitive des 4 problèmes (issue.md)

### DIFF
--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -102,21 +102,74 @@
     </div>
   </div>
 
-  <!-- Rules Status -->
+  <!-- Card a) Gestion Courant Victron -->
+  <div class="bms-card" id="card-charge" style="background:#0f172a;border:1px solid #1e293b;">
+    <div style="padding:0.7rem 0.9rem;border-bottom:1px solid #1e293b;display:flex;justify-content:space-between;align-items:center;">
+      <span style="font-family:monospace;font-weight:700;color:#7dd3fc;font-size:0.85rem;">⚡ GESTION COURANT VICTRON</span>
+      <span id="charge-ts" style="font-family:monospace;font-size:0.65rem;color:#475569;">—</span>
+    </div>
+    <div style="padding:0.75rem 0.9rem;display:flex;flex-direction:column;gap:0.5rem;">
+      <div style="display:flex;align-items:center;gap:0.55rem;font-family:monospace;font-size:0.73rem;">
+        <span style="color:#94a3b8;flex:1;">Courant max charge</span>
+        <span id="charge-current-val" style="font-weight:700;color:#22c55e;">— A</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:0.55rem;font-family:monospace;font-size:0.73rem;">
+        <span style="color:#94a3b8;flex:1;">Power Assist (VEBus)</span>
+        <span id="charge-assist-val" style="font-weight:700;color:#94a3b8;">—</span>
+      </div>
+      <div id="charge-rule-grid" style="display:flex;flex-direction:column;gap:0.4rem;margin-top:0.3rem;padding-top:0.4rem;border-top:1px solid #1e293b;"></div>
+    </div>
+  </div>
+
+  <!-- Card b) Gestion du Chauffe-eau -->
   <div class="bms-card" id="card-rules" style="background:#0f172a;border:1px solid #1e293b;">
     <div style="padding:0.7rem 0.9rem;border-bottom:1px solid #1e293b;display:flex;justify-content:space-between;align-items:center;">
-      <span style="font-family:monospace;font-weight:700;color:#7dd3fc;font-size:0.85rem;">◈ RÈGLES CHAUFFE-EAU</span>
+      <span style="font-family:monospace;font-weight:700;color:#7dd3fc;font-size:0.85rem;">🚿 GESTION CHAUFFE-EAU</span>
       <span id="rules-mode-badge" style="font-family:monospace;font-size:0.72rem;padding:2px 8px;border-radius:4px;background:#1e293b;color:#475569;">—</span>
     </div>
     <div style="padding:0.75rem 0.9rem;display:flex;flex-direction:column;gap:0.55rem;">
-
-      <div id="rule-grid" style="display:flex;flex-direction:column;gap:0.5rem;"></div>
-
-      <div style="margin-top:0.4rem;border-top:1px solid #1e293b;padding-top:0.5rem;display:flex;align-items:center;gap:0.5rem;">
-        <span style="font-family:monospace;font-size:0.68rem;color:#475569;">Résultat :</span>
+      <!-- LG ThinQ real values -->
+      <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:0.4rem;">
+        <div style="background:#1e293b;border-radius:6px;padding:0.4rem 0.55rem;">
+          <div style="font-family:monospace;font-size:0.6rem;color:#64748b;margin-bottom:2px;">MODE LG</div>
+          <div id="wh-mode-val" style="font-family:monospace;font-size:0.78rem;font-weight:700;color:#7dd3fc;">—</div>
+        </div>
+        <div style="background:#1e293b;border-radius:6px;padding:0.4rem 0.55rem;">
+          <div style="font-family:monospace;font-size:0.6rem;color:#64748b;margin-bottom:2px;">TEMP. ACTUELLE</div>
+          <div id="wh-temp-val" style="font-family:monospace;font-size:0.78rem;font-weight:700;color:#f97316;">—</div>
+        </div>
+        <div style="background:#1e293b;border-radius:6px;padding:0.4rem 0.55rem;">
+          <div style="font-family:monospace;font-size:0.6rem;color:#64748b;margin-bottom:2px;">TEMP. CIBLE</div>
+          <div id="wh-target-val" style="font-family:monospace;font-size:0.78rem;font-weight:700;color:#a78bfa;">—</div>
+        </div>
+      </div>
+      <div style="font-family:monospace;font-size:0.62rem;color:#475569;">LG lu le : <span id="wh-read-ts">—</span></div>
+      <!-- Rule conditions -->
+      <div id="rule-grid" style="display:flex;flex-direction:column;gap:0.4rem;padding-top:0.3rem;border-top:1px solid #1e293b;"></div>
+      <div style="display:flex;align-items:center;gap:0.5rem;">
+        <span style="font-family:monospace;font-size:0.68rem;color:#475569;">Décision :</span>
         <span id="rules-decision" style="font-family:monospace;font-size:0.75rem;font-weight:700;color:#94a3b8;">—</span>
       </div>
+    </div>
+  </div>
 
+  <!-- Card c) Gestion des relais DEYE -->
+  <div class="bms-card" id="card-deye" style="background:#0f172a;border:1px solid #1e293b;">
+    <div style="padding:0.7rem 0.9rem;border-bottom:1px solid #1e293b;display:flex;justify-content:space-between;align-items:center;">
+      <span style="font-family:monospace;font-weight:700;color:#7dd3fc;font-size:0.85rem;">🔌 GESTION RELAIS DEYE</span>
+      <span id="deye-state-badge" style="font-family:monospace;font-size:0.72rem;padding:2px 8px;border-radius:4px;background:#1e293b;color:#475569;">—</span>
+    </div>
+    <div style="padding:0.75rem 0.9rem;display:flex;flex-direction:column;gap:0.5rem;">
+      <div style="display:flex;align-items:center;gap:0.55rem;font-family:monospace;font-size:0.73rem;">
+        <span id="deye-dot" style="width:8px;height:8px;border-radius:50%;flex-shrink:0;display:inline-block;background:#475569;"></span>
+        <span style="color:#94a3b8;flex:1;">Relais DEYE</span>
+        <span id="deye-on-val" style="font-weight:700;color:#94a3b8;">—</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:0.55rem;font-family:monospace;font-size:0.73rem;">
+        <span style="color:#94a3b8;flex:1;">Dernier changement</span>
+        <span id="deye-change-ts" style="color:#64748b;font-size:0.65rem;">—</span>
+      </div>
+      <div id="deye-rule-grid" style="display:flex;flex-direction:column;gap:0.4rem;margin-top:0.3rem;padding-top:0.4rem;border-top:1px solid #1e293b;"></div>
     </div>
   </div>
 
@@ -399,7 +452,7 @@ async function loadLogFile(){
   } catch(e){wrap.innerHTML='<div style="padding:1rem;color:#dc2626">Erreur: '+e.message+'</div>';}
 }
 
-// ── Rules Status (water heater) ──────────────────────────────────────────────
+// ── Helpers ──────────────────────────────────────────────────────────────────
 function ruleRow(label, ok, valueStr, detail) {
   const dot = `<span style="width:8px;height:8px;border-radius:50%;flex-shrink:0;display:inline-block;background:${ok?'#22c55e':'#ef4444'};${ok?'box-shadow:0 0 5px #22c55e66':''}"></span>`;
   return `<div style="display:flex;align-items:center;gap:0.55rem;font-family:monospace;font-size:0.73rem;">
@@ -410,49 +463,73 @@ function ruleRow(label, ok, valueStr, detail) {
   </div>`;
 }
 
+function fmtTs(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (isNaN(d)) return '—';
+  const age = Math.floor((Date.now() - d) / 1000);
+  const timeStr = d.toLocaleTimeString('fr-FR');
+  if (age < 60) return `${timeStr} (${age}s)`;
+  if (age < 3600) return `${timeStr} (${Math.floor(age/60)}min)`;
+  return `${timeStr} (${Math.floor(age/3600)}h)`;
+}
+
+const EM_BASE = 'http://' + location.hostname + ':8081';
+
 async function fetchRulesStatus() {
+  const safe = p => p.catch(() => null);
+
+  // Fetch local BMS/irradiance/inverter data from daly-bms-server
+  const [bms1r, bms2r, irrR, invR, emR] = await Promise.all([
+    safe(fetch('/api/v1/bms/1/status').then(r => r.ok ? r.json() : null)),
+    safe(fetch('/api/v1/bms/2/status').then(r => r.ok ? r.json() : null)),
+    safe(fetch('/api/v1/irradiance/status').then(r => r.ok ? r.json() : null)),
+    safe(fetch('/api/v1/venus/inverter').then(r => r.ok ? r.json() : null)),
+    safe(fetch(EM_BASE + '/api/rules-status').then(r => r.ok ? r.json() : null)),
+  ]);
+
+  // ── SOC ──────────────────────────────────────────────────────────────────
+  const validBms = [bms1r, bms2r].filter(b => b && b.Soc != null);
+  const avgSoc = validBms.length ? validBms.reduce((s, b) => s + b.Soc, 0) / validBms.length : null;
+  const socOk  = avgSoc != null && avgSoc >= 90;
+
+  // ── Irradiance ──────────────────────────────────────────────────────────
+  const irr   = irrR?.irradiance_wm2 ?? null;
+  const irrOk = irr != null && irr >= 300;
+
+  // ── Grid / AC IN ─────────────────────────────────────────────────────────
+  const inv       = invR?.inverter ?? null;
+  const acIgnore  = inv?.ac_in_ignore ?? null;
+  const gridOffOk = acIgnore === true;
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Card b) Chauffe-eau
+  // ══════════════════════════════════════════════════════════════════════════
   try {
-    const safe = p => p.catch(() => null);
-    const [bms1r, bms2r, irrR, invR] = await Promise.all([
-      safe(fetch('/api/v1/bms/1/status').then(r => r.ok ? r.json() : null)),
-      safe(fetch('/api/v1/bms/2/status').then(r => r.ok ? r.json() : null)),
-      safe(fetch('/api/v1/irradiance/status').then(r => r.ok ? r.json() : null)),
-      safe(fetch('/api/v1/venus/inverter').then(r => r.ok ? r.json() : null)),
-    ]);
-
-    // SOC — moyenne des BMS disponibles
-    const validBms = [bms1r, bms2r].filter(b => b && b.Soc != null);
-    const avgSoc = validBms.length ? validBms.reduce((s, b) => s + b.Soc, 0) / validBms.length : null;
-    const socOk  = avgSoc != null && avgSoc >= 90;
-
-    // Irradiance
-    const irr    = irrR?.irradiance_wm2 ?? null;
-    const irrOk  = irr != null && irr >= 300;
-
-    // AC IN Ignored (grid disconnected)
-    const inv       = invR?.inverter ?? null;
-    const acIgnore  = inv?.ac_in_ignore ?? null;
-    const gridOffOk = acIgnore === true;
-
-    // Mode actuel (heatpump mqtt_index=1)
-    const hpR = await safe(fetch('/api/v1/venus/heatpumps').then(r => r.ok ? r.json() : null));
-    const hp1 = (hpR?.heatpumps ?? []).find(h => h.mqtt_index === 1) ?? null;
-    const venusState = hp1?.State ?? null;
-    const modeLabel  = venusState === 1 ? 'HEAT_PUMP' : venusState === 0 ? 'VACATION' : '—';
-    const modeOk     = venusState === 1;
+    const wh = emR?.water_heater ?? null;
+    const whMode = wh?.mode ?? '—';
+    const modeOk = whMode === 'HEAT_PUMP';
 
     const badge = document.getElementById('rules-mode-badge');
     if (badge) {
-      badge.textContent = modeLabel;
+      badge.textContent = whMode;
       badge.style.background = modeOk ? '#14532d' : '#1c1917';
       badge.style.color      = modeOk ? '#4ade80' : '#78716c';
     }
+    const modeEl = document.getElementById('wh-mode-val');
+    if (modeEl) { modeEl.textContent = whMode; modeEl.style.color = modeOk ? '#4ade80' : '#f87171'; }
+    const tempEl = document.getElementById('wh-temp-val');
+    if (tempEl) tempEl.textContent = wh?.current_temp_c != null ? wh.current_temp_c.toFixed(1) + ' °C' : '—';
+    const tgtEl = document.getElementById('wh-target-val');
+    if (tgtEl) tgtEl.textContent = wh?.target_temp_c != null ? wh.target_temp_c.toFixed(1) + ' °C' : '—';
+    const readTs = document.getElementById('wh-read-ts');
+    if (readTs) readTs.textContent = fmtTs(wh?.last_read_ts);
 
     const grid = document.getElementById('rule-grid');
     if (grid) {
       grid.innerHTML = [
-        ruleRow('SOC ≥ 90 %',          socOk,    avgSoc  != null ? `${avgSoc.toFixed(1)} %`   : '—', '(condition remplie si vert)'),
-        ruleRow('Irradiance ≥ 300 W/m²', irrOk,  irr     != null ? `${irr.toFixed(0)} W/m²`  : '—', null),
+        ruleRow('SOC ≥ 90 %',                      socOk,    avgSoc != null ? `${avgSoc.toFixed(1)} %`  : '—', null),
+        ruleRow('Irradiance ≥ 300 W/m²',           irrOk,    irr    != null ? `${irr.toFixed(0)} W/m²` : '—', null),
         ruleRow('Grid déconnecté (AC IN Ignored)', gridOffOk, acIgnore != null ? (acIgnore ? 'ACTIF' : 'Normal') : '—', null),
       ].join('');
     }
@@ -460,10 +537,80 @@ async function fetchRulesStatus() {
     const allOk = socOk && irrOk && gridOffOk;
     const dec = document.getElementById('rules-decision');
     if (dec) {
-      dec.textContent = allOk ? '→ HEAT_PUMP activé' : '→ VACATION (en attente des conditions)';
+      dec.textContent = allOk ? '→ HEAT_PUMP' : '→ VACATION (conditions non remplies)';
       dec.style.color = allOk ? '#4ade80' : '#94a3b8';
     }
-  } catch(e) { console.warn('fetchRulesStatus:', e); }
+  } catch(e) { console.warn('fetchRulesStatus/wh:', e); }
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Card a) Courant Victron
+  // ══════════════════════════════════════════════════════════════════════════
+  try {
+    const cc = emR?.charge_current ?? null;
+    const currentA = cc?.current_a ?? null;
+    const assist   = cc?.power_assist ?? null;
+
+    const curEl = document.getElementById('charge-current-val');
+    if (curEl) {
+      curEl.textContent = currentA != null ? `${currentA} A` : '—';
+      curEl.style.color = currentA != null ? '#22c55e' : '#94a3b8';
+    }
+    const assEl = document.getElementById('charge-assist-val');
+    if (assEl) {
+      assEl.textContent = assist != null ? (assist === 1 ? 'ACTIVÉ' : 'Désactivé') : '—';
+      assEl.style.color = assist === 1 ? '#22c55e' : '#94a3b8';
+    }
+    const tsEl = document.getElementById('charge-ts');
+    if (tsEl) tsEl.textContent = fmtTs(cc?.last_ts);
+
+    // Condition rows for charge card
+    const offgrid = acIgnore === true;
+    const cGrid = document.getElementById('charge-rule-grid');
+    if (cGrid) {
+      cGrid.innerHTML = [
+        ruleRow('Mode réseau', !offgrid, offgrid ? 'Off-grid' : 'Grid', null),
+        ruleRow('SOC batteries', avgSoc != null, avgSoc != null ? `${avgSoc.toFixed(1)} %` : '—', null),
+        ruleRow('Courant VEBus appliqué', currentA != null, currentA != null ? `${currentA} A` : '—', null),
+      ].join('');
+    }
+  } catch(e) { console.warn('fetchRulesStatus/charge:', e); }
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Card c) Relais DEYE
+  // ══════════════════════════════════════════════════════════════════════════
+  try {
+    const deye = emR?.deye ?? null;
+    const deyeOn = deye?.on ?? null;
+
+    const badge = document.getElementById('deye-state-badge');
+    if (badge) {
+      badge.textContent   = deyeOn === true ? 'ON' : deyeOn === false ? 'OFF' : '—';
+      badge.style.background = deyeOn ? '#14532d' : '#1c1917';
+      badge.style.color      = deyeOn ? '#4ade80' : '#78716c';
+    }
+    const dot = document.getElementById('deye-dot');
+    if (dot) {
+      dot.style.background = deyeOn ? '#22c55e' : '#ef4444';
+      dot.style.boxShadow  = deyeOn ? '0 0 5px #22c55e66' : '';
+    }
+    const onEl = document.getElementById('deye-on-val');
+    if (onEl) {
+      onEl.textContent = deyeOn === true ? 'Actif' : deyeOn === false ? 'Inactif' : '—';
+      onEl.style.color = deyeOn ? '#22c55e' : '#94a3b8';
+    }
+    const chEl = document.getElementById('deye-change-ts');
+    if (chEl) chEl.textContent = fmtTs(deye?.last_change);
+
+    // Conditions for DEYE
+    const dGrid = document.getElementById('deye-rule-grid');
+    if (dGrid) {
+      dGrid.innerHTML = [
+        ruleRow('Grid déconnecté',      gridOffOk, acIgnore != null ? (acIgnore ? 'ACTIF' : 'Normal') : '—', null),
+        ruleRow('Irradiance ≥ 300 W/m²', irrOk,   irr != null ? `${irr.toFixed(0)} W/m²` : '—', null),
+        ruleRow('Relais DEYE actif',    !!deyeOn,  deyeOn != null ? (deyeOn ? 'ON' : 'OFF') : '—', null),
+      ].join('');
+    }
+  } catch(e) { console.warn('fetchRulesStatus/deye:', e); }
 }
 
 fetchMonitor();

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -209,7 +209,7 @@ const atsExecRef = useRef(null);
           case 'e-ats-maison':
           case 'e-maison-switchs':  fv = Math.abs(et8?.power_w              ?? 0); break;
           case 'e-ats-micro':       fv = Math.abs(et7?.power_w              ?? 0); break;
-          case 'e-onduleur-ats':    fv = Math.abs(inverter?.ac_output_power_w ?? 0); rev = true; break;
+          case 'e-onduleur-ats':    fv = Math.abs(inverter?.ac_output_power_w ?? inverter?.power_w ?? 0); rev = true; break;
           case 'e-ats-reseau':
           case 'e-reseau-onduleur': fv = Math.abs(et9?.power_w              ?? 0); break;
           case 'e-mppt-shu':        fv = mpptTotalPowerW;                          break;
@@ -261,7 +261,7 @@ const atsExecRef = useRef(null);
           });
         }
         if (sw1C) {
-          const e1pwr = Math.abs(inverter?.ac_output_power_w ?? 0);
+          const e1pwr = Math.abs(inverter?.ac_output_power_w ?? inverter?.power_w ?? 0);
           atsEdges.push({
             id: 'ats-e1', source: 'ats-onduleur', target: 'ats-main',
             sourceHandle: 'onduleur-out', targetHandle: 'ats-in-onduleur',

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -192,12 +192,15 @@ pub struct LgThinqConfig {
     pub client_id: String,
     #[serde(default = "default_lg_poll_secs")]
     pub poll_interval_secs: u64,
+    #[serde(default = "default_lg_vm_url")]
+    pub vm_url: String,
 }
 
 fn default_lg_base_url()  -> String { "https://api-eic.lgthinq.com".into() }
 fn default_lg_country()   -> String { "FR".into() }
 fn default_lg_client_id() -> String { "energy-manager".into() }
 fn default_lg_poll_secs() -> u64 { 600 }
+fn default_lg_vm_url()    -> String { "http://127.0.0.1:8428".into() }
 
 impl Default for LgThinqConfig {
     fn default() -> Self {
@@ -210,6 +213,7 @@ impl Default for LgThinqConfig {
             country: default_lg_country(),
             client_id: default_lg_client_id(),
             poll_interval_secs: default_lg_poll_secs(),
+            vm_url: default_lg_vm_url(),
         }
     }
 }
@@ -321,6 +325,9 @@ pub struct WaterHeaterConfig {
     /// Minimum irradiance to allow HEAT_PUMP mode (W/m²)
     #[serde(default = "default_irradiance_min_wm2")]
     pub irradiance_min_wm2: f64,
+    /// VictoriaMetrics write URL for water heater metrics
+    #[serde(default = "default_wh_vm_url")]
+    pub vm_url: String,
 }
 
 fn default_solar_min_w() -> f64 { 1000.0 }
@@ -331,6 +338,7 @@ fn default_vacation_target_c() -> f64 { 45.0 }
 fn default_temp_set_delay_secs() -> u64 { 15 }
 fn default_keepalive_secs() -> u64 { 25 }
 fn default_irradiance_min_wm2() -> f64 { 300.0 }
+fn default_wh_vm_url() -> String { "http://127.0.0.1:8428".into() }
 
 impl Default for WaterHeaterConfig {
     fn default() -> Self {
@@ -343,6 +351,7 @@ impl Default for WaterHeaterConfig {
             temp_set_delay_secs: default_temp_set_delay_secs(),
             keepalive_secs: default_keepalive_secs(),
             irradiance_min_wm2: default_irradiance_min_wm2(),
+            vm_url: default_wh_vm_url(),
         }
     }
 }

--- a/crates/energy-manager/src/http_clients/lg_thinq.rs
+++ b/crates/energy-manager/src/http_clients/lg_thinq.rs
@@ -214,19 +214,38 @@ pub async fn spawn_poller(
     let bus2   = bus.clone();
     let state2 = state.clone();
     tokio::spawn(async move {
-        let poller = LgThinqClient::new(cfg2);
+        let poller = LgThinqClient::new(cfg2.clone());
+        let vm_url = cfg2.vm_url.clone();
         let mut ticker = interval(Duration::from_secs(poller.cfg.poll_interval_secs));
         loop {
             ticker.tick().await;
+            let now = chrono::Utc::now();
             match poller.get_state().await {
                 Ok(snap) => {
                     {
                         let mut s = state2.write().await;
-                        s.water_heater_mode     = snap.mode;
-                        s.water_heater_temp_c   = snap.current_temp_c;
-                        s.water_heater_target_c = snap.target_temp_c;
+                        s.water_heater_mode      = snap.mode;
+                        s.water_heater_temp_c    = snap.current_temp_c;
+                        s.water_heater_target_c  = snap.target_temp_c;
+                        s.water_heater_last_read = Some(now);
                     }
                     bus2.emit_live(LiveEvent::new("water_heater", &snap));
+
+                    // Write 3 LG ThinQ metrics to VictoriaMetrics
+                    let ts_ms = now.timestamp_millis();
+                    let mut lines = Vec::new();
+                    lines.push(format!("wh_mode{{}} {} {}", snap.mode.to_venus_state(), ts_ms));
+                    if let Some(t) = snap.current_temp_c {
+                        lines.push(format!("wh_current_temp_c{{}} {} {}", t, ts_ms));
+                    }
+                    if let Some(t) = snap.target_temp_c {
+                        lines.push(format!("wh_target_temp_c{{}} {} {}", t, ts_ms));
+                    }
+                    let body = lines.join("\n");
+                    let url  = format!("{}/api/v1/import/prometheus", vm_url);
+                    if let Err(e) = reqwest::Client::new().post(&url).body(body).send().await {
+                        warn!("LG ThinQ VM write error: {e}");
+                    }
                 }
                 Err(e) => error!("LG ThinQ poll error: {e}"),
             }

--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -24,6 +24,7 @@ use tracing::info;
 
 use crate::http_clients::lg_thinq::LgThinqClient;
 use crate::types::{EnergyState, LiveEvent, WaterHeaterMode};
+use chrono::{DateTime, Utc};
 
 #[derive(Clone)]
 struct ServerState {
@@ -50,6 +51,7 @@ pub async fn serve(
         .route("/health",                   get(health_handler))
         .route("/api/water-heater",         get(wh_status_handler))
         .route("/api/water-heater/mode",    post(wh_set_mode_handler))
+        .route("/api/rules-status",         get(rules_status_handler))
         .with_state(srv)
         .layer(cors);
 
@@ -112,6 +114,66 @@ async fn wh_set_mode_handler(
         s.water_heater_mode = mode;
     }
     (StatusCode::OK, "ok").into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Rules status — aggregated data for monitor.html cards
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct WaterHeaterCard {
+    mode:           String,
+    current_temp_c: Option<f64>,
+    target_temp_c:  Option<f64>,
+    last_read_ts:   Option<DateTime<Utc>>,
+    last_change_ts: Option<DateTime<Utc>>,
+    send_count:     u32,
+    lg_enabled:     bool,
+}
+
+#[derive(Serialize)]
+struct ChargeCurrent {
+    current_a:    Option<f64>,
+    power_assist: Option<i64>,
+    last_ts:      Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize)]
+struct DeyeCard {
+    on:            bool,
+    last_change:   Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize)]
+struct RulesStatus {
+    water_heater:   WaterHeaterCard,
+    charge_current: ChargeCurrent,
+    deye:           DeyeCard,
+}
+
+async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
+    let s = srv.state.read().await;
+    let status = RulesStatus {
+        water_heater: WaterHeaterCard {
+            mode:           s.water_heater_mode.to_lg_str().to_string(),
+            current_temp_c: s.water_heater_temp_c,
+            target_temp_c:  s.water_heater_target_c,
+            last_read_ts:   s.water_heater_last_read,
+            last_change_ts: s.water_heater_last_change,
+            send_count:     s.water_heater_send_count,
+            lg_enabled:     srv.lg.is_some(),
+        },
+        charge_current: ChargeCurrent {
+            current_a:    s.last_charge_current_a,
+            power_assist: s.last_power_assist,
+            last_ts:      s.last_charge_ts,
+        },
+        deye: DeyeCard {
+            on:          s.deye_on,
+            last_change: s.deye_last_change,
+        },
+    };
+    Json(status).into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/energy-manager/src/logic/charge_current/mod.rs
+++ b/crates/energy-manager/src/logic/charge_current/mod.rs
@@ -3,6 +3,7 @@
 /// Mode selection is handled by rust-rule-engine (rules/charge_current.grl).
 mod rules;
 
+use chrono::Utc;
 use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -122,6 +123,7 @@ async fn compute_and_publish(
         let mut s = state.write().await;
         s.last_charge_current_a = Some(charge_a);
         s.last_power_assist     = Some(power_assist);
+        s.last_charge_ts        = Some(Utc::now());
     }
 
     bus.publish(MqttOutgoing::transient(

--- a/crates/energy-manager/src/logic/inverter/mod.rs
+++ b/crates/energy-manager/src/logic/inverter/mod.rs
@@ -1,7 +1,5 @@
 /// Aggregates VEBus topics into santuario/inverter/venus (retained).
-/// AC power availability is determined by the rule engine (rules/inverter.grl).
-mod rules;
-
+/// AC power falls back to V×I when the direct measurement topic is absent.
 use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -30,14 +28,6 @@ async fn run(
     let pfx_vebus  = format!("N/{pid}/vebus/{vb}/");
     let pfx_system = format!("N/{pid}/system/0/");
 
-    let mut rule_engine = match rules::InverterRuleEngine::new() {
-        Ok(e) => e,
-        Err(e) => {
-            tracing::error!("Failed to init inverter rule engine: {e}");
-            return;
-        }
-    };
-
     let mut rx = bus.subscribe_mqtt();
     loop {
         let msg = match rx.recv().await {
@@ -46,7 +36,7 @@ async fn run(
         };
 
         if handle(&msg, &pfx_vebus, &pfx_system, &state).await {
-            publish_state(&mut rule_engine, &bus, &state).await;
+            publish_state(&bus, &state).await;
         }
     }
 }
@@ -109,7 +99,6 @@ async fn handle(
 }
 
 async fn publish_state(
-    rule_engine: &mut rules::InverterRuleEngine,
     bus: &AppBus,
     state: &Arc<RwLock<EnergyState>>,
 ) {
@@ -126,19 +115,10 @@ async fn publish_state(
     let ac_out_power = s.ac_out_power_w;
     drop(s);
 
-    // Prefer direct power measurement (Ac/Out/L1/P); fall back to V*I when available
-    let ac_power = if ac_out_power.is_some() {
-        ac_out_power
-    } else {
-        match rule_engine.ac_power_ready(ac_voltage.is_some(), ac_current.is_some()) {
-            Ok(true)  => ac_voltage.zip(ac_current).map(|(v, i)| v * i),
-            Ok(false) => None,
-            Err(e) => {
-                tracing::error!("Inverter rule engine error: {e}");
-                None
-            }
-        }
-    };
+    // Prefer direct measurement (Ac/Out/L1/P); fall back to V×I
+    let ac_power = ac_out_power.or_else(|| {
+        ac_voltage.zip(ac_current).map(|(v, i)| v * i)
+    });
 
     let payload = json!({
         "Voltage":     dc_voltage,

--- a/crates/energy-manager/src/logic/water_heater/mod.rs
+++ b/crates/energy-manager/src/logic/water_heater/mod.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::{interval, sleep, Duration};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use crate::bus::AppBus;
 use crate::config::WaterHeaterConfig;
 use crate::http_clients::lg_thinq::LgThinqClient;
@@ -46,6 +46,28 @@ async fn publish_to_venus(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
     bus.emit_live(LiveEvent::new("water_heater_venus", &payload));
 }
 
+async fn write_wh_metrics(vm_url: &str, mode: WaterHeaterMode, temp: Option<f64>, target: Option<f64>) {
+    let ts_ms = Utc::now().timestamp_millis();
+    let mut lines = Vec::new();
+    lines.push(format!("wh_mode{{}} {} {}", mode.to_venus_state(), ts_ms));
+    if let Some(t) = temp {
+        lines.push(format!("wh_current_temp_c{{}} {} {}", t, ts_ms));
+    }
+    if let Some(t) = target {
+        lines.push(format!("wh_target_temp_c{{}} {} {}", t, ts_ms));
+    }
+    let body = lines.join("\n");
+    let url = format!("{}/api/v1/import/prometheus", vm_url);
+    if let Err(e) = reqwest::Client::new()
+        .post(&url)
+        .body(body)
+        .send()
+        .await
+    {
+        warn!("Water heater VM write error: {e}");
+    }
+}
+
 async fn control_task(
     cfg: WaterHeaterConfig,
     lg: Arc<LgThinqClient>,
@@ -53,14 +75,56 @@ async fn control_task(
     state: Arc<RwLock<EnergyState>>,
 ) {
     let mut last_change: Option<DateTime<Utc>> = None;
-    let mut last_sent_mode: Option<WaterHeaterMode> = None;
-    let mut ticker = interval(Duration::from_secs(30));
+    // Count consecutive send failures to detect and alert on persistent issues
+    let mut consecutive_fails: u32 = 0;
+    // Tick every 5 minutes as requested
+    let mut ticker = interval(Duration::from_secs(300));
 
-    info!("Water heater control task started");
+    info!("Water heater control task started (5min interval)");
 
     loop {
         ticker.tick().await;
         let now = Utc::now();
+
+        // Read actual state from LG ThinQ before deciding
+        let lg_snapshot = match lg.get_state().await {
+            Ok(snap) => {
+                {
+                    let mut s = state.write().await;
+                    s.water_heater_mode     = snap.mode;
+                    s.water_heater_temp_c   = snap.current_temp_c;
+                    s.water_heater_target_c = snap.target_temp_c;
+                    s.water_heater_last_read = Some(now);
+                }
+                write_wh_metrics(
+                    &cfg.vm_url,
+                    snap.mode,
+                    snap.current_temp_c,
+                    snap.target_temp_c,
+                ).await;
+                Some(snap)
+            }
+            Err(e) => {
+                error!("LG ThinQ get_state error: {e}");
+                None
+            }
+        };
+
+        // Read energy conditions — skip evaluation if MQTT data not yet available
+        let (ac_ignore_opt, soc_opt, irradiance) = {
+            let s = state.read().await;
+            (s.ac_ignore, s.soc_pct, s.irradiance_wm2)
+        };
+
+        if ac_ignore_opt.is_none() || soc_opt.is_none() {
+            info!("Water heater: waiting for MQTT data (ac_ignore={:?}, soc={:?}) — skip", ac_ignore_opt, soc_opt);
+            continue;
+        }
+
+        let ac_ignore = ac_ignore_opt.unwrap_or(0);
+        let soc       = soc_opt.unwrap_or(0.0);
+        let irradiance_low = irradiance.map(|w| w < cfg.irradiance_min_wm2).unwrap_or(true);
+        let grid_connected = ac_ignore == 0;
 
         let mut rule_engine = match rules::WaterHeaterRuleEngine::new() {
             Ok(e) => e,
@@ -70,14 +134,6 @@ async fn control_task(
                 continue;
             }
         };
-
-        let (ac_ignore, soc, irradiance) = {
-            let s = state.read().await;
-            (s.ac_ignore.unwrap_or(0), s.soc_pct.unwrap_or(0.0), s.irradiance_wm2)
-        };
-
-        let irradiance_low = irradiance.map(|w| w < cfg.irradiance_min_wm2).unwrap_or(true);
-        let grid_connected = ac_ignore == 0;
 
         let target_mode_str = match rule_engine.evaluate(grid_connected, soc, irradiance_low) {
             Ok(m) => m,
@@ -92,40 +148,60 @@ async fn control_task(
             _ => WaterHeaterMode::Vacation,
         };
 
+        // Use actual LG state (from readback) as the reference for comparison
+        let actual_mode = lg_snapshot
+            .as_ref()
+            .map(|s| s.mode)
+            .unwrap_or_else(|| state.try_read().map(|s| s.water_heater_mode).unwrap_or(WaterHeaterMode::Vacation));
+
+        let should_send = actual_mode != target_mode;
+
+        if !should_send {
+            info!(
+                "Water heater: target={:?} matches actual={:?}, no change (soc={:.1}%, grid={}, irr_low={})",
+                target_mode, actual_mode, soc, grid_connected, irradiance_low
+            );
+            consecutive_fails = 0;
+            continue;
+        }
+
         let can_change = last_change
             .map(|t| (now - t).num_seconds() as u64 >= cfg.mode_change_min_secs)
             .unwrap_or(true);
 
-        let should_send = match last_sent_mode {
-            Some(last) => last != target_mode,
-            None => true,
-        };
-
-        let force_refresh = last_change
-            .map(|t| (now - t).num_minutes() >= 10)
-            .unwrap_or(true);
-
-        if (!should_send && !force_refresh) || !can_change {
+        if !can_change {
+            let secs_left = cfg.mode_change_min_secs.saturating_sub(
+                last_change.map(|t| (now - t).num_seconds() as u64).unwrap_or(0)
+            );
+            info!("Water heater: cooldown active, {}s remaining — target={:?}", secs_left, target_mode);
             continue;
         }
 
         info!(
-            "Water heater: SEND {:?} (soc={:.1}%, grid={}, irradiance_low={})",
-            target_mode, soc, grid_connected, irradiance_low
+            "Water heater: SEND {:?} (actual={:?}, soc={:.1}%, grid={}, irradiance_low={})",
+            target_mode, actual_mode, soc, grid_connected, irradiance_low
         );
 
         if let Err(e) = lg.set_mode(target_mode).await {
             error!("LG set_mode error: {e}");
+            consecutive_fails += 1;
+            if consecutive_fails >= 3 {
+                warn!(
+                    "Water heater: {} consecutive send failures — LG ThinQ may be unreachable!",
+                    consecutive_fails
+                );
+            }
             continue;
         }
 
-        last_sent_mode = Some(target_mode);
+        consecutive_fails = 0;
         last_change = Some(now);
 
         {
             let mut s = state.write().await;
             s.water_heater_mode = target_mode;
             s.water_heater_last_change = Some(now);
+            s.water_heater_send_count += 1;
         }
         publish_to_venus(&bus, &state).await;
 

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -147,6 +147,8 @@ pub struct EnergyState {
     pub water_heater_temp_c: Option<f64>,
     pub water_heater_target_c: Option<f64>,
     pub water_heater_last_change: Option<DateTime<Utc>>,
+    pub water_heater_last_read: Option<DateTime<Utc>>,
+    pub water_heater_send_count: u32,
 
     // --- DEYE relay (Shelly) ---
     pub deye_on: bool,
@@ -185,6 +187,7 @@ pub struct EnergyState {
     // --- Charge current (last published) ---
     pub last_charge_current_a: Option<f64>,
     pub last_power_assist: Option<i64>,
+    pub last_charge_ts: Option<DateTime<Utc>>,
 
     // --- SmartShunt Ah accumulators (backup: current integration, reset at midnight) ---
     pub ah_charged_today: f64,


### PR DESCRIPTION
Issue 1 — ac_output_power_w null:
- Supprime le rule engine inverter pour le calcul V×I (inutile)
- Remplace par un simple `.or_else(|| zip(V,I).map(v*i))`
- La métrique venus_inverter_ac_output_power_w sera désormais présente dans VictoriaMetrics dès que V et I sont disponibles

Issue 2 — Animations edges Onduleur↔ATS manquantes:
- Fallback sur `power_w` (DC) quand `ac_output_power_w` est null pour les edges e-onduleur-ats et ats-e1 dans visualization.html

Issue 3 — Logique waterheater ne envoie pas HEAT_PUMP:
- Intervalle passe de 30 s à 5 min (300 s) comme demandé
- Évaluation skippée si ac_ignore ou soc_pct pas encore reçus (évite le VACATION «par défaut» qui bloquait le cooldown 15 min)
- Lecture LG ThinQ réelle avant chaque évaluation; comparaison avec l'état réel plutôt qu'un état mémorisé local
- Alertes consécutives en cas d'échec d'envoi (≥3 = WARN)
- Métriques wh_mode / wh_current_temp_c / wh_target_temp_c écrites dans VictoriaMetrics après chaque lecture LG ThinQ
- Timestamp water_heater_last_read ajouté à EnergyState

Issue 4 — Page monitoring: 3 cards règles obligatoires:
- Card a) Gestion Courant Victron: courant max, power_assist, conditions
- Card b) Gestion Chauffe-eau: valeurs réelles LG ThinQ (mode/temp/cible)
  + timestamp dernière lecture + 3 conditions (SOC/irradiance/grid)
- Card c) Gestion Relais DEYE: état réel + timestamp + conditions
- Nouvel endpoint GET /api/rules-status dans energy-manager (port 8081)
- Timestamp last_charge_ts ajouté à EnergyState

https://claude.ai/code/session_01L2VJBoJL3k9u6vtqkD2A5F