### PR TITLE
fix(solar): appliquer recommendations review Gemini PR #365

### DIFF
--- a/crates/daly-bms-server/src/api/system.rs
+++ b/crates/daly-bms-server/src/api/system.rs
@@ -155,13 +155,10 @@ pub async fn set_mppt_yield(
     if let Some(kwh) = body.total_yield_kwh.or(body.mppt_yield_kwh) {
         *state.mppt_yield_kwh.write().await = kwh;
     }
-    // dc_pv_power_w est la source canonique ; mppt_power_w est l'alias rétrocompat
-    if let Some(v) = body.dc_pv_power_w {
+    // dc_pv_power_w est prioritaire ; mppt_power_w est l'alias rétrocompat
+    if let Some(v) = body.dc_pv_power_w.or(body.mppt_power_w) {
         *state.dc_pv_power_w.write().await = v;
         *state.mppt_power_w.write().await  = v;
-    } else if let Some(pw) = body.mppt_power_w {
-        *state.mppt_power_w.write().await  = pw;
-        *state.dc_pv_power_w.write().await = pw;
     }
     if let Some(v) = body.pvinv_power_w {
         *state.pvinv_power_w.write().await = v;

--- a/crates/energy-manager/src/logic/solar_power/mod.rs
+++ b/crates/energy-manager/src/logic/solar_power/mod.rs
@@ -198,9 +198,11 @@ async fn writer_task(
         bus.emit_live(LiveEvent::new("solar", json!({
             "solar_total_w": solar_total,
             "dc_pv_power_w": dc_pv_w,
+            "mppt_power_w":  dc_pv_w,   // alias rétrocompat dashboard
             "mppt_273_w":    m273_w,
             "mppt_289_w":    m289_w,
             "pvinv_power_w": pvinv_w,
+            "pvinv_w":       pvinv_w,   // alias rétrocompat dashboard
             "house_power_w": house_power,
         })));
     }


### PR DESCRIPTION
- system.rs: simplifier Option::or (dc_pv_power_w prioritaire sur mppt_power_w)
- solar_power: restaurer alias rétrocompat dans LiveEvent WebSocket
  * mppt_power_w = dc_pv_w  (dashboard overview.html:518 lit ce champ)
  * pvinv_w = pvinv_w       (alias de pvinv_power_w pour clients existants)

https://claude.ai/code/session_019r6Ct2JbLpTL5miLWBwvZW