### PR TITLE
fix(irradiance): bus emit_live + rule engine in http_poll_task; rever…

### DIFF
--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -505,8 +505,8 @@ async function fetchRulesStatus() {
   const emSoc  = emR?.soc_pct ?? null;
   const socOk  = emSoc != null && emSoc >= 90;
 
-  // ── Irradiance — valeur vue par l'energy-manager (santuario/irradiance/raw)
-  const irr   = emR?.irradiance_wm2 ?? irrR?.irradiance_wm2 ?? null;
+  // ── Irradiance — valeur directe du capteur PRALRAN (daly-bms-server)
+  const irr   = irrR?.irradiance_wm2 ?? null;
   const irrOk = irr != null && irr >= 300;
 
   // ── Grid / AC IN — valeur vue par l'energy-manager (VEBus IgnoreAcIn1) ───

--- a/crates/energy-manager/src/logic/irradiance/mod.rs
+++ b/crates/energy-manager/src/logic/irradiance/mod.rs
@@ -13,17 +13,24 @@ use crate::types::EnergyState;
 const TOPIC: &str = "santuario/irradiance/raw";
 
 pub async fn spawn(bus: AppBus, state: Arc<RwLock<EnergyState>>, bms_server_url: String) {
-    tokio::spawn(http_poll_task(bms_server_url, state.clone()));
+    tokio::spawn(http_poll_task(bms_server_url, bus.clone(), state.clone()));
     tokio::spawn(mqtt_task(bus, state));
 }
 
 /// Polls daly-bms-server GET /api/v1/irradiance/status every 30s.
 /// This is the primary irradiance source — always has the correct value
 /// directly from the PRALRAN RS485 sensor.
-async fn http_poll_task(bms_server_url: String, state: Arc<RwLock<EnergyState>>) {
+async fn http_poll_task(bms_server_url: String, bus: AppBus, state: Arc<RwLock<EnergyState>>) {
     let url = format!("{}/api/v1/irradiance/status", bms_server_url.trim_end_matches('/'));
     let client = reqwest::Client::new();
     let mut ticker = interval(Duration::from_secs(30));
+    let mut rule_engine = match rules::IrradianceRuleEngine::new() {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::error!("Irradiance HTTP: failed to init rule engine: {e}");
+            return;
+        }
+    };
 
     info!("Irradiance HTTP poll started → {url}");
 
@@ -35,16 +42,26 @@ async fn http_poll_task(bms_server_url: String, state: Arc<RwLock<EnergyState>>)
                     Ok(json) => {
                         if let Some(wm2) = json.get("irradiance_wm2").and_then(|v| v.as_f64()) {
                             let connected = json.get("connected").and_then(|v| v.as_bool()).unwrap_or(true);
-                            if connected && wm2 >= 0.0 && wm2 <= 2000.0 {
-                                let prev = state.read().await.irradiance_wm2;
-                                state.write().await.irradiance_wm2 = Some(wm2);
-                                if prev.map(|p| (p - wm2).abs() > 5.0).unwrap_or(true) {
-                                    info!("Irradiance HTTP: {:.0} W/m²", wm2);
-                                } else {
-                                    debug!("Irradiance HTTP: {:.0} W/m²", wm2);
-                                }
-                            } else if !connected {
+                            if !connected {
                                 debug!("Irradiance HTTP: sensor not connected");
+                                continue;
+                            }
+                            match rule_engine.validate(wm2) {
+                                Ok(true) => {
+                                    let prev = state.read().await.irradiance_wm2;
+                                    state.write().await.irradiance_wm2 = Some(wm2);
+                                    bus.emit_live(crate::types::LiveEvent::new(
+                                        "irradiance",
+                                        serde_json::json!({ "irradiance_wm2": wm2 }),
+                                    ));
+                                    if prev.map(|p| (p - wm2).abs() > 5.0).unwrap_or(true) {
+                                        info!("Irradiance HTTP: {:.0} W/m²", wm2);
+                                    } else {
+                                        debug!("Irradiance HTTP: {:.0} W/m²", wm2);
+                                    }
+                                }
+                                Ok(false) => debug!("Irradiance HTTP: out of range: {wm2}"),
+                                Err(e)    => tracing::error!("Irradiance HTTP: rule engine error: {e}"),
                             }
                         }
                     }


### PR DESCRIPTION
…t monitor to sensor source

- irradiance/mod.rs: pass bus to http_poll_task, emit live events after HTTP poll update, use IrradianceRuleEngine for validation (consistent with MQTT path)
- monitor.html: revert irradiance source to irrR (daly-bms-server direct PRALRAN sensor) instead of emR (energy-manager, which had stale MQTT retained value at startup)

https://claude.ai/code/session_01L2VJBoJL3k9u6vtqkD2A5F