### PR TITLE
feat(history): agrégation PromQL par bucket — 1 barre par jour/mois

### DIFF
--- a/crates/daly-bms-server/src/api/history.rs
+++ b/crates/daly-bms-server/src/api/history.rs
@@ -39,57 +39,66 @@ pub async fn get_energy_history(
     };
 
     let now_ms = Utc::now().timestamp_millis();
-    let (start_ms, step_ms): (i64, i64) = match period {
-        "week"  => (now_ms - 7 * 86_400_000,   3_600_000),
-        "month" => (now_ms - 30 * 86_400_000,  21_600_000),
-        "year"  => (now_ms - 365 * 86_400_000, 86_400_000),
-        _       => (now_ms - 86_400_000,        900_000),
+
+    // step = résolution d'un bucket ; window = fenêtre PromQL pour agréger
+    let (start_ms, step_ms, window): (i64, i64, &str) = match period {
+        "week"  => (now_ms -   7 * 86_400_000,  86_400_000,    "1d"),
+        "month" => (now_ms -  30 * 86_400_000,  86_400_000,    "1d"),
+        "year"  => (now_ms - 365 * 86_400_000,  2_592_000_000, "30d"),
+        _       => (now_ms -       86_400_000,  3_600_000,     "1h"),  // day
     };
 
-    // ── Requêtes PromQL en parallèle ────────────────────────────────────────────
+    // ── Requêtes PromQL avec fenêtres d'agrégation ──────────────────────────────
+    let q_solar_w        = format!("avg_over_time(solar_total_w[{}])", window);
+    let q_import_w       = format!("avg_over_time(et112_power_w{{address=\"0x09\"}}[{}])", window);
+    let q_consump_w      = format!("avg_over_time(et112_power_w{{address=\"0x08\"}}[{}])", window);
+    let q_solar_energy   = format!("increase(et112_energy_import_wh{{address=\"0x07\"}}[{}])", window);
+    let q_import_energy  = format!("increase(et112_energy_import_wh{{address=\"0x09\"}}[{}])", window);
+    let q_export_energy  = format!("increase(et112_energy_export_wh{{address=\"0x09\"}}[{}])", window);
+    let q_consump_energy = format!("increase(et112_energy_import_wh{{address=\"0x08\"}}[{}])", window);
+    let q_charge_ah      = format!("max_over_time(venus_shunt_ah_charged_today[{}])", window);
+    let q_discharge_ah   = format!("max_over_time(venus_shunt_ah_discharged_today[{}])", window);
+
     let (solar_w_r, import_w_r, consumption_w_r,
          solar_energy_r, import_energy_r, export_energy_r, consumption_energy_r,
          charge_ah_r, discharge_ah_r) = tokio::join!(
-        vm.query_range_json("solar_total_w",                               start_ms, now_ms, step_ms),
-        vm.query_range_json("et112_power_w{address=\"0x09\"}",             start_ms, now_ms, step_ms),
-        vm.query_range_json("et112_power_w{address=\"0x08\"}",             start_ms, now_ms, step_ms),
-        vm.query_range_json("et112_energy_import_wh{address=\"0x07\"}",    start_ms, now_ms, step_ms),
-        vm.query_range_json("et112_energy_import_wh{address=\"0x09\"}",    start_ms, now_ms, step_ms),
-        vm.query_range_json("et112_energy_export_wh{address=\"0x09\"}",    start_ms, now_ms, step_ms),
-        vm.query_range_json("et112_energy_import_wh{address=\"0x08\"}",    start_ms, now_ms, step_ms),
-        vm.query_range_json("venus_shunt_ah_charged_today",                start_ms, now_ms, step_ms),
-        vm.query_range_json("venus_shunt_ah_discharged_today",             start_ms, now_ms, step_ms),
+        vm.query_range_json(&q_solar_w,        start_ms, now_ms, step_ms),
+        vm.query_range_json(&q_import_w,       start_ms, now_ms, step_ms),
+        vm.query_range_json(&q_consump_w,      start_ms, now_ms, step_ms),
+        vm.query_range_json(&q_solar_energy,   start_ms, now_ms, step_ms),
+        vm.query_range_json(&q_import_energy,  start_ms, now_ms, step_ms),
+        vm.query_range_json(&q_export_energy,  start_ms, now_ms, step_ms),
+        vm.query_range_json(&q_consump_energy, start_ms, now_ms, step_ms),
+        vm.query_range_json(&q_charge_ah,      start_ms, now_ms, step_ms),
+        vm.query_range_json(&q_discharge_ah,   start_ms, now_ms, step_ms),
     );
 
-    // ── Extraction des séries ────────────────────────────────────────────────────
-    let (ts_solar,   solar_w)    = extract_ts_values(solar_w_r.ok());
-    let (ts_import,  import_w)   = extract_ts_values(import_w_r.ok());
-    let (ts_consump, consump_w)  = extract_ts_values(consumption_w_r.ok());
+    // ── Extraction ──────────────────────────────────────────────────────────────
+    let (ts_solar,   solar_w)   = extract_ts_values(solar_w_r.ok());
+    let (ts_import,  import_w)  = extract_ts_values(import_w_r.ok());
+    let (ts_consump, consump_w) = extract_ts_values(consumption_w_r.ok());
 
-    let solar_energy_pts   = extract_cumul(solar_energy_r.ok());
-    let import_energy_pts  = extract_cumul(import_energy_r.ok());
-    let export_energy_pts  = extract_cumul(export_energy_r.ok());
-    let consump_energy_pts = extract_cumul(consumption_energy_r.ok());
+    // increase() retourne le delta Wh par fenêtre — conversion directe en kWh/bucket
+    let (_, solar_energy_wh)    = extract_ts_values(solar_energy_r.ok());
+    let (_, import_energy_wh)   = extract_ts_values(import_energy_r.ok());
+    let (_, export_energy_wh)   = extract_ts_values(export_energy_r.ok());
+    let (_, consump_energy_wh)  = extract_ts_values(consumption_energy_r.ok());
 
+    let solar_kwh_series:   Vec<f64> = solar_energy_wh.iter().map(|&v| round2(v.max(0.0) / 1000.0)).collect();
+    let import_kwh_series:  Vec<f64> = import_energy_wh.iter().map(|&v| round2(v.max(0.0) / 1000.0)).collect();
+    let consump_kwh_series: Vec<f64> = consump_energy_wh.iter().map(|&v| round2(v.max(0.0) / 1000.0)).collect();
+
+    let solar_kwh  = round2(solar_energy_wh.iter().map(|&v| v.max(0.0)).sum::<f64>() / 1000.0);
+    let import_kwh = round2(import_energy_wh.iter().map(|&v| v.max(0.0)).sum::<f64>() / 1000.0);
+    let export_kwh = round2(export_energy_wh.iter().map(|&v| v.max(0.0)).sum::<f64>() / 1000.0);
+    let consump_kwh= round2(consump_energy_wh.iter().map(|&v| v.max(0.0)).sum::<f64>() / 1000.0);
+
+    // max_over_time donne le total journalier (compteur SmartShunt remis à 0 à minuit)
     let (ts_charge,    charge_ah_pts)    = extract_ts_values(charge_ah_r.ok());
     let (ts_discharge, discharge_ah_pts) = extract_ts_values(discharge_ah_r.ok());
 
-    let solar_kwh   = delta_wh_to_kwh(&solar_energy_pts);
-    let import_kwh  = delta_wh_to_kwh(&import_energy_pts);
-    let export_kwh  = delta_wh_to_kwh(&export_energy_pts);
-    let consump_kwh = delta_wh_to_kwh(&consump_energy_pts);
-
-    let solar_kwh_series   = cumul_delta_kwh(&solar_energy_pts);
-    let import_kwh_series  = cumul_delta_kwh(&import_energy_pts);
-    let consump_kwh_series = cumul_delta_kwh(&consump_energy_pts);
-
-    let v_nom = 51.2_f64;
-    let solar_ah   = solar_kwh   * 1000.0 / v_nom;
-    let import_ah  = import_kwh  * 1000.0 / v_nom;
-    let consump_ah = consump_kwh * 1000.0 / v_nom;
-
-    let charge_ah_now    = charge_ah_pts.last().copied().unwrap_or(0.0);
-    let discharge_ah_now = discharge_ah_pts.last().copied().unwrap_or(0.0);
+    let charge_ah_total    = round2(charge_ah_pts.iter().map(|&v| v.max(0.0)).sum::<f64>());
+    let discharge_ah_total = round2(discharge_ah_pts.iter().map(|&v| v.max(0.0)).sum::<f64>());
 
     Json(json!({
         "ok":     true,
@@ -109,22 +118,18 @@ pub async fn get_energy_history(
         "import_kwh_series":  import_kwh_series,
         "consump_kwh_series": consump_kwh_series,
 
-        "solar_ah":   round2(solar_ah),
-        "import_ah":  round2(import_ah),
-        "consump_ah": round2(consump_ah),
-
         "charge_ah_series":    charge_ah_pts,
         "discharge_ah_series": discharge_ah_pts,
-        "charge_ah_now":    round2(charge_ah_now),
-        "discharge_ah_now": round2(discharge_ah_now),
+        "charge_ah_now":    charge_ah_total,
+        "discharge_ah_now": discharge_ah_total,
 
         "totals": {
-            "solar_kwh":   round2(solar_kwh),
-            "import_kwh":  round2(import_kwh),
-            "export_kwh":  round2(export_kwh),
-            "consump_kwh": round2(consump_kwh),
-            "charge_ah":   round2(charge_ah_now),
-            "discharge_ah":round2(discharge_ah_now),
+            "solar_kwh":   solar_kwh,
+            "import_kwh":  import_kwh,
+            "export_kwh":  export_kwh,
+            "consump_kwh": consump_kwh,
+            "charge_ah":   charge_ah_total,
+            "discharge_ah":discharge_ah_total,
         }
     }))
 }
@@ -149,38 +154,6 @@ fn extract_ts_values(result: Option<Value>) -> (Vec<i64>, Vec<f64>) {
     }).unzip()
 }
 
-/// Extrait les valeurs brutes d'un compteur cumulatif (en Wh).
-fn extract_cumul(result: Option<Value>) -> Vec<f64> {
-    let result = match result { Some(v) => v, None => return Vec::new() };
-    let empty = vec![];
-    let series_list = result["data"]["result"].as_array().unwrap_or(&empty);
-    match series_list.first() {
-        Some(first) => match first["values"].as_array() {
-            Some(values) => values.iter()
-                .map(|entry| entry[1].as_str().unwrap_or("0").parse::<f64>().unwrap_or(0.0))
-                .collect(),
-            None => Vec::new(),
-        },
-        None => Vec::new(),
-    }
-}
-
-/// Delta total (dernier - premier) en kWh depuis des valeurs Wh.
-fn delta_wh_to_kwh(pts: &[f64]) -> f64 {
-    if pts.len() < 2 { return 0.0; }
-    let first = pts.first().copied().unwrap_or(0.0);
-    let last  = pts.last().copied().unwrap_or(0.0);
-    if last >= first { (last - first) / 1000.0 } else { 0.0 }
-}
-
-/// Série de kWh cumulatifs depuis le début de période (delta par rapport au premier point).
-fn cumul_delta_kwh(pts: &[f64]) -> Vec<f64> {
-    if pts.is_empty() { return Vec::new(); }
-    let base = pts[0];
-    pts.iter()
-        .map(|&v| round2(if v >= base { (v - base) / 1000.0 } else { 0.0 }))
-        .collect()
-}
 
 #[inline]
 fn round2(v: f64) -> f64 { (v * 100.0).round() / 100.0 }

--- a/crates/daly-bms-server/templates/history.html
+++ b/crates/daly-bms-server/templates/history.html
@@ -239,16 +239,13 @@ function themeColors() {
   };
 }
 
-// ── Format timestamp → label ────────────────────────────────────────────────
+// ── Format timestamp → label (adapté au step de chaque période) ─────────────
 function fmtTs(ms, period) {
   const d = new Date(ms);
-  if (period === 'day') {
-    return d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
-  } else if (period === 'week' || period === 'month') {
-    return d.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit' }) + ' ' +
-           d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
-  }
-  return d.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit' });
+  if (period === 'day')   return d.toLocaleTimeString('fr-FR', { hour: '2-digit' }) + 'h';
+  if (period === 'week')  return d.toLocaleDateString('fr-FR', { weekday: 'short', day: '2-digit', month: '2-digit' });
+  if (period === 'month') return d.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit' });
+  return d.toLocaleDateString('fr-FR', { month: 'short' }); // year → Jan, Fév…
 }
 
 // ── Base option (horizontal stacked bar — bar-y-category-stack) ────────────
@@ -296,69 +293,64 @@ function baseOpt(c, unit, period, yLabels) {
 }
 
 // ── Render charts ──────────────────────────────────────────────────────────
+// L'API retourne déjà des valeurs agrégées par bucket via PromQL :
+//   increase([window])     → kWh par bucket
+//   avg_over_time([window])→ W moyen par bucket
+//   max_over_time([window])→ Ah SmartShunt par bucket (remise à 0 à minuit)
 function renderCharts(data) {
   const period = data.period || 'day';
   const c = themeColors();
 
-  // X-axis labels for each series
-  const xSolar   = (data.ts_solar_ms   || []).map(ms => fmtTs(ms, period));
-  const xImport  = (data.ts_import_ms  || []).map(ms => fmtTs(ms, period));
-  const xConsump = (data.ts_consump_ms || []).map(ms => fmtTs(ms, period));
-  const xCharge  = (data.ts_charge_ms  || []).map(ms => fmtTs(ms, period));
+  // Labels depuis les timestamps (un par bucket)
+  const tsSolar  = data.ts_solar_ms    || [];
+  const tsCharge = data.ts_charge_ms   || [];
+  const tsDischg = data.ts_discharge_ms|| [];
+  const xMain  = tsSolar.map(ms => fmtTs(ms, period));
+  const xShunt = (tsCharge.length ? tsCharge : tsDischg).map(ms => fmtTs(ms, period));
 
-  // All series share the longest x-axis (for kWh / Ah charts use solar x)
-  const xMain = xSolar.length >= xImport.length ? xSolar : xImport;
-
-  // ── 1. kWh cumulatif ─────────────────────────────────────────────────────
-  const hasSolarKwh  = (data.solar_kwh_series  || []).length > 0;
-  const hasImportKwh = (data.import_kwh_series || []).length > 0;
-  const hasConsumpKwh= (data.consump_kwh_series|| []).length > 0;
-  const hasKwh = hasSolarKwh || hasImportKwh || hasConsumpKwh;
+  // ── 1. kWh par bucket ─────────────────────────────────────────────────────
+  const solarKwh   = data.solar_kwh_series   || [];
+  const importKwh  = data.import_kwh_series  || [];
+  const consumpKwh = data.consump_kwh_series || [];
+  const hasKwh = solarKwh.length > 0 || importKwh.length > 0 || consumpKwh.length > 0;
 
   document.getElementById('nd-kwh').classList.toggle('hidden', hasKwh);
-  document.getElementById('meta-kwh').textContent =
-    hasKwh ? `☀ ${(data.totals?.solar_kwh||0).toFixed(2)} · 🔌 ${(data.totals?.import_kwh||0).toFixed(2)} · 🏠 ${(data.totals?.consump_kwh||0).toFixed(2)} kWh` : '—';
+  document.getElementById('meta-kwh').textContent = hasKwh
+    ? `☀ ${(data.totals?.solar_kwh||0).toFixed(2)} · 🔌 ${(data.totals?.import_kwh||0).toFixed(2)} · 🏠 ${(data.totals?.consump_kwh||0).toFixed(2)} kWh` : '—';
 
   cKwh.setOption({
     ...baseOpt(c, 'kWh', period, xMain),
     series: [
-      { name: '☀️ Solaire',      type: 'bar', stack: 'energy', data: data.solar_kwh_series   || [], itemStyle: { color: c.solar   }, emphasis: { focus: 'series' } },
-      { name: '🔌 Importée',     type: 'bar', stack: 'energy', data: data.import_kwh_series  || [], itemStyle: { color: c.import  }, emphasis: { focus: 'series' } },
-      { name: '🏠 Consommation', type: 'bar', stack: 'energy', data: data.consump_kwh_series || [], itemStyle: { color: c.consump }, emphasis: { focus: 'series' } },
+      { name: '☀️ Solaire',      type: 'bar', stack: 'energy', data: solarKwh,   itemStyle: { color: c.solar   }, emphasis: { focus: 'series' } },
+      { name: '🔌 Importée',     type: 'bar', stack: 'energy', data: importKwh,  itemStyle: { color: c.import  }, emphasis: { focus: 'series' } },
+      { name: '🏠 Consommation', type: 'bar', stack: 'energy', data: consumpKwh, itemStyle: { color: c.consump }, emphasis: { focus: 'series' } },
     ],
   }, true);
 
-  // ── 2. Puissance W ───────────────────────────────────────────────────────
-  const hasSolarW  = (data.solar_w  || []).length > 0;
-  const hasImportW = (data.import_w || []).length > 0;
-  const hasConsumpW= (data.consump_w|| []).length > 0;
-  const hasW = hasSolarW || hasImportW || hasConsumpW;
+  // ── 2. Puissance W (moyenne par bucket via avg_over_time) ─────────────────
+  const solarW   = data.solar_w  || [];
+  const importW  = data.import_w || [];
+  const consumpW = data.consump_w|| [];
+  const hasW = solarW.length > 0 || importW.length > 0 || consumpW.length > 0;
 
   document.getElementById('nd-w').classList.toggle('hidden', hasW);
-  const maxW = Math.max(
-    ...(data.solar_w  || [0]),
-    ...(data.import_w || [0]),
-    ...(data.consump_w|| [0])
-  );
+  const maxW = Math.max(...(solarW.length ? solarW : [0]), ...(importW.length ? importW : [0]), ...(consumpW.length ? consumpW : [0]));
   document.getElementById('meta-w').textContent = hasW ? `Max ${maxW.toFixed(0)} W` : '—';
 
   cW.setOption({
     ...baseOpt(c, 'W', period, xMain),
     series: [
-      { name: '☀️ Solaire',      type: 'bar', stack: 'power', data: data.solar_w  || [], itemStyle: { color: c.solar   }, emphasis: { focus: 'series' } },
-      { name: '🔌 Importée',     type: 'bar', stack: 'power', data: data.import_w || [], itemStyle: { color: c.import  }, emphasis: { focus: 'series' } },
-      { name: '🏠 Consommation', type: 'bar', stack: 'power', data: data.consump_w|| [], itemStyle: { color: c.consump }, emphasis: { focus: 'series' } },
+      { name: '☀️ Solaire',      type: 'bar', stack: 'power', data: solarW,   itemStyle: { color: c.solar   }, emphasis: { focus: 'series' } },
+      { name: '🔌 Importée',     type: 'bar', stack: 'power', data: importW,  itemStyle: { color: c.import  }, emphasis: { focus: 'series' } },
+      { name: '🏠 Consommation', type: 'bar', stack: 'power', data: consumpW, itemStyle: { color: c.consump }, emphasis: { focus: 'series' } },
     ],
   }, true);
 
-  // ── 3. Ah dérivés (kWh / V_nom) ─────────────────────────────────────────
-  function kwhToAh(arr) {
-    return (arr || []).map(v => Math.round(v * 1000 / V_NOM * 100) / 100);
-  }
-  const solarAhSeries  = kwhToAh(data.solar_kwh_series);
-  const importAhSeries = kwhToAh(data.import_kwh_series);
-  const consumpAhSeries= kwhToAh(data.consump_kwh_series);
-  const hasAh = solarAhSeries.length > 0 || importAhSeries.length > 0 || consumpAhSeries.length > 0;
+  // ── 3. Ah (kWh × 1000 / V_nom) par bucket ────────────────────────────────
+  const solarAh   = solarKwh.map(v => Math.round(v * 1000 / V_NOM * 100) / 100);
+  const importAh  = importKwh.map(v => Math.round(v * 1000 / V_NOM * 100) / 100);
+  const consumpAh = consumpKwh.map(v => Math.round(v * 1000 / V_NOM * 100) / 100);
+  const hasAh = solarAh.length > 0 || importAh.length > 0 || consumpAh.length > 0;
 
   document.getElementById('nd-ah').classList.toggle('hidden', hasAh);
   document.getElementById('meta-ah').textContent = hasAh
@@ -368,16 +360,16 @@ function renderCharts(data) {
   cAh.setOption({
     ...baseOpt(c, 'Ah', period, xMain),
     series: [
-      { name: '☀️ Solaire',      type: 'bar', stack: 'ah', data: solarAhSeries,   itemStyle: { color: c.solar   }, emphasis: { focus: 'series' } },
-      { name: '🔌 Importée',     type: 'bar', stack: 'ah', data: importAhSeries,  itemStyle: { color: c.import  }, emphasis: { focus: 'series' } },
-      { name: '🏠 Consommation', type: 'bar', stack: 'ah', data: consumpAhSeries, itemStyle: { color: c.consump }, emphasis: { focus: 'series' } },
+      { name: '☀️ Solaire',      type: 'bar', stack: 'ah', data: solarAh,   itemStyle: { color: c.solar   }, emphasis: { focus: 'series' } },
+      { name: '🔌 Importée',     type: 'bar', stack: 'ah', data: importAh,  itemStyle: { color: c.import  }, emphasis: { focus: 'series' } },
+      { name: '🏠 Consommation', type: 'bar', stack: 'ah', data: consumpAh, itemStyle: { color: c.consump }, emphasis: { focus: 'series' } },
     ],
   }, true);
 
-  // ── 4. Charge / Décharge Ah SmartShunt ──────────────────────────────────
-  const hasCharge  = (data.charge_ah_series   || []).length > 0;
-  const hasDischrg = (data.discharge_ah_series|| []).length > 0;
-  const hasShunt   = hasCharge || hasDischrg;
+  // ── 4. Charge / Décharge Ah SmartShunt (max_over_time par bucket) ─────────
+  const chargeAh  = data.charge_ah_series    || [];
+  const dischrgAh = data.discharge_ah_series || [];
+  const hasShunt  = chargeAh.length > 0 || dischrgAh.length > 0;
 
   document.getElementById('nd-shunt').classList.toggle('hidden', hasShunt);
   document.getElementById('meta-shunt').textContent = hasShunt
@@ -385,10 +377,10 @@ function renderCharts(data) {
     : '—';
 
   cShunt.setOption({
-    ...baseOpt(c, 'Ah', period, xCharge.length ? xCharge : xMain),
+    ...baseOpt(c, 'Ah', period, xShunt),
     series: [
-      { name: '⬆ Charge Ah',   type: 'bar', stack: 'shunt', data: data.charge_ah_series   || [], itemStyle: { color: c.charge  }, emphasis: { focus: 'series' } },
-      { name: '⬇ Décharge Ah', type: 'bar', stack: 'shunt', data: data.discharge_ah_series|| [], itemStyle: { color: c.dischrg }, emphasis: { focus: 'series' } },
+      { name: '⬆ Charge Ah',   type: 'bar', stack: 'shunt', data: chargeAh,  itemStyle: { color: c.charge  }, emphasis: { focus: 'series' } },
+      { name: '⬇ Décharge Ah', type: 'bar', stack: 'shunt', data: dischrgAh, itemStyle: { color: c.dischrg }, emphasis: { focus: 'series' } },
     ],
   }, true);
 }


### PR DESCRIPTION
API (history.rs) :
- step/window adaptés : day=1h, week/month=1d, year=30d
- increase([window]) pour énergie kWh → delta Wh/bucket direct
- avg_over_time([window]) pour puissance W → moyenne W/bucket
- max_over_time([window]) pour SmartShunt → total Ah/jour (reset midnight)
- Totaux = somme des buckets (plus delta first/last)
- Suppression extract_cumul / delta_wh_to_kwh / cumul_delta_kwh

Frontend (history.html) :
- fmtTs : labels adaptés (00h, Lun 01/05, Jan…)
- renderCharts : utilise directement les valeurs de l'API (no agrégation client)

https://claude.ai/code/session_01RR9Cdd9kJM4XQWUfGPjXu6