### PR TITLE
feat(mqtt): remplace Mosquitto/Docker par rumqttd + bridge Rust natif

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,12 @@
 | Logs BMS | `journalctl -u daly-bms -f` |
 | Compiler Pi5 | `make build-arm` |
 | Déployer binaire Pi5 | `sudo systemctl stop daly-bms && sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/ && sudo systemctl start daly-bms` |
-| Docker start/stop/logs | `make up` / `make down` / `make logs` |
+| MQTT start/stop/logs | `make mqtt-start` / `make mqtt-stop` / `make mqtt-logs` |
+| Compiler MQTT (broker+bridge) | `make build-mqtt-arm` |
+| Déployer mqtt-broker | `sudo systemctl stop mqtt-broker && sudo cp target/aarch64-unknown-linux-gnu/release/mqtt-broker /usr/local/bin/ && sudo systemctl start mqtt-broker` |
+| Déployer mqtt-bridge | `sudo systemctl stop mqtt-bridge && sudo cp target/aarch64-unknown-linux-gnu/release/mqtt-bridge /usr/local/bin/ && sudo systemctl start mqtt-bridge` |
+| Métriques broker | `curl http://localhost:8082/metrics` |
+| Métriques bridge | `curl http://localhost:8084/metrics` |
 | Logs energy-manager | `journalctl -u energy-manager -f` |
 | Compiler energy-manager | `make build-energy-arm` |
 | Déployer energy-manager | `sudo systemctl stop energy-manager && sudo cp target/aarch64-unknown-linux-gnu/release/energy-manager /usr/local/bin/ && sudo systemctl start energy-manager` |
@@ -49,6 +54,9 @@ make build-venus-v7 && make install-venus-v7
 3d. Config NanoPi       : scp nanoPi/config-nanopi.toml root@192.168.1.120:/data/daly-bms/config.toml && ssh root@192.168.1.120 "svc -t /service/dbus-mqtt-venus"
 3e. energy-manager code : make build-energy-arm → sudo systemctl stop energy-manager → sudo cp target/aarch64-unknown-linux-gnu/release/energy-manager /usr/local/bin/ → sudo systemctl start energy-manager
 3f. Config seule (energy): sudo cp Config.toml /etc/daly-bms/config.toml && sudo systemctl restart energy-manager
+3g. mqtt-broker code    : make build-mqtt-arm → sudo systemctl restart mqtt-broker mqtt-bridge
+3h. Config bridge seule : sudo cp Config.toml /etc/daly-bms/config.toml && sudo systemctl restart mqtt-bridge
+3i. Config broker seule : sudo cp crates/mqtt-broker/mqtt-broker.toml /etc/daly-bms/ && sudo systemctl restart mqtt-broker
 ```
 
 ---
@@ -57,17 +65,25 @@ make build-venus-v7 && make install-venus-v7
 
 ```
 Pi5 (192.168.1.141, pi5compute)
+  mqtt-broker (systemd, :1883/:9001) ← rumqttd — remplace Mosquitto/Docker
+    ├── TCP  :1883  ← tous les clients MQTT locaux
+    ├── WS   :9001  ← explorateur dashboard JS
+    ├── HTTP :8082  ← /metrics pour monitor agent
+    └── Persistence : /var/lib/mqtt-broker
+  mqtt-bridge (systemd) ← bridge Pi5 ↔ NanoPi
+    ├── SUB localhost:1883 → republish NanoPi (W/ R/ santuario/ shellypro2pm/)
+    ├── SUB NanoPi:1883   → republish local  (N/ santuario/ shellypro2pm/)
+    └── HTTP :8084  ← /metrics (compteurs, état connexion)
   daly-bms-server (systemd, :8080)
     ├── RS485 /dev/ttyUSB0 → 2 BMS + 3 ET112 + 1 PRALRAN
     ├── REST API + WebSocket :8080
-    ├── MQTT publish → 192.168.1.120:1883
+    ├── MQTT publish → localhost:1883 (broker local rumqttd)
     └── VictoriaMetrics → localhost:8428
   energy-manager (systemd, :8081)
-    ├── MQTT subscribe/publish → 192.168.1.120:1883
+    ├── MQTT subscribe/publish → localhost:1883 (broker local rumqttd)
     ├── Logique solaire, DEYE, chauffe-eau, charge, météo
     ├── WebSocket live events :8081/live
     └── VictoriaMetrics → localhost:8428
-  Docker: mosquitto:1883
 
 NanoPi (192.168.1.120, root)
   dbus-mqtt-venus (runit /service/dbus-mqtt-venus)
@@ -123,6 +139,14 @@ crates/energy-manager/rules/            ← règles `.grl` (rust-rule-engine) :
                                           charge_current, deye_command, inverter,
                                           irradiance, smartshunt, solar_power,
                                           water_heater
+crates/mqtt-broker/src/                 ← broker MQTT Rust (rumqttd) — remplace Mosquitto
+  main.rs                               ← wrapper rumqttd + HTTP /metrics :8082
+  mqtt-broker.toml                      ← config déployée dans /etc/daly-bms/
+crates/mqtt-bridge/src/                 ← bridge bidirectionnel Pi5 ↔ NanoPi (rumqttc)
+  main.rs                               ← entrée, métriques HTTP :8084
+  bridge.rs                             ← demi-bridges nanopi→local et local→nanopi
+  config.rs                             ← lecture [mqtt_bridge] depuis Config.toml
+  metrics.rs                            ← compteurs atomiques + snapshot JSON
 crates/dbus-mqtt-venus/src/             ← bridge MQTT→D-Bus NanoPi
 contrib/daly-bms.service                ← unité systemd daly-bms-server
 contrib/energy-manager.service          ← unité systemd energy-manager
@@ -283,7 +307,11 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 | Dashboard affiche cumul brut | Vérifier `pvinv_baseline` retained MQTT (`santuario/persist/pvinv_baseline`) |
 | energy-manager ne démarre pas | `journalctl -u energy-manager -n 50` — souvent TOML manquant ou `.env` absent |
 | `missing field energy_manager` | `sudo cp Config.toml /etc/daly-bms/config.toml` — section `[energy_manager]` absente |
-| energy-manager ne reçoit pas MQTT | Vérifier `portal_id` dans Config.toml et que Mosquitto est accessible sur `mqtt.host` |
+| energy-manager ne reçoit pas MQTT | Vérifier `portal_id` dans Config.toml et que mqtt-broker est actif (`systemctl status mqtt-broker`) |
+| mqtt-broker ne démarre pas | `journalctl -u mqtt-broker -n 30` — souvent `/var/lib/mqtt-broker` owner incorrect |
+| mqtt-bridge déconnecté NanoPi | `journalctl -u mqtt-bridge -n 30` — NanoPi inaccessible? `ping 192.168.1.120` |
+| Retained messages perdus après migration | Normaux — recréés au prochain publish retain (ex: `pvinv_baseline` par energy-manager) |
+| Double messages venus (boucle bridge) | Vérifier que client_id des bridges sont uniques (déjà le cas dans le code) |
 | LG ThinQ ne répond pas | Vérifier `LG_BEARER_TOKEN` et `LG_API_KEY` dans `/etc/daly-bms/.env` |
 
 ---
@@ -302,6 +330,8 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 10. Nom exact D-Bus onduleur Victron direct : `cgwacs_ttyUSB0_mb2` (pas `rs485`).
 11. `make reset` efface les volumes Docker (retained MQTT perdu) → préférer `make down && make up`.
 12. Secrets : ne jamais committer `.env`.
+13. **MQTT** : broker = `mqtt-broker` (rumqttd systemd), plus de Docker. `make mqtt-start/stop/logs` remplace `make up/down/logs`.
+14. Config bridge MQTT : `[mqtt_bridge]` dans Config.toml (portal_id + remote_host NanoPi).
 
 ---
 
@@ -315,4 +345,5 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 | Debug MQTT | `MQTT_DEBUGGING_GUIDE.md` |
 | Debug onduleur / SmartShunt | `DEBUG_ONDULEUR_SMARTSHUNT.md` |
 | Guide energy-manager — modifier/ajouter/retirer une fonctionnalité | `docs/energy-manager-guide.md` |
+| Migration MQTT / broker rumqttd / bridge / dashboard | `docs/mqtt-broker.md` |
 | Architecture bus RS485 unifié (`rs485-bus` vs `daly-bms-core`) | `docs/architecture-rs485-bus.md` |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ members = [
     "crates/daly-bms-server",
     "crates/dbus-mqtt-venus",
     "crates/energy-manager",
+    "crates/mqtt-broker",
+    "crates/mqtt-bridge",
 ]
 
 [workspace.package]
@@ -52,6 +54,7 @@ tower-http    = { version = "0.5",  features = ["cors", "trace", "compression-gz
 
 # ── MQTT ───────────────────────────────────────────────────────────────────────
 rumqttc       = "0.25"
+rumqttd       = { version = "0.19", default-features = false }
 
 # ── SQLite (alertes) ───────────────────────────────────────────────────────────
 rusqlite      = { version = "0.31", features = ["bundled"] }

--- a/Config.toml
+++ b/Config.toml
@@ -74,10 +74,10 @@ format = "pretty"
 [mqtt]
 enabled = true
 
-# Windows avec Docker Desktop local → "localhost"
-# Windows avec NanoPi comme broker → "192.168.1.120"
-# Raspberry Pi 5 production        → "localhost" (Mosquitto local) ou IP NanoPi
-host = "192.168.1.120"
+# Broker local rumqttd (ex-Mosquitto Docker)
+# Pi5 production → "127.0.0.1" (broker rumqttd local)
+# Dev Windows    → "192.168.1.141" (IP Pi5 avec rumqttd)
+host = "127.0.0.1"
 port = 1883
 
 # Préfixe des topics (ex: santuario/bms/1/venus)
@@ -526,7 +526,7 @@ device_instance = 152
 
 # --- MQTT ---
 [energy_manager.mqtt]
-host              = "192.168.1.141"   # broker Mosquitto local Pi5
+host              = "127.0.0.1"       # broker rumqttd local Pi5 (ex-Mosquitto Docker)
 port              = 1883
 keep_alive_secs   = 60
 reconnect_delay_secs = 10
@@ -605,3 +605,17 @@ host_tag             = "pi5"
 # --- Statut plateforme ---
 [energy_manager.platform]
 publish_interval_secs = 60
+
+# =============================================================================
+# Bridge MQTT — Pi5 (rumqttd :1883) ↔ NanoPi (192.168.1.120:1883)
+# Utilisé par le service mqtt-bridge (remplace section bridge mosquitto.conf)
+# portal_id doit correspondre à l'ID Victron GX (voir energy_manager.portal_id)
+# =============================================================================
+[mqtt_bridge]
+local_host       = "127.0.0.1"
+local_port       = 1883
+remote_host      = "192.168.1.120"
+remote_port      = 1883
+portal_id        = "c0619ab9929a"
+reconnect_secs   = 30
+keepalive_secs   = 60

--- a/Makefile
+++ b/Makefile
@@ -38,30 +38,44 @@ CROSS_LINKER_MUSL := aarch64-linux-musl-gcc
 CROSS_LINKER_ARMV7 := arm-linux-gnueabihf-gcc
 
 # =============================================================================
-# Infrastructure Docker (Mosquitto uniquement — Tsink est embarqué dans daly-bms-server)
+# MQTT — Broker rumqttd + Bridge Pi5↔NanoPi (remplace Mosquitto/Docker)
 # =============================================================================
 
-.PHONY: up down restart logs reset ps
+MQTT_BROKER_BIN := mqtt-broker
+MQTT_BRIDGE_BIN := mqtt-bridge
 
-up:
-	docker compose -f docker-compose.infra.yml up -d
-	@echo "✓ Infra démarrée — Mosquitto MQTT:1883"
+.PHONY: up down restart logs ps mqtt-start mqtt-stop mqtt-restart mqtt-logs mqtt-status
 
-down:
-	docker compose -f docker-compose.infra.yml down
+# Aliases de compatibilité (anciennement Docker)
+up: mqtt-start
+down: mqtt-stop
+restart: mqtt-restart
+logs: mqtt-logs
+ps: mqtt-status
 
-restart:
-	docker compose -f docker-compose.infra.yml restart
+mqtt-start:
+	sudo systemctl start mqtt-broker mqtt-bridge
+	@echo "✓ MQTT démarré — broker :1883 | ws :9001 | bridge Pi5↔NanoPi"
 
-logs:
-	docker compose -f docker-compose.infra.yml logs -f
+mqtt-stop:
+	sudo systemctl stop mqtt-bridge mqtt-broker
 
-reset:
-	docker compose -f docker-compose.infra.yml down -v
-	@echo "⚠ Volumes Mosquitto supprimés (MQTT retained perdu)"
+mqtt-restart:
+	sudo systemctl restart mqtt-bridge mqtt-broker
 
-ps:
-	docker compose -f docker-compose.infra.yml ps
+mqtt-logs:
+	journalctl -u mqtt-broker -u mqtt-bridge -f --no-pager
+
+mqtt-status:
+	@systemctl status mqtt-broker mqtt-bridge --no-pager -l || true
+
+build-mqtt-arm: check-arm-deps
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(CROSS_LINKER_GNU) \
+	RUSTFLAGS="$(ARM_RUSTFLAGS)" \
+	$(CARGO) build --release --target $(TARGET_ARM) --bin $(MQTT_BROKER_BIN) --bin $(MQTT_BRIDGE_BIN)
+	@echo "✓ Binaires MQTT ARM Pi5 :"
+	@echo "  $(ARM_RELEASE_DIR)/$(MQTT_BROKER_BIN)"
+	@echo "  $(ARM_RELEASE_DIR)/$(MQTT_BRIDGE_BIN)"
 
 # =============================================================================
 # Vérification des dépendances cross-compilation
@@ -104,7 +118,7 @@ check-musl-deps:
 # Compilation — Version optimisée
 # =============================================================================
 
-.PHONY: build build-arm build-arm-debug build-arm-musl build-arm-v7 build-venus build-venus-arm build-venus-armv7 build-venus-v7 build-energy build-energy-arm install-energy run-energy
+.PHONY: build build-arm build-arm-debug build-arm-musl build-arm-v7 build-venus build-venus-arm build-venus-armv7 build-venus-v7 build-energy build-energy-arm install-energy run-energy build-mqtt-arm
 
 VENUS_BIN := dbus-mqtt-venus
 

--- a/contrib/mqtt-bridge.service
+++ b/contrib/mqtt-bridge.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Bridge MQTT Rust — Pi5 (rumqttd :1883) ↔ NanoPi (192.168.1.120:1883)
+Documentation=https://github.com/thieryus007-cloud/Daly-BMS-Rust
+After=network-online.target mqtt-broker.service
+Wants=network-online.target
+Requires=mqtt-broker.service
+
+[Service]
+Type=notify
+NotifyAccess=main
+WatchdogSec=90
+User=pi5compute
+Group=pi5compute
+
+ExecStart=/usr/local/bin/mqtt-bridge \
+    --config /etc/daly-bms/config.toml \
+    --metrics-addr 127.0.0.1:8084
+
+WorkingDirectory=/home/pi5compute/Daly-BMS-Rust
+
+Environment=RUST_LOG=info
+EnvironmentFile=-/etc/daly-bms/.env
+
+Restart=on-failure
+RestartSec=10s
+StartLimitIntervalSec=0
+
+LimitNOFILE=4096
+MemoryMax=30M
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/mqtt-broker.service
+++ b/contrib/mqtt-broker.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=Broker MQTT Rust (rumqttd) — remplace Mosquitto/Docker sur Pi5
+Documentation=https://github.com/thieryus007-cloud/Daly-BMS-Rust
+After=network.target
+Before=daly-bms.service energy-manager.service mqtt-bridge.service
+
+[Service]
+Type=notify
+NotifyAccess=main
+WatchdogSec=60
+User=mqtt-broker
+Group=mqtt-broker
+
+ExecStart=/usr/local/bin/mqtt-broker \
+    --config /etc/daly-bms/mqtt-broker.toml \
+    --metrics-addr 127.0.0.1:8082
+
+WorkingDirectory=/var/lib/mqtt-broker
+
+Environment=RUST_LOG=info
+
+Restart=on-failure
+RestartSec=5s
+StartLimitIntervalSec=0
+
+# Répertoire de travail pour la persistence rumqttd
+StateDirectory=mqtt-broker
+StateDirectoryMode=0750
+
+# Ports MQTT accessibles depuis le réseau local
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Sécurité
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/mqtt-broker
+PrivateTmp=true
+
+# Limits
+LimitNOFILE=65536
+MemoryMax=100M
+
+[Install]
+WantedBy=multi-user.target

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -14,6 +14,7 @@ pub mod chart;
 pub mod history;
 pub mod promql;
 pub mod health;
+pub mod mqtt;
 
 use crate::dashboard;
 use crate::state::AppState;
@@ -56,6 +57,9 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/monitor/rs485-health",  get(system::get_rs485_health))
         .route("/api/v1/monitor/logs",          get(system::get_monitor_logs))
         .route("/api/v1/monitor/logs/content",  get(system::get_monitor_log_content))
+
+        // ── MQTT Broker + Bridge ─────────────────────────────────────────────
+        .route("/api/v1/mqtt/status",           get(mqtt::get_mqtt_status))
 
         // ── BMS — Lecture ────────────────────────────────────────────────────
         .route("/api/v1/bms/:id/status",      get(bms::get_bms_status))

--- a/crates/daly-bms-server/src/api/mqtt.rs
+++ b/crates/daly-bms-server/src/api/mqtt.rs
@@ -1,0 +1,30 @@
+//! Endpoint REST : statut MQTT broker (rumqttd) + bridge NanoPi.
+
+use crate::state::AppState;
+use axum::{extract::State, Json};
+
+/// GET /api/v1/mqtt/status
+///
+/// Retourne le dernier statut connu du broker MQTT local (rumqttd)
+/// et du bridge bidirectionnel Pi5 ↔ NanoPi.
+/// Mis à jour toutes les 30 s par le monitor agent.
+pub async fn get_mqtt_status(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let s = state.mqtt_status_latest().await;
+    Json(serde_json::json!({
+        "broker": {
+            "running":      s.broker_running,
+            "uptime_secs":  s.broker_uptime_secs,
+            "messages_rx":  s.broker_msgs_rx,
+        },
+        "bridge": {
+            "local_connected":      s.bridge_local_ok,
+            "remote_connected":     s.bridge_remote_ok,
+            "msgs_local_to_remote": s.bridge_l2r_total,
+            "msgs_remote_to_local": s.bridge_r2l_total,
+            "reconnects_local":     s.bridge_reconnects_local,
+            "reconnects_remote":    s.bridge_reconnects_remote,
+            "uptime_secs":          s.bridge_uptime_secs,
+        },
+        "timestamp": s.timestamp.map(|t| t.to_rfc3339()),
+    }))
+}

--- a/crates/daly-bms-server/src/dashboard/mod.rs
+++ b/crates/daly-bms-server/src/dashboard/mod.rs
@@ -766,6 +766,15 @@ pub async fn dashboard_monitor() -> Response {
 }
 
 #[derive(Template)]
+#[template(path = "mqtt.html")]
+struct MqttTemplate {}
+
+/// Page dashboard MQTT broker + bridge (standalone, données via API JS).
+pub async fn dashboard_mqtt() -> Response {
+    render(MqttTemplate {})
+}
+
+#[derive(Template)]
 #[template(path = "console.html")]
 struct ConsoleTemplate {}
 
@@ -817,6 +826,7 @@ pub fn build_dashboard_router() -> Router<AppState> {
         .route("/dashboard/tasmota/:id",       get(dashboard_tasmota))
         .route("/dashboard/ats",               get(dashboard_ats))
         .route("/dashboard/monitor",           get(dashboard_monitor))
+        .route("/dashboard/mqtt",              get(dashboard_mqtt))
         .route("/dashboard/console",           get(dashboard_console))
         .route("/dashboard/visualization",     get(dashboard_visualization))
         .route("/visualization",               get(dashboard_visualization))

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -1,15 +1,16 @@
 //! Agent de monitoring autonome — surveille l'ensemble du système Pi5.
 //!
 //! Vérifie toutes les 30 secondes :
-//! - Services systemd daly-bms + energy-manager (via systemctl)
-//! - Services réseau via sonde TCP : mosquitto, energy-manager, venus MQTT
+//! - Services systemd daly-bms, energy-manager, mqtt-broker, mqtt-bridge
+//! - Services réseau via sonde TCP : mqtt-broker :1883, energy-manager :8081, venus MQTT :1883
+//! - Métriques MQTT via HTTP : mqtt-broker :8082/metrics, mqtt-bridge :8084/metrics
 //! - Port série RS485 (/dev/ttyUSB0)
 //! - CPU, RAM, disque, charge système, uptime
 //! - Liste des processus (top 20 par CPU%)
 //! - I/O réseau (octets/s)
 //! - Température CPU
 
-use crate::state::{AppState, MonitorSnapshot, ProcessInfo, ServiceStatus};
+use crate::state::{AppState, MqttStatus, MonitorSnapshot, ProcessInfo, ServiceStatus};
 use crate::vm_client::VmRow;
 use chrono::Utc;
 use std::time::{Duration, Instant};
@@ -18,15 +19,19 @@ use tokio::process::Command;
 use tokio::time::interval;
 use tracing::{info, warn};
 
-/// Services réseau à sonder : (label, host, port, conteneur_docker_pour_restart).
-const TCP_SERVICES: &[(&str, &str, u16, Option<&str>)] = &[
-    ("mosquitto",      "127.0.0.1",     1883, Some("mosquitto")),
-    ("energy-manager", "127.0.0.1",     8081, None),
-    ("venus-mqtt",     "192.168.1.120", 1883, None),
+/// Services réseau à sonder : (label, host, port).
+const TCP_SERVICES: &[(&str, &str, u16)] = &[
+    ("mqtt-broker",  "127.0.0.1",     1883),
+    ("energy-manager", "127.0.0.1",   8081),
+    ("venus-mqtt",   "192.168.1.120", 1883),
 ];
 
 /// Port série RS485.
 const RS485_PORT: &str = "/dev/ttyUSB0";
+
+/// URL métriques HTTP des services MQTT (broker + bridge).
+const MQTT_BROKER_METRICS: &str = "http://127.0.0.1:8082/metrics";
+const MQTT_BRIDGE_METRICS:  &str = "http://127.0.0.1:8084/metrics";
 
 // =============================================================================
 // Agent principal
@@ -64,6 +69,10 @@ pub async fn run_monitor_agent(state: AppState) {
         }
 
         state.on_monitor_snapshot(snap).await;
+
+        // Collecte statut MQTT (broker + bridge via HTTP /metrics)
+        let mqtt = collect_mqtt_status().await;
+        state.on_mqtt_status(mqtt).await;
     }
 }
 
@@ -96,42 +105,25 @@ async fn collect_snapshot(_state: &AppState, net_rx_bps: u64, net_tx_bps: u64) -
         } else if em_status.is_empty() { "unknown".to_string() } else { em_status },
     });
 
-    let mosquitto_systemd = check_systemd_service("mosquitto").await == "active";
-    services.push(ServiceStatus {
-        name:   "mosquitto".to_string(),
-        active: mosquitto_systemd || tcp_probe("127.0.0.1", 1883).await,
-        status: if mosquitto_systemd { "active".to_string() } else { "inactive".to_string() },
-    });
+    // Services MQTT (broker + bridge) via systemd
+    for svc in &["mqtt-broker", "mqtt-bridge"] {
+        let st = check_systemd_service(svc).await;
+        let active = st == "active";
+        services.push(ServiceStatus {
+            name:   svc.to_string(),
+            active,
+            status: if active { "active".to_string() } else if st.is_empty() { "unknown".to_string() } else { st },
+        });
+    }
 
     // ── Sondes TCP ───────────────────────────────────────────────────────────
-    for &(name, host, port, docker_name) in TCP_SERVICES {
+    for &(name, host, port) in TCP_SERVICES {
         let reachable = tcp_probe(host, port).await;
-
-        if !reachable {
-            if let Some(cname) = docker_name {
-                if restart_docker_container(cname).await {
-                    let msg = format!("Redémarré conteneur Docker: {}", cname);
-                    info!("{}", msg);
-                    auto_actions.push(msg);
-                    network_services.push(ServiceStatus {
-                        name: name.to_string(), active: false, status: "restarted".to_string(),
-                    });
-                } else {
-                    warn!("Échec redémarrage conteneur Docker: {}", cname);
-                    network_services.push(ServiceStatus {
-                        name: name.to_string(), active: false, status: "down".to_string(),
-                    });
-                }
-            } else {
-                network_services.push(ServiceStatus {
-                    name: name.to_string(), active: false, status: "unreachable".to_string(),
-                });
-            }
-        } else {
-            network_services.push(ServiceStatus {
-                name: name.to_string(), active: true, status: format!("{}:{}", host, port),
-            });
-        }
+        network_services.push(ServiceStatus {
+            name:   name.to_string(),
+            active: reachable,
+            status: if reachable { format!("{}:{}", host, port) } else { "unreachable".to_string() },
+        });
     }
 
     // ── Port série RS485 ─────────────────────────────────────────────────────
@@ -316,11 +308,81 @@ async fn check_systemd_service(name: &str) -> String {
     }
 }
 
-async fn restart_docker_container(name: &str) -> bool {
-    match Command::new("docker").args(["restart", name]).output().await {
-        Ok(out) => out.status.success(),
-        Err(_)  => false,
+/// Collecte les statuts MQTT en appelant les endpoints HTTP /metrics du broker et du bridge.
+async fn collect_mqtt_status() -> MqttStatus {
+    use tokio::time::timeout;
+
+    // ── Broker metrics ────────────────────────────────────────────────────────
+    let broker = timeout(Duration::from_secs(2), fetch_json(MQTT_BROKER_METRICS)).await;
+    let (broker_running, broker_uptime_secs, broker_msgs_rx) = match broker {
+        Ok(Ok(v)) => (
+            v.get("status").and_then(|s| s.as_str()) == Some("running"),
+            v.get("uptime_secs").and_then(|v| v.as_u64()).unwrap_or(0),
+            v.get("messages_rx").and_then(|v| v.as_u64()).unwrap_or(0),
+        ),
+        _ => {
+            // Si HTTP échoue, on tente la sonde TCP directement
+            let tcp_ok = tcp_probe("127.0.0.1", 1883).await;
+            (tcp_ok, 0, 0)
+        }
+    };
+
+    // ── Bridge metrics ────────────────────────────────────────────────────────
+    let bridge = timeout(Duration::from_secs(2), fetch_json(MQTT_BRIDGE_METRICS)).await;
+    let (bridge_local_ok, bridge_remote_ok, bridge_l2r, bridge_r2l,
+         bridge_recon_local, bridge_recon_remote, bridge_uptime) = match bridge {
+        Ok(Ok(v)) => (
+            v.get("local_connected").and_then(|b| b.as_bool()).unwrap_or(false),
+            v.get("remote_connected").and_then(|b| b.as_bool()).unwrap_or(false),
+            v.get("msgs_local_to_remote").and_then(|n| n.as_u64()).unwrap_or(0),
+            v.get("msgs_remote_to_local").and_then(|n| n.as_u64()).unwrap_or(0),
+            v.get("reconnects_local").and_then(|n| n.as_u64()).unwrap_or(0),
+            v.get("reconnects_remote").and_then(|n| n.as_u64()).unwrap_or(0),
+            v.get("uptime_secs").and_then(|n| n.as_u64()).unwrap_or(0),
+        ),
+        _ => (false, false, 0, 0, 0, 0, 0),
+    };
+
+    MqttStatus {
+        timestamp:             Some(Utc::now()),
+        broker_running,
+        broker_uptime_secs,
+        broker_msgs_rx,
+        bridge_local_ok,
+        bridge_remote_ok,
+        bridge_l2r_total:      bridge_l2r,
+        bridge_r2l_total:      bridge_r2l,
+        bridge_reconnects_local:  bridge_recon_local,
+        bridge_reconnects_remote: bridge_recon_remote,
+        bridge_uptime_secs:    bridge_uptime,
     }
+}
+
+/// Fetch JSON depuis une URL locale (pas de dépendance reqwest — tokio + hyper léger).
+async fn fetch_json(url: &str) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    let addr = url
+        .trim_start_matches("http://")
+        .splitn(2, '/')
+        .next()
+        .unwrap_or("127.0.0.1:8082");
+    let path = url
+        .trim_start_matches("http://")
+        .splitn(2, '/')
+        .nth(1)
+        .map(|p| format!("/{p}"))
+        .unwrap_or_else(|| "/metrics".to_string());
+
+    let stream = TcpStream::connect(addr).await?;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut stream = stream;
+    let req = format!("GET {path} HTTP/1.0\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream.write_all(req.as_bytes()).await?;
+
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await?;
+    let text = std::str::from_utf8(&buf).unwrap_or("");
+    let body = text.splitn(2, "\r\n\r\n").nth(1).unwrap_or(text);
+    Ok(serde_json::from_str(body)?)
 }
 
 async fn read_load_avg() -> [f32; 3] {

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -303,6 +303,32 @@ pub struct ProcessInfo {
     pub state:       String,
 }
 
+/// Statut agrégé du broker MQTT et du bridge — alimenté par le monitor agent.
+#[derive(Clone, Serialize, Debug, Default)]
+pub struct MqttStatus {
+    pub timestamp: Option<DateTime<Utc>>,
+    /// Broker rumqttd accessible sur :1883
+    pub broker_running:    bool,
+    /// Uptime broker en secondes (depuis démarrage du process)
+    pub broker_uptime_secs: u64,
+    /// Messages reçus par le broker depuis son démarrage
+    pub broker_msgs_rx:    u64,
+    /// Bridge connecté au broker local
+    pub bridge_local_ok:   bool,
+    /// Bridge connecté au NanoPi distant
+    pub bridge_remote_ok:  bool,
+    /// Messages forwarded Pi5 → NanoPi depuis démarrage du bridge
+    pub bridge_l2r_total:  u64,
+    /// Messages forwarded NanoPi → Pi5 depuis démarrage du bridge
+    pub bridge_r2l_total:  u64,
+    /// Reconnexions bridge (côté local)
+    pub bridge_reconnects_local:  u64,
+    /// Reconnexions bridge (côté NanoPi)
+    pub bridge_reconnects_remote: u64,
+    /// Uptime bridge en secondes
+    pub bridge_uptime_secs: u64,
+}
+
 /// Snapshot de monitoring système Pi5.
 #[derive(Clone, Serialize, Debug)]
 pub struct MonitorSnapshot {
@@ -424,6 +450,9 @@ pub struct AppState {
     /// Dernier snapshot du monitoring système Pi5.
     pub monitor_snapshot: Arc<RwLock<Option<MonitorSnapshot>>>,
 
+    /// Statut MQTT (broker rumqttd + bridge NanoPi) — mis à jour par le monitor agent.
+    pub mqtt_status: Arc<RwLock<MqttStatus>>,
+
     /// Dernier snapshot ATS CHINT (None si non configuré ou en attente).
     pub ats_snapshot: Arc<RwLock<Option<AtsSnapshot>>>,
 
@@ -517,6 +546,7 @@ impl AppState {
             venus_temperatures: Arc::new(RwLock::new(BTreeMap::new())),
             venus_heatpumps: Arc::new(RwLock::new(BTreeMap::new())),
             monitor_snapshot: Arc::new(RwLock::new(None)),
+            mqtt_status: Arc::new(RwLock::new(MqttStatus::default())),
             ats_snapshot: Arc::new(RwLock::new(None)),
             ats_bus: Arc::new(RwLock::new(None)),
             rs485_stats: Arc::new(RwLock::new(BTreeMap::new())),
@@ -1022,6 +1052,18 @@ impl AppState {
     /// Retourne le dernier snapshot de monitoring système.
     pub async fn monitor_latest(&self) -> Option<MonitorSnapshot> {
         self.monitor_snapshot.read().await.clone()
+    }
+
+    // ==========================================================================
+    // Méthodes MQTT status
+    // ==========================================================================
+
+    pub async fn on_mqtt_status(&self, status: MqttStatus) {
+        *self.mqtt_status.write().await = status;
+    }
+
+    pub async fn mqtt_status_latest(&self) -> MqttStatus {
+        self.mqtt_status.read().await.clone()
     }
 
     // ==========================================================================

--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -823,6 +823,9 @@
     <a href="/dashboard/monitor" class="nav-link {% block nav_monitor %}{% endblock %}">
       <span class="nav-icon">🖥</span> Monitoring
     </a>
+    <a href="/dashboard/mqtt" class="nav-link {% block nav_mqtt %}{% endblock %}">
+      <span class="nav-icon">📡</span> MQTT Broker
+    </a>
     <a href="/dashboard/console" class="nav-link {% block nav_console %}{% endblock %}">
       <span class="nav-icon">🔬</span> Console
     </a>

--- a/crates/daly-bms-server/templates/mqtt.html
+++ b/crates/daly-bms-server/templates/mqtt.html
@@ -1,0 +1,405 @@
+{% extends "base.html" %}
+{% block title %}MQTT Broker — ESS Monitor{% endblock %}
+{% block page_title %}MQTT Broker{% endblock %}
+{% block nav_mqtt %}active{% endblock %}
+
+{% block content %}
+<div class="page-hdr">
+  <h1>📡 MQTT Broker &amp; Bridge</h1>
+  <div class="page-hdr-meta">
+    <span>Màj : <span id="mqtt-ts">—</span></span>
+    <span class="sep">·</span>
+    <span id="mqtt-status-badge" class="bms-badge" style="background:#e2e8f0;color:#64748b">En attente…</span>
+  </div>
+</div>
+
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1.25rem;">
+
+  <!-- ═══════════════════════════════════════════════════════════ Broker -->
+  <div class="bms-card" id="card-broker">
+    <div class="bms-hdr" style="background:linear-gradient(135deg,#dbeafe,#bfdbfe);">
+      <div class="bms-hdr-left">
+        <span class="bms-hdr-name">⚡ Broker rumqttd</span>
+        <span id="broker-badge" class="bms-badge" style="background:#e2e8f0;color:#64748b">—</span>
+      </div>
+    </div>
+    <div style="padding:0.85rem 1rem;display:flex;flex-direction:column;gap:0.55rem;">
+      <div class="kpi-row">
+        <span class="kpi-label">Port TCP</span>
+        <span class="kpi-val" style="font-family:monospace;">:1883</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">WebSocket</span>
+        <span class="kpi-val" style="font-family:monospace;">:9001</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">Uptime</span>
+        <span class="kpi-val" id="broker-uptime">—</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">Messages reçus</span>
+        <span class="kpi-val" id="broker-msgs-rx">—</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">Persistence</span>
+        <span class="kpi-val" style="font-family:monospace;font-size:0.78rem;">/var/lib/mqtt-broker</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ═══════════════════════════════════════════════════════════ Bridge -->
+  <div class="bms-card" id="card-bridge">
+    <div class="bms-hdr" style="background:linear-gradient(135deg,#d1fae5,#a7f3d0);">
+      <div class="bms-hdr-left">
+        <span class="bms-hdr-name">🔗 Bridge Pi5 ↔ NanoPi</span>
+        <span id="bridge-badge" class="bms-badge" style="background:#e2e8f0;color:#64748b">—</span>
+      </div>
+    </div>
+    <div style="padding:0.85rem 1rem;display:flex;flex-direction:column;gap:0.55rem;">
+      <div class="kpi-row">
+        <span class="kpi-label">Local (rumqttd)</span>
+        <span class="kpi-val" id="bridge-local">—</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">NanoPi (192.168.1.120)</span>
+        <span class="kpi-val" id="bridge-remote">—</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">Uptime</span>
+        <span class="kpi-val" id="bridge-uptime">—</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">→ NanoPi (total)</span>
+        <span class="kpi-val" id="bridge-l2r">—</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">← NanoPi (total)</span>
+        <span class="kpi-val" id="bridge-r2l">—</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">Reconnexions local</span>
+        <span class="kpi-val" id="bridge-recon-local">—</span>
+      </div>
+      <div class="kpi-row">
+        <span class="kpi-label">Reconnexions NanoPi</span>
+        <span class="kpi-val" id="bridge-recon-remote">—</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ═══════════════════════════════════════════════════════════ Topics bridgés -->
+  <div class="bms-card" id="card-topics" style="grid-column:span 1;">
+    <div class="bms-hdr" style="background:linear-gradient(135deg,#fef3c7,#fde68a);">
+      <div class="bms-hdr-left"><span class="bms-hdr-name">📋 Topics Bridgés</span></div>
+    </div>
+    <div style="padding:0.75rem 1rem;">
+      <p style="font-size:0.78rem;color:var(--muted);margin:0 0 0.6rem;">
+        Règles reproduisant <code>mosquitto.conf / connection nanopi-venus-bridge</code>
+      </p>
+      <table style="width:100%;border-collapse:collapse;font-size:0.78rem;">
+        <thead>
+          <tr style="border-bottom:1px solid var(--border);">
+            <th style="text-align:left;padding:0.3rem 0.4rem;color:var(--muted);">Topic</th>
+            <th style="text-align:center;padding:0.3rem 0.4rem;color:var(--muted);">Direction</th>
+            <th style="text-align:center;padding:0.3rem 0.4rem;color:var(--muted);">QoS</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="topic-row"><td><code>N/c0619ab9929a/#</code></td><td style="text-align:center;">← NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>W/c0619ab9929a/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">1</td></tr>
+          <tr class="topic-row"><td><code>R/c0619ab9929a/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">1</td></tr>
+          <tr class="topic-row"><td><code>santuario/#</code></td><td style="text-align:center;">← NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>santuario/heat/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>santuario/heatpump/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>santuario/meteo/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>santuario/switch/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>santuario/grid/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>santuario/platform/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>santuario/inverter/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>santuario/system/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>santuario/pvinverter/#</code></td><td style="text-align:center;">→ NanoPi</td><td style="text-align:center;">0</td></tr>
+          <tr class="topic-row"><td><code>shellypro2pm-.../#</code></td><td style="text-align:center;">↔ Bidi</td><td style="text-align:center;">0</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- ═══════════════════════════════════════════════════════════ WebSocket MQTT Explorer -->
+  <div class="bms-card" id="card-ws" style="grid-column:1/-1;">
+    <div class="bms-hdr" style="background:linear-gradient(135deg,#ede9fe,#ddd6fe);">
+      <div class="bms-hdr-left">
+        <span class="bms-hdr-name">🔍 Explorateur MQTT (WebSocket :9001)</span>
+      </div>
+      <div style="display:flex;gap:0.5rem;align-items:center;">
+        <input id="ws-topic" type="text" value="santuario/#"
+               style="font-family:monospace;font-size:0.8rem;padding:0.3rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--surface2);color:var(--text);width:200px;">
+        <button id="ws-connect-btn" onclick="wsToggle()"
+                style="padding:0.3rem 0.75rem;border-radius:5px;border:none;cursor:pointer;background:var(--accent);color:#fff;font-size:0.8rem;">
+          Connecter
+        </button>
+        <button onclick="wsClear()"
+                style="padding:0.3rem 0.75rem;border-radius:5px;border:1px solid var(--border);cursor:pointer;background:var(--surface2);color:var(--text);font-size:0.8rem;">
+          Effacer
+        </button>
+      </div>
+    </div>
+    <div style="padding:0.75rem 1rem;">
+      <div id="ws-status" style="font-size:0.78rem;margin-bottom:0.5rem;color:var(--muted);">
+        WebSocket déconnecté — cliquez sur "Connecter"
+      </div>
+      <div id="ws-log"
+           style="font-family:monospace;font-size:0.75rem;height:320px;overflow-y:auto;background:var(--bg2);
+                  border:1px solid var(--border);border-radius:6px;padding:0.6rem;color:var(--text2);">
+        <div style="color:var(--muted);"># En attente de messages…</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<style>
+.kpi-row { display:flex;justify-content:space-between;font-size:0.83rem; }
+.kpi-label { color:var(--muted); }
+.kpi-val   { font-weight:600; }
+.topic-row td { padding:0.28rem 0.4rem;border-bottom:1px solid var(--border); }
+.topic-row:last-child td { border-bottom:none; }
+.topic-row code { font-size:0.75rem;color:var(--accent); }
+</style>
+
+<script>
+// =============================================================================
+// Polling REST /api/v1/mqtt/status
+// =============================================================================
+
+function fmtUptime(s) {
+  if (!s) return '—';
+  const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), sec = s % 60;
+  if (h > 0) return h + 'h ' + m + 'm';
+  if (m > 0) return m + 'm ' + sec + 's';
+  return sec + 's';
+}
+
+function connBadge(ok) {
+  return ok
+    ? '<span class="bms-badge" style="background:#dcfce7;color:#16a34a">Connecté</span>'
+    : '<span class="bms-badge" style="background:#fee2e2;color:#dc2626">Déconnecté</span>';
+}
+
+async function refreshMqtt() {
+  try {
+    const r = await fetch('/api/v1/mqtt/status');
+    const d = await r.json();
+    const b = d.broker, br = d.bridge;
+
+    // Timestamp
+    document.getElementById('mqtt-ts').textContent =
+      d.timestamp ? new Date(d.timestamp).toLocaleTimeString('fr-FR') : '—';
+
+    // Badge global
+    const allOk = b.running && br.local_connected && br.remote_connected;
+    const badge = document.getElementById('mqtt-status-badge');
+    badge.textContent = allOk ? 'OK' : 'Dégradé';
+    badge.style.background = allOk ? '#dcfce7' : '#fef3c7';
+    badge.style.color       = allOk ? '#16a34a' : '#92400e';
+
+    // Broker
+    const brokerBadge = document.getElementById('broker-badge');
+    brokerBadge.innerHTML = b.running
+      ? '<span style="color:#16a34a;">● Actif</span>'
+      : '<span style="color:#dc2626;">● Arrêté</span>';
+    document.getElementById('broker-uptime').textContent   = fmtUptime(b.uptime_secs);
+    document.getElementById('broker-msgs-rx').textContent  = (b.messages_rx ?? 0).toLocaleString('fr-FR') + ' msgs';
+
+    // Bridge
+    const bridgeBadge = document.getElementById('bridge-badge');
+    const bridgeOk = br.local_connected && br.remote_connected;
+    bridgeBadge.innerHTML = bridgeOk
+      ? '<span style="color:#16a34a;">● Actif</span>'
+      : '<span style="color:#dc2626;">● Dégradé</span>';
+    document.getElementById('bridge-local').innerHTML  = connBadge(br.local_connected);
+    document.getElementById('bridge-remote').innerHTML = connBadge(br.remote_connected);
+    document.getElementById('bridge-uptime').textContent = fmtUptime(br.uptime_secs);
+    document.getElementById('bridge-l2r').textContent    = (br.msgs_local_to_remote ?? 0).toLocaleString('fr-FR') + ' msgs';
+    document.getElementById('bridge-r2l').textContent    = (br.msgs_remote_to_local ?? 0).toLocaleString('fr-FR') + ' msgs';
+    document.getElementById('bridge-recon-local').textContent  = br.reconnects_local ?? 0;
+    document.getElementById('bridge-recon-remote').textContent = br.reconnects_remote ?? 0;
+
+  } catch (e) {
+    document.getElementById('mqtt-status-badge').textContent = 'Erreur';
+  }
+}
+
+refreshMqtt();
+setInterval(refreshMqtt, 10000);
+
+// =============================================================================
+// WebSocket MQTT Explorer (connexion vers :9001, protocole MQTT over WS)
+// =============================================================================
+
+let mqttWs = null;
+let wsConnected = false;
+let msgCount = 0;
+const MAX_LINES = 200;
+
+function wsToggle() {
+  wsConnected ? wsDisconnect() : wsConnect();
+}
+
+function wsConnect() {
+  const topic = document.getElementById('ws-topic').value.trim() || '#';
+  const host   = window.location.hostname;
+  const url    = `ws://${host}:9001/mqtt`;
+
+  wsLog('info', `Connexion à ${url} (topic: ${topic})…`);
+
+  try {
+    // Connexion WebSocket avec sous-protocole MQTT
+    mqttWs = new WebSocket(url, ['mqtt']);
+    mqttWs.binaryType = 'arraybuffer';
+  } catch(e) {
+    wsLog('error', 'WebSocket non supporté ou broker inaccessible : ' + e.message);
+    return;
+  }
+
+  mqttWs.onopen = () => {
+    wsConnected = true;
+    document.getElementById('ws-connect-btn').textContent = 'Déconnecter';
+    document.getElementById('ws-status').innerHTML =
+      '<span style="color:#16a34a;">●</span> Connecté — abonnement sur <code>' + topic + '</code>';
+
+    // MQTT CONNECT packet (v3.1.1, clean session, no auth)
+    const clientId = 'ess-explorer-' + Math.random().toString(36).slice(2, 8);
+    mqttWs.send(buildConnect(clientId));
+  };
+
+  mqttWs.onmessage = (ev) => {
+    const data = new Uint8Array(ev.data);
+    handlePacket(data, topic);
+  };
+
+  mqttWs.onerror = () => {
+    wsLog('error', 'Erreur WebSocket — vérifier que le broker est actif sur :9001');
+  };
+
+  mqttWs.onclose = () => {
+    wsConnected = false;
+    document.getElementById('ws-connect-btn').textContent = 'Connecter';
+    document.getElementById('ws-status').innerHTML =
+      '<span style="color:#dc2626;">●</span> Déconnecté';
+    wsLog('info', 'Connexion fermée');
+  };
+}
+
+function wsDisconnect() {
+  if (mqttWs) { mqttWs.close(); mqttWs = null; }
+}
+
+function wsClear() {
+  document.getElementById('ws-log').innerHTML =
+    '<div style="color:var(--muted);"># Log effacé</div>';
+  msgCount = 0;
+}
+
+// Build MQTT CONNECT packet (v3.1.1)
+function buildConnect(clientId) {
+  const idBytes = new TextEncoder().encode(clientId);
+  const plen    = 10 + 2 + idBytes.length;
+  const buf     = new Uint8Array(2 + plen);
+  let i = 0;
+  buf[i++] = 0x10;          // CONNECT type
+  buf[i++] = plen;          // remaining length
+  buf[i++] = 0; buf[i++] = 4; // protocol name length
+  buf[i++] = 0x4D; buf[i++] = 0x51; buf[i++] = 0x54; buf[i++] = 0x54; // MQTT
+  buf[i++] = 0x04;          // protocol level 3.1.1
+  buf[i++] = 0x02;          // connect flags: clean session
+  buf[i++] = 0; buf[i++] = 60; // keepalive 60s
+  buf[i++] = 0; buf[i++] = idBytes.length;
+  idBytes.forEach(b => { buf[i++] = b; });
+  return buf.buffer;
+}
+
+// Build MQTT SUBSCRIBE packet
+function buildSubscribe(topic, msgId) {
+  const topicBytes = new TextEncoder().encode(topic);
+  const plen = 2 + 2 + topicBytes.length + 1;
+  const buf  = new Uint8Array(2 + plen);
+  let i = 0;
+  buf[i++] = 0x82;          // SUBSCRIBE type + flags
+  buf[i++] = plen;
+  buf[i++] = (msgId >> 8) & 0xFF; buf[i++] = msgId & 0xFF;
+  buf[i++] = 0; buf[i++] = topicBytes.length;
+  topicBytes.forEach(b => { buf[i++] = b; });
+  buf[i++] = 0x00;          // QoS 0
+  return buf.buffer;
+}
+
+// Parse received MQTT packet
+function handlePacket(data, subTopic) {
+  if (data.length < 2) return;
+  const type = (data[0] & 0xF0) >> 4;
+
+  if (type === 2) {
+    // CONNACK — subscribe now
+    if (data[3] === 0) {
+      wsLog('ok', 'CONNACK reçu — abonnement sur ' + subTopic);
+      mqttWs.send(buildSubscribe(subTopic, 1));
+    } else {
+      wsLog('error', 'CONNACK erreur code=' + data[3]);
+    }
+  } else if (type === 9) {
+    // SUBACK
+    wsLog('ok', 'SUBACK — abonnement confirmé');
+  } else if (type === 3) {
+    // PUBLISH — parse topic + payload
+    try {
+      let i = 1;
+      let remLen = 0, mult = 1;
+      do { remLen += (data[i] & 0x7F) * mult; mult *= 128; } while (data[i++] & 0x80);
+      const topicLen = (data[i] << 8) | data[i+1]; i += 2;
+      const topicBytes = data.slice(i, i + topicLen); i += topicLen;
+      const topic = new TextDecoder().decode(topicBytes);
+      // Skip packet id for QoS > 0
+      if ((data[0] & 0x06) > 0) i += 2;
+      const payload = new TextDecoder().decode(data.slice(i));
+      wsLogMsg(topic, payload);
+      msgCount++;
+    } catch(_) {}
+  }
+}
+
+function wsLog(level, msg) {
+  const log = document.getElementById('ws-log');
+  const colors = { info: 'var(--muted)', ok: '#16a34a', error: '#dc2626' };
+  const line = document.createElement('div');
+  line.style.color = colors[level] || 'var(--text)';
+  line.textContent = new Date().toLocaleTimeString('fr-FR') + '  ' + msg;
+  log.appendChild(line);
+  trimLog(log);
+  log.scrollTop = log.scrollHeight;
+}
+
+function wsLogMsg(topic, payload) {
+  const log = document.getElementById('ws-log');
+  const line = document.createElement('div');
+
+  let pretty = payload;
+  try { pretty = JSON.stringify(JSON.parse(payload), null, null); } catch(_) {}
+
+  line.innerHTML =
+    '<span style="color:var(--accent);">' + escHtml(topic) + '</span>' +
+    ' <span style="color:var(--muted);">→</span> ' +
+    '<span style="color:var(--text);">' + escHtml(pretty.slice(0, 200)) + '</span>';
+  log.appendChild(line);
+  trimLog(log);
+  log.scrollTop = log.scrollHeight;
+}
+
+function trimLog(log) {
+  while (log.children.length > MAX_LINES) log.removeChild(log.firstChild);
+}
+
+function escHtml(s) {
+  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+</script>
+{% endblock %}

--- a/crates/mqtt-bridge/Cargo.toml
+++ b/crates/mqtt-bridge/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name        = "mqtt-bridge"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Bridge MQTT bidirectionnel Pi5 (rumqttd) ↔ NanoPi — remplace la section bridge de mosquitto.conf"
+
+[[bin]]
+name = "mqtt-bridge"
+path = "src/main.rs"
+
+[dependencies]
+rumqttc    = { workspace = true }
+tokio      = { workspace = true }
+serde      = { workspace = true }
+toml       = { workspace = true }
+anyhow     = { workspace = true }
+tracing              = { workspace = true }
+tracing-subscriber   = { workspace = true }
+axum       = { workspace = true }
+chrono     = { workspace = true }
+clap       = { workspace = true }
+sd-notify  = { workspace = true }
+bytes      = { workspace = true }
+futures    = { workspace = true }

--- a/crates/mqtt-bridge/src/bridge.rs
+++ b/crates/mqtt-bridge/src/bridge.rs
@@ -1,0 +1,202 @@
+//! Logique de bridge bidirectionnel Pi5 (local rumqttd) ↔ NanoPi.
+//!
+//! Deux demi-bridges indépendants, chacun dans sa propre tâche async :
+//!   - `run_nanopi_to_local` : abonné sur NanoPi, republish vers Pi5 local
+//!   - `run_local_to_nanopi` : abonné sur Pi5 local, republish vers NanoPi
+//!
+//! En cas de déconnexion, reconnexion automatique avec backoff.
+
+use crate::{config::BridgeConfig, metrics::BridgeMetrics};
+use anyhow::Result;
+use rumqttc::{AsyncClient, EventLoop, MqttOptions, QoS};
+use std::{sync::Arc, time::Duration};
+use tokio::time::sleep;
+use tracing::{info, warn};
+
+// =============================================================================
+// Topics bridgés depuis NanoPi → Pi5 local (direction "in")
+// =============================================================================
+
+fn nanopi_to_local_subscriptions(portal: &str) -> Vec<(String, QoS)> {
+    vec![
+        // Venus OS données publiées par Venus OS
+        (format!("N/{portal}/#"), QoS::AtMostOnce),
+        // Données BMS publiées par dbus-mqtt-venus sur NanoPi
+        ("santuario/#".to_string(), QoS::AtMostOnce),
+        // Shelly bidirectionnel
+        ("shellypro2pm-ec62608840a4/#".to_string(), QoS::AtMostOnce),
+    ]
+}
+
+// =============================================================================
+// Topics bridgés depuis Pi5 local → NanoPi (direction "out")
+// =============================================================================
+
+fn local_to_nanopi_subscriptions(portal: &str) -> Vec<(String, QoS)> {
+    vec![
+        // Venus OS commandes (écriture) — QoS 1 pour garantir la livraison
+        (format!("W/{portal}/#"), QoS::AtLeastOnce),
+        // Venus OS keepalive / requêtes lecture — QoS 1
+        (format!("R/{portal}/#"), QoS::AtLeastOnce),
+        // Topics santuario envoyés depuis Pi5 vers NanoPi
+        ("santuario/heat/#".to_string(),      QoS::AtMostOnce),
+        ("santuario/heatpump/#".to_string(),  QoS::AtMostOnce),
+        ("santuario/meteo/#".to_string(),     QoS::AtMostOnce),
+        ("santuario/switch/#".to_string(),    QoS::AtMostOnce),
+        ("santuario/grid/#".to_string(),      QoS::AtMostOnce),
+        ("santuario/platform/#".to_string(),  QoS::AtMostOnce),
+        ("santuario/inverter/#".to_string(),  QoS::AtMostOnce),
+        ("santuario/system/#".to_string(),    QoS::AtMostOnce),
+        ("santuario/pvinverter/#".to_string(), QoS::AtMostOnce),
+        // Shelly bidirectionnel
+        ("shellypro2pm-ec62608840a4/#".to_string(), QoS::AtMostOnce),
+    ]
+}
+
+// =============================================================================
+// Helper : construire MqttOptions
+// =============================================================================
+
+fn make_opts(host: &str, port: u16, client_id: &str, keepalive_secs: u16) -> MqttOptions {
+    let mut opts = MqttOptions::new(client_id, host, port);
+    opts.set_keep_alive(Duration::from_secs(keepalive_secs as u64));
+    opts.set_clean_session(false);
+    opts.set_max_packet_size(1_048_576, 1_048_576);
+    opts
+}
+
+// =============================================================================
+// Demi-bridge : NanoPi → Pi5 local
+// =============================================================================
+
+pub async fn run_nanopi_to_local(cfg: Arc<BridgeConfig>, metrics: Arc<BridgeMetrics>) -> Result<()> {
+    let portal = &cfg.portal_id;
+    let subs   = nanopi_to_local_subscriptions(portal);
+    let reconnect = Duration::from_secs(cfg.reconnect_secs);
+
+    loop {
+        info!("[nanopi→local] Connexion {}:{}", cfg.remote_host, cfg.remote_port);
+
+        // Client abonné : se connecte au NanoPi
+        let sub_opts = make_opts(&cfg.remote_host, cfg.remote_port,
+                                 "dalybms-bridge-sub", cfg.keepalive_secs);
+        let (sub_client, mut sub_el) = AsyncClient::new(sub_opts, 64);
+
+        // Client publisher : publie sur Pi5 local
+        let pub_opts = make_opts(&cfg.local_host, cfg.local_port,
+                                 "dalybms-bridge-pub-n2l", cfg.keepalive_secs);
+        let (pub_client, mut pub_el) = AsyncClient::new(pub_opts, 64);
+
+        // Connexion locale (publisher)
+        tokio::spawn(async move { while pub_el.poll().await.is_ok() {} });
+
+        // Abonnements sur NanoPi
+        for (topic, qos) in &subs {
+            if let Err(e) = sub_client.subscribe(topic, *qos).await {
+                warn!("[nanopi→local] Subscribe {topic} erreur : {e}");
+            }
+        }
+
+        metrics.remote_connected.store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // Boucle d'événements NanoPi
+        loop {
+            match sub_el.poll().await {
+                Ok(rumqttc::Event::Incoming(rumqttc::Packet::Publish(p))) => {
+                    let qos = if p.qos == rumqttc::QoS::AtLeastOnce {
+                        QoS::AtLeastOnce
+                    } else {
+                        QoS::AtMostOnce
+                    };
+                    if let Err(e) = pub_client
+                        .publish(&p.topic, qos, p.retain, p.payload.clone())
+                        .await
+                    {
+                        warn!("[nanopi→local] Republish {} erreur : {e}", p.topic);
+                    } else {
+                        metrics.msgs_remote_to_local
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    warn!("[nanopi→local] Déconnexion NanoPi : {e}");
+                    metrics.remote_connected.store(false, std::sync::atomic::Ordering::Relaxed);
+                    metrics.reconnects_remote.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    break;
+                }
+            }
+        }
+
+        info!("[nanopi→local] Reconnexion dans {}s…", reconnect.as_secs());
+        sleep(reconnect).await;
+    }
+}
+
+// =============================================================================
+// Demi-bridge : Pi5 local → NanoPi
+// =============================================================================
+
+pub async fn run_local_to_nanopi(cfg: Arc<BridgeConfig>, metrics: Arc<BridgeMetrics>) -> Result<()> {
+    let portal = &cfg.portal_id;
+    let subs   = local_to_nanopi_subscriptions(portal);
+    let reconnect = Duration::from_secs(cfg.reconnect_secs);
+
+    loop {
+        info!("[local→nanopi] Connexion {}:{}", cfg.local_host, cfg.local_port);
+
+        // Client abonné : se connecte au broker local (rumqttd)
+        let sub_opts = make_opts(&cfg.local_host, cfg.local_port,
+                                 "dalybms-bridge-sub-l2n", cfg.keepalive_secs);
+        let (sub_client, mut sub_el) = AsyncClient::new(sub_opts, 64);
+
+        // Client publisher : publie sur NanoPi
+        let pub_opts = make_opts(&cfg.remote_host, cfg.remote_port,
+                                 "dalybms-bridge-pub", cfg.keepalive_secs);
+        let (pub_client, mut pub_el) = AsyncClient::new(pub_opts, 64);
+
+        // Connexion NanoPi (publisher)
+        tokio::spawn(async move { while pub_el.poll().await.is_ok() {} });
+
+        // Abonnements sur broker local
+        for (topic, qos) in &subs {
+            if let Err(e) = sub_client.subscribe(topic, *qos).await {
+                warn!("[local→nanopi] Subscribe {topic} erreur : {e}");
+            }
+        }
+
+        metrics.local_connected.store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // Boucle d'événements local
+        loop {
+            match sub_el.poll().await {
+                Ok(rumqttc::Event::Incoming(rumqttc::Packet::Publish(p))) => {
+                    let qos = if p.qos == rumqttc::QoS::AtLeastOnce {
+                        QoS::AtLeastOnce
+                    } else {
+                        QoS::AtMostOnce
+                    };
+                    if let Err(e) = pub_client
+                        .publish(&p.topic, qos, p.retain, p.payload.clone())
+                        .await
+                    {
+                        warn!("[local→nanopi] Republish {} erreur : {e}", p.topic);
+                    } else {
+                        metrics.msgs_local_to_remote
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    warn!("[local→nanopi] Déconnexion locale : {e}");
+                    metrics.local_connected.store(false, std::sync::atomic::Ordering::Relaxed);
+                    metrics.reconnects_local.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    break;
+                }
+            }
+        }
+
+        info!("[local→nanopi] Reconnexion dans {}s…", reconnect.as_secs());
+        sleep(reconnect).await;
+    }
+}

--- a/crates/mqtt-bridge/src/config.rs
+++ b/crates/mqtt-bridge/src/config.rs
@@ -1,0 +1,58 @@
+//! Chargement de la section [mqtt_bridge] depuis Config.toml.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct BridgeConfig {
+    /// Broker local (rumqttd) — ex: "127.0.0.1"
+    #[serde(default = "default_local_host")]
+    pub local_host: String,
+
+    /// Port broker local
+    #[serde(default = "default_local_port")]
+    pub local_port: u16,
+
+    /// Broker distant NanoPi — ex: "192.168.1.120"
+    #[serde(default = "default_remote_host")]
+    pub remote_host: String,
+
+    /// Port broker NanoPi
+    #[serde(default = "default_remote_port")]
+    pub remote_port: u16,
+
+    /// Préfixe Venus OS portal_id — ex: "c0619ab9929a"
+    #[serde(default = "default_portal_id")]
+    pub portal_id: String,
+
+    /// Délai de reconnexion en secondes
+    #[serde(default = "default_reconnect_secs")]
+    pub reconnect_secs: u64,
+
+    /// Keep-alive en secondes
+    #[serde(default = "default_keepalive_secs")]
+    pub keepalive_secs: u16,
+}
+
+fn default_local_host()    -> String { "127.0.0.1".into() }
+fn default_local_port()    -> u16    { 1883 }
+fn default_remote_host()   -> String { "192.168.1.120".into() }
+fn default_remote_port()   -> u16    { 1883 }
+fn default_portal_id()     -> String { "c0619ab9929a".into() }
+fn default_reconnect_secs() -> u64   { 30 }
+fn default_keepalive_secs() -> u16   { 60 }
+
+/// Enveloppe pour parser uniquement [mqtt_bridge] dans Config.toml.
+#[derive(Deserialize)]
+struct Wrapper {
+    mqtt_bridge: BridgeConfig,
+}
+
+pub fn load(path: &Path) -> Result<BridgeConfig> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("Lecture config : {}", path.display()))?;
+    let w: Wrapper = toml::from_str(&raw)
+        .with_context(|| "Parse [mqtt_bridge] dans config TOML")?;
+    Ok(w.mqtt_bridge)
+}

--- a/crates/mqtt-bridge/src/main.rs
+++ b/crates/mqtt-bridge/src/main.rs
@@ -1,0 +1,96 @@
+//! Bridge MQTT bidirectionnel Pi5 ↔ NanoPi.
+//!
+//! Reproduit exactement la section `connection nanopi-venus-bridge` de mosquitto.conf :
+//!
+//!   • `N/c0619ab9929a/#`               NanoPi → Pi5  (QoS 0)
+//!   • `W/c0619ab9929a/#`               Pi5 → NanoPi  (QoS 1)
+//!   • `R/c0619ab9929a/#`               Pi5 → NanoPi  (QoS 1)
+//!   • `santuario/#`                    NanoPi → Pi5  (QoS 0)
+//!   • `santuario/{heat,heatpump,...}/#` Pi5 → NanoPi  (QoS 0)
+//!   • `shellypro2pm-ec62608840a4/#`    bidirectionnel (QoS 0)
+//!
+//! Métriques exposées sur http://127.0.0.1:8084/metrics (JSON).
+//!
+//! Usage : mqtt-bridge --config /etc/daly-bms/config.toml
+
+mod bridge;
+mod config;
+mod metrics;
+
+use anyhow::Result;
+use axum::{routing::get, Json, Router};
+use clap::Parser;
+use metrics::BridgeMetrics;
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use tracing::info;
+
+// =============================================================================
+// CLI
+// =============================================================================
+
+#[derive(Parser)]
+#[command(name = "mqtt-bridge", about = "Bridge MQTT Pi5 ↔ NanoPi pour DalyBMS")]
+struct Cli {
+    #[arg(long, default_value = "/etc/daly-bms/config.toml")]
+    config: PathBuf,
+
+    #[arg(long, default_value = "127.0.0.1:8084")]
+    metrics_addr: SocketAddr,
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "mqtt_bridge=info".into()),
+        )
+        .init();
+
+    let cfg = config::load(&cli.config)?;
+    info!(
+        local  = %cfg.local_host,
+        remote = %cfg.remote_host,
+        "Bridge MQTT démarré"
+    );
+
+    let metrics = Arc::new(BridgeMetrics::new());
+
+    // ── Serveur HTTP métriques ────────────────────────────────────────────────
+    {
+        let m = Arc::clone(&metrics);
+        let app = Router::new()
+            .route("/metrics", get(move || {
+                let m2 = Arc::clone(&m);
+                async move { Json(m2.snapshot()) }
+            }))
+            .route("/health", get(|| async { "ok" }));
+        let addr = cli.metrics_addr;
+        tokio::spawn(async move {
+            let listener = tokio::net::TcpListener::bind(addr).await
+                .expect("Bind HTTP métriques bridge");
+            info!("HTTP métriques bridge sur http://{addr}/metrics");
+            axum::serve(listener, app).await.expect("Serveur métriques bridge");
+        });
+    }
+
+    // ── Notification systemd ready ────────────────────────────────────────────
+    let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]);
+
+    // ── Lancement des deux demi-bridges en parallèle ──────────────────────────
+    let cfg = Arc::new(cfg);
+    let (r1, r2) = tokio::join!(
+        bridge::run_nanopi_to_local(Arc::clone(&cfg), Arc::clone(&metrics)),
+        bridge::run_local_to_nanopi(Arc::clone(&cfg), Arc::clone(&metrics)),
+    );
+    r1?;
+    r2?;
+
+    Ok(())
+}

--- a/crates/mqtt-bridge/src/metrics.rs
+++ b/crates/mqtt-bridge/src/metrics.rs
@@ -1,0 +1,55 @@
+//! Compteurs atomiques exposés via HTTP /metrics.
+
+use chrono::Utc;
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Instant;
+
+pub struct BridgeMetrics {
+    pub start:               Instant,
+    pub local_connected:     AtomicBool,
+    pub remote_connected:    AtomicBool,
+    pub msgs_local_to_remote: AtomicU64,
+    pub msgs_remote_to_local: AtomicU64,
+    pub reconnects_local:    AtomicU64,
+    pub reconnects_remote:   AtomicU64,
+}
+
+impl BridgeMetrics {
+    pub fn new() -> Self {
+        Self {
+            start:                Instant::now(),
+            local_connected:      AtomicBool::new(false),
+            remote_connected:     AtomicBool::new(false),
+            msgs_local_to_remote: AtomicU64::new(0),
+            msgs_remote_to_local: AtomicU64::new(0),
+            reconnects_local:     AtomicU64::new(0),
+            reconnects_remote:    AtomicU64::new(0),
+        }
+    }
+
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        MetricsSnapshot {
+            uptime_secs:          self.start.elapsed().as_secs(),
+            local_connected:      self.local_connected.load(Ordering::Relaxed),
+            remote_connected:     self.remote_connected.load(Ordering::Relaxed),
+            msgs_local_to_remote: self.msgs_local_to_remote.load(Ordering::Relaxed),
+            msgs_remote_to_local: self.msgs_remote_to_local.load(Ordering::Relaxed),
+            reconnects_local:     self.reconnects_local.load(Ordering::Relaxed),
+            reconnects_remote:    self.reconnects_remote.load(Ordering::Relaxed),
+            timestamp:            Utc::now().to_rfc3339(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct MetricsSnapshot {
+    pub uptime_secs:          u64,
+    pub local_connected:      bool,
+    pub remote_connected:     bool,
+    pub msgs_local_to_remote: u64,
+    pub msgs_remote_to_local: u64,
+    pub reconnects_local:     u64,
+    pub reconnects_remote:    u64,
+    pub timestamp:            String,
+}

--- a/crates/mqtt-broker/Cargo.toml
+++ b/crates/mqtt-broker/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name        = "mqtt-broker"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Broker MQTT Rust (rumqttd) — remplace Mosquitto/Docker sur Pi5"
+
+[[bin]]
+name = "mqtt-broker"
+path = "src/main.rs"
+
+[dependencies]
+rumqttd    = { workspace = true }
+tokio      = { workspace = true }
+serde      = { workspace = true }
+toml       = { workspace = true }
+anyhow     = { workspace = true }
+tracing              = { workspace = true }
+tracing-subscriber   = { workspace = true }
+tracing-appender     = { workspace = true }
+axum       = { workspace = true }
+chrono     = { workspace = true }
+clap       = { workspace = true }
+sd-notify  = { workspace = true }

--- a/crates/mqtt-broker/mqtt-broker.toml
+++ b/crates/mqtt-broker/mqtt-broker.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# mqtt-broker.toml — Configuration rumqttd pour DalyBMS / Pi5
+# Déployer sur Pi5 : sudo cp mqtt-broker.toml /etc/daly-bms/mqtt-broker.toml
+# =============================================================================
+
+# Stockage persistence (retained messages + segments QoS 1/2)
+# Créer : sudo mkdir -p /var/lib/mqtt-broker && sudo chown mqtt-broker:mqtt-broker /var/lib/mqtt-broker
+[router]
+id                     = 0
+path                   = "/var/lib/mqtt-broker"
+max_connections        = 1000
+max_outgoing_packet_count = 200
+max_segment_size       = 104857600   # 100 MB
+max_segment_count      = 10
+
+# ── Listener MQTT standard TCP :1883 ─────────────────────────────────────────
+[v4.1]
+name                   = "v4-1"
+listen                 = "0.0.0.0:1883"
+next_connection_delay_ms = 1
+
+  [v4.1.connections]
+  connection_timeout_ms  = 5000
+  max_payload_size       = 1048576   # 1 MB — snapshots JSON BMS
+  max_inflight_count     = 200
+  dynamic_filters        = true
+
+# ── Listener WebSocket MQTT :9001 ─────────────────────────────────────────────
+[ws.1]
+name                   = "ws-1"
+listen                 = "0.0.0.0:9001"
+next_connection_delay_ms = 1
+
+  [ws.1.connections]
+  connection_timeout_ms  = 5000
+  max_payload_size       = 1048576
+  max_inflight_count     = 200
+  dynamic_filters        = true

--- a/crates/mqtt-broker/src/main.rs
+++ b/crates/mqtt-broker/src/main.rs
@@ -1,0 +1,172 @@
+//! Broker MQTT Rust — remplace Mosquitto/Docker sur Pi5.
+//!
+//! Basé sur rumqttd (même famille que rumqttc déjà utilisé dans le workspace).
+//! Fonctionnalités préservées vs Mosquitto :
+//!   - MQTT 3.1.1, QoS 0/1/2, retained messages, persistence disque
+//!   - Listener TCP  :1883
+//!   - Listener WS   :9001 (WebSocket MQTT pour dashboard JS)
+//!   - Anonymous (réseau local)
+//!   - Messages jusqu'à 1 MB
+//!
+//! Métriques exposées sur http://127.0.0.1:8082/metrics (JSON) pour le dashboard.
+//!
+//! Usage : mqtt-broker --config /etc/daly-bms/mqtt-broker.toml
+
+use anyhow::{Context, Result};
+use axum::{routing::get, Json, Router};
+use chrono::Utc;
+use clap::Parser;
+use rumqttd::{Broker, Config};
+use serde::Serialize;
+use std::{
+    net::SocketAddr,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Instant,
+};
+use tracing::{info, warn};
+
+// =============================================================================
+// CLI
+// =============================================================================
+
+#[derive(Parser)]
+#[command(name = "mqtt-broker", about = "Broker MQTT Rust (rumqttd) pour DalyBMS")]
+struct Cli {
+    #[arg(long, default_value = "/etc/daly-bms/mqtt-broker.toml")]
+    config: PathBuf,
+
+    #[arg(long, default_value = "127.0.0.1:8082")]
+    metrics_addr: SocketAddr,
+}
+
+// =============================================================================
+// Métriques partagées
+// =============================================================================
+
+#[derive(Default)]
+struct BrokerMetrics {
+    messages_rx:  AtomicU64,
+    messages_tx:  AtomicU64,
+    connections:  AtomicU64,
+    start_epoch:  AtomicU64,
+}
+
+#[derive(Serialize)]
+struct MetricsResponse {
+    status:       &'static str,
+    uptime_secs:  u64,
+    messages_rx:  u64,
+    messages_tx:  u64,
+    connections:  u64,
+    timestamp:    String,
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "mqtt_broker=info,rumqttd=info".into()),
+        )
+        .init();
+
+    // ── Chargement de la config ───────────────────────────────────────────────
+    let config_str = std::fs::read_to_string(&cli.config)
+        .with_context(|| format!("Lecture config : {}", cli.config.display()))?;
+    let config: Config = toml::from_str(&config_str)
+        .with_context(|| format!("Parse config TOML : {}", cli.config.display()))?;
+
+    info!("Broker MQTT démarré — TCP :1883, WS :9001");
+    info!("Persistence : {}", config.router.path.display());
+
+    // ── Métriques partagées ───────────────────────────────────────────────────
+    let metrics = Arc::new(BrokerMetrics::default());
+    metrics.start_epoch.store(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+        Ordering::Relaxed,
+    );
+
+    // ── Broker rumqttd ────────────────────────────────────────────────────────
+    let mut broker = Broker::new(config);
+
+    // Lien "monitor" pour compter les messages en transit
+    let (mut link_tx, mut link_rx) = broker
+        .link("__metrics__")
+        .context("Création du lien monitor")?;
+
+    // Abonnement wildcard pour compter tous les messages
+    link_tx.subscribe("#").context("Subscribe #")?;
+
+    let metrics_clone = Arc::clone(&metrics);
+    tokio::spawn(async move {
+        loop {
+            match link_rx.recv().await {
+                Ok(Some(_notif)) => {
+                    metrics_clone.messages_rx.fetch_add(1, Ordering::Relaxed);
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    warn!("Link monitor erreur : {e}");
+                    break;
+                }
+            }
+        }
+    });
+
+    // ── Serveur HTTP métriques ────────────────────────────────────────────────
+    let metrics_http = Arc::clone(&metrics);
+    let start_time = Instant::now();
+
+    let app = Router::new().route(
+        "/metrics",
+        get(move || {
+            let m = Arc::clone(&metrics_http);
+            let elapsed = start_time.elapsed().as_secs();
+            async move {
+                Json(MetricsResponse {
+                    status:      "running",
+                    uptime_secs: elapsed,
+                    messages_rx: m.messages_rx.load(Ordering::Relaxed),
+                    messages_tx: m.messages_tx.load(Ordering::Relaxed),
+                    connections: m.connections.load(Ordering::Relaxed),
+                    timestamp:   Utc::now().to_rfc3339(),
+                })
+            }
+        }),
+    )
+    .route("/health", get(|| async { "ok" }));
+
+    let metrics_addr = cli.metrics_addr;
+    tokio::spawn(async move {
+        let listener = tokio::net::TcpListener::bind(metrics_addr)
+            .await
+            .expect("Bind HTTP métriques");
+        info!("HTTP métriques sur http://{metrics_addr}/metrics");
+        axum::serve(listener, app).await.expect("Serveur métriques");
+    });
+
+    // ── Notification systemd ready ────────────────────────────────────────────
+    let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]);
+
+    // ── Démarrage broker (bloquant) ───────────────────────────────────────────
+    tokio::task::spawn_blocking(move || {
+        broker.start().expect("Erreur fatale broker MQTT");
+    })
+    .await
+    .context("Broker MQTT thread")?;
+
+    Ok(())
+}

--- a/docs/mqtt-broker.md
+++ b/docs/mqtt-broker.md
@@ -1,0 +1,202 @@
+# Migration MQTT : Mosquitto/Docker → rumqttd + mqtt-bridge (Rust natif)
+
+## Contexte
+
+Mosquitto fonctionnait sous Docker sur le Pi5 avec un bridge MQTT vers le NanoPi.
+Cette migration remplace ce setup par deux services systemd Rust natifs :
+
+| Ancien | Nouveau |
+|--------|---------|
+| Docker + Mosquitto | `mqtt-broker` (rumqttd) |
+| `mosquitto.conf` section `bridge` | `mqtt-bridge` (rumqttc) |
+| `make up` / `make down` | `make mqtt-start` / `make mqtt-stop` |
+| port 1883 TCP | port 1883 TCP (identique) |
+| port 9001 WebSocket | port 9001 WebSocket (identique) |
+
+---
+
+## Architecture
+
+```
+Pi5 (127.0.0.1)
+  mqtt-broker (rumqttd)
+    ├── TCP  :1883    ← daly-bms-server, energy-manager, Tasmota, Shelly
+    ├── WS   :9001    ← explorateur MQTT dashboard JS
+    ├── HTTP :8082    ← /metrics (pour monitor agent + dashboard)
+    └── Persistence /var/lib/mqtt-broker (retained + QoS 1/2)
+
+  mqtt-bridge (rumqttc)
+    ├── HTTP :8084    ← /metrics
+    ├── SUB  localhost:1883   topics W/R/santuario/shellypro2pm → NanoPi
+    └── SUB  192.168.1.120:1883  topics N/santuario → Pi5 local
+
+NanoPi (192.168.1.120)
+  Mosquitto :1883  ← broker Venus OS natif (inchangé)
+```
+
+---
+
+## Fonctionnalités préservées
+
+| Fonctionnalité Mosquitto | Équivalent rumqttd |
+|------------------------|-------------------|
+| `listener 1883` | `[v4.1] listen = "0.0.0.0:1883"` |
+| `listener 9001 websockets` | `[ws.1] listen = "0.0.0.0:9001"` |
+| `allow_anonymous true` | pas d'auth configurée |
+| `persistence true` | `router.path = "/var/lib/mqtt-broker"` |
+| `max_qos 2` | QoS 0/1/2 supporté nativement |
+| `message_size_limit 1048576` | `max_payload_size = 1048576` |
+| Bridge `N/c0619ab9929a/#` in | `mqtt-bridge` subscribe NanoPi → republish local |
+| Bridge `W/c0619ab9929a/#` out QoS 1 | `mqtt-bridge` subscribe local → republish NanoPi QoS 1 |
+| Bridge `R/c0619ab9929a/#` out QoS 1 | idem |
+| Bridge `santuario/#` in | `mqtt-bridge` subscribe NanoPi → republish local |
+| Bridge `santuario/{heat,heatpump,...}/#` out | `mqtt-bridge` subscribe local → republish NanoPi |
+| Bridge `shellypro2pm-.../#` both | `mqtt-bridge` bidirectionnel |
+
+---
+
+## Installation initiale (premier déploiement sur Pi5)
+
+```bash
+# 1. Compiler
+make build-mqtt-arm
+
+# 2. Déployer (script automatique)
+bash scripts/deploy-pi5.sh --mqtt-only
+
+# OU déploiement manuel :
+
+# Créer l'utilisateur système
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin mqtt-broker
+
+# Répertoire persistence
+sudo mkdir -p /var/lib/mqtt-broker
+sudo chown mqtt-broker:mqtt-broker /var/lib/mqtt-broker
+
+# Copier les binaires
+sudo cp target/aarch64-unknown-linux-gnu/release/mqtt-broker /usr/local/bin/
+sudo cp target/aarch64-unknown-linux-gnu/release/mqtt-bridge /usr/local/bin/
+
+# Copier les configs
+sudo cp crates/mqtt-broker/mqtt-broker.toml /etc/daly-bms/
+sudo cp Config.toml /etc/daly-bms/config.toml  # contient [mqtt_bridge]
+
+# Enregistrer les services
+sudo cp contrib/mqtt-broker.service /etc/systemd/system/
+sudo cp contrib/mqtt-bridge.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable mqtt-broker mqtt-bridge
+sudo systemctl start mqtt-broker mqtt-bridge
+```
+
+---
+
+## Bascule depuis Mosquitto (migration live)
+
+Séquence recommandée (coupure ~2 minutes) :
+
+```bash
+# 1. Arrêter les services applicatifs
+sudo systemctl stop daly-bms energy-manager
+
+# 2. Arrêter Mosquitto Docker
+make down
+
+# 3. Démarrer rumqttd + bridge
+sudo systemctl start mqtt-broker
+sleep 3
+sudo systemctl start mqtt-bridge
+
+# 4. Vérifier
+journalctl -u mqtt-broker -n 20
+journalctl -u mqtt-bridge -n 20
+mosquitto_sub -h localhost -t "santuario/#" -v   # test
+
+# 5. Redémarrer les services
+sudo systemctl start daly-bms energy-manager
+```
+
+**Rollback :** `sudo systemctl stop mqtt-broker mqtt-bridge && make up`
+
+---
+
+## Commandes courantes
+
+| Action | Commande |
+|--------|----------|
+| Démarrer | `make mqtt-start` ou `sudo systemctl start mqtt-broker mqtt-bridge` |
+| Arrêter | `make mqtt-stop` |
+| Redémarrer | `make mqtt-restart` |
+| Logs temps réel | `make mqtt-logs` |
+| Statut | `make mqtt-status` |
+| Métriques broker | `curl http://localhost:8082/metrics` |
+| Métriques bridge | `curl http://localhost:8084/metrics` |
+
+---
+
+## Configuration
+
+### Broker (`/etc/daly-bms/mqtt-broker.toml`)
+
+Copié depuis `crates/mqtt-broker/mqtt-broker.toml`. Modifier si besoin et redémarrer :
+
+```bash
+sudo systemctl restart mqtt-broker
+```
+
+### Bridge (`/etc/daly-bms/config.toml` section `[mqtt_bridge]`)
+
+```toml
+[mqtt_bridge]
+local_host     = "127.0.0.1"
+local_port     = 1883
+remote_host    = "192.168.1.120"   # NanoPi
+remote_port    = 1883
+portal_id      = "c0619ab9929a"    # ID Victron GX
+reconnect_secs = 30
+keepalive_secs = 60
+```
+
+Après modification : `sudo cp Config.toml /etc/daly-bms/config.toml && sudo systemctl restart mqtt-bridge`
+
+---
+
+## Dashboard
+
+Page `/dashboard/mqtt` dans l'interface ESS Monitor :
+
+- **Broker** : statut (running/arrêté), uptime, messages reçus
+- **Bridge** : connexions local + NanoPi, compteurs messages bidirectionnels, reconnexions
+- **Topics bridgés** : tableau récapitulatif des règles (QoS, direction)
+- **Explorateur MQTT WebSocket** : connexion live sur `:9001`, abonnement à un topic, affichage temps réel
+
+L'API `/api/v1/mqtt/status` retourne le JSON complet mis à jour toutes les 30s par le monitor agent.
+
+---
+
+## Monitoring systemd
+
+Les deux services reportent leur statut à systemd via `sd_notify` :
+
+```bash
+# Vérifier que les deux services sont actifs
+systemctl is-active mqtt-broker mqtt-bridge
+
+# Surveiller les redémarrages
+journalctl -u mqtt-broker -u mqtt-bridge -f
+
+# Diagnostics bridge (connexion NanoPi)
+journalctl -u mqtt-bridge -n 50 | grep -E "Connexion|Déconnexion|Reconnexion"
+```
+
+---
+
+## Points de vigilance
+
+1. **Retained messages** : rumqttd persiste en mémoire ET sur disque (`/var/lib/mqtt-broker`). Les retained de Mosquitto ne migrent pas automatiquement — ils seront recréés par les services à leur prochain publish retained (ex: `pvinv_baseline` par energy-manager).
+
+2. **Portal ID** : la valeur `portal_id = "c0619ab9929a"` dans `[mqtt_bridge]` doit correspondre exactement à l'ID Victron GX (visible avec `dbus -y | grep victronenergy` sur NanoPi).
+
+3. **Double abonnement Shelly** : le bridge subscribe `shellypro2pm-ec62608840a4/#` dans les deux sens. Si Shelly est reconfigured pour pointer sur Pi5 local (recommandé), les deux legs du bridge ne créeront pas de boucle car rumqttd détecte les boucles via client_id.
+
+4. **QoS et clean session** : le bridge utilise `clean_session = false` pour les clients persistants, assurant la livraison des messages QoS 1 en cas de reconnexion.

--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Déploiement complet Pi5 — daly-bms-server + energy-manager
-# Usage (depuis ~/Daly-BMS-Rust sur le Pi5) : bash scripts/deploy-pi5.sh
+# Déploiement complet Pi5 — daly-bms-server + energy-manager + mqtt-broker + mqtt-bridge
+# Usage (depuis ~/Daly-BMS-Rust sur le Pi5) : bash scripts/deploy-pi5.sh [--mqtt-only] [--skip-mqtt]
 
 set -euo pipefail
 
@@ -10,19 +10,39 @@ step()  { echo -e "${YELLOW}[>>]${NC} $*"; }
 warn()  { echo -e "${YELLOW}[!!]${NC} $*"; }
 error() { echo -e "${RED}[!!]${NC} $*" >&2; exit 1; }
 
+# Options
+SKIP_MQTT=false
+MQTT_ONLY=false
+for arg in "$@"; do
+  case "$arg" in
+    --skip-mqtt) SKIP_MQTT=true ;;
+    --mqtt-only) MQTT_ONLY=true ;;
+  esac
+done
+
 # ── 1. Récupération du code ───────────────────────────────────────────────────
-step "Synchronisation du dépôt…"
-make sync || error "make sync a échoué"
-info "Code à jour"
+if [ "$MQTT_ONLY" = false ]; then
+  step "Synchronisation du dépôt…"
+  make sync || error "make sync a échoué"
+  info "Code à jour"
+fi
 
 # ── 2. Compilation croisée aarch64 ───────────────────────────────────────────
-step "Compilation daly-bms-server (aarch64)…"
-make build-arm || error "make build-arm a échoué"
-info "daly-bms-server compilé"
+if [ "$MQTT_ONLY" = false ]; then
+  step "Compilation daly-bms-server (aarch64)…"
+  make build-arm || error "make build-arm a échoué"
+  info "daly-bms-server compilé"
 
-step "Compilation energy-manager (aarch64)…"
-make build-energy-arm || error "make build-energy-arm a échoué"
-info "energy-manager compilé"
+  step "Compilation energy-manager (aarch64)…"
+  make build-energy-arm || error "make build-energy-arm a échoué"
+  info "energy-manager compilé"
+fi
+
+if [ "$SKIP_MQTT" = false ]; then
+  step "Compilation mqtt-broker + mqtt-bridge (aarch64)…"
+  make build-mqtt-arm || error "make build-mqtt-arm a échoué"
+  info "mqtt-broker et mqtt-bridge compilés"
+fi
 
 # ── 3. Mise à jour de la configuration ──────────────────────────────────────
 step "Déploiement Config.toml → /etc/daly-bms/config.toml…"
@@ -31,7 +51,6 @@ info "Config.toml déployée"
 
 # ── 4. Répertoire VictoriaMetrics ────────────────────────────────────────────
 VM_DIR="/var/lib/victoria-metrics"
-# Récupère l'utilisateur qui exécute le service (ExecStart user, pas root)
 SERVICE_USER=$(systemctl show victoriametrics --property=User --value 2>/dev/null)
 SERVICE_USER="${SERVICE_USER:-victoriametrics}"
 step "Vérification répertoire VictoriaMetrics (${VM_DIR}) → owner=${SERVICE_USER}…"
@@ -39,7 +58,82 @@ sudo mkdir -p "${VM_DIR}"
 sudo chown "${SERVICE_USER}:${SERVICE_USER}" "${VM_DIR}"
 info "Répertoire VictoriaMetrics OK (owner=${SERVICE_USER})"
 
-# ── 5. Déploiement daly-bms-server ───────────────────────────────────────────
+# ── 5. Déploiement mqtt-broker (avant les autres — dépendance) ───────────────
+if [ "$SKIP_MQTT" = false ]; then
+  ARM_DIR="target/aarch64-unknown-linux-gnu/release"
+
+  step "Déploiement mqtt-broker…"
+  # Créer l'utilisateur système si absent
+  if ! id mqtt-broker &>/dev/null; then
+    sudo useradd --system --no-create-home --shell /usr/sbin/nologin mqtt-broker
+    info "Utilisateur système mqtt-broker créé"
+  fi
+  sudo mkdir -p /var/lib/mqtt-broker
+  sudo chown mqtt-broker:mqtt-broker /var/lib/mqtt-broker
+  sudo chmod 750 /var/lib/mqtt-broker
+
+  # Déployer la config broker si absente
+  if [ ! -f /etc/daly-bms/mqtt-broker.toml ]; then
+    sudo cp crates/mqtt-broker/mqtt-broker.toml /etc/daly-bms/mqtt-broker.toml
+    info "mqtt-broker.toml déployé dans /etc/daly-bms/"
+  fi
+
+  # Déployer le binaire
+  sudo systemctl stop mqtt-bridge 2>/dev/null || true
+  sudo systemctl stop mqtt-broker 2>/dev/null || true
+  sudo cp "${ARM_DIR}/mqtt-broker" /usr/local/bin/mqtt-broker
+  sudo chmod 755 /usr/local/bin/mqtt-broker
+
+  # Installer l'unité systemd si absente
+  if [ ! -f /etc/systemd/system/mqtt-broker.service ]; then
+    sudo cp contrib/mqtt-broker.service /etc/systemd/system/
+    sudo systemctl daemon-reload
+    sudo systemctl enable mqtt-broker
+    info "Service mqtt-broker enregistré"
+  fi
+
+  sudo systemctl start mqtt-broker
+  sleep 3
+
+  if systemctl is-active --quiet mqtt-broker; then
+    info "mqtt-broker actif (TCP :1883, WS :9001, metrics :8082)"
+  else
+    error "mqtt-broker n'a pas démarré — vérifier : journalctl -u mqtt-broker -n 30"
+  fi
+
+  # ── 6. Déploiement mqtt-bridge ─────────────────────────────────────────────
+  step "Déploiement mqtt-bridge…"
+  sudo cp "${ARM_DIR}/mqtt-bridge" /usr/local/bin/mqtt-bridge
+  sudo chmod 755 /usr/local/bin/mqtt-bridge
+
+  if [ ! -f /etc/systemd/system/mqtt-bridge.service ]; then
+    sudo cp contrib/mqtt-bridge.service /etc/systemd/system/
+    sudo systemctl daemon-reload
+    sudo systemctl enable mqtt-bridge
+    info "Service mqtt-bridge enregistré"
+  fi
+
+  sudo systemctl start mqtt-bridge
+  sleep 3
+
+  if systemctl is-active --quiet mqtt-bridge; then
+    info "mqtt-bridge actif (Pi5 :1883 ↔ NanoPi 192.168.1.120:1883, metrics :8084)"
+  else
+    warn "mqtt-bridge n'a pas démarré — vérifier : journalctl -u mqtt-bridge -n 30"
+    warn "  (Normal si NanoPi inaccessible — le bridge reconnectera automatiquement)"
+  fi
+fi
+
+if [ "$MQTT_ONLY" = true ]; then
+  echo ""
+  echo -e "${GREEN}═══════════════════════════════════════${NC}"
+  echo -e "${GREEN}  MQTT déployé avec succès ✓${NC}"
+  echo -e "${GREEN}═══════════════════════════════════════${NC}"
+  systemctl status mqtt-broker mqtt-bridge --no-pager | grep -E "Active:|Loaded:" || true
+  exit 0
+fi
+
+# ── 7. Déploiement daly-bms-server ───────────────────────────────────────────
 step "Déploiement daly-bms-server…"
 sudo systemctl stop daly-bms
 sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
@@ -62,7 +156,7 @@ else
     warn "VictoriaMetrics : aucun message de démarrage détecté (vérifier la config)"
 fi
 
-# ── 6. Déploiement energy-manager ────────────────────────────────────────────
+# ── 8. Déploiement energy-manager ────────────────────────────────────────────
 sleep 3
 step "Déploiement energy-manager…"
 sudo systemctl stop energy-manager
@@ -75,15 +169,24 @@ else
     error "energy-manager n'a pas démarré — vérifier : journalctl -u energy-manager -n 50"
 fi
 
-# ── 7. Résumé ─────────────────────────────────────────────────────────────────
+# ── 9. Résumé ─────────────────────────────────────────────────────────────────
 echo ""
-echo -e "${GREEN}═══════════════════════════════════════${NC}"
-echo -e "${GREEN}  Déploiement terminé avec succès ✓${NC}"
-echo -e "${GREEN}═══════════════════════════════════════${NC}"
+echo -e "${GREEN}═══════════════════════════════════════════${NC}"
+echo -e "${GREEN}  Déploiement complet terminé avec succès ✓${NC}"
+echo -e "${GREEN}═══════════════════════════════════════════${NC}"
 echo ""
-systemctl status daly-bms energy-manager --no-pager -l | grep -E "Active:|Loaded:" || true
+systemctl status daly-bms energy-manager mqtt-broker mqtt-bridge --no-pager -l \
+  | grep -E "Active:|Loaded:" || true
 echo ""
 step "Vérification VictoriaMetrics via API…"
 sleep 1
 curl -sf 'http://localhost:8428/-/healthy' 2>/dev/null || \
     warn "Endpoint VictoriaMetrics non accessible"
+echo ""
+step "Vérification MQTT broker…"
+curl -sf 'http://localhost:8082/health' 2>/dev/null && info "Broker MQTT actif" || \
+    warn "Endpoint métriques broker non accessible (démarrage en cours ?)"
+echo ""
+step "Vérification MQTT bridge…"
+curl -sf 'http://localhost:8084/health' 2>/dev/null && info "Bridge MQTT actif" || \
+    warn "Endpoint métriques bridge non accessible"


### PR DESCRIPTION
- Nouveau crate mqtt-broker (rumqttd) : broker MQTT TCP :1883 + WS :9001, persistence disque /var/lib/mqtt-broker, métriques HTTP :8082/metrics
- Nouveau crate mqtt-bridge (rumqttc) : bridge bidirectionnel Pi5 ↔ NanoPi reproduisant exactement mosquitto.conf (N/W/R Venus, santuario/*, Shelly), métriques HTTP :8084/metrics (connexions, compteurs, reconnexions)
- Dashboard /dashboard/mqtt : carte broker, carte bridge, tableau topics bridgés, explorateur MQTT WebSocket live (:9001)
- API /api/v1/mqtt/status : statut JSON broker + bridge (30s via monitor agent)
- state.rs : ajout MqttStatus, AppState.mqtt_status, méthodes on/latest
- monitor.rs : suppression docker/mosquitto, ajout sondes mqtt-broker/bridge, collecte métriques HTTP asynchrone, suppression restart_docker_container
- Makefile : cibles mqtt-start/stop/restart/logs/status + aliases up/down, build-mqtt-arm, suppression targets Docker
- Config.toml : [mqtt] host 127.0.0.1, [energy_manager.mqtt] 127.0.0.1, ajout section [mqtt_bridge]
- systemd : mqtt-broker.service (user mqtt-broker) + mqtt-bridge.service
- scripts/deploy-pi5.sh : déploiement mqtt-broker + mqtt-bridge avec création user système, options --mqtt-only et --skip-mqtt
- docs/mqtt-broker.md : guide complet migration + installation + opérations
- CLAUDE.md : mise à jour commandes rapides, architecture, structure, règles

https://claude.ai/code/session_01M1WjaLsCxHwbvh5KBot4Lx