### PR TITLE
feat(energy-manager): hot-reload rules, tests, DEYE persistence, conf…

### DIFF
--- a/crates/energy-manager/rules/deye_command.grl
+++ b/crates/energy-manager/rules/deye_command.grl
@@ -14,6 +14,11 @@
 //   DY.next_state             (string, absent if no transition)
 //   DY.relay_on               (bool)
 //   DY.relay_off              (bool)
+//
+// IMPORTANT: normal rules (salience 100) include `DY.grid_connected == false`
+// to prevent them from overwriting grid-reconnect rules (salience 200).
+// The rule engine fires all matching rules; higher-salience fires first but
+// lower-salience can still overwrite the same fact without this guard.
 
 // ── Normal state machine transitions (salience 100) ─────────────────────────
 
@@ -42,26 +47,26 @@ rule "DY_PendingCut_Elapsed" salience 100 no-loop {
         DY.relay_off = true;
 }
 
-// Lockout → Off once lockout expires
+// Lockout → Off once lockout expires (guard: grid not connected, else reconnect rule takes priority)
 rule "DY_Lockout_Expired" salience 100 no-loop {
     when
-        DY.state == "Lockout" && DY.lockout_expired == true
+        DY.state == "Lockout" && DY.lockout_expired == true && DY.grid_connected == false
     then
         DY.next_state = "Off";
 }
 
-// Off → PendingRestore when frequency drops to low threshold
+// Off → PendingRestore when frequency drops to low threshold (guard: grid not connected)
 rule "DY_Off_LowFreq" salience 100 no-loop {
     when
-        DY.state == "Off" && DY.freq_low_reached == true
+        DY.state == "Off" && DY.freq_low_reached == true && DY.grid_connected == false
     then
         DY.next_state = "PendingRestore";
 }
 
-// PendingRestore: cancel if frequency climbs back (mutually exclusive with _Elapsed)
+// PendingRestore: cancel if frequency climbs back (guard: grid not connected)
 rule "DY_PendingRestore_FreqClimb" salience 100 no-loop {
     when
-        DY.state == "PendingRestore" && DY.freq_low_reached == false
+        DY.state == "PendingRestore" && DY.freq_low_reached == false && DY.grid_connected == false
     then
         DY.next_state = "Off";
 }

--- a/crates/energy-manager/rules/water_heater.grl
+++ b/crates/energy-manager/rules/water_heater.grl
@@ -1,17 +1,17 @@
 // crates/energy-manager/rules/water_heater.grl
-///Water heater automation rules.
+// Water heater automation rules.
 // Decides between HeatPump and Vacation mode based on energy conditions.
 //
 // Input facts (injected from Rust before evaluate):
 //   WH.want_vacation   (bool, initialised to false — set true by any condition rule)
 //   WH.grid_connected  (bool, true = ac_ignore == 0, grid ON → Vacation)
-//   WH.soc_pct         (number, battery SOC %)
-//   WH.irradiance_low  (bool, true when irradiance < irradiance_min_wm2)
+//   WH.soc_low         (bool, pre-computed: soc_pct < soc_min_pct from WaterHeaterConfig)
+//   WH.irradiance_low  (bool, true when irradiance < irradiance_min_wm2 from WaterHeaterConfig)
 //
 // Output facts (read from Rust after execute):
-//   WH.target_mode     (string: "HeatPump" | "Vacation")
+//   WH.target_mode     (string: "HEAT_PUMP" | "VACATION")
 //
-// HEAT_PUMP requires ALL: SOC >= 90%, irradiance >= 300 W/m², grid disconnected (ac_ignore = 1)
+// HEAT_PUMP requires ALL: soc_low=false, irradiance_low=false, grid_connected=false
 
 // ── Condition rules (salience 100) ──────────────────────────────────────────
 
@@ -24,7 +24,7 @@ rule "WH_Cond_Grid" salience 100 {
 
 rule "WH_Cond_SOC_Low" salience 100 {
     when
-        WH.soc_pct < 90
+        WH.soc_low == true
     then
         WH.want_vacation = true;
 }
@@ -45,7 +45,7 @@ rule "WH_Decide_Vacation" salience 200 {
         WH.target_mode = "VACATION";
 }
 
-rule "WH_Decide_HeatPump" salience 200  {
+rule "WH_Decide_HeatPump" salience 200 {
     when
         WH.want_vacation == false
     then

--- a/crates/energy-manager/src/bus.rs
+++ b/crates/energy-manager/src/bus.rs
@@ -2,20 +2,23 @@ use tokio::sync::{broadcast, mpsc};
 use crate::types::{LiveEvent, MqttIncoming, MqttOutgoing};
 
 // Capacity constants
-const MQTT_IN_CAPACITY:  usize = 512;
-const MQTT_OUT_CAPACITY: usize = 256;
-const LIVE_CAPACITY:     usize = 64;
+const MQTT_IN_CAPACITY:    usize = 512;
+const MQTT_OUT_CAPACITY:   usize = 256;
+const LIVE_CAPACITY:       usize = 64;
+const RULE_RELOAD_CAPACITY: usize = 16;
 
 /// Central message bus passed to all tasks.
 /// Clone it freely — each field is Arc-backed.
 #[derive(Clone)]
 pub struct AppBus {
     /// Broadcast of all incoming MQTT messages → all logic tasks subscribe
-    pub mqtt_in:  broadcast::Sender<MqttIncoming>,
+    pub mqtt_in:     broadcast::Sender<MqttIncoming>,
     /// MPSC → MQTT publisher task
-    pub mqtt_out: mpsc::Sender<MqttOutgoing>,
+    pub mqtt_out:    mpsc::Sender<MqttOutgoing>,
     /// Broadcast → live WebSocket clients
-    pub live:     broadcast::Sender<LiveEvent>,
+    pub live:        broadcast::Sender<LiveEvent>,
+    /// Broadcast rule reload signals → logic tasks (rule_name or "*" for all)
+    pub rule_reload: broadcast::Sender<String>,
 }
 
 pub struct AppBusReceivers {
@@ -24,11 +27,12 @@ pub struct AppBusReceivers {
 
 impl AppBus {
     pub fn new() -> (Self, AppBusReceivers) {
-        let (mqtt_in, _)      = broadcast::channel(MQTT_IN_CAPACITY);
+        let (mqtt_in, _)           = broadcast::channel(MQTT_IN_CAPACITY);
         let (mqtt_out, mqtt_out_rx) = mpsc::channel(MQTT_OUT_CAPACITY);
-        let (live, _)               = broadcast::channel(LIVE_CAPACITY);
+        let (live, _)              = broadcast::channel(LIVE_CAPACITY);
+        let (rule_reload, _)       = broadcast::channel(RULE_RELOAD_CAPACITY);
 
-        let bus = Self { mqtt_in, mqtt_out, live };
+        let bus = Self { mqtt_in, mqtt_out, live, rule_reload };
         let rxs = AppBusReceivers { mqtt_out_rx };
         (bus, rxs)
     }
@@ -40,6 +44,16 @@ impl AppBus {
     #[allow(dead_code)]
     pub fn subscribe_live(&self) -> broadcast::Receiver<LiveEvent> {
         self.live.subscribe()
+    }
+
+    pub fn subscribe_rule_reload(&self) -> broadcast::Receiver<String> {
+        self.rule_reload.subscribe()
+    }
+
+    /// Trigger a hot-reload of `rule_name` (or "*" for all rules) in all logic tasks.
+    #[allow(dead_code)]
+    pub fn trigger_rule_reload(&self, rule_name: &str) {
+        let _ = self.rule_reload.send(rule_name.to_string());
     }
 
     /// Publish a message to MQTT (non-blocking, drops if channel full)

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -33,6 +33,21 @@ pub struct EnergyManagerConfig {
     pub solar: SolarConfig,
     #[serde(default)]
     pub platform: PlatformConfig,
+    #[serde(default)]
+    pub rules: RulesConfig,
+}
+
+// ---------------------------------------------------------------------------
+// Rules hot-reload
+// ---------------------------------------------------------------------------
+
+/// Optional directory containing .grl rule files to load at startup instead of
+/// the embedded versions. Hot-reload is triggered via POST /api/v1/em/rules/reload.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct RulesConfig {
+    /// Path to directory containing .grl files (e.g. "/etc/daly-bms/rules").
+    /// If absent or files not found, embedded rules are used as fallback.
+    pub dir: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -325,6 +340,9 @@ pub struct WaterHeaterConfig {
     /// Minimum irradiance to allow HEAT_PUMP mode (W/m²)
     #[serde(default = "default_irradiance_min_wm2")]
     pub irradiance_min_wm2: f64,
+    /// Minimum battery SOC to allow HEAT_PUMP mode (%)
+    #[serde(default = "default_soc_min_pct")]
+    pub soc_min_pct: f64,
     /// VictoriaMetrics write URL for water heater metrics
     #[serde(default = "default_wh_vm_url")]
     pub vm_url: String,
@@ -338,6 +356,7 @@ fn default_vacation_target_c() -> f64 { 45.0 }
 fn default_temp_set_delay_secs() -> u64 { 15 }
 fn default_keepalive_secs() -> u64 { 25 }
 fn default_irradiance_min_wm2() -> f64 { 300.0 }
+fn default_soc_min_pct() -> f64 { 90.0 }
 fn default_wh_vm_url() -> String { "http://127.0.0.1:8428".into() }
 
 impl Default for WaterHeaterConfig {
@@ -351,6 +370,7 @@ impl Default for WaterHeaterConfig {
             temp_set_delay_secs: default_temp_set_delay_secs(),
             keepalive_secs: default_keepalive_secs(),
             irradiance_min_wm2: default_irradiance_min_wm2(),
+            soc_min_pct: default_soc_min_pct(),
             vm_url: default_wh_vm_url(),
         }
     }

--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -1,10 +1,13 @@
 /// HTTP + WebSocket server for energy-manager.
 ///
 /// Routes:
-///   GET  /live               — WebSocket live event stream
-///   GET  /health             — health check
-///   GET  /api/water-heater   — current water heater state (JSON)
-///   POST /api/water-heater/mode   — set mode ("HEAT_PUMP" | "VACATION" | "TURBO")
+///   GET  /live                       — WebSocket live event stream
+///   GET  /health                     — health check
+///   GET  /api/water-heater           — current water heater state (JSON)
+///   POST /api/water-heater/mode      — set mode ("HEAT_PUMP" | "VACATION" | "TURBO")
+///   GET  /api/rules-status           — aggregated rules status for monitor.html
+///   GET  /api/v1/em/rules            — list loaded rules (name, origin, loaded_at)
+///   POST /api/v1/em/rules/reload     — hot-reload rules from disk (body: {"name":"*"})
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
@@ -23,14 +26,17 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
 
 use crate::http_clients::lg_thinq::LgThinqClient;
+use crate::rules_loader::RulesLoader;
 use crate::types::{EnergyState, LiveEvent, WaterHeaterMode};
 use chrono::{DateTime, Utc};
 
 #[derive(Clone)]
 struct ServerState {
-    tx:       broadcast::Sender<LiveEvent>,
-    state:    Arc<RwLock<EnergyState>>,
-    lg:       Option<Arc<LgThinqClient>>,
+    tx:          broadcast::Sender<LiveEvent>,
+    state:       Arc<RwLock<EnergyState>>,
+    lg:          Option<Arc<LgThinqClient>>,
+    loader:      Arc<RulesLoader>,
+    rule_reload: broadcast::Sender<String>,
 }
 
 pub async fn serve(
@@ -38,8 +44,10 @@ pub async fn serve(
     live_tx: broadcast::Sender<LiveEvent>,
     state: Arc<RwLock<EnergyState>>,
     lg: Option<Arc<LgThinqClient>>,
+    loader: Arc<RulesLoader>,
+    rule_reload: broadcast::Sender<String>,
 ) {
-    let srv = ServerState { tx: live_tx, state, lg };
+    let srv = ServerState { tx: live_tx, state, lg, loader, rule_reload };
 
     let cors = CorsLayer::new()
         .allow_origin(Any)
@@ -47,11 +55,13 @@ pub async fn serve(
         .allow_headers(Any);
 
     let app = Router::new()
-        .route("/live",                     get(ws_handler))
-        .route("/health",                   get(health_handler))
-        .route("/api/water-heater",         get(wh_status_handler))
-        .route("/api/water-heater/mode",    post(wh_set_mode_handler))
-        .route("/api/rules-status",         get(rules_status_handler))
+        .route("/live",                         get(ws_handler))
+        .route("/health",                       get(health_handler))
+        .route("/api/water-heater",             get(wh_status_handler))
+        .route("/api/water-heater/mode",        post(wh_set_mode_handler))
+        .route("/api/rules-status",             get(rules_status_handler))
+        .route("/api/v1/em/rules",              get(rules_list_handler))
+        .route("/api/v1/em/rules/reload",       post(rules_reload_handler))
         .with_state(srv)
         .layer(cors);
 
@@ -183,6 +193,31 @@ async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
         ac_ignore:      s.ac_ignore,
     };
     Json(status).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Rules hot-reload endpoints
+// ---------------------------------------------------------------------------
+
+async fn rules_list_handler(State(srv): State<ServerState>) -> Response {
+    Json(srv.loader.info()).into_response()
+}
+
+#[derive(Deserialize)]
+struct ReloadRequest {
+    #[serde(default = "default_reload_name")]
+    name: String,
+}
+fn default_reload_name() -> String { "*".to_string() }
+
+async fn rules_reload_handler(
+    State(srv): State<ServerState>,
+    body: Option<Json<ReloadRequest>>,
+) -> Response {
+    let name = body.map(|b| b.name.clone()).unwrap_or_else(|| "*".to_string());
+    srv.rule_reload.send(name.clone()).ok();
+    info!("Rules hot-reload triggered: {name}");
+    (StatusCode::OK, format!("reload triggered: {name}")).into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/energy-manager/src/logic/charge_current/mod.rs
+++ b/crates/energy-manager/src/logic/charge_current/mod.rs
@@ -12,6 +12,7 @@ use tracing::info;
 use crate::bus::AppBus;
 use crate::config::{ChargeCurrent as ChargeCfg, VictronConfig};
 use crate::mqtt::topics::publish;
+use crate::rules_loader::RulesLoader;
 use crate::types::{EnergyState, MqttOutgoing};
 
 pub async fn spawn(
@@ -19,8 +20,9 @@ pub async fn spawn(
     cfg: ChargeCfg,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
+    loader: Arc<RulesLoader>,
 ) {
-    tokio::spawn(run(vic, cfg, bus, state));
+    tokio::spawn(run(vic, cfg, bus, state, loader));
 }
 
 async fn run(
@@ -28,6 +30,7 @@ async fn run(
     cfg: ChargeCfg,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
+    loader: Arc<RulesLoader>,
 ) {
     let vb  = vic.vebus_instance;
     let pid = vic.portal_id.clone();
@@ -36,7 +39,8 @@ async fn run(
     let topic_pv_power = format!("N/{pid}/system/0/Ac/PvOnOutput/L1/Power");
     let topic_consump  = format!("N/{pid}/system/0/Ac/ConsumptionOnOutput/L1/Power");
 
-    let mut rule_engine = match rules::ChargeRuleEngine::new() {
+    let src = loader.load("charge_current");
+    let mut rule_engine = match rules::ChargeRuleEngine::with_source(&src) {
         Ok(e) => e,
         Err(e) => {
             tracing::error!("Failed to init charge current rule engine: {e}");
@@ -44,37 +48,47 @@ async fn run(
         }
     };
 
-    let mut rx = bus.subscribe_mqtt();
+    let mut rx          = bus.subscribe_mqtt();
+    let mut reload_rx   = bus.subscribe_rule_reload();
+
     loop {
-        let msg = match rx.recv().await {
-            Ok(m)  => m,
-            Err(_) => continue,
-        };
-
-        let t = &msg.topic;
-        if t != &topic_ignore && t != &topic_pv_power && t != &topic_consump {
-            continue;
-        }
-
-        // Update state from MQTT
-        {
-            let mut s = state.write().await;
-            if t == &topic_ignore {
-                if let Some(v) = msg.victron_value::<i64>() {
-                    s.ac_ignore = Some(v);
+        tokio::select! {
+            Ok(msg) = rx.recv() => {
+                let t = &msg.topic;
+                if t != &topic_ignore && t != &topic_pv_power && t != &topic_consump {
+                    continue;
                 }
-            } else if t == &topic_pv_power {
-                if let Some(v) = msg.victron_value::<f64>() {
-                    s.mppt_power_273_w = Some(v);
+
+                {
+                    let mut s = state.write().await;
+                    if t == &topic_ignore {
+                        if let Some(v) = msg.victron_value::<i64>() {
+                            s.ac_ignore = Some(v);
+                        }
+                    } else if t == &topic_pv_power {
+                        if let Some(v) = msg.victron_value::<f64>() {
+                            s.mppt_power_273_w = Some(v);
+                        }
+                    } else if t == &topic_consump {
+                        if let Some(v) = msg.victron_value::<f64>() {
+                            s.house_power_w = Some(v);
+                        }
+                    }
                 }
-            } else if t == &topic_consump {
-                if let Some(v) = msg.victron_value::<f64>() {
-                    s.house_power_w = Some(v);
+
+                compute_and_publish(&mut rule_engine, &bus, &state, &cfg, &pid, vb).await;
+            }
+
+            Ok(name) = reload_rx.recv() => {
+                if name == "charge_current" || name == "*" {
+                    let src = loader.load("charge_current");
+                    match rules::ChargeRuleEngine::with_source(&src) {
+                        Ok(e) => { rule_engine = e; info!("charge_current rule engine reloaded"); }
+                        Err(e) => tracing::warn!("charge_current reload failed (keeping old engine): {e}"),
+                    }
                 }
             }
         }
-
-        compute_and_publish(&mut rule_engine, &bus, &state, &cfg, &pid, vb).await;
     }
 }
 
@@ -93,7 +107,6 @@ async fn compute_and_publish(
     let cons_w    = s.house_power_w.unwrap_or(0.0);
     let pv_excess = (pv_w - cons_w) > cfg.pv_excess_threshold_w;
 
-    // Rule engine decides the charging mode
     let mode = match rule_engine.evaluate(offgrid, pv_excess) {
         Ok(m)  => m,
         Err(e) => {
@@ -103,12 +116,11 @@ async fn compute_and_publish(
     };
 
     let (charge_a, power_assist, feed_in) = match mode.as_str() {
-        "offgrid"        => (cfg.offgrid_max_a,      1i64, None),
-        "grid_pv_excess" => (cfg.grid_pv_excess_a,   0i64, Some(0i64)),
-        _                => (cfg.grid_no_excess_a,   0i64, Some(0i64)),
+        "offgrid"        => (cfg.offgrid_max_a,    1i64, None),
+        "grid_pv_excess" => (cfg.grid_pv_excess_a, 0i64, Some(0i64)),
+        _                => (cfg.grid_no_excess_a, 0i64, Some(0i64)),
     };
 
-    // Only publish if changed
     let changed = s.last_charge_current_a != Some(charge_a)
         || s.last_power_assist != Some(power_assist);
     drop(s);

--- a/crates/energy-manager/src/logic/charge_current/rules.rs
+++ b/crates/energy-manager/src/logic/charge_current/rules.rs
@@ -1,17 +1,23 @@
 use anyhow::Context;
 use rust_rule_engine::{Facts, KnowledgeBase, RustRuleEngine, Value};
 
-const GRL: &str = include_str!("../../../rules/charge_current.grl");
+#[cfg(test)]
+const GRL_EMBEDDED: &str = include_str!("../../../rules/charge_current.grl");
 
 pub struct ChargeRuleEngine {
     engine: RustRuleEngine,
 }
 
 impl ChargeRuleEngine {
+    #[cfg(test)]
     pub fn new() -> anyhow::Result<Self> {
+        Self::with_source(GRL_EMBEDDED)
+    }
+
+    pub fn with_source(grl: &str) -> anyhow::Result<Self> {
         let kb = KnowledgeBase::new("charge_current");
-        kb.add_rules_from_grl(GRL)
-            .context("Failed to load charge_current.grl")?;
+        kb.add_rules_from_grl(grl)
+            .context("Failed to load charge_current rules")?;
         Ok(Self {
             engine: RustRuleEngine::new(kb),
         })
@@ -36,5 +42,32 @@ impl ChargeRuleEngine {
             .unwrap_or_else(|| "grid_no_excess".to_string());
 
         Ok(mode)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn e() -> ChargeRuleEngine { ChargeRuleEngine::new().unwrap() }
+
+    #[test]
+    fn offgrid_ignores_pv_excess() {
+        assert_eq!(e().evaluate(true, false).unwrap(), "offgrid");
+    }
+
+    #[test]
+    fn offgrid_with_pv_excess_still_offgrid() {
+        assert_eq!(e().evaluate(true, true).unwrap(), "offgrid");
+    }
+
+    #[test]
+    fn grid_with_pv_excess() {
+        assert_eq!(e().evaluate(false, true).unwrap(), "grid_pv_excess");
+    }
+
+    #[test]
+    fn grid_no_excess() {
+        assert_eq!(e().evaluate(false, false).unwrap(), "grid_no_excess");
     }
 }

--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -1,28 +1,29 @@
 /// DEYE relay control via Shelly Pro 2PM (MQTT RPC).
 /// State machine: On → PendingCut (15s) → Lockout (120s) → Off → PendingRestore (45s) → On
 /// State transitions are decided by rust-rule-engine (rules/deye_command.grl).
-/// Timestamp tracking and relay I/O remain in Rust.
+/// State is persisted to santuario/persist/deye_state (retained MQTT) to survive restarts.
 mod rules;
 
 use chrono::{DateTime, Utc};
 use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tokio::time::{interval, Duration};
+use tokio::time::{interval, sleep, Duration};
 use tracing::info;
 
 use crate::bus::AppBus;
 use crate::config::{DeyeConfig, VictronConfig};
 use crate::mqtt::topics::publish;
+use crate::rules_loader::RulesLoader;
 use crate::types::{EnergyState, MqttOutgoing};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum DeyeState {
     On,
-    PendingCut(DateTime<Utc>),     // high freq first seen at
+    PendingCut(DateTime<Utc>),
     Off,
-    PendingRestore(DateTime<Utc>), // low freq first seen at
-    Lockout(DateTime<Utc>),        // locked out until this timestamp
+    PendingRestore(DateTime<Utc>),
+    Lockout(DateTime<Utc>),
 }
 
 fn state_name(s: &DeyeState) -> &'static str {
@@ -57,8 +58,9 @@ pub async fn spawn(
     cfg: DeyeConfig,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
+    loader: Arc<RulesLoader>,
 ) {
-    tokio::spawn(run(vic, cfg, bus, state));
+    tokio::spawn(run(vic, cfg, bus, state, loader));
 }
 
 async fn run(
@@ -66,6 +68,7 @@ async fn run(
     cfg: DeyeConfig,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
+    loader: Arc<RulesLoader>,
 ) {
     let pid = &vic.portal_id;
     let vb  = vic.vebus_instance;
@@ -81,7 +84,8 @@ async fn run(
         return;
     }
 
-    let mut rule_engine = match rules::DeyeRuleEngine::new() {
+    let src = loader.load("deye_command");
+    let mut rule_engine = match rules::DeyeRuleEngine::with_source(&src) {
         Ok(e) => e,
         Err(e) => {
             tracing::error!("Failed to init DEYE rule engine: {e}");
@@ -89,10 +93,32 @@ async fn run(
         }
     };
 
-    let mut deye_sm   = DeyeState::On;
+    // Restore persisted state — wait up to 3s for retained MQTT message.
+    // This prevents spurious relay-on when restarting while DEYE is cut.
+    let initial_state = {
+        sleep(Duration::from_secs(3)).await;
+        let s = state.read().await;
+        match s.deye_persisted_state.as_deref() {
+            Some("Off") | Some("Lockout") | Some("PendingRestore") => {
+                info!("DEYE: restoring state=Off from retained MQTT");
+                DeyeState::Off
+            }
+            Some(other) => {
+                info!("DEYE: starting with state=On (persisted={other})");
+                DeyeState::On
+            }
+            None => {
+                info!("DEYE: no persisted state — starting with On");
+                DeyeState::On
+            }
+        }
+    };
+
+    let mut deye_sm   = initial_state;
     let mut last_freq: f64 = 50.0;
-    let mut rx = bus.subscribe_mqtt();
-    let mut ticker = interval(Duration::from_secs(1));
+    let mut rx        = bus.subscribe_mqtt();
+    let mut reload_rx = bus.subscribe_rule_reload();
+    let mut ticker    = interval(Duration::from_secs(1));
 
     loop {
         tokio::select! {
@@ -106,11 +132,10 @@ async fn run(
                         let connected = {
                             state.read().await.ac_ignore.map(|v| v == 0).unwrap_or(true)
                         };
-                        // Frequency-based logic applies only in off-grid mode
                         if connected { continue; }
 
                         let now = Utc::now();
-                        deye_sm = apply_decision(
+                        let new_state = apply_decision(
                             rule_engine.evaluate(
                                 state_name(&deye_sm),
                                 last_freq,
@@ -129,18 +154,23 @@ async fn run(
                             shelly_id,
                             channel,
                         ).await;
+                        if new_state != deye_sm {
+                            deye_sm = new_state;
+                            persist_deye_state(&bus, &deye_sm).await;
+                            update_deye_state(&state, &deye_sm).await;
+                        }
                     }
 
                 } else if *t == t_connected {
                     if let Some(v) = msg.victron_value::<i64>() {
                         if v == 1 {
                             let now = Utc::now();
-                            deye_sm = apply_decision(
+                            let new_state = apply_decision(
                                 rule_engine.evaluate(
                                     state_name(&deye_sm),
                                     last_freq,
                                     0,
-                                    true, // grid reconnected → rule engine restores On
+                                    true,
                                     cfg.freq_high_hz,
                                     cfg.freq_low_hz,
                                     cfg.cut_delay_secs,
@@ -154,6 +184,11 @@ async fn run(
                                 shelly_id,
                                 channel,
                             ).await;
+                            if new_state != deye_sm {
+                                deye_sm = new_state;
+                                persist_deye_state(&bus, &deye_sm).await;
+                                update_deye_state(&state, &deye_sm).await;
+                            }
                         }
                     }
                 }
@@ -161,7 +196,7 @@ async fn run(
 
             _ = ticker.tick() => {
                 let now = Utc::now();
-                deye_sm = apply_decision(
+                let new_state = apply_decision(
                     rule_engine.evaluate(
                         state_name(&deye_sm),
                         last_freq,
@@ -180,12 +215,45 @@ async fn run(
                     shelly_id,
                     channel,
                 ).await;
+                if new_state != deye_sm {
+                    deye_sm = new_state;
+                    persist_deye_state(&bus, &deye_sm).await;
+                    update_deye_state(&state, &deye_sm).await;
+                }
+            }
+
+            Ok(name) = reload_rx.recv() => {
+                if name == "deye_command" || name == "*" {
+                    let src = loader.load("deye_command");
+                    match rules::DeyeRuleEngine::with_source(&src) {
+                        Ok(e) => { rule_engine = e; info!("deye_command rule engine reloaded"); }
+                        Err(e) => tracing::warn!("deye_command reload failed (keeping old engine): {e}"),
+                    }
+                }
             }
         }
     }
 }
 
-/// Applies a rule engine decision: send relay commands and return updated DeyeState.
+/// Publishes DEYE state as retained MQTT for persistence across restarts.
+/// Only stable states are persisted: "On" and "Off".
+async fn persist_deye_state(bus: &AppBus, state: &DeyeState) {
+    let persisted = match state {
+        DeyeState::On | DeyeState::PendingCut(_) => "On",
+        DeyeState::Off | DeyeState::Lockout(_) | DeyeState::PendingRestore(_) => "Off",
+    };
+    bus.publish(MqttOutgoing::raw(
+        publish::DEYE_STATE, persisted, true,
+    )).await;
+}
+
+/// Updates EnergyState with DEYE relay info for the REST /api/rules-status endpoint.
+async fn update_deye_state(state: &Arc<RwLock<EnergyState>>, deye: &DeyeState) {
+    let mut s = state.write().await;
+    s.deye_on          = matches!(deye, DeyeState::On | DeyeState::PendingCut(_));
+    s.deye_last_change = Some(Utc::now());
+}
+
 async fn apply_decision(
     decision: anyhow::Result<rules::DeyeDecision>,
     current: DeyeState,

--- a/crates/energy-manager/src/logic/deye_command/rules.rs
+++ b/crates/energy-manager/src/logic/deye_command/rules.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
 use rust_rule_engine::{Facts, KnowledgeBase, RustRuleEngine, Value};
 
-const GRL: &str = include_str!("../../../rules/deye_command.grl");
+#[cfg(test)]
+const GRL_EMBEDDED: &str = include_str!("../../../rules/deye_command.grl");
 
 pub struct DeyeRuleEngine {
     engine: RustRuleEngine,
@@ -18,10 +19,15 @@ pub struct DeyeDecision {
 }
 
 impl DeyeRuleEngine {
+    #[cfg(test)]
     pub fn new() -> anyhow::Result<Self> {
+        Self::with_source(GRL_EMBEDDED)
+    }
+
+    pub fn with_source(grl: &str) -> anyhow::Result<Self> {
         let kb = KnowledgeBase::new("deye_command");
-        kb.add_rules_from_grl(GRL)
-            .context("Failed to load deye_command.grl")?;
+        kb.add_rules_from_grl(grl)
+            .context("Failed to load deye_command rules")?;
         Ok(Self {
             engine: RustRuleEngine::new(kb),
         })
@@ -70,5 +76,84 @@ impl DeyeRuleEngine {
         }).unwrap_or(false);
 
         Ok(DeyeDecision { next_state, relay_on, relay_off })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn e() -> DeyeRuleEngine { DeyeRuleEngine::new().unwrap() }
+
+    // Shorthand: evaluate with default config thresholds (52 Hz / 50.3 Hz / 15s / 45s)
+    fn eval(engine: &mut DeyeRuleEngine, state: &str, freq: f64, time_s: u64, grid: bool, lockout_exp: bool) -> DeyeDecision {
+        engine.evaluate(state, freq, time_s, grid, 52.0, 50.3, 15, 45, lockout_exp).unwrap()
+    }
+
+    #[test]
+    fn on_normal_freq_no_transition() {
+        let d = eval(&mut e(), "On", 50.0, 0, false, false);
+        assert!(d.next_state.is_none());
+        assert!(!d.relay_on);
+        assert!(!d.relay_off);
+    }
+
+    #[test]
+    fn on_high_freq_transitions_pending_cut() {
+        let d = eval(&mut e(), "On", 52.5, 0, false, false);
+        assert_eq!(d.next_state.as_deref(), Some("PendingCut"));
+    }
+
+    #[test]
+    fn pending_cut_freq_drops_cancels() {
+        let d = eval(&mut e(), "PendingCut", 50.0, 5, false, false);
+        assert_eq!(d.next_state.as_deref(), Some("On"));
+    }
+
+    #[test]
+    fn pending_cut_delay_elapsed_high_freq_locks() {
+        let d = eval(&mut e(), "PendingCut", 52.5, 20, false, false);
+        assert_eq!(d.next_state.as_deref(), Some("Lockout"));
+        assert!(d.relay_off);
+    }
+
+    #[test]
+    fn lockout_expires_transitions_off() {
+        let d = eval(&mut e(), "Lockout", 50.0, 0, false, true);
+        assert_eq!(d.next_state.as_deref(), Some("Off"));
+    }
+
+    #[test]
+    fn off_low_freq_transitions_pending_restore() {
+        let d = eval(&mut e(), "Off", 50.1, 0, false, false);
+        assert_eq!(d.next_state.as_deref(), Some("PendingRestore"));
+    }
+
+    #[test]
+    fn pending_restore_elapsed_low_freq_restores() {
+        let d = eval(&mut e(), "PendingRestore", 50.0, 50, false, false);
+        assert_eq!(d.next_state.as_deref(), Some("On"));
+        assert!(d.relay_on);
+    }
+
+    #[test]
+    fn grid_reconnect_from_off_restores_immediately() {
+        let d = eval(&mut e(), "Off", 50.0, 0, true, false);
+        assert_eq!(d.next_state.as_deref(), Some("On"));
+        assert!(d.relay_on);
+    }
+
+    #[test]
+    fn grid_reconnect_from_lockout_restores_immediately() {
+        let d = eval(&mut e(), "Lockout", 50.0, 0, true, false);
+        assert_eq!(d.next_state.as_deref(), Some("On"));
+        assert!(d.relay_on);
+    }
+
+    #[test]
+    fn grid_reconnect_from_pending_cut_restores_immediately() {
+        let d = eval(&mut e(), "PendingCut", 52.5, 5, true, false);
+        assert_eq!(d.next_state.as_deref(), Some("On"));
+        assert!(d.relay_on);
     }
 }

--- a/crates/energy-manager/src/logic/irradiance/mod.rs
+++ b/crates/energy-manager/src/logic/irradiance/mod.rs
@@ -1,24 +1,23 @@
-// crates/energy-manager/src/logic/irradiance/mod.rs
-//
 mod rules;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::{interval, Duration};
 use tracing::{debug, info, warn};
 use crate::bus::AppBus;
+use crate::rules_loader::RulesLoader;
 use crate::types::EnergyState;
 
-pub async fn spawn(bus: AppBus, state: Arc<RwLock<EnergyState>>, bms_server_url: String) {
-    // ✅ bus.clone() passé à http_poll_task
-    tokio::spawn(http_poll_task(bms_server_url, state.clone(), bus));
+pub async fn spawn(bus: AppBus, state: Arc<RwLock<EnergyState>>, bms_server_url: String, loader: Arc<RulesLoader>) {
+    tokio::spawn(http_poll_task(bms_server_url, state.clone(), bus, loader));
 }
 
-async fn http_poll_task(bms_server_url: String, state: Arc<RwLock<EnergyState>>, bus: AppBus) {
+async fn http_poll_task(bms_server_url: String, state: Arc<RwLock<EnergyState>>, bus: AppBus, loader: Arc<RulesLoader>) {
     let url = format!("{}/api/v1/irradiance/status", bms_server_url.trim_end_matches('/'));
     let client = reqwest::Client::new();
     let mut ticker = interval(Duration::from_secs(30));
-    
-    let mut rule_engine = match rules::IrradianceRuleEngine::new() {
+    let mut reload_rx = bus.subscribe_rule_reload();
+
+    let mut rule_engine = match rules::IrradianceRuleEngine::with_source(&loader.load("irradiance")) {
         Ok(e) => e,
         Err(e) => {
             tracing::error!("Irradiance HTTP: failed to init rule engine: {e}");
@@ -28,50 +27,58 @@ async fn http_poll_task(bms_server_url: String, state: Arc<RwLock<EnergyState>>,
     info!("Irradiance HTTP poll started → {url}");
 
     loop {
-        ticker.tick().await;
-        match client.get(&url).timeout(Duration::from_secs(5)).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                match resp.json::<serde_json::Value>().await {
-                    Ok(json) => {
-                        if let Some(wm2) = json.get("irradiance_wm2").and_then(|v| v.as_f64()) {
-                            let connected = json.get("connected").and_then(|v| v.as_bool()).unwrap_or(true);
-                            
-                            // ✅ LOG explicite pour le debug
-                            debug!("Irradiance HTTP: raw={wm2}, connected={connected}");
-                            
-                            if !connected {
-                                warn!("Irradiance HTTP: sensor disconnected (connected=false), keeping last value");
-                                continue;
-                            }
-                            
-                            // ✅ TOUJOURS mettre à jour le state avec la valeur brute,
-                            // même si le rule engine la considère hors range.
-                            // Le water_heater fait sa propre comparaison avec irradiance_min_wm2.
-                            state.write().await.irradiance_wm2 = Some(wm2);
-                            
-                            match rule_engine.validate(wm2) {
-                                Ok(true) => {
-                                    bus.emit_live(crate::types::LiveEvent::new(
-                                        "irradiance",
-                                        serde_json::json!({ "irradiance_wm2": wm2 }),
-                                    ));
-                                    info!("🔍 HTTP Poll Success: {:.0} W/m²", wm2);
+        tokio::select! {
+            _ = ticker.tick() => {
+                match client.get(&url).timeout(Duration::from_secs(5)).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        match resp.json::<serde_json::Value>().await {
+                            Ok(json) => {
+                                if let Some(wm2) = json.get("irradiance_wm2").and_then(|v| v.as_f64()) {
+                                    let connected = json.get("connected").and_then(|v| v.as_bool()).unwrap_or(true);
+
+                                    debug!("Irradiance HTTP: raw={wm2}, connected={connected}");
+
+                                    if !connected {
+                                        warn!("Irradiance HTTP: sensor disconnected (connected=false), keeping last value");
+                                        continue;
+                                    }
+
+                                    state.write().await.irradiance_wm2 = Some(wm2);
+
+                                    match rule_engine.validate(wm2) {
+                                        Ok(true) => {
+                                            bus.emit_live(crate::types::LiveEvent::new(
+                                                "irradiance",
+                                                serde_json::json!({ "irradiance_wm2": wm2 }),
+                                            ));
+                                            info!("Irradiance HTTP poll: {:.0} W/m²", wm2);
+                                        }
+                                        Ok(false) => {
+                                            warn!("Irradiance HTTP: out of range: {wm2} W/m² (state updated)");
+                                        }
+                                        Err(e) => tracing::error!("Irradiance HTTP: rule engine error: {e}"),
+                                    }
+                                } else {
+                                    warn!("Irradiance HTTP: missing 'irradiance_wm2' field in JSON");
                                 }
-                                Ok(false) => {
-                                    // ✅ La valeur est maintenant dans le state, on log juste le rejet
-                                    warn!("Irradiance HTTP: out of range: {wm2} W/m² (rule engine rejected, but state updated)");
-                                }
-                                Err(e) => tracing::error!("Irradiance HTTP: rule engine error: {e}"),
                             }
-                        } else {
-                            warn!("Irradiance HTTP: missing 'irradiance_wm2' field in JSON");
+                            Err(e) => warn!("Irradiance HTTP: JSON parse error: {e}"),
                         }
                     }
-                    Err(e) => warn!("Irradiance HTTP: JSON parse error: {e}"),
+                    Ok(resp) => warn!("Irradiance HTTP: status {}", resp.status()),
+                    Err(e) => warn!("Irradiance HTTP: request failed: {e}"),
                 }
             }
-            Ok(resp) => warn!("Irradiance HTTP: status {}", resp.status()),
-            Err(e) => warn!("Irradiance HTTP: request failed: {e}"),
+
+            Ok(name) = reload_rx.recv() => {
+                if name == "irradiance" || name == "*" {
+                    let src = loader.load("irradiance");
+                    match rules::IrradianceRuleEngine::with_source(&src) {
+                        Ok(e) => { rule_engine = e; info!("irradiance rule engine reloaded"); }
+                        Err(e) => tracing::warn!("irradiance reload failed (keeping old engine): {e}"),
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/energy-manager/src/logic/irradiance/rules.rs
+++ b/crates/energy-manager/src/logic/irradiance/rules.rs
@@ -1,39 +1,75 @@
-// crates/energy-manager/src/logic/irradiance/rules.rs
-//
 use anyhow::Context;
 use rust_rule_engine::{Facts, KnowledgeBase, RustRuleEngine, Value};
 
-const GRL: &str = include_str!("../../../rules/irradiance.grl");
+#[cfg(test)]
+const GRL_EMBEDDED: &str = include_str!("../../../rules/irradiance.grl");
 
 pub struct IrradianceRuleEngine {
     engine: RustRuleEngine,
 }
 
 impl IrradianceRuleEngine {
+    #[cfg(test)]
     pub fn new() -> anyhow::Result<Self> {
+        Self::with_source(GRL_EMBEDDED)
+    }
+
+    pub fn with_source(grl: &str) -> anyhow::Result<Self> {
         let kb = KnowledgeBase::new("irradiance");
-        kb.add_rules_from_grl(GRL)
-            .context("Failed to load irradiance.grl")?;
+        kb.add_rules_from_grl(grl)
+            .context("Failed to load irradiance rules")?;
         Ok(Self {
             engine: RustRuleEngine::new(kb),
         })
     }
 
     pub fn validate(&mut self, raw: f64) -> anyhow::Result<bool> {
-        let mut facts = Facts::new(); // ✅ mut obligatoire
-        facts.set("IR.raw", Value::Number(raw));
+        let mut facts = Facts::new();
+        facts.set("IR.raw",   Value::Number(raw));
         facts.set("IR.valid", Value::Boolean(false));
 
         self.engine
-            .execute(&mut facts) // ✅ &mut obligatoire
+            .execute(&mut facts)
             .context("Irradiance rule engine evaluation failed")?;
 
         Ok(facts
             .get("IR.valid")
             .and_then(|v| match v {
-                Value::Boolean(b) => Some(b), // ✅ => et non = >
+                Value::Boolean(b) => Some(b),
                 _ => None,
             })
             .unwrap_or(false))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn e() -> IrradianceRuleEngine { IrradianceRuleEngine::new().unwrap() }
+
+    #[test]
+    fn zero_is_valid() {
+        assert!(e().validate(0.0).unwrap());
+    }
+
+    #[test]
+    fn max_is_valid() {
+        assert!(e().validate(2000.0).unwrap());
+    }
+
+    #[test]
+    fn midrange_is_valid() {
+        assert!(e().validate(750.0).unwrap());
+    }
+
+    #[test]
+    fn negative_is_invalid() {
+        assert!(!e().validate(-1.0).unwrap());
+    }
+
+    #[test]
+    fn above_max_is_invalid() {
+        assert!(!e().validate(2001.0).unwrap());
     }
 }

--- a/crates/energy-manager/src/logic/smartshunt/mod.rs
+++ b/crates/energy-manager/src/logic/smartshunt/mod.rs
@@ -19,13 +19,14 @@ use tracing::{debug, info};
 use crate::bus::AppBus;
 use crate::config::VictronConfig;
 use crate::mqtt::topics::publish;
+use crate::rules_loader::RulesLoader;
 use crate::types::{EnergyState, LiveEvent, MqttIncoming, MqttOutgoing};
 
-pub async fn spawn(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState>>) {
-    tokio::spawn(run(vic, bus, state));
+pub async fn spawn(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState>>, loader: Arc<RulesLoader>) {
+    tokio::spawn(run(vic, bus, state, loader));
 }
 
-async fn run(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState>>) {
+async fn run(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState>>, loader: Arc<RulesLoader>) {
     let pid   = &vic.portal_id;
     let shunt = vic.smartshunt_instance;
 
@@ -36,7 +37,7 @@ async fn run(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState
     let t_ttg     = format!("N/{pid}/battery/{shunt}/TimeToGo");
     let t_state   = format!("N/{pid}/battery/{shunt}/State");
 
-    let mut rule_engine = match rules::SmartShuntRuleEngine::new() {
+    let mut rule_engine = match rules::SmartShuntRuleEngine::with_source(&loader.load("smartshunt")) {
         Ok(e) => e,
         Err(e) => {
             tracing::error!("Failed to init SmartShunt rule engine: {e}");
@@ -44,20 +45,31 @@ async fn run(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState
         }
     };
 
-    let mut rx = bus.subscribe_mqtt();
-    loop {
-        let msg = match rx.recv().await {
-            Ok(m)  => m,
-            Err(_) => continue,
-        };
+    let mut rx        = bus.subscribe_mqtt();
+    let mut reload_rx = bus.subscribe_rule_reload();
 
-        if let Some(dirty) = handle(
-            &msg, &state, &mut rule_engine,
-            &t_voltage, &t_current, &t_power,
-            &t_soc, &t_ttg, &t_state,
-        ).await {
-            if dirty {
-                publish_state(&bus, &state).await;
+    loop {
+        tokio::select! {
+            Ok(msg) = rx.recv() => {
+                if let Some(dirty) = handle(
+                    &msg, &state, &mut rule_engine,
+                    &t_voltage, &t_current, &t_power,
+                    &t_soc, &t_ttg, &t_state,
+                ).await {
+                    if dirty {
+                        publish_state(&bus, &state).await;
+                    }
+                }
+            }
+
+            Ok(name) = reload_rx.recv() => {
+                if name == "smartshunt" || name == "*" {
+                    let src = loader.load("smartshunt");
+                    match rules::SmartShuntRuleEngine::with_source(&src) {
+                        Ok(e) => { rule_engine = e; tracing::info!("smartshunt rule engine reloaded"); }
+                        Err(e) => tracing::warn!("smartshunt reload failed (keeping old engine): {e}"),
+                    }
+                }
             }
         }
     }

--- a/crates/energy-manager/src/logic/smartshunt/rules.rs
+++ b/crates/energy-manager/src/logic/smartshunt/rules.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
 use rust_rule_engine::{Facts, KnowledgeBase, RustRuleEngine, Value};
 
-const GRL: &str = include_str!("../../../rules/smartshunt.grl");
+#[cfg(test)]
+const GRL_EMBEDDED: &str = include_str!("../../../rules/smartshunt.grl");
 
 pub struct SmartShuntRuleEngine {
     engine: RustRuleEngine,
@@ -14,10 +15,15 @@ pub struct BaselineDecision {
 }
 
 impl SmartShuntRuleEngine {
+    #[cfg(test)]
     pub fn new() -> anyhow::Result<Self> {
+        Self::with_source(GRL_EMBEDDED)
+    }
+
+    pub fn with_source(grl: &str) -> anyhow::Result<Self> {
         let kb = KnowledgeBase::new("smartshunt");
-        kb.add_rules_from_grl(GRL)
-            .context("Failed to load smartshunt.grl")?;
+        kb.add_rules_from_grl(grl)
+            .context("Failed to load smartshunt rules")?;
         Ok(Self {
             engine: RustRuleEngine::new(kb),
         })
@@ -54,5 +60,54 @@ impl SmartShuntRuleEngine {
             .unwrap_or(false);
 
         Ok(BaselineDecision { capture_charged, capture_discharged })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn e() -> SmartShuntRuleEngine { SmartShuntRuleEngine::new().unwrap() }
+
+    #[test]
+    fn new_day_captures_charged() {
+        let d = e().baseline_decision(true, false, false, false).unwrap();
+        assert!(d.capture_charged);
+        assert!(!d.capture_discharged);
+    }
+
+    #[test]
+    fn missing_baseline_captures_charged() {
+        let d = e().baseline_decision(false, true, false, false).unwrap();
+        assert!(d.capture_charged);
+        assert!(!d.capture_discharged);
+    }
+
+    #[test]
+    fn new_day_captures_discharged() {
+        let d = e().baseline_decision(false, false, true, false).unwrap();
+        assert!(!d.capture_charged);
+        assert!(d.capture_discharged);
+    }
+
+    #[test]
+    fn missing_baseline_captures_discharged() {
+        let d = e().baseline_decision(false, false, false, true).unwrap();
+        assert!(!d.capture_charged);
+        assert!(d.capture_discharged);
+    }
+
+    #[test]
+    fn all_false_captures_nothing() {
+        let d = e().baseline_decision(false, false, false, false).unwrap();
+        assert!(!d.capture_charged);
+        assert!(!d.capture_discharged);
+    }
+
+    #[test]
+    fn all_true_captures_both() {
+        let d = e().baseline_decision(true, true, true, true).unwrap();
+        assert!(d.capture_charged);
+        assert!(d.capture_discharged);
     }
 }

--- a/crates/energy-manager/src/logic/solar_power/mod.rs
+++ b/crates/energy-manager/src/logic/solar_power/mod.rs
@@ -13,6 +13,7 @@ use tracing::debug;
 use crate::bus::AppBus;
 use crate::config::{SolarConfig, VictronConfig};
 use crate::mqtt::topics::publish;
+use crate::rules_loader::RulesLoader;
 use crate::types::{EnergyState, LiveEvent, MqttOutgoing};
 
 pub async fn spawn(
@@ -20,12 +21,13 @@ pub async fn spawn(
     cfg: SolarConfig,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
+    loader: Arc<RulesLoader>,
 ) {
     let bus2   = bus.clone();
     let state2 = state.clone();
     let vic2   = vic.clone();
 
-    tokio::spawn(mqtt_task(vic2, bus2, state2));
+    tokio::spawn(mqtt_task(vic2, bus2, state2, loader));
     tokio::spawn(writer_task(cfg, bus, state));
 }
 
@@ -33,6 +35,7 @@ async fn mqtt_task(
     vic: Arc<VictronConfig>,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
+    loader: Arc<RulesLoader>,
 ) {
     let pid = &vic.portal_id;
     let m1  = vic.mppt1_instance;
@@ -54,7 +57,7 @@ async fn mqtt_task(
     let t_m2_dc_i   = format!("N/{pid}/solarcharger/{m2}/Dc/0/Current");
     let t_consump   = format!("N/{pid}/system/0/Ac/ConsumptionOnOutput/L1/Power");
 
-    let mut rule_engine = match rules::SolarRuleEngine::new() {
+    let mut rule_engine = match rules::SolarRuleEngine::with_source(&loader.load("solar_power")) {
         Ok(e) => e,
         Err(e) => {
             tracing::error!("Failed to init solar rule engine: {e}");
@@ -62,12 +65,12 @@ async fn mqtt_task(
         }
     };
 
-    let mut rx = bus.subscribe_mqtt();
+    let mut rx        = bus.subscribe_mqtt();
+    let mut reload_rx = bus.subscribe_rule_reload();
+
     loop {
-        let msg = match rx.recv().await {
-            Ok(m)  => m,
-            Err(_) => continue,
-        };
+        tokio::select! {
+            Ok(msg) = rx.recv() => {
         let t = &msg.topic;
 
         let mut publish_baseline: Option<(i32, f64)> = None;
@@ -149,7 +152,19 @@ async fn mqtt_task(
             )).await;
             debug!("pvinv_baseline published as retained: day={day} kwh={kwh:.3}");
         }
-    }
+            }   // close Ok(msg) arm
+
+            Ok(name) = reload_rx.recv() => {
+                if name == "solar_power" || name == "*" {
+                    let src = loader.load("solar_power");
+                    match rules::SolarRuleEngine::with_source(&src) {
+                        Ok(e) => { rule_engine = e; tracing::info!("solar_power rule engine reloaded"); }
+                        Err(e) => tracing::warn!("solar_power reload failed (keeping old engine): {e}"),
+                    }
+                }
+            }
+        }   // close select!
+    }       // close loop
 }
 
 async fn writer_task(

--- a/crates/energy-manager/src/logic/solar_power/rules.rs
+++ b/crates/energy-manager/src/logic/solar_power/rules.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
 use rust_rule_engine::{Facts, KnowledgeBase, RustRuleEngine, Value};
 
-const GRL: &str = include_str!("../../../rules/solar_power.grl");
+#[cfg(test)]
+const GRL_EMBEDDED: &str = include_str!("../../../rules/solar_power.grl");
 
 pub struct SolarRuleEngine {
     engine: RustRuleEngine,
@@ -16,10 +17,15 @@ pub struct BaselineDecision {
 }
 
 impl SolarRuleEngine {
+    #[cfg(test)]
     pub fn new() -> anyhow::Result<Self> {
+        Self::with_source(GRL_EMBEDDED)
+    }
+
+    pub fn with_source(grl: &str) -> anyhow::Result<Self> {
         let kb = KnowledgeBase::new("solar_power");
-        kb.add_rules_from_grl(GRL)
-            .context("Failed to load solar_power.grl")?;
+        kb.add_rules_from_grl(grl)
+            .context("Failed to load solar_power rules")?;
         Ok(Self {
             engine: RustRuleEngine::new(kb),
         })
@@ -53,5 +59,40 @@ impl SolarRuleEngine {
             .unwrap_or(false);
 
         Ok(BaselineDecision { reset, capture })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn e() -> SolarRuleEngine { SolarRuleEngine::new().unwrap() }
+
+    #[test]
+    fn new_day_resets_and_captures() {
+        let d = e().baseline_decision(true, false).unwrap();
+        assert!(d.reset);
+        assert!(d.capture);
+    }
+
+    #[test]
+    fn absent_baseline_captures_no_reset() {
+        let d = e().baseline_decision(false, true).unwrap();
+        assert!(!d.reset);
+        assert!(d.capture);
+    }
+
+    #[test]
+    fn neither_flag_no_action() {
+        let d = e().baseline_decision(false, false).unwrap();
+        assert!(!d.reset);
+        assert!(!d.capture);
+    }
+
+    #[test]
+    fn new_day_and_absent_both_trigger() {
+        let d = e().baseline_decision(true, true).unwrap();
+        assert!(d.reset);
+        assert!(d.capture);
     }
 }

--- a/crates/energy-manager/src/logic/water_heater/mod.rs
+++ b/crates/energy-manager/src/logic/water_heater/mod.rs
@@ -11,6 +11,7 @@ use crate::bus::AppBus;
 use crate::config::WaterHeaterConfig;
 use crate::http_clients::lg_thinq::LgThinqClient;
 use crate::mqtt::topics::publish;
+use crate::rules_loader::RulesLoader;
 use crate::types::{EnergyState, LiveEvent, MqttOutgoing, WaterHeaterMode};
 
 pub async fn spawn(
@@ -18,10 +19,11 @@ pub async fn spawn(
     lg: Option<Arc<LgThinqClient>>,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
+    loader: Arc<RulesLoader>,
 ) {
     tokio::spawn(keepalive_task(cfg.keepalive_secs, bus.clone(), state.clone()));
     if let Some(lg_client) = lg {
-        tokio::spawn(control_task(cfg, lg_client, bus, state));
+        tokio::spawn(control_task(cfg, lg_client, bus, state, loader));
     } else {
         info!("Water heater auto-control disabled (no LG ThinQ client)");
     }
@@ -75,17 +77,26 @@ async fn control_task(
     lg: Arc<LgThinqClient>,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
+    loader: Arc<RulesLoader>,
 ) {
     let mut last_change: Option<DateTime<Utc>> = None;
-    // Count consecutive send failures to detect and alert on persistent issues
     let mut consecutive_fails: u32 = 0;
-    // Tick every 5 minutes as requested
-    let mut ticker = interval(Duration::from_secs(300));
+    let mut ticker    = interval(Duration::from_secs(300));
+    let mut reload_rx = bus.subscribe_rule_reload();
+
+    let mut rule_engine = match rules::WaterHeaterRuleEngine::with_source(&loader.load("water_heater")) {
+        Ok(e) => e,
+        Err(e) => {
+            error!("Failed to init water heater rule engine: {e}");
+            return;
+        }
+    };
 
     info!("Water heater control task started (5min interval)");
 
     loop {
-        ticker.tick().await;
+        tokio::select! {
+        _ = ticker.tick() => {
         let now = Utc::now();
 
         // Read actual state from LG ThinQ before deciding
@@ -154,21 +165,13 @@ async fn control_task(
             }
         };
         let grid_connected = ac_ignore == 0;
+        let soc_low = soc < cfg.soc_min_pct;
         info!(
-            "Water heater: ac_ignore={}, grid_connected={}, soc={:.1}%, irradiance_low={}",
-            ac_ignore, grid_connected, soc, irradiance_low
+            "Water heater: ac_ignore={}, grid_connected={}, soc={:.1}% (min={}%, soc_low={}), irradiance_low={}",
+            ac_ignore, grid_connected, soc, cfg.soc_min_pct, soc_low, irradiance_low
         );
 
-        let mut rule_engine = match rules::WaterHeaterRuleEngine::new() {
-            Ok(e) => e,
-            Err(e) => {
-                error!("Failed to init water heater rule engine: {e}");
-                sleep(Duration::from_secs(5)).await;
-                continue;
-            }
-        };
-
-        let target_mode_str = match rule_engine.evaluate(grid_connected, soc, irradiance_low) {
+        let target_mode_str = match rule_engine.evaluate(grid_connected, soc_low, irradiance_low) {
             Ok(m) => {
                 info!("Water heater: rule engine → target_mode={m} (grid_connected={}, soc={:.1}%, irradiance_low={})",
                     grid_connected, soc, irradiance_low);
@@ -271,5 +274,17 @@ async fn control_task(
             }
             publish_to_venus(&bus2, &state2).await;
         });
-    }
+        }   // close _ = ticker.tick() arm
+
+        Ok(name) = reload_rx.recv() => {
+            if name == "water_heater" || name == "*" {
+                let src = loader.load("water_heater");
+                match rules::WaterHeaterRuleEngine::with_source(&src) {
+                    Ok(e) => { rule_engine = e; info!("water_heater rule engine reloaded"); }
+                    Err(e) => tracing::warn!("water_heater reload failed (keeping old engine): {e}"),
+                }
+            }
+        }
+        }   // close select!
+    }       // close loop
 }

--- a/crates/energy-manager/src/logic/water_heater/rules.rs
+++ b/crates/energy-manager/src/logic/water_heater/rules.rs
@@ -1,31 +1,43 @@
-// crates/energy-manager/src/logic/water_heater/rules.rs
-//
 use anyhow::Context;
 use rust_rule_engine::{Facts, KnowledgeBase, RustRuleEngine, Value};
 
-const GRL: &str = include_str!("../../../rules/water_heater.grl");
+#[cfg(test)]
+const GRL_EMBEDDED: &str = include_str!("../../../rules/water_heater.grl");
 
 pub struct WaterHeaterRuleEngine {
     engine: RustRuleEngine,
 }
 
 impl WaterHeaterRuleEngine {
+    #[cfg(test)]
     pub fn new() -> anyhow::Result<Self> {
+        Self::with_source(GRL_EMBEDDED)
+    }
+
+    pub fn with_source(grl: &str) -> anyhow::Result<Self> {
         let kb = KnowledgeBase::new("water_heater");
-        kb.add_rules_from_grl(GRL)
-            .context("Failed to load water_heater.grl")?;
+        kb.add_rules_from_grl(grl)
+            .context("Failed to load water_heater rules")?;
         Ok(Self {
             engine: RustRuleEngine::new(kb),
         })
     }
 
-    pub fn evaluate(&mut self, grid_connected: bool, soc: f64, irradiance_low: bool) -> anyhow::Result<String> {
+    /// Returns "HEAT_PUMP" or "VACATION".
+    ///
+    /// `soc_low` is pre-computed by the caller: `soc_pct < cfg.soc_min_pct`.
+    pub fn evaluate(
+        &mut self,
+        grid_connected: bool,
+        soc_low: bool,
+        irradiance_low: bool,
+    ) -> anyhow::Result<String> {
         let mut facts = Facts::new();
-        facts.set("WH.want_vacation", Value::Boolean(false));
+        facts.set("WH.want_vacation",  Value::Boolean(false));
         facts.set("WH.grid_connected", Value::Boolean(grid_connected));
-        facts.set("WH.soc_pct", Value::Number(soc));
+        facts.set("WH.soc_low",        Value::Boolean(soc_low));
         facts.set("WH.irradiance_low", Value::Boolean(irradiance_low));
-        facts.set("WH.target_mode", Value::String("VACATION".to_string()));
+        facts.set("WH.target_mode",    Value::String("VACATION".to_string()));
 
         self.engine
             .execute(&mut facts)
@@ -38,5 +50,41 @@ impl WaterHeaterRuleEngine {
                 _ => None,
             })
             .unwrap_or_else(|| "VACATION".to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn e() -> WaterHeaterRuleEngine { WaterHeaterRuleEngine::new().unwrap() }
+
+    fn eval(grid: bool, soc_low: bool, irr_low: bool) -> String {
+        e().evaluate(grid, soc_low, irr_low).unwrap()
+    }
+
+    #[test]
+    fn all_ok_gives_heat_pump() {
+        assert_eq!(eval(false, false, false), "HEAT_PUMP");
+    }
+
+    #[test]
+    fn grid_connected_forces_vacation() {
+        assert_eq!(eval(true, false, false), "VACATION");
+    }
+
+    #[test]
+    fn soc_low_forces_vacation() {
+        assert_eq!(eval(false, true, false), "VACATION");
+    }
+
+    #[test]
+    fn irradiance_low_forces_vacation() {
+        assert_eq!(eval(false, false, true), "VACATION");
+    }
+
+    #[test]
+    fn all_bad_forces_vacation() {
+        assert_eq!(eval(true, true, true), "VACATION");
     }
 }

--- a/crates/energy-manager/src/main.rs
+++ b/crates/energy-manager/src/main.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::info;
@@ -11,9 +12,13 @@ mod logic;
 mod monitoring;
 mod mqtt;
 mod persist;
+#[allow(dead_code)]
+mod rule_metrics;
+mod rules_loader;
 mod types;
 
 use bus::AppBus;
+use rules_loader::RulesLoader;
 use types::EnergyState;
 
 #[tokio::main]
@@ -31,6 +36,11 @@ async fn main() -> anyhow::Result<()> {
     let cfg = config::load()?;
     info!("Config loaded — portal_id={}, mqtt={}:{}",
         cfg.victron.portal_id, cfg.mqtt.host, cfg.mqtt.port);
+
+    // --- Rules loader (disk-first with embedded fallback) ---
+    let rules_dir = cfg.rules.dir.as_deref().map(Path::new);
+    let loader    = Arc::new(RulesLoader::new(rules_dir));
+    info!("Rules loader initialized (dir={:?})", cfg.rules.dir);
 
     // --- Shared state ---
     let state: Arc<RwLock<EnergyState>> = Arc::new(RwLock::new(EnergyState::default()));
@@ -73,25 +83,27 @@ async fn main() -> anyhow::Result<()> {
     let vic = Arc::new(cfg.victron.clone());
 
     logic::inverter::spawn(vic.clone(), bus.clone(), state.clone()).await;
-    logic::smartshunt::spawn(vic.clone(), bus.clone(), state.clone()).await;
-    logic::irradiance::spawn(bus.clone(), state.clone(), cfg.solar.bms_server_url.clone()).await;
+    logic::smartshunt::spawn(vic.clone(), bus.clone(), state.clone(), loader.clone()).await;
+    logic::irradiance::spawn(bus.clone(), state.clone(), cfg.solar.bms_server_url.clone(), loader.clone()).await;
     logic::tasmota::spawn(vic.clone(), bus.clone(), state.clone()).await;
     logic::switch_ats::spawn(bus.clone(), state.clone()).await;
     logic::platform::spawn(cfg.platform.clone(), bus.clone()).await;
-    logic::charge_current::spawn(vic.clone(), cfg.charge_current.clone(), bus.clone(), state.clone()).await;
-    logic::solar_power::spawn(vic.clone(), cfg.solar.clone(), bus.clone(), state.clone()).await;
-    logic::deye_command::spawn(vic.clone(), cfg.deye.clone(), bus.clone(), state.clone()).await;
-    logic::water_heater::spawn(cfg.water_heater.clone(), lg_arc.clone(), bus.clone(), state.clone()).await;
+    logic::charge_current::spawn(vic.clone(), cfg.charge_current.clone(), bus.clone(), state.clone(), loader.clone()).await;
+    logic::solar_power::spawn(vic.clone(), cfg.solar.clone(), bus.clone(), state.clone(), loader.clone()).await;
+    logic::deye_command::spawn(vic.clone(), cfg.deye.clone(), bus.clone(), state.clone(), loader.clone()).await;
+    logic::water_heater::spawn(cfg.water_heater.clone(), lg_arc.clone(), bus.clone(), state.clone(), loader.clone()).await;
     logic::meteo::spawn(cfg.solar.clone(), bus.clone(), state.clone()).await;
     logic::victron_keepalive::spawn(cfg.victron.portal_id.clone(), bus.clone()).await;
 
     // --- Live WebSocket + REST server ---
-    let bind     = cfg.api.bind.clone();
-    let live_tx  = bus.live.clone();
-    let srv_state = state.clone();
-    let srv_lg    = lg_arc.clone();
+    let bind         = cfg.api.bind.clone();
+    let live_tx      = bus.live.clone();
+    let srv_state    = state.clone();
+    let srv_lg       = lg_arc.clone();
+    let srv_loader   = loader.clone();
+    let srv_reload   = bus.rule_reload.clone();
     tokio::spawn(async move {
-        live_ws::server::serve(&bind, live_tx, srv_state, srv_lg).await;
+        live_ws::server::serve(&bind, live_tx, srv_state, srv_lg, srv_loader, srv_reload).await;
     });
 
     // --- Module monitoring Pi5 (métriques système + tokio → VictoriaMetrics) ---
@@ -134,6 +146,9 @@ fn spawn_persist_watcher(bus: AppBus, state: Arc<RwLock<EnergyState>>) {
                 }
                 "santuario/persist/yield_yesterday" => {
                     persist::baseline::on_retained_yield_yesterday(msg.payload_str(), &state).await;
+                }
+                "santuario/persist/deye_state" => {
+                    persist::deye_state::on_retained_deye_state(msg.payload_str(), &state).await;
                 }
                 _ => {}
             }

--- a/crates/energy-manager/src/mqtt/topics.rs
+++ b/crates/energy-manager/src/mqtt/topics.rs
@@ -79,9 +79,10 @@ pub fn all_subscriptions(portal_id: &str, vebus: u32, mppt1: u32, mppt2: u32, pv
         "stat/tongou_3BC764/POWER".to_string(),
         "tele/tongou_3BC764/SENSOR".to_string(),
 
-        // --- Persist (retained baselines) ---
+        // --- Persist (retained baselines + DEYE state) ---
         "santuario/persist/pvinv_baseline".to_string(),
         "santuario/persist/yield_yesterday".to_string(),
+        "santuario/persist/deye_state".to_string(),
     ]
 }
 
@@ -120,6 +121,7 @@ pub mod publish {
     pub const METEO_VENUS:    &str = "santuario/meteo/venus";
     pub const INVERTER_VENUS: &str = "santuario/inverter/venus";
     pub const SYSTEM_VENUS:   &str = "santuario/system/venus";
-    pub const PVINV_BASELINE: &str = "santuario/persist/pvinv_baseline";
+    pub const PVINV_BASELINE:  &str = "santuario/persist/pvinv_baseline";
     pub const YIELD_YESTERDAY: &str = "santuario/persist/yield_yesterday";
+    pub const DEYE_STATE:      &str = "santuario/persist/deye_state";
 }

--- a/crates/energy-manager/src/persist/deye_state.rs
+++ b/crates/energy-manager/src/persist/deye_state.rs
@@ -1,0 +1,18 @@
+/// Restores DEYE relay state at startup from retained MQTT topic.
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use crate::types::EnergyState;
+
+/// Called when retained `santuario/persist/deye_state` arrives.
+/// Payload is a plain string: "On" | "Off".
+pub async fn on_retained_deye_state(payload: &str, state: &Arc<RwLock<EnergyState>>) {
+    let trimmed = payload.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    let mut s = state.write().await;
+    s.deye_persisted_state = Some(trimmed.to_string());
+    info!("DEYE persisted state restored: {trimmed}");
+}

--- a/crates/energy-manager/src/persist/mod.rs
+++ b/crates/energy-manager/src/persist/mod.rs
@@ -1,1 +1,2 @@
 pub mod baseline;
+pub mod deye_state;

--- a/crates/energy-manager/src/rule_metrics.rs
+++ b/crates/energy-manager/src/rule_metrics.rs
@@ -1,0 +1,17 @@
+/// Push rule-engine evaluation metrics to VictoriaMetrics (Prometheus format).
+/// Call this after each rule evaluation to track which rules fire and how often.
+use tracing::warn;
+
+pub async fn record_rule_eval(vm_url: &str, rule_name: &str) {
+    let ts_ms = chrono::Utc::now().timestamp_millis();
+    let line  = format!("rule_eval_total{{rule=\"{rule_name}\"}} 1 {ts_ms}");
+    let url   = format!("{vm_url}/api/v1/import/prometheus");
+    if let Err(e) = reqwest::Client::new()
+        .post(&url)
+        .body(line)
+        .send()
+        .await
+    {
+        warn!("rule_metrics: VM write failed for {rule_name}: {e}");
+    }
+}

--- a/crates/energy-manager/src/rules_loader.rs
+++ b/crates/energy-manager/src/rules_loader.rs
@@ -1,0 +1,98 @@
+/// Loads .grl rule sources from disk (if configured) with embedded fallback.
+///
+/// Usage:
+///   let loader = Arc::new(RulesLoader::new(cfg.rules.dir.as_deref().map(Path::new)));
+///   let src = loader.load("water_heater");
+///
+/// Hot-reload: trigger via POST /api/v1/em/rules/reload — the endpoint broadcasts
+/// a signal via AppBus::rule_reload; each logic module recreates its engine.
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+// Embedded fallbacks compiled into the binary
+const EMBEDDED: &[(&str, &str)] = &[
+    ("charge_current", include_str!("../rules/charge_current.grl")),
+    ("deye_command",   include_str!("../rules/deye_command.grl")),
+    ("irradiance",     include_str!("../rules/irradiance.grl")),
+    ("smartshunt",     include_str!("../rules/smartshunt.grl")),
+    ("solar_power",    include_str!("../rules/solar_power.grl")),
+    ("water_heater",   include_str!("../rules/water_heater.grl")),
+];
+
+/// Metadata about a loaded rule, exposed via GET /api/v1/em/rules.
+#[derive(Debug, Clone, Serialize)]
+pub struct RuleInfo {
+    pub name:       String,
+    pub origin:     String,           // "disk" | "embedded"
+    pub path:       Option<String>,   // disk path if origin == "disk"
+    pub loaded_at:  DateTime<Utc>,
+    pub size_bytes: usize,
+}
+
+pub struct RulesLoader {
+    dir:  Option<PathBuf>,
+    info: Arc<RwLock<HashMap<String, RuleInfo>>>,
+}
+
+impl RulesLoader {
+    pub fn new(dir: Option<&Path>) -> Self {
+        Self {
+            dir:  dir.map(PathBuf::from),
+            info: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Load a rule source by name. Tries disk first if a dir is configured,
+    /// falls back to the embedded constant.
+    pub fn load(&self, name: &str) -> String {
+        if let Some(dir) = &self.dir {
+            let path = dir.join(format!("{name}.grl"));
+            if let Ok(src) = std::fs::read_to_string(&path) {
+                let info = RuleInfo {
+                    name:       name.to_string(),
+                    origin:     "disk".to_string(),
+                    path:       Some(path.to_string_lossy().into_owned()),
+                    loaded_at:  Utc::now(),
+                    size_bytes: src.len(),
+                };
+                if let Ok(mut map) = self.info.write() {
+                    map.insert(name.to_string(), info);
+                }
+                tracing::info!("rules_loader: {name}.grl loaded from {:?} ({} bytes)", path, src.len());
+                return src;
+            }
+            tracing::warn!("rules_loader: {name}.grl not found in {:?} — using embedded fallback", dir);
+        }
+
+        let src = Self::embedded(name);
+        let info = RuleInfo {
+            name:       name.to_string(),
+            origin:     "embedded".to_string(),
+            path:       None,
+            loaded_at:  Utc::now(),
+            size_bytes: src.len(),
+        };
+        if let Ok(mut map) = self.info.write() {
+            map.insert(name.to_string(), info);
+        }
+        src.to_string()
+    }
+
+    /// Returns metadata for all rules that have been loaded at least once.
+    pub fn info(&self) -> Vec<RuleInfo> {
+        let map = self.info.read().unwrap_or_else(|e| e.into_inner());
+        let mut list: Vec<RuleInfo> = map.values().cloned().collect();
+        list.sort_by(|a, b| a.name.cmp(&b.name));
+        list
+    }
+
+    fn embedded(name: &str) -> &'static str {
+        EMBEDDED.iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, src)| *src)
+            .unwrap_or("")
+    }
+}

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -155,6 +155,8 @@ pub struct EnergyState {
     pub deye_on: bool,
     pub deye_last_change: Option<DateTime<Utc>>,
     pub deye_lockout_until: Option<DateTime<Utc>>,
+    /// Persisted DEYE state from retained MQTT (set by persist watcher at startup)
+    pub deye_persisted_state: Option<String>,
 
     // --- Irradiance ---
     pub irradiance_wm2: Option<f64>,

--- a/docs/energy-manager-guide.md
+++ b/docs/energy-manager-guide.md
@@ -41,8 +41,8 @@ MQTT (Mosquitto :1883)
 |-------|------|-------|
 | `mqtt_in` | `broadcast::Sender<MqttIncoming>` | Tous les messages MQTT entrants → tous les modules |
 | `mqtt_out` | `mpsc::Sender<MqttOutgoing>` | Publish MQTT depuis n'importe quel module |
-| 
 | `live` | `broadcast::Sender<LiveEvent>` | Événements WebSocket live |
+| `rule_reload` | `broadcast::Sender<String>` | Signal hot-reload → tous les modules de règles |
 
 Cloner `AppBus` est gratuit (tous les champs sont `Arc`-backed).
 
@@ -100,6 +100,12 @@ debounce_secs       = 300      # Délai de stabilisation (5 min)
 mode_change_min_secs = 900     # Intervalle min entre changements (15 min)
 heat_pump_target_c  = 60.0
 vacation_target_c   = 45.0
+soc_min_pct         = 90.0     # SOC minimum pour activer HEAT_PUMP (défaut 90%)
+
+[energy_manager.rules]
+# Optionnel — si défini, les règles .grl sont lues depuis ce répertoire
+# (hot-reload sans recompilation). Fallback sur les règles embarquées.
+# dir = "/etc/daly-bms/rules"
 
 [energy_manager.charge_current]
 offgrid_max_a        = 70.0
@@ -343,6 +349,43 @@ sudo cp Config.toml /etc/daly-bms/config.toml
 sudo systemctl restart energy-manager
 ```
 
+### Hot-reload des règles (sans recompilation)
+
+Les règles `.grl` peuvent être modifiées **en production** sans recompiler ni redémarrer.
+
+**Prérequis** : configurer un répertoire dans `Config.toml` :
+
+```toml
+[energy_manager.rules]
+dir = "/etc/daly-bms/rules"
+```
+
+Copier les règles initiales :
+```bash
+sudo mkdir -p /etc/daly-bms/rules
+sudo cp crates/energy-manager/rules/*.grl /etc/daly-bms/rules/
+```
+
+**Recharger après modification d'un fichier** :
+```bash
+# Recharger UNE règle (ex: water_heater)
+curl -s -X POST http://192.168.1.141:8081/api/v1/em/rules/reload \
+     -H "Content-Type: application/json" \
+     -d '{"name":"water_heater"}'
+
+# Recharger TOUTES les règles
+curl -s -X POST http://192.168.1.141:8081/api/v1/em/rules/reload \
+     -H "Content-Type: application/json" \
+     -d '{"name":"*"}'
+```
+
+**Lister les règles chargées** (origine: disk ou embedded, timestamp) :
+```bash
+curl -s http://192.168.1.141:8081/api/v1/em/rules | python3 -m json.tool
+```
+
+Si `rules.dir` n'est pas configuré ou si le fichier n'existe pas sur disque, le système utilise automatiquement la règle embarquée dans le binaire.
+
 ### Changer la logique métier (recompilation requise)
 
 Exemples de modifications courantes :
@@ -358,7 +401,53 @@ Exemples de modifications courantes :
 
 ---
 
-## 8. Supprimer un module
+## 8. Tests unitaires des règles
+
+Chaque module de règles `.grl` a une suite de tests unitaires dans son fichier `rules.rs`.
+
+```bash
+# Lancer tous les tests (34 tests, ~0.3s)
+cargo test -p energy-manager
+
+# Lancer les tests d'une règle spécifique
+cargo test -p energy-manager deye_command
+cargo test -p energy-manager water_heater
+```
+
+Les tests couvrent :
+- `charge_current` — 4 tests (offgrid, grid+PV, grid sans PV, etc.)
+- `deye_command` — 9 tests (toutes transitions, grille reconnectée, lockout)
+- `irradiance` — 5 tests (valides/invalides, plage 0–2000 W/m²)
+- `smartshunt` — 6 tests (capture baseline chargée/déchargée)
+- `solar_power` — 4 tests (nouveau jour, baseline absente)
+- `water_heater` — 5 tests (grid connecté, SOC bas, irradiance faible)
+
+**Ajouter un test** : dans le module `rules.rs` concerné, ajouter dans `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn mon_nouveau_cas() {
+    let mut e = MonRuleEngine::new().unwrap();
+    let result = e.evaluate(/* params */);
+    assert_eq!(result.unwrap(), "EXPECTED");
+}
+```
+
+---
+
+## 9. Persistance d'état DEYE
+
+L'état du relais DEYE (On/Off) est persisté en MQTT retained sur `santuario/persist/deye_state`.  
+Au redémarrage, le service attend 3 secondes avant d'activer la logique DEYE pour laisser
+le temps au broker MQTT de livrer le message retained.
+
+États persistés :
+- `"On"` — DEYE actif (états `On` ou `PendingCut`)
+- `"Off"` — DEYE coupé (états `Off`, `Lockout`, `PendingRestore`)
+
+---
+
+## 10. Supprimer un module
 
 1. Supprimer le fichier `logic/mon_module.rs`
 2. Retirer `pub mod mon_module;` dans `logic/mod.rs`
@@ -370,7 +459,7 @@ Exemples de modifications courantes :
 
 ---
 
-## 9. Ajouter un nouveau publish MQTT
+## 11. Ajouter un nouveau publish MQTT
 
 **1. Déclarer le topic** dans `mqtt/topics.rs` :
 
@@ -406,7 +495,7 @@ bus.publish(MqttOutgoing::raw(publish::MON_TOPIC, "valeur", false)).await;
 
 ---
 
-## 11. Débogage
+## 12. Débogage
 
 ```bash
 # Logs en continu
@@ -429,7 +518,7 @@ websocat ws://192.168.1.141:8081/live
 
 ---
 
-## 12. Installation initiale du service (première fois)
+## 13. Installation initiale du service (première fois)
 
 ```bash
 # Depuis le repo sur Pi5 :


### PR DESCRIPTION
…igurable SOC

- RulesLoader: load .grl from disk (cfg rules.dir) with embedded fallback; hot-reload triggered via POST /api/v1/em/rules/reload or AppBus::rule_reload broadcast
- All 6 rule engines: with_source(grl: &str) constructor for testability + hot-reload; reload handler wired into every logic module tokio::select! loop
- 34 unit tests across charge_current, deye_command, irradiance, smartshunt, solar_power, water_heater rules
- DEYE state persistence: retained MQTT (santuario/persist/deye_state); 3s startup delay to restore state from broker before DEYE logic activates
- deye_command.grl bug fix: DY_Off_LowFreq, DY_Lockout_Expired, DY_PendingRestore_FreqClimb now guard on grid_connected==false to prevent overriding grid-reconnect rules (salience 200)
- water_heater: soc_min_pct configurable in [energy_manager.water_heater] (default 90.0); water_heater.grl uses WH.soc_low bool instead of hardcoded 90 threshold
- live_ws/server: GET /api/v1/em/rules (list rules + origin) and POST /api/v1/em/rules/reload
- rule_metrics.rs: stub for per-rule VictoriaMetrics counters
- docs/energy-manager-guide.md: hot-reload section, tests section, DEYE persistence, soc_min_pct config, AppBus rule_reload canal, section renumbering

https://claude.ai/code/session_01BQ4r2FtsXxUeVgwm5P3fSx