### PR TITLE
fix(irradiance): poll daly-bms-server HTTP as primary irradiance source

### DIFF
--- a/crates/energy-manager/src/logic/irradiance/mod.rs
+++ b/crates/energy-manager/src/logic/irradiance/mod.rs
@@ -1,20 +1,64 @@
 /// Receives santuario/irradiance/raw → validates via rule engine → stores in state.
+/// Also polls daly-bms-server HTTP API every 30s as primary reliable source.
 mod rules;
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::debug;
+use tokio::time::{interval, Duration};
+use tracing::{debug, info, warn};
 
 use crate::bus::AppBus;
 use crate::types::EnergyState;
 
 const TOPIC: &str = "santuario/irradiance/raw";
 
-pub async fn spawn(bus: AppBus, state: Arc<RwLock<EnergyState>>) {
-    tokio::spawn(run(bus, state));
+pub async fn spawn(bus: AppBus, state: Arc<RwLock<EnergyState>>, bms_server_url: String) {
+    tokio::spawn(http_poll_task(bms_server_url, state.clone()));
+    tokio::spawn(mqtt_task(bus, state));
 }
 
-async fn run(bus: AppBus, state: Arc<RwLock<EnergyState>>) {
+/// Polls daly-bms-server GET /api/v1/irradiance/status every 30s.
+/// This is the primary irradiance source — always has the correct value
+/// directly from the PRALRAN RS485 sensor.
+async fn http_poll_task(bms_server_url: String, state: Arc<RwLock<EnergyState>>) {
+    let url = format!("{}/api/v1/irradiance/status", bms_server_url.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    let mut ticker = interval(Duration::from_secs(30));
+
+    info!("Irradiance HTTP poll started → {url}");
+
+    loop {
+        ticker.tick().await;
+        match client.get(&url).timeout(Duration::from_secs(5)).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                match resp.json::<serde_json::Value>().await {
+                    Ok(json) => {
+                        if let Some(wm2) = json.get("irradiance_wm2").and_then(|v| v.as_f64()) {
+                            let connected = json.get("connected").and_then(|v| v.as_bool()).unwrap_or(true);
+                            if connected && wm2 >= 0.0 && wm2 <= 2000.0 {
+                                let prev = state.read().await.irradiance_wm2;
+                                state.write().await.irradiance_wm2 = Some(wm2);
+                                if prev.map(|p| (p - wm2).abs() > 5.0).unwrap_or(true) {
+                                    info!("Irradiance HTTP: {:.0} W/m²", wm2);
+                                } else {
+                                    debug!("Irradiance HTTP: {:.0} W/m²", wm2);
+                                }
+                            } else if !connected {
+                                debug!("Irradiance HTTP: sensor not connected");
+                            }
+                        }
+                    }
+                    Err(e) => warn!("Irradiance HTTP: JSON parse error: {e}"),
+                }
+            }
+            Ok(resp) => warn!("Irradiance HTTP: status {}", resp.status()),
+            Err(e)   => warn!("Irradiance HTTP: request failed: {e}"),
+        }
+    }
+}
+
+/// Listens to santuario/irradiance/raw MQTT topic as supplementary source.
+async fn mqtt_task(bus: AppBus, state: Arc<RwLock<EnergyState>>) {
     let mut rule_engine = match rules::IrradianceRuleEngine::new() {
         Ok(e) => e,
         Err(e) => {
@@ -38,7 +82,7 @@ async fn run(bus: AppBus, state: Arc<RwLock<EnergyState>>) {
         match rule_engine.validate(raw) {
             Ok(true)  => {}
             Ok(false) => {
-                debug!("Irradiance out of range: {raw}");
+                debug!("Irradiance MQTT out of range: {raw}");
                 continue;
             }
             Err(e) => {
@@ -47,7 +91,7 @@ async fn run(bus: AppBus, state: Arc<RwLock<EnergyState>>) {
             }
         }
 
-        debug!("Irradiance: {raw} W/m²");
+        debug!("Irradiance MQTT: {raw} W/m²");
         state.write().await.irradiance_wm2 = Some(raw);
         bus.emit_live(crate::types::LiveEvent::new(
             "irradiance",

--- a/crates/energy-manager/src/main.rs
+++ b/crates/energy-manager/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
 
     logic::inverter::spawn(vic.clone(), bus.clone(), state.clone()).await;
     logic::smartshunt::spawn(vic.clone(), bus.clone(), state.clone()).await;
-    logic::irradiance::spawn(bus.clone(), state.clone()).await;
+    logic::irradiance::spawn(bus.clone(), state.clone(), cfg.solar.bms_server_url.clone()).await;
     logic::tasmota::spawn(vic.clone(), bus.clone(), state.clone()).await;
     logic::switch_ats::spawn(bus.clone(), state.clone()).await;
     logic::platform::spawn(cfg.platform.clone(), bus.clone()).await;


### PR DESCRIPTION
The MQTT topic santuario/irradiance/raw contained a stale retained value (10 W/m²) while the PRALRAN RS485 sensor correctly reads ~422 W/m² (confirmed by VictoriaMetrics). The energy-manager was using the stale MQTT value, causing irradiance_low=true → water heater target=VACATION → HEAT_PUMP never sent.

Fix: add HTTP poll task every 30s to GET /api/v1/irradiance/status on the daly-bms-server (bms_server_url from config). This always reflects the real RS485 sensor reading and updates state.irradiance_wm2 reliably. The MQTT subscription is kept as a supplementary source.

https://claude.ai/code/session_01L2VJBoJL3k9u6vtqkD2A5F