### PR TITLE
docs: aligner CLAUDE.md, Readme.md et DEPLOYMENT.md sur le code actuel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,17 +107,27 @@ crates/daly-bms-server/src/             ← serveur principal RS485/API
 crates/energy-manager/src/              ← gestionnaire énergie (remplace Node-RED)
   config.rs                             ← chargement [energy_manager] depuis Config.toml
   types.rs                              ← types partagés (EnergyState, MqttIncoming, ...)
-  bus.rs                                ← AppBus (broadcast MQTT )
+  bus.rs                                ← AppBus (broadcast MQTT)
   main.rs                               ← démarrage séquentiel de tous les modules
-  logic/                                ← modules logiques métier
+  monitoring.rs                         ← métriques système + tokio → VictoriaMetrics
+  logic/                                ← modules logiques métier (charge_current,
+                                          deye_command, inverter, irradiance, meteo,
+                                          platform, smartshunt, solar_power,
+                                          switch_ats, tasmota, victron_keepalive,
+                                          water_heater)
   mqtt/                                 ← client MQTT rumqttc + topics
-  VictoriaMetrics/                               ← client VictoriaMetrics writer
   http_clients/                         ← Open-Meteo + LG ThinQ
   live_ws/                              ← WebSocket live events
   persist/                              ← restauration baselines au démarrage
+crates/energy-manager/rules/            ← règles `.grl` (rust-rule-engine) :
+                                          charge_current, deye_command, inverter,
+                                          irradiance, smartshunt, solar_power,
+                                          water_heater
 crates/dbus-mqtt-venus/src/             ← bridge MQTT→D-Bus NanoPi
 contrib/irradiance-rs485/               ← service Python irradiance
+contrib/daly-bms.service                ← unité systemd daly-bms-server
 contrib/energy-manager.service          ← unité systemd energy-manager
+contrib/node-exporter.service           ← unité systemd Prometheus node_exporter
 ```
 
 **IMPORTANT** : Le service lit `/etc/daly-bms/config.toml`, PAS `~/Daly-BMS-Rust/Config.toml`.
@@ -181,18 +191,81 @@ ssh root@192.168.1.120 "dbus -y | grep victronenergy"
 
 ---
 
-## 7. API ENDPOINTS
+## 7. API ENDPOINTS (extraits — voir `crates/daly-bms-server/src/api/mod.rs`)
 
 ```
-GET  /api/v1/system/status
-GET  /api/v1/bms/{id}/snapshot    GET  /api/v1/bms/{id}/history
-WS   /api/v1/bms/{id}/stream
-GET  /api/v1/et112/{addr}/status  GET  /api/v1/et112/{addr}/history
-POST /api/v1/bms/{id}/charge-mos  POST /api/v1/bms/{id}/discharge-mos
-POST /api/v1/bms/{id}/soc         POST /api/v1/bms/{id}/reset
+# Système
+GET  /api/v1/system/status            GET  /api/v1/system/totals
+GET  /api/v1/system/logs              GET  /api/v1/config
+GET  /api/v1/discover                 GET  /api/v1/irradiance/status
+POST /api/v1/solar/mppt-yield
+
+# Venus (lecture cache D-Bus / MQTT)
+GET  /api/v1/venus/mppt               GET  /api/v1/venus/smartshunt
+GET  /api/v1/venus/inverter           GET  /api/v1/venus/temperatures
+GET  /api/v1/venus/heatpumps
+
+# Monitor (RS485 health, logs)
+GET  /api/v1/monitor/status           GET  /api/v1/monitor/rs485-health
+GET  /api/v1/monitor/logs             GET  /api/v1/monitor/logs/content
+
+# BMS — lecture
+GET  /api/v1/bms/:id/status           GET  /api/v1/bms/:id/cells
+GET  /api/v1/bms/:id/temperatures     GET  /api/v1/bms/:id/alarms
+GET  /api/v1/bms/:id/mos              GET  /api/v1/bms/:id/history
+GET  /api/v1/bms/:id/history/summary  GET  /api/v1/bms/:id/export/csv
+GET  /api/v1/bms/compare              GET  /api/v1/bms/:id/settings
+
+# BMS — écriture (api_key requis si configurée)
+POST /api/v1/bms/:id/mos              POST /api/v1/bms/:id/soc
+POST /api/v1/bms/:id/soc/full         POST /api/v1/bms/:id/soc/empty
+POST /api/v1/bms/:id/reset
+POST /api/v1/bms/:id/settings/cell-voltage-alarms
+POST /api/v1/bms/:id/settings/pack-voltage-alarms
+POST /api/v1/bms/:id/settings/current-alarms
+POST /api/v1/bms/:id/settings/delta-alarms
+POST /api/v1/bms/:id/settings/balancing
+
+# ATS CHINT
+GET  /api/v1/ats/status
+POST /api/v1/ats/remote_on            POST /api/v1/ats/remote_off
+POST /api/v1/ats/force_source1        POST /api/v1/ats/force_source2
+POST /api/v1/ats/force_double         POST /api/v1/ats/send_raw
+GET  /api/v1/ats/debug_on             GET  /api/v1/ats/debug_off
+
+# ET112
+GET  /api/v1/et112                    GET  /api/v1/et112/:addr/status
+GET  /api/v1/et112/:addr/history
+
+# Charts / History
+GET  /api/v1/chart/history            GET  /api/v1/chart/edge-history
+GET  /api/v1/history/energy
+
+# Tasmota / Shelly
+GET  /api/v1/tasmota                  GET  /api/v1/tasmota/:id/status
+GET  /api/v1/tasmota/:id/history      POST /api/v1/tasmota/:id/control
+GET  /api/v1/shelly                   GET  /api/v1/shelly/:id/status
+POST /api/v1/shelly/:id/channel/:ch/control
+
+# PromQL (compat Grafana)
+GET  /api/v1/query                    GET  /api/v1/query_range
+GET  /api/v1/labels
+
+# Alertes
+GET  /api/v1/alerts/list              GET  /api/v1/alerts/stats
+POST /api/v1/alerts/:id/acknowledge
+
+# Health + WebSocket
+GET  /health
+WS   /ws/bms/stream                   WS   /ws/bms/:id/stream
+WS   /ws/venus/stream                 WS   /ws/console
 ```
 
-Dashboard SSR : `/dashboard/et112/{addr}`
+Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
+`/dashboard/et112`, `/dashboard/et112/:addr`, `/dashboard/tasmota`,
+`/dashboard/tasmota/:id`, `/dashboard/ats`, `/dashboard/monitor`,
+`/dashboard/console`, `/dashboard/visualization`, `/dashboard/history`,
+`/dashboard/alerts`, `/dashboard/logs`, `/dashboard/settings`.
 
 ---
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,7 +1,8 @@
-# 🚀 SOLUTION PROFESSIONNELLE COMPLÈTE — DÉPLOIEMENT ESS
+# 🚀 DÉPLOIEMENT ESS (Energy Storage System)
 
-**Version:** 1.0 (2026-04-05)  
-**Branche:** `claude/realtime-metrics-dashboard-lUKF3`  
+**Version:** 1.1 (mise à jour mai 2026)
+**Branche:** `main` (la feature `claude/realtime-metrics-dashboard-lUKF3` a été
+mergée — voir l'historique git pour le détail)
 **Statut:** ✅ PRODUCTION READY
 
 ---

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,9 @@
 # Daly-BMS — Rust Edition
 
-**Version Rust complète** — mise à jour 17 mars 2026
-Remplacement total de la stack Python/FastAPI par **Rust** (workspace multi-crates : `daly-bms-core` + `daly-bms-server` + `daly-bms-cli` + `daly-bms-probe` + `dbus-mqtt-venus`).
+**Version Rust complète** — mise à jour mai 2026
+Remplacement total de la stack Python/FastAPI **et** des flows Node-RED par **Rust**
+(workspace multi-crates : `rs485-bus` + `daly-bms-core` + `daly-bms-server` +
+`energy-manager` + `daly-bms-cli` + `daly-bms-probe` + `dbus-mqtt-venus`).
 
 > Dashboard intégré **SSR Rust** (Askama + ECharts) — aucun npm.
 > Infrastructure Docker **inchangée** (Mosquitto, VictoriaMetrics ).
@@ -22,41 +24,50 @@ Remplacement total de la stack Python/FastAPI par **Rust** (workspace multi-crat
 ┌─────────────────────────────────────────────────────────────────────┐
 │                    Raspberry Pi 5 CM  (Master)                      │
 │                                                                     │
-│  RS485 Bus 1 ── BMS Pack A (0x01, 360Ah)                           │
-│  RS485 Bus 1 ── BMS Pack B (0x02, 320Ah)  ──► daly-bms-server     │
-│  RS485 Bus 2 ── [TODO] Irradiance / Météo  ──► daly-bms-solar      │
-│  RS485 Bus 3 ── [TODO] ATS (bascule réseau/Victron/grid)           │
-│  API LG Cloud ─ FAIT PAC chauffe-eau     ──► daly-bms-heatpump   │
-│  API LG Cloud ─ [TODO] PAC climatisation   ──► daly-bms-heatpump   │
-│                                │                                    │
-│                         Mosquitto :1883                             │
-│                                │                                    │
-│    ┌──────────────┬────────────┴──────────┬────────────────────┐   │
-│    ▼              ▼                       ▼                    ▼   │
-│ VictoriaMetrics       AlertEngine           energy-manager              Dashboard│
-│ :8428          (SQLite)              :8081 (Pi5)            SSR     │
-│    │                                                               │
-│ Grafana :3001                                                       │
+│  RS485 /dev/ttyUSB0 ── BMS-360Ah  (0x01)                            │
+│                     ── BMS-320Ah  (0x02)                            │
+│                     ── ET112 PV   (0x07) — Micro-Onduleurs          │
+│                     ── ET112 House (0x08) — Consommation maison    │
+│                     ── ET112 Grid  (0x09) — Réseau                 │
+│                     ── PRALRAN     (0x05) — Irradiance / Météo     │
+│                     ── ATS CHINT   (RS485) — bascule grid/inverter │
+│                                  │                                  │
+│                                  ▼                                  │
+│                          daly-bms-server :8080                      │
+│                          (REST/WS + Dashboard SSR + AlertEngine)    │
+│                                  │                                  │
+│  API LG ThinQ ──► energy-manager :8081 (PAC chauffe-eau / Deye)    │
+│                                  │                                  │
+│                          Mosquitto :1883                            │
+│                                  │                                  │
+│         ┌────────────────────────┴────────────────────────┐         │
+│         ▼                                                 ▼         │
+│  VictoriaMetrics :8428                              Grafana :3001   │
 └────────────────────────────────┬────────────────────────────────────┘
-                                 │ MQTT
+                                 │ MQTT (santuario/*/venus)
                                  ▼
 ┌────────────────────────────────────────────────────────────────────┐
 │                  NanoPi Neo3  (Venus OS — D-Bus bridge)            │
 │                                                                    │
-│   dbus-mqtt-venus ◄── MQTT santuario/bms/{n}/venus         │
-│   (+ solar, heat, ats)  ◄── MQTT santuario/solar/{n}/venus        │
-│                         ◄── MQTT santuario/heat/{n}/venus         │
-│                         ◄── MQTT santuario/ats/venus              │
-│                │                                                   │
-│                ▼  D-Bus (zbus / pur Rust)                          │
-│   com.victronenergy.battery.*        (BMS × 2)                    │
-│   com.victronenergy.meteo.*          [TODO]                        │
-│   com.victronenergy.temperature.*   Fait                        │
-│   com.victronenergy.grid.*          [TODO] ATS                    │
+│   dbus-mqtt-venus  (binaire unique, zbus pur Rust)                 │
+│      ▲                                                             │
+│      │  Souscrit à : santuario/bms/{n}/venus                       │
+│      │               santuario/heatpump/{n}/venus                  │
+│      │               santuario/pvinverter/{n}/venus                │
+│      │               santuario/heat/{n}/venus                      │
+│      │               santuario/switch/{n}/venus                    │
+│      │               santuario/meteo/venus                         │
+│      ▼                                                             │
+│   com.victronenergy.battery.mqtt_*    (BMS × 2)         ✅         │
+│   com.victronenergy.pvinverter.mqtt_* (ET112 PV)        ✅         │
+│   com.victronenergy.heatpump.mqtt_*   (ET112 House+Grid) ✅        │
+│   com.victronenergy.temperature.mqtt_* (capteurs)        ✅        │
+│   com.victronenergy.switch.mqtt_*     (ATS + Tongou)     ✅        │
+│   com.victronenergy.meteo             (PRALRAN)          ✅        │
 │                │                                                   │
 │                ▼                                                   │
-│   systemcalc-py ── VRM Portal ── Venus GUI                        │
-│   hub4-control  (DVCC charge/discharge)                           │
+│   systemcalc-py ── VRM Portal ── Venus GUI                         │
+│   hub4-control  (DVCC charge/discharge)                            │
 └────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -64,15 +75,16 @@ Remplacement total de la stack Python/FastAPI par **Rust** (workspace multi-crat
 > **Validé en production** sur RPi5 au 17 mars 2026 — données confirmées dans VictoriaMetrics.
 > **Pi5 = master** : tous les capteurs RS485 y sont connectés, le NanoPi reste dédié Venus OS / D-Bus.
 
-### Flux MQTT par domaine
+### Flux MQTT par domaine (préfixe `santuario/`)
 
 | Topic MQTT | Source (Pi5) | Bridge NanoPi | Cible D-Bus Venus |
 |---|---|---|---|
-| `santuario/bms/{n}/venus` | `daly-bms-server` ✅ | `dbus-mqtt-venus` ✅ | `com.victronenergy.battery.{n}` |
-| `santuario/solar/{n}/venus` | `santuario-solar` 🔜 | `dbus-mqtt-venus` 🔜 | `com.victronenergy.meteo.{n}` |
-| `santuario/meteo/venus` | `santuario-solar` 🔜 | `dbus-mqtt-venus` 🔜 | `com.victronenergy.meteo` |
-| `santuario/heat/{n}/venus` | `santuario-heatpump` ✅ | `dbus-mqtt-venus` ✅ | `com.victronenergy.temperature.{n}` |
-| `santuario/ats/venus` | `santuario-ats` 🔜 | `dbus-mqtt-venus` 🔜 | `com.victronenergy.grid` |
+| `bms/{n}/venus` | `daly-bms-server` ✅ | `dbus-mqtt-venus` ✅ | `com.victronenergy.battery.mqtt_{n}` |
+| `pvinverter/{n}/venus` | `daly-bms-server` (ET112) ✅ | `dbus-mqtt-venus` ✅ | `com.victronenergy.pvinverter.mqtt_{n}` |
+| `heatpump/{n}/venus` | `daly-bms-server` (ET112) ✅ | `dbus-mqtt-venus` ✅ | `com.victronenergy.heatpump.mqtt_{n}` |
+| `heat/{n}/venus` | `energy-manager` (LG ThinQ) ✅ | `dbus-mqtt-venus` ✅ | `com.victronenergy.temperature.mqtt_{n}` |
+| `switch/{n}/venus` | `daly-bms-server` (ATS / Tongou) ✅ | `dbus-mqtt-venus` ✅ | `com.victronenergy.switch.mqtt_{n}` |
+| `meteo/venus` | `daly-bms-server` (PRALRAN) ✅ | `dbus-mqtt-venus` ✅ | `com.victronenergy.meteo` |
 
 > `dbus-mqtt-venus` est le **seul binaire sur le NanoPi** — il souscrit à tous les topics
 > et enregistre tous les services D-Bus. Un seul processus, ~5–8 Mo RAM.
@@ -119,59 +131,50 @@ Simulateur ──► run_simulator()              ← mode --simulate (sans mat�
                   (Venus OS / NanoPi)
 ```
 
-### Capteurs à venir (architecture cible)
+### Capteurs additionnels (implémentés)
 
 ```
-RS485 Bus 2 ──► daly-bms-solar::poll_loop()
-                              │
-                         MqttBridge ──► santuario/solar/{n}/venus
-                                               │
-                         dbus-mqtt-venus (extension solar)
-                              com.victronenergy.meteo.*
+ET112 Modbus RTU (0x07/0x08/0x09) ──► daly-bms-server::et112::poll_loop()
+                                          │
+                                    MqttBridge ──► santuario/pvinverter/{n}/venus
+                                                  santuario/heatpump/{n}/venus
+                                          │
+                                    dbus-mqtt-venus (pvinverter / heatpump services)
 
-LG ThinQ API ──► daly-bms-heatpump::lg_cloud_poll()
-(PAC chauffe-eau + clim)      │
-                         MqttBridge ──► santuario/heat/{n}/venus
-                                               │
-                         dbus-mqtt-venus (extension heat)
-                              com.victronenergy.temperature.*
+PRALRAN RS485 (0x05)              ──► daly-bms-server::irradiance::poll_loop()
+                                          │
+                                    MqttBridge ──► santuario/meteo/venus
+                                          │
+                                    dbus-mqtt-venus (meteo service)
 
-RS485 Bus 3 ──► daly-bms-ats::poll_loop()
-                              │
-                         MqttBridge ──► santuario/ats/venus
-                         + commandes ◄── (bascule maison/grid/Victron)
-                                               │
-                         dbus-mqtt-venus (extension ats)
-                              com.victronenergy.grid.*
+LG ThinQ API (PAC chauffe-eau)    ──► energy-manager::http_clients::lg_thinq
+                                          │
+                                    MqttBridge ──► santuario/heat/{n}/venus
+                                          │
+                                    dbus-mqtt-venus (temperature service)
+
+ATS CHINT RS485                   ──► daly-bms-server::ats (lecture + commandes)
+                                          │
+                                    MqttBridge ──► santuario/switch/{n}/venus
+                                          │
+                                    dbus-mqtt-venus (switch service)
 ```
 
 ---
 
 ## Workspace Rust
 
-### Convention de nommage
-
-| Préfixe | Scope | Exemples |
-|---|---|---|
-| `daly-bms-*` | Spécifique au protocole / matériel Daly | `daly-bms-core`, `daly-bms-cli`, `daly-bms-probe` |
-| `santuario-*` | Services du projet (indépendants du matériel) | `santuario-bms`, `santuario-solar`, `dbus-mqtt-venus` |
-
-> `daly-bms-core` garde son nom : c'est une bibliothèque liée à la **marque et au protocole**.
-> Tous les nouveaux **services** (binaires) adoptent le préfixe `santuario-`.
-
 ### Crates du workspace
 
 | Crate / Binaire | Hôte | Statut | Rôle |
 |---|---|---|---|
+| `rs485-bus` | — | ✅ Production | Lib : bus RS485 partagé (mutex tokio) + Modbus RTU pur Rust |
 | `daly-bms-core` | — | ✅ Production | Lib : protocole UART Daly, parsing trames, types (`BmsSnapshot`), polling |
-| `daly-bms-server` | Pi5 | ✅ Production | Binaire Pi5 : API Axum (REST + WebSocket) + Dashboard SSR + bridges (MQTT, VictoriaMetrics, Alertes) |
-| `dbus-mqtt-venus` | NanoPi | ✅ Production | Binaire NanoPi : MQTT → D-Bus Venus OS (zbus pur Rust) — tous les services `com.victronenergy.*` |
+| `daly-bms-server` | Pi5 | ✅ Production | Binaire Pi5 : API Axum (REST + WebSocket) + Dashboard SSR + bridges (MQTT, VictoriaMetrics, AlertEngine SQLite) — gère BMS, ET112, ATS, irradiance, Tasmota, Shelly |
+| `energy-manager` | Pi5 | ✅ Production | Binaire Pi5 (port 8081) — automatisation énergie via `rust-rule-engine` (charge_current, deye_command, inverter, irradiance, smartshunt, solar_power, water_heater, switch_ats, victron_keepalive) + clients HTTP Open-Meteo et LG ThinQ |
+| `dbus-mqtt-venus` | NanoPi (armv7) | ✅ Production | Binaire NanoPi : MQTT → D-Bus Venus OS (zbus pur Rust) — services `battery`, `pvinverter`, `heatpump`, `temperature`, `switch`, `meteo`, `platform` |
 | `daly-bms-cli` | Pi5 | ✅ Stable | Outil CLI de diagnostic et contrôle RS485 |
 | `daly-bms-probe` | Pi5 | ✅ Stable | Outil diagnostic bas niveau — trames brutes, test 3 variantes d'adressage |
-| `santuario-core` | — | 🔜 TODO | Lib : traits partagés `DevicePoller`, `VenusPayload`, `MqttPublisher` |
-| `santuario-solar` | Pi5 | 🔜 TODO | Binaire Pi5 : polling RS485 irradiance + météo → MQTT |
-| `santuario-heatpump` | Pi5 |✅ | Binaire Pi5 : API LG ThinQ (PAC chauffe-eau + clim) → MQTT |
-| `santuario-ats` | Pi5 | 🔜 TODO | Binaire Pi5 : ATS RS485 (bascule maison/grid/Victron) → MQTT |
 
 ---
 
@@ -192,73 +195,75 @@ Daly-BMS-Rust/
 ├── .gitignore
 │
 ├── crates/
-│   ├── daly-bms-core/         ← Bibliothèque protocole
+│   ├── rs485-bus/                ← Bus RS485 partagé + Modbus RTU pur Rust
+│   │   └── src/{lib.rs, modbus_rtu.rs}
+│   │
+│   ├── daly-bms-core/            ← Bibliothèque protocole Daly
+│   │   └── src/{lib.rs, error.rs, types.rs, protocol.rs, bus.rs,
+│   │            commands.rs, write.rs, poll.rs}
+│   │
+│   ├── daly-bms-server/          ← Serveur principal Pi5 (REST/WS + Dashboard SSR)
+│   │   ├── src/
+│   │   │   ├── main.rs, config.rs, state.rs, autodetect.rs,
+│   │   │   ├── simulator.rs, monitor.rs, console.rs, vm_client.rs
+│   │   │   ├── api/              ← Router Axum : bms, system, ats, et112,
+│   │   │   │                       chart, history, alerts, tasmota, shelly,
+│   │   │   │                       promql, console, health
+│   │   │   ├── ats/              ← ATS CHINT (RS485 + commandes)
+│   │   │   ├── et112/            ← Compteurs énergie ET112 (Modbus RTU)
+│   │   │   ├── irradiance/       ← Capteur PRALRAN (RS485)
+│   │   │   ├── tasmota/, shelly/ ← Capteurs / relais MQTT
+│   │   │   ├── bridges/          ← MQTT publisher + AlertEngine SQLite
+│   │   │   └── dashboard/        ← Routes SSR + génération ECharts
+│   │   └── templates/            ← Templates Askama (.html) compilés dans le binaire
+│   │
+│   ├── energy-manager/           ← Automatisation Rust (remplace Node-RED)
+│   │   ├── src/
+│   │   │   ├── main.rs, config.rs, types.rs, bus.rs, monitoring.rs
+│   │   │   ├── mqtt/             ← Client rumqttc + topics
+│   │   │   ├── http_clients/     ← Open-Meteo + LG ThinQ
+│   │   │   ├── live_ws/          ← WebSocket debug live
+│   │   │   ├── persist/          ← Restauration baselines
+│   │   │   └── logic/            ← 12 modules de décision
+│   │   │       (charge_current, deye_command, inverter, irradiance,
+│   │   │        meteo, platform, smartshunt, solar_power, switch_ats,
+│   │   │        tasmota, victron_keepalive, water_heater)
+│   │   └── rules/                ← Fichiers `.grl` (rust-rule-engine)
+│   │
+│   ├── dbus-mqtt-venus/          ← Binaire NanoPi : MQTT → D-Bus Venus OS
 │   │   └── src/
-│   │       ├── lib.rs
-│   │       ├── error.rs       ← DalyError, Result<T>
-│   │       ├── types.rs       ← BmsSnapshot, Alarms, SystemData…
-│   │       ├── protocol.rs    ← DataId, RequestFrame, checksum + 7 tests unitaires
-│   │       ├── bus.rs         ← DalyPort (Mutex), DalyBusManager
-│   │       ├── commands.rs    ← get_pack_status, get_cell_voltages…
-│   │       ├── write.rs       ← set_charge_mos, set_soc, reset_bms
-│   │       └── poll.rs        ← poll_loop + backoff + retry
+│   │       ├── main.rs, config.rs, types.rs, manager.rs, mqtt_source.rs,
+│   │       ├── battery_service.rs / battery_manager.rs
+│   │       ├── pvinverter_service.rs / pvinverter_manager.rs
+│   │       ├── heatpump_service.rs / heatpump_manager.rs
+│   │       ├── temperature_service.rs
+│   │       ├── switch_service.rs / switch_manager.rs
+│   │       ├── meteo_service.rs / meteo_manager.rs
+│   │       ├── grid_service.rs / grid_manager.rs
+│   │       ├── platform_service.rs / platform_manager.rs
+│   │       └── sensor_manager.rs
 │   │
-│   ├── daly-bms-server/       ← Serveur principal
-│   │   └── src/
-│   │       ├── main.rs        ← Entrypoint, CLI flags (--simulate, --port, --bms…)
-│   │       ├── config.rs      ← AppConfig (TOML → struct), per-BMS config
-│   │       ├── state.rs       ← AppState, ring buffer, broadcast channel
-│   │       ├── simulator.rs   ← Simulateur BMS (physique LiFePO4, sans matériel)
-│   │       ├── autodetect.rs  ← Détection automatique port série + adresses BMS
-│   │       ├── api/
-│   │       │   ├── mod.rs     ← Router Axum (toutes les routes)
-│   │       │   ├── system.rs  ← GET /api/v1/system/*
-│   │       │   └── bms.rs     ← GET/POST /api/v1/bms/*, WebSocket
-│   │       ├── bridges/
-│   │       │   ├── mod.rs
-│   │       │   ├── mqtt.rs    ← rumqttc, topics, Venus OS payload
-│   │       │   ├── victoriaMetrics  ← VictoriaMetrics2-client, batch write
-│   │       │   └── alerts.rs  ← AlertEngine, SQLite, Telegram/SMTP (Todo)
-│   │       └── dashboard/
-│   │           ├── mod.rs     ← Routes /dashboard, templates Askama
-│   │           └── charts.rs  ← Génération JSON ECharts (boxplot, séries…)
-│   │
-│   ├── dbus-mqtt-venus/ ← Binaire NanoPi : MQTT → D-Bus (tous devices)
-│   │   └── src/
-│   │       ├── main.rs         ← Entrypoint, tokio runtime
-│   │       ├── config.rs       ← VenusConfig (TOML)
-│   │       ├── types.rs        ← VenusPayload (serde_json)
-│   │       ├── mqtt_source.rs  ← Subscriber rumqttc (tous topics santuario/*)
-│   │       ├── battery_service.rs ← com.victronenergy.battery.* (zbus)
-│   │       └── manager.rs      ← Orchestration, watchdog, keepalive
-│   │   [à venir]
-│   │       ├── solar_service.rs   ← com.victronenergy.meteo.*
-│   │       ├── heat_service.rs    ← com.victronenergy.temperature.*
-│   │       └── ats_service.rs     ← com.victronenergy.grid.*
-│   │
-│   ├── daly-bms-cli/          ← Outil CLI
-│   │   └── src/main.rs        ← clap, sous-commandes
-│   │
-│   └── daly-bms-probe/        ← Outil diagnostic bas niveau
-│       └── src/main.rs        ← Trames brutes, test 3 variantes d'adressage
+│   ├── daly-bms-cli/             ← Outil CLI (clap)
+│   └── daly-bms-probe/           ← Outil diagnostic bas niveau (trames brutes)
 │
 ├── contrib/
-│   ├── daly-bms.service       ← Service systemd
-│   ├── nginx.conf             ← Reverse proxy nginx
-│   ├── install-systemd.sh     ← Script d'installation systemd
-│   └── uninstall-systemd.sh   ← Script de désinstallation
+│   ├── daly-bms.service          ← Unité systemd daly-bms-server
+│   ├── energy-manager.service    ← Unité systemd energy-manager
+│   ├── node-exporter.service     ← Unité systemd Prometheus node_exporter
+│   ├── victoriametrics-scrape.yml← Config scrape Prometheus pour VM
+│   ├── nginx.conf                ← Reverse proxy nginx
+│   ├── irradiance-rs485/         ← Service Python irradiance (legacy)
+│   ├── install-systemd.sh        ← Script d'installation systemd
+│   └── uninstall-systemd.sh      ← Script de désinstallation
 ├── docker/
-│   └── mosquitto/config/
-│       └── mosquitto.conf     ← Configuration broker MQTT
-├── docs/
-│   ├── Plan.md                ← Plan d'implémentation détaillé (v2.2)
-│   ├── JSONData.json          ← Structure de données de référence
-│   ├── Daly-UART_485-Communications-Protocol-V1.21-1.pdf
-│   └── dalyModbusProtocol.xlsx
-└── nanoPi/                    ← Config dbus-mqtt-battery (Venus OS)
-    ├── config-bms1.ini        ← Instance dbus-mqtt-battery-41 (BMS 0x01)
-    ├── config-bms2.ini        ← Instance dbus-mqtt-battery-42 (BMS 0x02)
-    └── README.md              ← Guide installation Venus OS
+│   └── mosquitto/config/mosquitto.conf
+├── docs/                         ← Guides détaillés (energy-manager, ATS, Venus, etc.)
+└── nanoPi/                       ← Config dbus-mqtt-venus (Venus OS)
+    ├── config-nanopi.toml        ← Config production dbus-mqtt-venus
+    ├── install-venus.sh          ← Script de déploiement
+    ├── cleanup-dbus-serialbattery.sh
+    ├── sv/                       ← Templates runit
+    └── README.md                 ← Guide installation Venus OS
 ```
 
 ### Estimation mémoire
@@ -268,13 +273,13 @@ Daly-BMS-Rust/
 | Service                    | RAM minimale | RAM confortable |
 |----------------------------|-------------|-----------------|
 | daly-bms-server (Rust)     | ~25 MB      | ~50 MB          |
+| energy-manager (Rust)      | ~30 MB      | ~100 MB (LimitMemoryMax=100M) |
 | Mosquitto                  | ~12 MB      | ~20 MB          |
 | VictoriaMetrics 2.x (Go)   | ~150 MB     | ~350 MB         |
-| energy-manager (Node.js)         | ~150 MB     | ~250 MB         |
 | OS Raspberry Pi OS Lite    | ~150 MB     | ~200 MB         |
 | Docker Engine + overhead   | ~100 MB     | ~150 MB         |
 | Marge tampon / cache       | ~200 MB     | ~400 MB         |
-| **TOTAL**                  | **~957 MB** | **~1220 MB**    |
+| **TOTAL**                  | **~667 MB** | **~1270 MB**    |
 
 #### NanoPi Neo3 (Venus OS — services Rust statiques)
 
@@ -323,8 +328,8 @@ cargo build --release
 # Lancer avec 2 BMS simulés
 cargo run --bin daly-bms-server -- --simulate --sim-bms 0x01,0x02
 
-# Ou avec Make
-make run-simulate
+# Ou avec Make (lance le binaire en release)
+make run
 
 # Accéder au dashboard
 # http://localhost:8080/dashboard
@@ -473,20 +478,39 @@ make ps            # État des containers
 make logs          # Logs de tous les containers (follow)
 make reset         # Arrêter + supprimer volumes + redémarrer (reset complet)
 
-make build         # Compiler (release, local)
-make build-arm     # Cross-compiler pour aarch64 (RPi)
-make build-all     # Tous les binaires
-make run           # Lancer le serveur
-make run-debug     # Debug (RUST_LOG=debug)
-make run-simulate  # Mode simulateur (sans matériel)
-make test          # Tests unitaires
-make test-core     # Tests protocole uniquement
-make lint          # Clippy
-make fmt           # Format code
-make check         # check + fmt + clippy
-make deploy        # Cross-compile + deploy SSH sur le Pi
-make install       # Installer service systemd
-make doc           # Générer et ouvrir la doc Rust
+make build              # Compiler (release, local)
+make build-arm          # Cross-compiler daly-bms-server pour aarch64 (Pi5)
+make build-arm-debug    # Build aarch64 avec symboles (profile release-debug)
+make build-arm-musl     # Build aarch64 statique (musl)
+make build-arm-v7       # Cross-compiler pour armv7 (NanoPi)
+make build-cli          # Compiler daly-bms-cli
+make build-venus        # Compiler dbus-mqtt-venus (host)
+make build-venus-arm    # dbus-mqtt-venus aarch64
+make build-venus-v7     # dbus-mqtt-venus armv7 (NanoPi)
+make install-venus      # Déployer dbus-mqtt-venus sur GX (aarch64)
+make install-venus-v7   # Déployer dbus-mqtt-venus sur NanoPi (armv7)
+make build-energy       # Compiler energy-manager (host)
+make build-energy-arm   # energy-manager aarch64 (Pi5)
+make install-energy     # Déployer energy-manager sur Pi5
+make run-energy         # Lancer energy-manager localement
+make build-all          # Tous les binaires
+make run                # Lancer daly-bms-server (release)
+make run-debug          # daly-bms-server avec RUST_LOG=debug
+make cli ARGS="..."     # Lancer daly-bms-cli
+make test               # Tests unitaires (workspace)
+make test-core          # Tests daly-bms-core uniquement
+make test-verbose       # Tests avec --nocapture
+make lint               # Clippy (--all-targets, deny warnings)
+make fmt                # cargo fmt
+make check              # cargo check + fmt + clippy
+make deploy             # Cross-compile + scp + restart sur Pi5
+make deploy-musl        # Idem en build musl
+make sync               # `git pull` côté Pi5 (executé sur la cible)
+make install            # Installer daly-bms-server systemd
+make uninstall          # Désinstaller daly-bms-server systemd
+make install-node-exporter  # Installer Prometheus node_exporter
+make profile-setup/-start/-stop  # Profiling perf/flamegraph
+make doc                # cargo doc (workspace, --open)
 ```
 
 ---


### PR DESCRIPTION
- CLAUDE.md
  - Section 4 (Structure projet) : retire `VictoriaMetrics/` (dossier inexistant), ajoute `monitoring.rs` et liste les 12 sous-modules `logic/` ainsi que les 7 fichiers `.grl` sous `rules/`. Ajoute les unités systemd `daly-bms.service` et `node-exporter.service`.
  - Section 7 (API endpoints) : remplace les routes inventees (`/snapshot`, `/charge-mos`, `/discharge-mos`) par les vrais noms du routeur Axum (`/status`, `/mos`, etc.) et complète avec les endpoints Venus, Monitor, ATS, ET112, Tasmota, Shelly, PromQL, Alertes, et toutes les routes WebSocket et Dashboard SSR.

- Readme.md
  - Diagramme architecture : remplace les marqueurs `[TODO]` par les capteurs réellement implémentés (ET112 PV/House/Grid, PRALRAN irradiance, ATS CHINT) et liste les services D-Bus actifs sur le NanoPi (`pvinverter`, `heatpump`, `temperature`, `switch`, `meteo`).
  - Flux MQTT : utilise les topics réels sous `santuario/` et marque toutes les sources comme implémentées.
  - Crates du workspace : ajoute `rs485-bus` et `energy-manager`, supprime les crates `santuario-*` qui n'existent pas.
  - Structure du dépôt : recense les modules réels du serveur (ATS, ET112, irradiance, Tasmota, Shelly) et tous les services `dbus-mqtt-venus` (battery, pvinverter, heatpump, temperature, switch, meteo, grid, platform).
  - Estimation mémoire : energy-manager passe de Node.js à Rust (LimitMemoryMax=100M).
  - Capteurs additionnels : section retitrée et flux mis à jour pour refléter l'implémentation actuelle.
  - Commandes Make : aligne sur le Makefile réel (build-energy-arm, install-venus-v7, build-arm-musl, profile-*, etc.) et supprime `make run-simulate` qui n'existe pas.

- DEPLOYMENT.md
  - Met à jour la version et indique que la branche feature `claude/realtime-metrics-dashboard-lUKF3` a été mergée dans `main`.