### PR TITLE
fix(mqtt-broker): suppression log config.router.dir (champ non exposé…

### DIFF
--- a/crates/mqtt-broker/src/main.rs
+++ b/crates/mqtt-broker/src/main.rs
@@ -27,7 +27,7 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{info, warn};
+use tracing::info;
 
 // =============================================================================
 // CLI
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
         .with_context(|| format!("Parse config TOML : {}", cli.config.display()))?;
 
     info!("Broker MQTT démarré — TCP :1883, WS :9001");
-    info!("Persistence : {}", config.router.dir.display());
+    info!("Persistence : /var/lib/mqtt-broker");
 
     // ── Métriques partagées ───────────────────────────────────────────────────
     let metrics = Arc::new(BrokerMetrics::default());


### PR DESCRIPTION
… en 0.19)

RouterConfig dans rumqttd 0.19 n'expose pas le répertoire de persistence via un champ public — remplacement par une chaîne statique. Nettoyage import warn inutilisé.

https://claude.ai/code/session_01M1WjaLsCxHwbvh5KBot4Lx