### PR TITLE
fix(mqtt): corrections compilation rumqttd 0.19 API

### DIFF
--- a/crates/mqtt-bridge/src/bridge.rs
+++ b/crates/mqtt-bridge/src/bridge.rs
@@ -8,7 +8,7 @@
 
 use crate::{config::BridgeConfig, metrics::BridgeMetrics};
 use anyhow::Result;
-use rumqttc::{AsyncClient, EventLoop, MqttOptions, QoS};
+use rumqttc::{AsyncClient, MqttOptions, QoS};
 use std::{sync::Arc, time::Duration};
 use tokio::time::sleep;
 use tracing::{info, warn};

--- a/crates/mqtt-broker/mqtt-broker.toml
+++ b/crates/mqtt-broker/mqtt-broker.toml
@@ -7,7 +7,7 @@
 # Créer : sudo mkdir -p /var/lib/mqtt-broker && sudo chown mqtt-broker:mqtt-broker /var/lib/mqtt-broker
 [router]
 id                     = 0
-path                   = "/var/lib/mqtt-broker"
+dir                    = "/var/lib/mqtt-broker"
 max_connections        = 1000
 max_outgoing_packet_count = 200
 max_segment_size       = 104857600   # 100 MB

--- a/crates/mqtt-broker/src/main.rs
+++ b/crates/mqtt-broker/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
         .with_context(|| format!("Parse config TOML : {}", cli.config.display()))?;
 
     info!("Broker MQTT démarré — TCP :1883, WS :9001");
-    info!("Persistence : {}", config.router.path.display());
+    info!("Persistence : {}", config.router.dir.display());
 
     // ── Métriques partagées ───────────────────────────────────────────────────
     let metrics = Arc::new(BrokerMetrics::default());
@@ -110,18 +110,15 @@ async fn main() -> Result<()> {
     // Abonnement wildcard pour compter tous les messages
     link_tx.subscribe("#").context("Subscribe #")?;
 
+    // link_rx.recv() est synchrone → spawn_blocking pour ne pas bloquer le runtime
     let metrics_clone = Arc::clone(&metrics);
-    tokio::spawn(async move {
+    tokio::task::spawn_blocking(move || {
         loop {
-            match link_rx.recv().await {
+            match link_rx.recv() {
                 Ok(Some(_notif)) => {
                     metrics_clone.messages_rx.fetch_add(1, Ordering::Relaxed);
                 }
-                Ok(None) => break,
-                Err(e) => {
-                    warn!("Link monitor erreur : {e}");
-                    break;
-                }
+                Ok(None) | Err(_) => break,
             }
         }
     });


### PR DESCRIPTION
- RouterConfig.path → .dir (champ correct dans rumqttd 0.19)
- mqtt-broker.toml : path = → dir = (clé TOML correspondante)
- link_rx.recv() est synchrone → suppression .await + spawn_blocking
- mqtt-bridge : suppression import EventLoop inutilisé (warning)

https://claude.ai/code/session_01M1WjaLsCxHwbvh5KBot4Lx