### PR TITLE
fix(mqtt-broker): websockets feature + service + arrêt Mosquitto Docker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tower-http    = { version = "0.5",  features = ["cors", "trace", "compression-gz
 
 # ── MQTT ───────────────────────────────────────────────────────────────────────
 rumqttc       = "0.25"
-rumqttd       = { version = "0.19", default-features = false }
+rumqttd       = { version = "0.19", default-features = false, features = ["websockets"] }
 
 # ── SQLite (alertes) ───────────────────────────────────────────────────────────
 rusqlite      = { version = "0.31", features = ["bundled"] }

--- a/contrib/mqtt-broker.service
+++ b/contrib/mqtt-broker.service
@@ -3,6 +3,7 @@ Description=Broker MQTT Rust (rumqttd) — remplace Mosquitto/Docker sur Pi5
 Documentation=https://github.com/thieryus007-cloud/Daly-BMS-Rust
 After=network.target
 Before=daly-bms.service energy-manager.service mqtt-bridge.service
+StartLimitIntervalSec=0
 
 [Service]
 Type=notify
@@ -21,13 +22,10 @@ Environment=RUST_LOG=info,rumqttd=warn
 
 Restart=on-failure
 RestartSec=5s
-StartLimitIntervalSec=0
 
-# Répertoire de travail pour la persistence rumqttd
 StateDirectory=mqtt-broker
 StateDirectoryMode=0750
 
-# Limits
 LimitNOFILE=65536
 MemoryMax=200M
 

--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -80,6 +80,14 @@ if [ "$SKIP_MQTT" = false ]; then
   sudo chmod 644 /etc/daly-bms/mqtt-broker.toml
   info "mqtt-broker.toml déployé dans /etc/daly-bms/"
 
+  # Arrêter Mosquitto Docker s'il tourne encore (libère le port :1883)
+  if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "mosquitto\|dalybms"; then
+    step "Arrêt Mosquitto Docker (libération port :1883)…"
+    docker compose -f docker-compose.infra.yml down 2>/dev/null || docker stop dalybms-mosquitto 2>/dev/null || true
+    sleep 2
+    info "Mosquitto Docker arrêté"
+  fi
+
   # Déployer le binaire
   sudo systemctl stop mqtt-bridge 2>/dev/null || true
   sudo systemctl stop mqtt-broker 2>/dev/null || true


### PR DESCRIPTION
- Cargo.toml : ajout feature 'websockets' à rumqttd (WS :9001 désactivé sinon)
- mqtt-broker.service : déplacement StartLimitIntervalSec dans [Unit]
- deploy-pi5.sh : arrêt automatique Mosquitto Docker avant démarrage mqtt-broker pour libérer le port :1883 (évite V4 error EADDRINUSE)

https://claude.ai/code/session_01M1WjaLsCxHwbvh5KBot4Lx