### PR TITLE
fix: use SmartShunt SOC everywhere + detailed water heater diagnostics

### DIFF
--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -501,19 +501,19 @@ async function fetchRulesStatus() {
     safe(fetch(EM_BASE + '/api/rules-status').then(r => r.ok ? r.json() : null)),
   ]);
 
-  // ── SOC ──────────────────────────────────────────────────────────────────
-  const validBms = [bms1r, bms2r].filter(b => b && b.Soc != null);
-  const avgSoc = validBms.length ? validBms.reduce((s, b) => s + b.Soc, 0) / validBms.length : null;
-  const socOk  = avgSoc != null && avgSoc >= 90;
+  // ── SOC — SmartShunt Victron (valeur exacte utilisée par l'energy-manager) ─
+  const emSoc  = emR?.soc_pct ?? null;
+  const socOk  = emSoc != null && emSoc >= 90;
 
-  // ── Irradiance ──────────────────────────────────────────────────────────
-  const irr   = irrR?.irradiance_wm2 ?? null;
+  // ── Irradiance — valeur vue par l'energy-manager (santuario/irradiance/raw)
+  const irr   = emR?.irradiance_wm2 ?? irrR?.irradiance_wm2 ?? null;
   const irrOk = irr != null && irr >= 300;
 
-  // ── Grid / AC IN ─────────────────────────────────────────────────────────
-  const inv       = invR?.inverter ?? null;
-  const acIgnore  = inv?.ac_in_ignore ?? null;
-  const gridOffOk = acIgnore === true;
+  // ── Grid / AC IN — valeur vue par l'energy-manager (VEBus IgnoreAcIn1) ───
+  const emAcIgnore = emR?.ac_ignore ?? null;          // 0=grid, 1=off-grid (i64)
+  const inv        = invR?.inverter ?? null;
+  const acIgnore   = emAcIgnore != null ? (emAcIgnore === 1) : (inv?.ac_in_ignore ?? null);
+  const gridOffOk  = acIgnore === true;
 
   const tsEl2 = document.getElementById('rules-ts');
   if (tsEl2) tsEl2.textContent = 'Màj ' + new Date().toLocaleTimeString('fr-FR');
@@ -544,7 +544,7 @@ async function fetchRulesStatus() {
     const grid = document.getElementById('rule-grid');
     if (grid) {
       grid.innerHTML = [
-        ruleRow('SOC ≥ 90 %',                      socOk,    avgSoc != null ? `${avgSoc.toFixed(1)} %`  : '—', null),
+        ruleRow('SOC ≥ 90 % (SmartShunt)',           socOk,    emSoc  != null ? `${emSoc.toFixed(1)} %`   : '—', null),
         ruleRow('Irradiance ≥ 300 W/m²',           irrOk,    irr    != null ? `${irr.toFixed(0)} W/m²` : '—', null),
         ruleRow('Grid déconnecté (AC IN Ignored)', gridOffOk, acIgnore != null ? (acIgnore ? 'ACTIF' : 'Normal') : '—', null),
       ].join('');
@@ -585,7 +585,7 @@ async function fetchRulesStatus() {
     if (cGrid) {
       cGrid.innerHTML = [
         ruleRow('Mode réseau', !offgrid, offgrid ? 'Off-grid' : 'Grid', null),
-        ruleRow('SOC batteries', avgSoc != null, avgSoc != null ? `${avgSoc.toFixed(1)} %` : '—', null),
+        ruleRow('SOC (SmartShunt)', emSoc != null, emSoc != null ? `${emSoc.toFixed(1)} %` : '—', null),
         ruleRow('Courant VEBus appliqué', currentA != null, currentA != null ? `${currentA} A` : '—', null),
       ].join('');
     }

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -187,6 +187,8 @@ const atsExecRef = useRef(null);
       ? (validBms.reduce((s, b) => s + (b.Soc ?? 0), 0) / validBms.length).toFixed(0)
       : null;
     const totalPwr = validBms.reduce((s, b) => s + (b.Dc?.Power ?? 0), 0);
+    // Use SmartShunt SOC (Victron) as primary — falls back to DALY average only if absent
+    const displaySoc = shunt?.soc_percent != null ? shunt.soc_percent : (avgSoc != null ? parseFloat(avgSoc) : null);
 
     const microPwr     = et7?.power_w ?? 0;
     const totalProdPwr = microPwr + mpptTotalPowerW;
@@ -194,9 +196,9 @@ const atsExecRef = useRef(null);
     const mpptYieldSumG = mpptList.reduce((s, m) => s + (m.yield_today_kwh ?? 0), 0);
     const prodSub      = et7 ? `${((et7.energy_export_wh ?? 0) / 1000).toFixed(1)} kWh ET112` : mpptList.length > 0 ? `${mpptYieldSumG.toFixed(2)} kWh MPPT` : 'Micro-onduleurs';
     const prodDot      = (et7?.connected || mpptList.length > 0) ? (totalProdPwr > 50 ? 'live' : '') : '';
-    const batVal       = avgSoc != null ? `SOC ${avgSoc}%` : '—';
+    const batVal       = displaySoc != null ? `SOC ${displaySoc.toFixed(0)}%` : '—';
     const batSub       = totalPwr ? `${totalPwr > 0 ? '+' : ''}${(totalPwr / 1000).toFixed(2)} kW` : '360 Ah + 320 Ah';
-    const batDot       = avgSoc == null ? '' : avgSoc > 50 ? 'live' : avgSoc > 20 ? 'warn' : 'alarm';
+    const batDot       = displaySoc == null ? '' : displaySoc > 50 ? 'live' : displaySoc > 20 ? 'warn' : 'alarm';
     const irrVal       = irr?.irradiance_wm2 != null ? `${irr.irradiance_wm2.toFixed(0)} W/m²` : '—';
     const irrSub       = irr?.total_yield_kwh != null ? `☀ ${irr.total_yield_kwh.toFixed(1)} kWh` : 'Irradiance solaire';
     const irrDot       = irr ? 'live' : '';
@@ -290,7 +292,7 @@ const atsExecRef = useRef(null);
           const mpptYieldSum  = mpptList.reduce((s, m) => s + (m.yield_today_kwh ?? 0), 0);
           const localProdKwh  = ((et7?.energy_export_wh ?? 0) / 1000) + mpptYieldSum;
           const totalYieldKwh = irr?.total_yield_kwh ?? localProdKwh;
-          return { ...n, data: { ...n.data, totalYieldKwh, prodKwh: localProdKwh, soc: avgSoc != null ? parseFloat(avgSoc) : 0, irrWm2: irr?.irradiance_wm2 ?? 0 } };
+          return { ...n, data: { ...n.data, totalYieldKwh, prodKwh: localProdKwh, soc: displaySoc ?? 0, irrWm2: irr?.irradiance_wm2 ?? 0 } };
         }
         case 'sankey': {
           const loadPwr        = tasmotaDevices.reduce((s, d) => s + (d.connected ? (d.power_w ?? 0) : 0), 0);

--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -149,6 +149,12 @@ struct RulesStatus {
     water_heater:   WaterHeaterCard,
     charge_current: ChargeCurrent,
     deye:           DeyeCard,
+    /// SmartShunt SOC used by the water heater rule engine (None = not yet received from MQTT)
+    soc_pct:        Option<f64>,
+    /// Irradiance W/m² used by the water heater rule engine (None = not yet received)
+    irradiance_wm2: Option<f64>,
+    /// ac_ignore flag from VEBus (0 = grid connected, 1 = grid ignored/off-grid)
+    ac_ignore:      Option<i64>,
 }
 
 async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
@@ -172,6 +178,9 @@ async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
             on:          s.deye_on,
             last_change: s.deye_last_change,
         },
+        soc_pct:        s.soc_pct,
+        irradiance_wm2: s.irradiance_wm2,
+        ac_ignore:      s.ac_ignore,
     };
     Json(status).into_response()
 }

--- a/crates/energy-manager/src/logic/water_heater/mod.rs
+++ b/crates/energy-manager/src/logic/water_heater/mod.rs
@@ -87,8 +87,13 @@ async fn control_task(
         let now = Utc::now();
 
         // Read actual state from LG ThinQ before deciding
+        info!("Water heater: calling lg.get_state()...");
         let lg_snapshot = match lg.get_state().await {
             Ok(snap) => {
+                info!(
+                    "Water heater: LG get_state OK → mode={:?}, temp={:?}°C, target={:?}°C",
+                    snap.mode, snap.current_temp_c, snap.target_temp_c
+                );
                 {
                     let mut s = state.write().await;
                     s.water_heater_mode     = snap.mode;
@@ -105,7 +110,7 @@ async fn control_task(
                 Some(snap)
             }
             Err(e) => {
-                error!("LG ThinQ get_state error: {e}");
+                error!("LG ThinQ get_state FAILED: {e} — will skip mode comparison this tick");
                 None
             }
         };
@@ -116,15 +121,41 @@ async fn control_task(
             (s.ac_ignore, s.soc_pct, s.irradiance_wm2)
         };
 
+        info!(
+            "Water heater tick — ac_ignore={:?}, soc={:?}, irradiance={:?} W/m² (min={})",
+            ac_ignore_opt, soc_opt, irradiance, cfg.irradiance_min_wm2
+        );
+
         if ac_ignore_opt.is_none() || soc_opt.is_none() {
-            info!("Water heater: waiting for MQTT data (ac_ignore={:?}, soc={:?}) — skip", ac_ignore_opt, soc_opt);
+            warn!(
+                "Water heater: MQTT data missing (ac_ignore={:?}, soc={:?}) — skipping evaluation. \
+                 Check that energy-manager subscriptions are received from broker.",
+                ac_ignore_opt, soc_opt
+            );
             continue;
         }
 
         let ac_ignore = ac_ignore_opt.unwrap_or(0);
         let soc       = soc_opt.unwrap_or(0.0);
-        let irradiance_low = irradiance.map(|w| w < cfg.irradiance_min_wm2).unwrap_or(true);
+        let irradiance_low = match irradiance {
+            Some(w) => {
+                let low = w < cfg.irradiance_min_wm2;
+                info!("Water heater: irradiance={:.1} W/m², min={}, irradiance_low={}", w, cfg.irradiance_min_wm2, low);
+                low
+            }
+            None => {
+                warn!(
+                    "Water heater: irradiance_wm2=None (topic 'santuario/irradiance/raw' not received yet) \
+                     — treating as irradiance_low=true → target will be VACATION"
+                );
+                true
+            }
+        };
         let grid_connected = ac_ignore == 0;
+        info!(
+            "Water heater: ac_ignore={}, grid_connected={}, soc={:.1}%, irradiance_low={}",
+            ac_ignore, grid_connected, soc, irradiance_low
+        );
 
         let mut rule_engine = match rules::WaterHeaterRuleEngine::new() {
             Ok(e) => e,
@@ -136,7 +167,11 @@ async fn control_task(
         };
 
         let target_mode_str = match rule_engine.evaluate(grid_connected, soc, irradiance_low) {
-            Ok(m) => m,
+            Ok(m) => {
+                info!("Water heater: rule engine → target_mode={m} (grid_connected={}, soc={:.1}%, irradiance_low={})",
+                    grid_connected, soc, irradiance_low);
+                m
+            }
             Err(e) => {
                 error!("Rule engine error: {e} — fallback VACATION");
                 "VACATION".to_string()
@@ -152,14 +187,22 @@ async fn control_task(
         let actual_mode = lg_snapshot
             .as_ref()
             .map(|s| s.mode)
-            .unwrap_or_else(|| state.try_read().map(|s| s.water_heater_mode).unwrap_or(WaterHeaterMode::Vacation));
+            .unwrap_or_else(|| {
+                warn!("Water heater: LG readback failed, using cached state for comparison");
+                state.try_read().map(|s| s.water_heater_mode).unwrap_or(WaterHeaterMode::Vacation)
+            });
+
+        info!(
+            "Water heater: target={:?}, actual (LG)={:?}, should_send={}",
+            target_mode, actual_mode, actual_mode != target_mode
+        );
 
         let should_send = actual_mode != target_mode;
 
         if !should_send {
             info!(
-                "Water heater: target={:?} matches actual={:?}, no change (soc={:.1}%, grid={}, irr_low={})",
-                target_mode, actual_mode, soc, grid_connected, irradiance_low
+                "Water heater: target={:?} matches actual={:?}, no command needed",
+                target_mode, actual_mode
             );
             consecutive_fails = 0;
             continue;


### PR DESCRIPTION
- visualization.html: battery card + spiral node now show SmartShunt Victron SOC (soc_percent) instead of DALY BMS average; falls back to DALY average only when SmartShunt data is absent
- monitor.html (water heater rule card): SOC condition now displays and evaluates against SmartShunt SOC from energy-manager (emR.soc_pct); irradiance and ac_ignore also sourced from energy-manager to reflect the exact values the rule engine sees
- energy-manager /api/rules-status: exposes soc_pct, irradiance_wm2 and ac_ignore so the monitor page shows the actual values used by rules
- water_heater/mod.rs: comprehensive diagnostic logging at every tick — all state values, LG get_state result, rule engine decision, and explicit WARN when irradiance_wm2 is None (silent VACATION trap)

https://claude.ai/code/session_01L2VJBoJL3k9u6vtqkD2A5F