### PR TITLE
feat(monitoring): add 3-layer Pi5 diagnostic monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,10 +701,12 @@ dependencies = [
  "rs485-bus",
  "rumqttc",
  "rusqlite",
+ "sd-notify",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-metrics",
  "tokio-serial",
  "toml",
  "tower 0.4.13",
@@ -807,10 +809,12 @@ dependencies = [
  "reqwest",
  "rumqttc",
  "rust-rule-engine",
+ "sd-notify",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-metrics",
  "toml",
  "tower-http 0.5.2",
  "tracing",
@@ -2296,6 +2300,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sd-notify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b943eadf71d8b69e661330cb0e2656e31040acf21ee7708e2c238a0ec6af2bf4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2733,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eace09241d62c98b7eeb1107d4c5c64ca3bd7da92e8c218c153ab3a78f9be112"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ tokio-modbus  = { version = "0.14", features = ["rtu"] }
 # ── Rule engine (energy-manager decision logic) ───────────────────────────────
 rust-rule-engine = "1.20"
 
+# ── Monitoring ─────────────────────────────────────────────────────────────────
+sd-notify     = "0.4"
+tokio-metrics = "0.3"
+
 # =============================================================================
 # Release profile — optimisé taille + vitesse pour le Pi
 # =============================================================================

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ check:
 # Installation (systemd)
 # =============================================================================
 
-.PHONY: install uninstall install-z8run
+.PHONY: install uninstall install-z8run install-node-exporter
 
 install: build
 	sudo bash contrib/install-systemd.sh
@@ -259,6 +259,23 @@ uninstall:
 
 install-z8run:
 	sudo bash contrib/install-z8run.sh
+
+# Installe node_exporter (ARM64) sur le Pi5 pour métriques système → VictoriaMetrics
+# Usage : make install-node-exporter  (à exécuter depuis le Pi5)
+NODE_EXPORTER_VERSION ?= 1.8.2
+NODE_EXPORTER_ARCH    ?= arm64
+install-node-exporter:
+	@echo "Téléchargement node_exporter $(NODE_EXPORTER_VERSION) ($(NODE_EXPORTER_ARCH))..."
+	curl -fsSL "https://github.com/prometheus/node_exporter/releases/download/v$(NODE_EXPORTER_VERSION)/node_exporter-$(NODE_EXPORTER_VERSION).linux-$(NODE_EXPORTER_ARCH).tar.gz" \
+		| tar -xz --strip-components=1 -C /tmp node_exporter-$(NODE_EXPORTER_VERSION).linux-$(NODE_EXPORTER_ARCH)/node_exporter
+	sudo install -m 755 /tmp/node_exporter /usr/local/bin/node_exporter
+	sudo cp contrib/node-exporter.service /etc/systemd/system/node-exporter.service
+	sudo systemctl daemon-reload
+	sudo systemctl enable --now node-exporter
+	sudo systemctl status node-exporter --no-pager -l
+	@echo "✓ node_exporter installé — métriques sur http://localhost:9100/metrics"
+	@echo "  → Configurer VictoriaMetrics pour scraper ce endpoint."
+	@echo "  → Copier contrib/victoriametrics-scrape.yml dans /etc/victoriametrics/scrape.yml"
 
 # =============================================================================
 # Cross-compile + déploiement SSH vers le Pi

--- a/contrib/daly-bms.service
+++ b/contrib/daly-bms.service
@@ -5,7 +5,9 @@ After=network.target
 Wants=network.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
+WatchdogSec=60
 User=dalybms
 Group=dalybms
 

--- a/contrib/energy-manager.service
+++ b/contrib/energy-manager.service
@@ -6,7 +6,9 @@ Wants=network-online.target
 PartOf=daly-bms.service
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
+WatchdogSec=60
 User=pi5compute
 Group=pi5compute
 

--- a/contrib/node-exporter.service
+++ b/contrib/node-exporter.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Prometheus Node Exporter — métriques système Pi5
+Documentation=https://prometheus.io/docs/guides/node-exporter/
+After=network.target
+
+[Service]
+Type=simple
+User=pi5compute
+Group=pi5compute
+
+ExecStart=/usr/local/bin/node_exporter \
+    --web.listen-address=0.0.0.0:9100 \
+    --collector.systemd \
+    --collector.processes
+
+Restart=on-failure
+RestartSec=5s
+StartLimitIntervalSec=0
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=node-exporter
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/victoriametrics-scrape.yml
+++ b/contrib/victoriametrics-scrape.yml
@@ -1,0 +1,30 @@
+# Configuration de scrape pour VictoriaMetrics (vmagent ou VM intégré).
+#
+# Déploiement sur Pi5 :
+#   sudo cp contrib/victoriametrics-scrape.yml /etc/victoriametrics/scrape.yml
+#
+# Puis redémarrer VictoriaMetrics avec :
+#   -promscrape.config=/etc/victoriametrics/scrape.yml
+#
+# OU via vmagent :
+#   vmagent -promscrape.config=/etc/victoriametrics/scrape.yml \
+#           -remoteWrite.url=http://127.0.0.1:8428/api/v1/write
+
+global:
+  scrape_interval: 60s
+  scrape_timeout:  10s
+
+scrape_configs:
+  # ── node_exporter — métriques OS complètes ────────────────────────────────
+  - job_name: "node"
+    static_configs:
+      - targets: ["127.0.0.1:9100"]
+    # Métriques clés pour diagnostiquer un freeze Pi5 :
+    # - node_cpu_seconds_total        → charge CPU par core
+    # - node_memory_MemAvailable_bytes → mémoire disponible
+    # - node_disk_io_time_seconds_total → saturation I/O disque (SD card !)
+    # - node_load1 / node_load5       → charge système
+    # - node_filesystem_avail_bytes   → espace disque
+    # - node_network_receive_bytes_total → I/O réseau
+    # - node_thermal_zone_temp        → température CPU (throttling)
+    # - node_systemd_unit_state       → état des services systemd

--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -38,3 +38,7 @@ futures        = { workspace = true }
 bytes          = { workspace = true }
 askama         = "0.12"
 # tokio-modbus supprimé — remplacé par rs485_bus::modbus_rtu (pur Rust)
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+sd-notify     = { workspace = true }
+tokio-metrics = { workspace = true }

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -651,9 +651,8 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // ── Agent de monitoring Pi5 ────────────────────────────────────────────────
-    tokio::spawn(monitor::run_monitor_agent(state.clone()));
-    tokio::spawn(monitor::run_watchdog_agent(state.clone()));
+    // ── Agent de monitoring Pi5 (+ watchdog sd_notify + métriques tokio→VM) ──
+    monitor::spawn_all(state.clone());
 
     // ── Serveur HTTP Axum ──────────────────────────────────────────────────────
     let router = api::build_router(state);
@@ -664,6 +663,9 @@ async fn main() -> anyhow::Result<()> {
     if args.simulate {
         info!("Docs → http://{}/api/v1/system/status", addr);
     }
+
+    // Notifie systemd que le service est prêt (Type=notify)
+    let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, router).await?;

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -10,6 +10,7 @@
 //! - Température CPU
 
 use crate::state::{AppState, MonitorSnapshot, ProcessInfo, ServiceStatus};
+use crate::vm_client::VmRow;
 use chrono::Utc;
 use std::time::{Duration, Instant};
 use tokio::net::TcpStream;
@@ -41,6 +42,9 @@ pub async fn run_monitor_agent(state: AppState) {
     loop {
         ticker.tick().await;
 
+        // Heartbeat watchdog systemd — doit arriver avant WatchdogSec=60
+        let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Watchdog]);
+
         let curr_net    = read_net_bytes().await;
         let elapsed_s   = prev_net_ts.elapsed().as_secs_f64().max(1.0);
         let net_rx_bps  = ((curr_net.0.saturating_sub(prev_net.0)) as f64 / elapsed_s) as u64;
@@ -49,6 +53,16 @@ pub async fn run_monitor_agent(state: AppState) {
         prev_net_ts     = Instant::now();
 
         let snap = collect_snapshot(&state, net_rx_bps, net_tx_bps).await;
+
+        // Écriture métriques système dans VictoriaMetrics
+        if let Some(vm) = &state.vm {
+            let ts_ms = snap.timestamp.timestamp_millis();
+            let rows  = build_monitor_vm_rows(&snap, ts_ms);
+            if let Err(e) = vm.write_rows(rows).await {
+                warn!("VM write monitor métriques: {}", e);
+            }
+        }
+
         state.on_monitor_snapshot(snap).await;
     }
 }
@@ -411,6 +425,109 @@ pub async fn run_watchdog_agent(_state: AppState) {
             }
         }
     }
+}
+
+// =============================================================================
+// Métriques système → VictoriaMetrics
+// =============================================================================
+
+fn build_monitor_vm_rows(snap: &MonitorSnapshot, ts_ms: i64) -> Vec<VmRow> {
+    let mut rows = vec![
+        VmRow::new("pi5_cpu_percent",    snap.cpu_percent    as f64, ts_ms),
+        VmRow::new("pi5_memory_percent", snap.memory_percent as f64, ts_ms),
+        VmRow::new("pi5_disk_percent",   snap.disk_percent   as f64, ts_ms),
+        VmRow::new("pi5_uptime_secs",    snap.uptime_secs    as f64, ts_ms),
+        VmRow::new("pi5_mem_used_mb",    snap.mem_used_mb    as f64, ts_ms),
+        VmRow::new("pi5_swap_used_mb",   snap.swap_used_mb   as f64, ts_ms),
+        VmRow::new("pi5_net_rx_bps",     snap.net_rx_bps     as f64, ts_ms),
+        VmRow::new("pi5_net_tx_bps",     snap.net_tx_bps     as f64, ts_ms),
+        VmRow::with_labels("pi5_load_avg", vec![("window", "1m")],  snap.load_avg[0] as f64, ts_ms),
+        VmRow::with_labels("pi5_load_avg", vec![("window", "5m")],  snap.load_avg[1] as f64, ts_ms),
+        VmRow::with_labels("pi5_load_avg", vec![("window", "15m")], snap.load_avg[2] as f64, ts_ms),
+    ];
+    if let Some(temp) = snap.cpu_temp_c {
+        rows.push(VmRow::new("pi5_cpu_temp_c", temp as f64, ts_ms));
+    }
+    // Top processus (CPU > 0.1%) — utile pour identifier le coupable lors d'un freeze
+    for proc in &snap.processes {
+        if proc.cpu_percent > 0.1 {
+            let pid = proc.pid.to_string();
+            rows.push(VmRow::with_labels(
+                "pi5_process_cpu_percent",
+                vec![("process", proc.name.as_str()), ("pid", pid.as_str())],
+                proc.cpu_percent as f64,
+                ts_ms,
+            ));
+            rows.push(VmRow::with_labels(
+                "pi5_process_mem_mb",
+                vec![("process", proc.name.as_str()), ("pid", pid.as_str())],
+                proc.mem_rss_mb as f64,
+                ts_ms,
+            ));
+        }
+    }
+    rows
+}
+
+// =============================================================================
+// Point d'entrée unique — remplace les deux tokio::spawn dans main.rs
+// =============================================================================
+
+/// Démarre monitor_agent, watchdog_agent et l'exporteur tokio-metrics.
+/// Appeler depuis main.rs à la place des deux tokio::spawn séparés.
+pub fn spawn_all(state: AppState) {
+    use tokio_metrics::TaskMonitor;
+
+    let monitor_tm  = TaskMonitor::new();
+    let watchdog_tm = TaskMonitor::new();
+
+    // Agents instrumentés avec TaskMonitor (mesure durée de polling tokio)
+    tokio::spawn(monitor_tm.instrument(run_monitor_agent(state.clone())));
+    tokio::spawn(watchdog_tm.instrument(run_watchdog_agent(state.clone())));
+
+    // Exporteur métriques tokio → VictoriaMetrics (toutes les 60s)
+    let vm = state.vm.clone();
+    tokio::spawn(async move {
+        let mut mon_ivals = monitor_tm.intervals();
+        let mut wdg_ivals = watchdog_tm.intervals();
+        let mut ticker    = interval(Duration::from_secs(60));
+        loop {
+            ticker.tick().await;
+            let ts_ms = Utc::now().timestamp_millis();
+            let mut rows: Vec<VmRow> = Vec::new();
+
+            for (name, m) in [
+                ("daly_bms_monitor",  mon_ivals.next()),
+                ("daly_bms_watchdog", wdg_ivals.next()),
+            ] {
+                let Some(m) = m else { continue };
+                rows.push(VmRow::with_labels(
+                    "tokio_task_polls_total",
+                    vec![("task", name)],
+                    m.total_poll_count as f64,
+                    ts_ms,
+                ));
+                rows.push(VmRow::with_labels(
+                    "tokio_task_mean_poll_us",
+                    vec![("task", name)],
+                    m.mean_poll_duration().as_micros() as f64,
+                    ts_ms,
+                ));
+                rows.push(VmRow::with_labels(
+                    "tokio_task_mean_scheduled_us",
+                    vec![("task", name)],
+                    m.mean_scheduled_duration().as_micros() as f64,
+                    ts_ms,
+                ));
+            }
+
+            if let Some(vm) = &vm {
+                if let Err(e) = vm.write_rows(rows).await {
+                    warn!("VM write tokio métriques: {}", e);
+                }
+            }
+        }
+    });
 }
 
 async fn restart_systemd_service(name: &str) -> bool {

--- a/crates/energy-manager/Cargo.toml
+++ b/crates/energy-manager/Cargo.toml
@@ -35,3 +35,7 @@ rust-rule-engine = { workspace = true }
 
 # ── Crate-specific ─────────────────────────────────────────────────────────────
 dotenvy = "0.15"
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+sd-notify     = { workspace = true }
+tokio-metrics = { workspace = true }

--- a/crates/energy-manager/src/main.rs
+++ b/crates/energy-manager/src/main.rs
@@ -8,6 +8,7 @@ mod config;
 mod http_clients;
 mod live_ws;
 mod logic;
+mod monitoring;
 mod mqtt;
 mod persist;
 mod types;
@@ -93,7 +94,22 @@ async fn main() -> anyhow::Result<()> {
         live_ws::server::serve(&bind, live_tx, srv_state, srv_lg).await;
     });
 
+    // --- Module monitoring Pi5 (métriques système + tokio → VictoriaMetrics) ---
+    monitoring::spawn(cfg.water_heater.vm_url.clone());
+
     info!("energy-manager fully started");
+
+    // Notifie systemd que le service est prêt (Type=notify)
+    let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]);
+
+    // Heartbeat watchdog systemd (doit arriver avant WatchdogSec=60)
+    tokio::spawn(async {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(30));
+        loop {
+            ticker.tick().await;
+            let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Watchdog]);
+        }
+    });
 
     // Wait forever (all work happens in spawned tasks)
     std::future::pending::<()>().await;

--- a/crates/energy-manager/src/monitoring.rs
+++ b/crates/energy-manager/src/monitoring.rs
@@ -1,0 +1,264 @@
+//! Agent de monitoring système pour energy-manager.
+//!
+//! Collecte toutes les 60 secondes :
+//! - CPU, RAM, swap, disque, load average, température CPU
+//! - I/O réseau (octets/s)
+//! - Top processus (par CPU%)
+//! - Métriques runtime tokio (polls, latences)
+//!
+//! Exporte vers VictoriaMetrics via POST /api/v1/import/prometheus.
+
+use std::time::{Duration, Instant};
+use tokio::process::Command;
+use tokio::time::interval;
+use tracing::warn;
+
+// =============================================================================
+// Point d'entrée
+// =============================================================================
+
+/// Spawne l'agent de monitoring en arrière-plan.
+pub fn spawn(vm_url: String) {
+    use tokio_metrics::TaskMonitor;
+
+    let task_mon = TaskMonitor::new();
+    let vm_url_mon = vm_url.clone();
+    tokio::spawn(task_mon.instrument(async move {
+        run_monitoring_loop(vm_url_mon).await;
+    }));
+
+    // Exporteur métriques tokio → VM (toutes les 60s)
+    tokio::spawn(async move {
+        let mut ivals  = task_mon.intervals();
+        let mut ticker = interval(Duration::from_secs(60));
+        let client     = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap_or_default();
+        loop {
+            ticker.tick().await;
+            let Some(m) = ivals.next() else { continue };
+            let ts_ms = chrono::Utc::now().timestamp_millis();
+            let lines = vec![
+                format!("em_tokio_task_polls_total{{task=\"energy_manager_monitor\"}} {} {}", m.total_poll_count, ts_ms),
+                format!("em_tokio_task_mean_poll_us{{task=\"energy_manager_monitor\"}} {} {}", m.mean_poll_duration().as_micros(), ts_ms),
+                format!("em_tokio_task_mean_scheduled_us{{task=\"energy_manager_monitor\"}} {} {}", m.mean_scheduled_duration().as_micros(), ts_ms),
+            ];
+            write_to_vm(&client, &vm_url, &lines.join("\n")).await;
+        }
+    });
+}
+
+// =============================================================================
+// Boucle principale
+// =============================================================================
+
+async fn run_monitoring_loop(vm_url: String) {
+    tracing::info!("energy-manager monitoring démarré (intervalle: 60s)");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap_or_default();
+
+    let mut ticker      = interval(Duration::from_secs(60));
+    let mut prev_net    = read_net_bytes().await;
+    let mut prev_net_ts = Instant::now();
+
+    loop {
+        ticker.tick().await;
+
+        let curr_net   = read_net_bytes().await;
+        let elapsed_s  = prev_net_ts.elapsed().as_secs_f64().max(1.0);
+        let net_rx_bps = ((curr_net.0.saturating_sub(prev_net.0)) as f64 / elapsed_s) as u64;
+        let net_tx_bps = ((curr_net.1.saturating_sub(prev_net.1)) as f64 / elapsed_s) as u64;
+        prev_net       = curr_net;
+        prev_net_ts    = Instant::now();
+
+        let ts_ms                           = chrono::Utc::now().timestamp_millis();
+        let cpu_percent                     = read_cpu_percent().await;
+        let (mem_total, mem_used, _)        = read_memory().await;
+        let (swap_total, swap_used)         = read_swap().await;
+        let disk_percent                    = read_disk_percent().await;
+        let load_avg                        = read_load_avg().await;
+        let cpu_temp                        = read_cpu_temp().await;
+        let processes                       = collect_processes().await;
+        let mem_percent = if mem_total > 0 { (mem_used as f64 / mem_total as f64) * 100.0 } else { 0.0 };
+
+        let mut lines = vec![
+            format!("em_cpu_percent {} {}", cpu_percent, ts_ms),
+            format!("em_memory_percent {} {}", mem_percent, ts_ms),
+            format!("em_mem_used_mb {} {}", mem_used, ts_ms),
+            format!("em_swap_used_mb {} {}", swap_used, ts_ms),
+            format!("em_disk_percent {} {}", disk_percent, ts_ms),
+            format!("em_net_rx_bps {} {}", net_rx_bps, ts_ms),
+            format!("em_net_tx_bps {} {}", net_tx_bps, ts_ms),
+            format!("em_load_avg{{window=\"1m\"}} {} {}", load_avg[0], ts_ms),
+            format!("em_load_avg{{window=\"5m\"}} {} {}", load_avg[1], ts_ms),
+            format!("em_load_avg{{window=\"15m\"}} {} {}", load_avg[2], ts_ms),
+        ];
+        let _ = (mem_total, swap_total); // calculés mais non exportés directement
+
+        if let Some(temp) = cpu_temp {
+            lines.push(format!("em_cpu_temp_c {} {}", temp, ts_ms));
+        }
+        for proc in &processes {
+            if proc.0 > 0.1 {
+                lines.push(format!(
+                    "em_process_cpu_percent{{process=\"{}\",pid=\"{}\"}} {} {}",
+                    proc.2, proc.3, proc.0, ts_ms
+                ));
+                lines.push(format!(
+                    "em_process_mem_mb{{process=\"{}\",pid=\"{}\"}} {} {}",
+                    proc.2, proc.3, proc.1, ts_ms
+                ));
+            }
+        }
+
+        write_to_vm(&client, &vm_url, &lines.join("\n")).await;
+    }
+}
+
+// =============================================================================
+// Écriture VM
+// =============================================================================
+
+async fn write_to_vm(client: &reqwest::Client, vm_url: &str, body: &str) {
+    let url = format!("{}/api/v1/import/prometheus", vm_url.trim_end_matches('/'));
+    if let Err(e) = client
+        .post(&url)
+        .header("Content-Type", "text/plain")
+        .body(body.to_string())
+        .send()
+        .await
+    {
+        warn!("energy-manager monitoring VM write: {}", e);
+    }
+}
+
+// =============================================================================
+// Lectures système (identiques à daly-bms-server/monitor.rs — /proc)
+// =============================================================================
+
+/// (rx_total, tx_total) pour toutes les interfaces non-loopback
+async fn read_net_bytes() -> (u64, u64) {
+    let Ok(content) = tokio::fs::read_to_string("/proc/net/dev").await else { return (0, 0) };
+    let mut rx = 0u64;
+    let mut tx = 0u64;
+    for line in content.lines() {
+        let line = line.trim();
+        let Some(colon) = line.find(':') else { continue };
+        if line[..colon].trim() == "lo" { continue }
+        let mut f = line[colon + 1..].split_whitespace();
+        if let Some(r) = f.next().and_then(|v| v.parse::<u64>().ok()) { rx += r; }
+        for _ in 0..7 { f.next(); }
+        if let Some(t) = f.next().and_then(|v| v.parse::<u64>().ok()) { tx += t; }
+    }
+    (rx, tx)
+}
+
+/// (total_mb, used_mb, avail_mb)
+async fn read_memory() -> (u64, u64, u64) {
+    let Ok(s) = tokio::fs::read_to_string("/proc/meminfo").await else { return (0, 0, 0) };
+    let mut total = 0u64;
+    let mut avail = 0u64;
+    for line in s.lines() {
+        if line.starts_with("MemTotal:")     { total = parse_kb(line); }
+        else if line.starts_with("MemAvailable:") { avail = parse_kb(line); }
+    }
+    (total / 1024, total.saturating_sub(avail) / 1024, avail / 1024)
+}
+
+async fn read_swap() -> (u64, u64) {
+    let Ok(s) = tokio::fs::read_to_string("/proc/meminfo").await else { return (0, 0) };
+    let mut total = 0u64;
+    let mut free  = 0u64;
+    for line in s.lines() {
+        if line.starts_with("SwapTotal:") { total = parse_kb(line); }
+        else if line.starts_with("SwapFree:") { free = parse_kb(line); }
+    }
+    (total / 1024, total.saturating_sub(free) / 1024)
+}
+
+fn parse_kb(line: &str) -> u64 {
+    line.split_whitespace().nth(1).and_then(|v| v.parse().ok()).unwrap_or(0)
+}
+
+async fn read_cpu_percent() -> f64 {
+    let read_stat = || async {
+        tokio::fs::read_to_string("/proc/stat").await.ok().and_then(|s| {
+            let line = s.lines().next()?;
+            let mut p = line.split_whitespace().skip(1);
+            let user:    u64 = p.next()?.parse().ok()?;
+            let nice:    u64 = p.next()?.parse().ok()?;
+            let system:  u64 = p.next()?.parse().ok()?;
+            let idle:    u64 = p.next()?.parse().ok()?;
+            let iowait:  u64 = p.next()?.parse().ok()?;
+            let irq:     u64 = p.next()?.parse().ok()?;
+            let softirq: u64 = p.next()?.parse().ok()?;
+            let total = user + nice + system + idle + iowait + irq + softirq;
+            Some((total, idle + iowait))
+        })
+    };
+    let before = read_stat().await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let after  = read_stat().await;
+    if let (Some((t1, i1)), Some((t2, i2))) = (before, after) {
+        let dt = (t2 - t1) as f64;
+        let di = (i2 - i1) as f64;
+        if dt > 0.0 { (1.0 - di / dt) * 100.0 } else { 0.0 }
+    } else { 0.0 }
+}
+
+async fn read_disk_percent() -> f64 {
+    match Command::new("df").args(["-h", "--output=pcent", "/"]).output().await {
+        Ok(out) => String::from_utf8_lossy(&out.stdout)
+            .lines().nth(1)
+            .and_then(|l| l.trim().trim_end_matches('%').parse::<f64>().ok())
+            .unwrap_or(0.0),
+        Err(_) => 0.0,
+    }
+}
+
+async fn read_load_avg() -> [f64; 3] {
+    tokio::fs::read_to_string("/proc/loadavg").await.ok()
+        .and_then(|s| {
+            let mut p = s.split_whitespace();
+            let a: f64 = p.next()?.parse().ok()?;
+            let b: f64 = p.next()?.parse().ok()?;
+            let c: f64 = p.next()?.parse().ok()?;
+            Some([a, b, c])
+        })
+        .unwrap_or([0.0, 0.0, 0.0])
+}
+
+async fn read_cpu_temp() -> Option<f64> {
+    for path in ["/sys/class/thermal/thermal_zone0/temp", "/sys/class/hwmon/hwmon0/temp1_input"] {
+        if let Ok(s) = tokio::fs::read_to_string(path).await {
+            if let Ok(v) = s.trim().parse::<f64>() {
+                return Some(v / 1000.0);
+            }
+        }
+    }
+    None
+}
+
+/// Retourne (cpu%, mem_mb, name, pid) pour les top 10 processus
+async fn collect_processes() -> Vec<(f32, f32, String, String)> {
+    let out = Command::new("ps")
+        .args(["--no-headers", "-eo", "pid,%cpu,rss,comm", "--sort=-%cpu"])
+        .output()
+        .await;
+    let Ok(out) = out else { return vec![] };
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .take(10)
+        .filter_map(|line| {
+            let mut p = line.split_whitespace();
+            let pid:    String = p.next()?.to_string();
+            let cpu:    f32    = p.next()?.parse().ok()?;
+            let rss_kb: f32    = p.next()?.parse().ok()?;
+            let name:   String = p.next()?.to_string();
+            Some((cpu, rss_kb / 1024.0, name, pid))
+        })
+        .collect()
+}


### PR DESCRIPTION
Layer 1 — systemd Watchdog:
- daly-bms.service + energy-manager.service: Type=notify, WatchdogSec=60, NotifyAccess=main
- daly-bms-server: sd_notify READY=1 on startup, WATCHDOG=1 every 30s in monitor loop
- energy-manager: sd_notify READY=1 on startup, WATCHDOG=1 heartbeat task every 30s
- Crates: sd-notify 0.4 added to workspace

Layer 2 — node_exporter:
- contrib/node-exporter.service: systemd unit for Prometheus node_exporter
- contrib/victoriametrics-scrape.yml: scrape config for VictoriaMetrics
- Makefile: install-node-exporter target (downloads ARM64 binary, enables service)

Layer 3 — System metrics + tokio-metrics → VictoriaMetrics:
- daly-bms-server/monitor.rs: spawn_all() replaces two separate tokio::spawn calls
  * wraps agents with TaskMonitor (tokio-metrics)
  * writes pi5_cpu/mem/disk/temp/net/process metrics to VM every 30s
  * writes tokio_task_polls/mean_poll_us/mean_scheduled_us to VM every 60s
- energy-manager/monitoring.rs: new module, same system metrics (em_* prefix)
  * uses water_heater.vm_url for VM writes
  * TaskMonitor on the monitoring loop itself
- Crates: tokio-metrics 0.3 added to workspace

https://claude.ai/code/session_01Dw8bs3VhPNZnjFuPEFEr9V