### PR TITLE
fix(solar): utiliser system/0/Dc/Pv/Power comme somme MPPT + Ac/Power…

### DIFF
--- a/crates/daly-bms-server/src/api/system.rs
+++ b/crates/daly-bms-server/src/api/system.rs
@@ -87,9 +87,10 @@ pub async fn get_logs(
 ///
 /// Retourne la dernière mesure du capteur d'irradiance PRALRAN.
 pub async fn get_irradiance_status(State(state): State<AppState>) -> impl IntoResponse {
-    let kwh  = *state.mppt_yield_kwh.read().await;
-    let mpw  = *state.mppt_power_w.read().await;
-    let solw = *state.solar_total_w.read().await;
+    let kwh    = *state.mppt_yield_kwh.read().await;
+    let dc_pv  = *state.dc_pv_power_w.read().await;
+    let pvinv  = *state.pvinv_power_w.read().await;
+    let solw   = *state.solar_total_w.read().await;
     let housew = *state.house_power_w.read().await;
     match state.latest_irradiance().await {
         Some(snap) => (
@@ -101,7 +102,9 @@ pub async fn get_irradiance_status(State(state): State<AppState>) -> impl IntoRe
                 "irradiance_wm2": snap.irradiance_wm2,
                 "timestamp": snap.timestamp.to_rfc3339(),
                 "total_yield_kwh": kwh,
-                "mppt_power_w":    mpw,
+                "dc_pv_power_w":   dc_pv,
+                "pvinv_power_w":   pvinv,
+                "mppt_power_w":    dc_pv,
                 "solar_total_w":   solw,
                 "house_power_w":   housew,
             })),
@@ -112,7 +115,9 @@ pub async fn get_irradiance_status(State(state): State<AppState>) -> impl IntoRe
                 "connected": false,
                 "irradiance_wm2": 0.0,
                 "total_yield_kwh": kwh,
-                "mppt_power_w":    mpw,
+                "dc_pv_power_w":   dc_pv,
+                "pvinv_power_w":   pvinv,
+                "mppt_power_w":    dc_pv,
                 "solar_total_w":   solw,
                 "house_power_w":   housew,
             })),
@@ -127,10 +132,13 @@ pub struct MpptYieldBody {
     pub total_yield_kwh: Option<f32>,
     /// Rétrocompat ancien nom de champ.
     pub mppt_yield_kwh:  Option<f32>,
-    /// Puissance MPPT seule en W (273+289, sans ET112).
+    /// Puissance MPPT agrégée en W = N/.../system/0/Dc/Pv/Power (alias de dc_pv_power_w).
     pub mppt_power_w:    Option<f32>,
-    /// Puissance solaire totale en W = MPPT + ET112 PVInverter (source VRM Node-RED).
-    /// Champ canonique depuis Solar_power.json — source de vérité pour le dashboard.
+    /// Puissance MPPT agrégée en W = N/.../system/0/Dc/Pv/Power (source de vérité).
+    pub dc_pv_power_w:   Option<f32>,
+    /// Puissance ET112 micro-onduleurs en W = N/.../pvinverter/32/Ac/Power.
+    pub pvinv_power_w:   Option<f32>,
+    /// Puissance solaire totale en W = dc_pv_power_w + pvinv_power_w.
     pub solar_total_w:   Option<f32>,
     /// Puissance maison en W = N/c0619ab9929a/system/0/Ac/ConsumptionOnOutput/L1/Power.
     pub house_power_w:   Option<f32>,
@@ -139,8 +147,7 @@ pub struct MpptYieldBody {
 /// POST /api/v1/solar/mppt-yield
 ///
 /// Mise à jour partielle : seuls les champs présents dans le body sont écrits.
-/// Solar_power.json envoie solar_total_w + mppt_power_w.
-/// meteo.json envoie total_yield_kwh + mppt_power_w (keepalive kWh).
+/// energy-manager envoie solar_total_w + dc_pv_power_w + pvinv_power_w + mppt_power_w.
 pub async fn set_mppt_yield(
     State(state): State<AppState>,
     Json(body): Json<MpptYieldBody>,
@@ -148,8 +155,16 @@ pub async fn set_mppt_yield(
     if let Some(kwh) = body.total_yield_kwh.or(body.mppt_yield_kwh) {
         *state.mppt_yield_kwh.write().await = kwh;
     }
-    if let Some(pw) = body.mppt_power_w {
-        *state.mppt_power_w.write().await = pw;
+    // dc_pv_power_w est la source canonique ; mppt_power_w est l'alias rétrocompat
+    if let Some(v) = body.dc_pv_power_w {
+        *state.dc_pv_power_w.write().await = v;
+        *state.mppt_power_w.write().await  = v;
+    } else if let Some(pw) = body.mppt_power_w {
+        *state.mppt_power_w.write().await  = pw;
+        *state.dc_pv_power_w.write().await = pw;
+    }
+    if let Some(v) = body.pvinv_power_w {
+        *state.pvinv_power_w.write().await = v;
     }
     if let Some(tw) = body.solar_total_w {
         *state.solar_total_w.write().await = tw;
@@ -159,25 +174,28 @@ pub async fn set_mppt_yield(
     }
 
     // Write solar metrics to VictoriaMetrics — throttlé à 1 écriture / 5s
-    // (energy-manager appelle cet endpoint toutes les secondes)
     if let Some(vm) = &state.vm {
         if state.vm_solar_rate_ok() {
-            let kwh_val = *state.mppt_yield_kwh.read().await;
-            let pw_val  = *state.mppt_power_w.read().await;
-            let total_w = *state.solar_total_w.read().await;
-            let rows = crate::vm_client::VmClient::solar_rows(total_w, pw_val, kwh_val);
+            let kwh_val    = *state.mppt_yield_kwh.read().await;
+            let dc_pv_val  = *state.dc_pv_power_w.read().await;
+            let pvinv_val  = *state.pvinv_power_w.read().await;
+            let total_w    = *state.solar_total_w.read().await;
+            let rows = crate::vm_client::VmClient::solar_rows(total_w, dc_pv_val, pvinv_val, kwh_val);
             let _ = vm.write_rows(rows).await;
         }
     }
 
-    let kwh  = *state.mppt_yield_kwh.read().await;
-    let pw   = *state.mppt_power_w.read().await;
-    let tw   = *state.solar_total_w.read().await;
+    let kwh    = *state.mppt_yield_kwh.read().await;
+    let dc_pv  = *state.dc_pv_power_w.read().await;
+    let pvinv  = *state.pvinv_power_w.read().await;
+    let tw     = *state.solar_total_w.read().await;
     let housew = *state.house_power_w.read().await;
     (StatusCode::OK, Json(json!({
         "ok": true,
         "total_yield_kwh": kwh,
-        "mppt_power_w":    pw,
+        "dc_pv_power_w":   dc_pv,
+        "pvinv_power_w":   pvinv,
+        "mppt_power_w":    dc_pv,
         "solar_total_w":   tw,
         "house_power_w":   housew,
     })))
@@ -336,16 +354,8 @@ pub struct SystemTotals {
 }
 
 pub async fn get_system_totals(State(state): State<AppState>) -> impl IntoResponse {
-    // Production : MPPT + PV Inverter (ET112 0x07)
-    let mppt_power = state.venus_mppt_total_power().await;
-    let pv_inverter_power = state
-        .et112_latest_all()
-        .await
-        .iter()
-        .find(|e| e.address == 0x07)
-        .map(|e| e.power_w)
-        .unwrap_or(0.0);
-    let production_w = mppt_power + pv_inverter_power;
+    // Production : source de vérité = solar_total_w (dc_pv_power_w + pvinv_power_w)
+    let production_w = *state.solar_total_w.read().await;
 
     // Consommation : maison
     let consumption_w = *state.house_power_w.read().await;

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -381,11 +381,17 @@ pub struct AppState {
     /// Publiée par energy-manager via POST /api/v1/solar/mppt-yield.
     pub mppt_yield_kwh: Arc<RwLock<f32>>,
 
-    /// Puissance MPPT instantanée totale en W (somme de tous les chargeurs solaires).
+    /// Puissance MPPT agrégée en W = N/.../system/0/Dc/Pv/Power (alias de dc_pv_power_w).
     /// Publiée par energy-manager via POST /api/v1/solar/mppt-yield.
     pub mppt_power_w: Arc<RwLock<f32>>,
 
-    /// Puissance solaire totale en W = MPPT 273+289 + PV Inverter ET112 (VRM).
+    /// Puissance MPPT agrégée en W = N/.../system/0/Dc/Pv/Power (source de vérité).
+    pub dc_pv_power_w: Arc<RwLock<f32>>,
+
+    /// Puissance ET112 micro-onduleurs en W = N/.../pvinverter/32/Ac/Power.
+    pub pvinv_power_w: Arc<RwLock<f32>>,
+
+    /// Puissance solaire totale en W = dc_pv_power_w + pvinv_power_w.
     /// Publiée par energy-manager via POST /api/v1/solar/mppt-yield.
     pub solar_total_w: Arc<RwLock<f32>>,
 
@@ -497,6 +503,8 @@ impl AppState {
             tasmota_buffers: Arc::new(RwLock::new(tasmota_buffers)),
             mppt_yield_kwh: Arc::new(RwLock::new(0.0)),
             mppt_power_w:   Arc::new(RwLock::new(0.0)),
+            dc_pv_power_w:  Arc::new(RwLock::new(0.0)),
+            pvinv_power_w:  Arc::new(RwLock::new(0.0)),
             solar_total_w:  Arc::new(RwLock::new(0.0)),
             house_power_w:  Arc::new(RwLock::new(0.0)),
             venus_mppts: Arc::new(RwLock::new(BTreeMap::new())),

--- a/crates/daly-bms-server/src/vm_client.rs
+++ b/crates/daly-bms-server/src/vm_client.rs
@@ -251,11 +251,19 @@ impl VmClient {
         rows
     }
 
-    pub fn solar_rows(solar_total_w: f32, mppt_power_w: f32, total_yield_kwh: f32) -> Vec<VmRow> {
+    /// Métriques solaires écrites dans VictoriaMetrics depuis energy-manager.
+    /// - `solar_total_w`  : total = dc_pv_power_w + pvinv_power_w
+    /// - `dc_pv_power_w`  : N/.../system/0/Dc/Pv/Power  (somme MPPT système)
+    /// - `pvinv_power_w`  : N/.../pvinverter/32/Ac/Power (ET112 micro-onduleurs)
+    /// - `mppt_power_w`   : alias de dc_pv_power_w pour rétrocompatibilité des graphes
+    /// - `solar_yield_kwh`: production journalière totale
+    pub fn solar_rows(solar_total_w: f32, dc_pv_power_w: f32, pvinv_power_w: f32, total_yield_kwh: f32) -> Vec<VmRow> {
         let ts = chrono::Utc::now().timestamp_millis();
         vec![
-            VmRow::new("solar_total_w",   solar_total_w as f64,   ts),
-            VmRow::new("mppt_power_w",    mppt_power_w as f64,    ts),
+            VmRow::new("solar_total_w",   solar_total_w  as f64, ts),
+            VmRow::new("dc_pv_power_w",   dc_pv_power_w  as f64, ts),
+            VmRow::new("pvinv_power_w",   pvinv_power_w  as f64, ts),
+            VmRow::new("mppt_power_w",    dc_pv_power_w  as f64, ts),
             VmRow::new("solar_yield_kwh", total_yield_kwh as f64, ts),
         ]
     }

--- a/crates/energy-manager/src/logic/solar_power/mod.rs
+++ b/crates/energy-manager/src/logic/solar_power/mod.rs
@@ -41,7 +41,8 @@ async fn mqtt_task(
 
     let t_m1_power  = format!("N/{pid}/solarcharger/{m1}/Yield/Power");
     let t_m2_power  = format!("N/{pid}/solarcharger/{m2}/Yield/Power");
-    let t_pv_power  = format!("N/{pid}/pvinverter/{pv}/Ac/L1/Power");
+    let t_dc_pv     = format!("N/{pid}/system/0/Dc/Pv/Power");
+    let t_pv_power  = format!("N/{pid}/pvinverter/{pv}/Ac/Power");
     let t_pv_energy = format!("N/{pid}/pvinverter/{pv}/Ac/Energy/Forward");
     let t_m1_yield  = format!("N/{pid}/solarcharger/{m1}/History/Daily/0/Yield");
     let t_m2_yield  = format!("N/{pid}/solarcharger/{m2}/History/Daily/0/Yield");
@@ -80,7 +81,11 @@ async fn mqtt_task(
             } else if *t == t_m2_power {
                 s.mppt_289.power_w = msg.victron_value::<f64>();
                 s.mppt_power_289_w = s.mppt_289.power_w;
+            } else if *t == t_dc_pv {
+                // Source de vérité pour la somme MPPT : N/.../system/0/Dc/Pv/Power
+                s.dc_pv_power_w = msg.victron_value::<f64>();
             } else if *t == t_pv_power {
+                // N/.../pvinverter/32/Ac/Power (ET112 micro-onduleurs, total AC)
                 s.pvinverter_power_w = msg.victron_value::<f64>();
             } else if *t == t_pv_energy {
                 if let Some(kwh) = msg.victron_value::<f64>() {
@@ -126,7 +131,8 @@ async fn mqtt_task(
                 continue;
             }
 
-            let mppt_total  = s.mppt_273.power_w.unwrap_or(0.0) + s.mppt_289.power_w.unwrap_or(0.0);
+            // MPPT sum = system aggregate (N/.../system/0/Dc/Pv/Power)
+            let mppt_total  = s.dc_pv_power_w.unwrap_or(0.0);
             let pvinv_total = s.pvinverter_power_w.unwrap_or(0.0);
             s.solar_total_w = mppt_total + pvinv_total;
 
@@ -158,11 +164,12 @@ async fn writer_task(
     loop {
         ticker.tick().await;
 
-        let (solar_total, house_power, m273_w, m289_w, pvinv_w, total_yield) = {
+        let (solar_total, house_power, dc_pv_w, m273_w, m289_w, pvinv_w, total_yield) = {
             let s = state.read().await;
             (
                 s.solar_total_w,
                 s.house_power_w.unwrap_or(0.0),
+                s.dc_pv_power_w.unwrap_or(0.0),
                 s.mppt_273.power_w.unwrap_or(0.0),
                 s.mppt_289.power_w.unwrap_or(0.0),
                 s.pvinverter_power_w.unwrap_or(0.0),
@@ -170,11 +177,11 @@ async fn writer_task(
             )
         };
 
-        let mppt_power = m273_w + m289_w;
-
         let body = json!({
             "solar_total_w":   solar_total,
-            "mppt_power_w":    mppt_power,
+            "dc_pv_power_w":   dc_pv_w,   // N/.../system/0/Dc/Pv/Power
+            "pvinv_power_w":   pvinv_w,   // N/.../pvinverter/32/Ac/Power
+            "mppt_power_w":    dc_pv_w,   // alias = dc_pv pour compatibilité API
             "total_yield_kwh": total_yield,
             "house_power_w":   house_power,
         });
@@ -190,10 +197,10 @@ async fn writer_task(
 
         bus.emit_live(LiveEvent::new("solar", json!({
             "solar_total_w": solar_total,
+            "dc_pv_power_w": dc_pv_w,
             "mppt_273_w":    m273_w,
             "mppt_289_w":    m289_w,
-            "mppt_power_w":  mppt_power,
-            "pvinv_w":       pvinv_w,
+            "pvinv_power_w": pvinv_w,
             "house_power_w": house_power,
         })));
     }

--- a/crates/energy-manager/src/mqtt/topics.rs
+++ b/crates/energy-manager/src/mqtt/topics.rs
@@ -66,7 +66,7 @@ pub fn all_subscriptions(portal_id: &str, vebus: u32, mppt1: u32, mppt2: u32, pv
         n(pid, &format!("solarcharger/{mppt2}/Dc/0/Current")),
 
         // --- PVInverter (ET112) ---
-        n(pid, &format!("pvinverter/{pvinv}/Ac/L1/Power")),
+        n(pid, &format!("pvinverter/{pvinv}/Ac/Power")),
         n(pid, &format!("pvinverter/{pvinv}/Ac/Energy/Forward")),
 
         // --- Irradiance ---

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -112,7 +112,8 @@ pub struct EnergyState {
     // --- Solar / PV ---
     pub mppt_power_273_w: Option<f64>,
     pub mppt_power_289_w: Option<f64>,
-    pub pvinverter_power_w: Option<f64>,
+    pub dc_pv_power_w: Option<f64>,     // N/.../system/0/Dc/Pv/Power (aggregate MPPT)
+    pub pvinverter_power_w: Option<f64>, // N/.../pvinverter/32/Ac/Power
     pub solar_total_w: f64,
     pub house_power_w: Option<f64>,
 


### PR DESCRIPTION
… pour ET112

Corrections :
- MPPT sum source : system/0/Dc/Pv/Power (agrégat système) au lieu de la somme manuelle solarcharger/273 + solarcharger/289
- ET112 topic : pvinverter/32/Ac/Power (total AC) au lieu de Ac/L1/Power
- VictoriaMetrics : ajout métriques dédiées dc_pv_power_w et pvinv_power_w (mppt_power_w conservé en alias de dc_pv_power_w pour rétrocompat graphes)
- get_system_totals : utilise solar_total_w (source de vérité) au lieu de recalculer depuis venus_mppt_total_power() + ET112 RS485

solar_total_w = N/.../system/0/Dc/Pv/Power + N/.../pvinverter/32/Ac/Power

https://claude.ai/code/session_019r6Ct2JbLpTL5miLWBwvZW