### PR TITLE
fix(mqtt-bridge): suppression boucle infinie santuario/# + doc anti-b…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,15 +202,47 @@ ssh root@192.168.1.120 "dbus -y | grep victronenergy"
 
 ## 6. TOPICS MQTT (préfixe `santuario/`)
 
-| Topic | Service D-Bus |
-|-------|---------------|
-| `bms/{n}/venus` | `battery.mqtt_{n}` |
-| `heat/{n}/venus` | `temperature.mqtt_{n}` |
-| `heatpump/{n}/venus` | `heatpump.mqtt_{n}` |
-| `switch/{n}/venus` | `switch.mqtt_{n}` |
-| `grid/{n}/venus` | `grid.mqtt_{n}` |
-| `pvinverter/{n}/venus` | `pvinverter.mqtt_{n}` |
-| `meteo/venus` | `meteo` (singleton) |
+| Topic | Publié par | Service D-Bus NanoPi |
+|-------|-----------|----------------------|
+| `bms/{n}/venus` | daly-bms-server (Pi5) | `battery.mqtt_{n}` |
+| `heat/{n}/venus` | daly-bms-server (Pi5) | `temperature.mqtt_{n}` |
+| `heatpump/{n}/venus` | daly-bms-server (Pi5) | `heatpump.mqtt_{n}` |
+| `switch/{n}/venus` | daly-bms-server (Pi5, ATS+Tongou) | `switch.mqtt_{n}` |
+| `grid/{n}/venus` | daly-bms-server (Pi5) | `grid.mqtt_{n}` |
+| `pvinverter/{n}/venus` | daly-bms-server (Pi5) | `pvinverter.mqtt_{n}` |
+| `meteo/venus` | daly-bms-server (Pi5) | `meteo` (singleton) |
+
+**TOUS les topics `santuario/*` sont publiés par Pi5 → bridgés vers NanoPi.**
+**NanoPi ne publie RIEN en `santuario/*`.** → Ne jamais mettre `santuario/#` dans la direction NanoPi→Pi5 du bridge (boucle infinie).
+
+### Règles bridge mqtt-bridge (CRITIQUE — anti-boucle)
+
+| Direction | Topics autorisés | Raison |
+|-----------|-----------------|--------|
+| **local→nanopi** | `santuario/#`, `W/{portal}/#`, `R/{portal}/#`, `cmnd/#`, `shellypro2pm-.../rpc` | Pi5 → NanoPi uniquement |
+| **nanopi→local** | `N/{portal}/#`, `tele/#`, `stat/#`, `shellypro2pm-.../#`, `daly-bms-shelly/rpc` | NanoPi → Pi5 uniquement |
+
+⚠ **Un topic dans les deux sens = boucle infinie = flood MQTT = devices qui flashent dans VRM.**
+
+### Commandes Tasmota/Tongou
+
+| Action | Topic | Direction bridge |
+|--------|-------|-----------------|
+| Mesure énergie | `tele/{id}/SENSOR` | NanoPi→Pi5 |
+| État relais | `stat/{id}/POWER` | NanoPi→Pi5 |
+| Commande ON/OFF depuis Pi5 web | `cmnd/{id}/POWER` | Pi5→NanoPi |
+| Commande depuis Venus console | `cmnd/{id}/Power` (dbus-mqtt-venus) | Direct NanoPi |
+
+### ATS CHINT vs Tongou — mqtt_index
+
+| mqtt_index | Device | Topic |
+|-----------|--------|-------|
+| 1 | ATS CHINT NXZB (RS485) | `santuario/switch/1/venus` |
+| 2 | Tongou Switch1 (tongou_3BC764) | `santuario/switch/2/venus` |
+| 3 | Tongou Switch2 (tongou_0A3FA0) | `santuario/switch/3/venus` |
+| 4 | Tongou Switch3 (tongou_0A3C14) | `santuario/switch/4/venus` |
+| 5 | Tongou Switch4 (tongou_0A4040) | `santuario/switch/5/venus` |
+| 6 | Tongou Switch5 (tongou_3ACC34) | `santuario/switch/6/venus` |
 
 ---
 
@@ -311,6 +343,9 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 | mqtt-broker ne démarre pas | `journalctl -u mqtt-broker -n 30` — souvent `/var/lib/mqtt-broker` owner incorrect |
 | mqtt-bridge déconnecté NanoPi | `journalctl -u mqtt-bridge -n 30` — NanoPi inaccessible? `ping 192.168.1.120` |
 | Retained messages perdus après migration | Normaux — recréés au prochain publish retain (ex: `pvinv_baseline` par energy-manager) |
+| **BMS/pvinverter flashent dans VRM (apparaissent/disparaissent)** | **Boucle bridge — vérifier que `santuario/#` N'EST PAS dans nanopi→local (voir bridge.rs)** |
+| **Flood MQTT (des centaines de messages/sec dans l'explorateur)** | **Boucle bridge — un topic est dans les deux directions simultanement** |
+| **Commandes Tongou depuis web Pi5 ignorées** | **`cmnd/#` absent de local→nanopi dans bridge.rs** |
 | Double messages venus (boucle bridge) | Vérifier que client_id des bridges sont uniques (déjà le cas dans le code) |
 | LG ThinQ ne répond pas | Vérifier `LG_BEARER_TOKEN` et `LG_API_KEY` dans `/etc/daly-bms/.env` |
 
@@ -332,6 +367,8 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 12. Secrets : ne jamais committer `.env`.
 13. **MQTT** : broker = `mqtt-broker` (rumqttd systemd), plus de Docker. `make mqtt-start/stop/logs` remplace `make up/down/logs`.
 14. Config bridge MQTT : `[mqtt_bridge]` dans Config.toml (portal_id + remote_host NanoPi).
+15. **BRIDGE ANTI-BOUCLE** : `santuario/#` = direction Pi5→NanoPi SEULEMENT. Ne JAMAIS mettre `santuario/#` dans nanopi→local. Voir section 6 pour les règles complètes.
+16. **Tasmota commandes** : Pi5 web publie `cmnd/{id}/POWER` sur broker local → bridge local→nanopi → switch sur NanoPi. `cmnd/#` doit être dans local→nanopi.
 
 ---
 

--- a/crates/mqtt-bridge/src/bridge.rs
+++ b/crates/mqtt-bridge/src/bridge.rs
@@ -4,6 +4,21 @@
 //!   - `run_nanopi_to_local` : abonné sur NanoPi, republish vers Pi5 local
 //!   - `run_local_to_nanopi` : abonné sur Pi5 local, republish vers NanoPi
 //!
+//! ⚠ RÈGLE ANTI-BOUCLE (CRITICAL)
+//! ─────────────────────────────
+//! Un broker MQTT n'a pas de protection native contre les boucles de bridge.
+//! Mosquitto a un mécanisme interne (bridge protocol) ; notre bridge custom NON.
+//! Règle absolue : un topic ne peut apparaître que dans UNE SEULE direction.
+//!
+//!   - santuario/*  → UNIQUEMENT local→nanopi  (publié par Pi5, consommé par NanoPi)
+//!   - N/{portal}/# → UNIQUEMENT nanopi→local   (publié par Venus OS sur NanoPi)
+//!   - tele/# stat/# → UNIQUEMENT nanopi→local  (publié par Tongou/Tasmota sur NanoPi)
+//!   - cmnd/#        → UNIQUEMENT local→nanopi  (commandes Pi5 vers Tongou sur NanoPi)
+//!   - shellypro2pm-ec62608840a4/# → nanopi→local (status Shelly depuis NanoPi)
+//!   - shellypro2pm-ec62608840a4/rpc → local→nanopi (commandes RPC vers Shelly)
+//!
+//! Si un topic est ajouté dans les deux sens → boucle instantanée → flood MQTT.
+//!
 //! En cas de déconnexion, reconnexion automatique avec backoff.
 
 use crate::{config::BridgeConfig, metrics::BridgeMetrics};
@@ -18,16 +33,16 @@ use tracing::{info, warn};
 // =============================================================================
 
 fn nanopi_to_local_subscriptions(portal: &str) -> Vec<(String, QoS)> {
+    // ⚠ NE PAS ajouter santuario/* ici — ces topics viennent de Pi5, pas de NanoPi.
+    // Les ajouter créerait une boucle infinie avec local_to_nanopi_subscriptions().
     vec![
-        // Venus OS données publiées par Venus OS
+        // Venus OS données télémétriques publiées par Cerbo GX sur NanoPi
         (format!("N/{portal}/#"), QoS::AtMostOnce),
-        // Données BMS publiées par dbus-mqtt-venus sur NanoPi
-        ("santuario/#".to_string(), QoS::AtMostOnce),
-        // Shelly Pro 2PM : status et événements publiés par le device sur NanoPi
+        // Shelly Pro 2PM : status/events publiés par le device connecté au broker NanoPi
         ("shellypro2pm-ec62608840a4/#".to_string(), QoS::AtMostOnce),
-        // Réponses RPC Shelly (topic de réponse daly-bms-shelly/rpc sur NanoPi)
+        // Réponses RPC Shelly (le device répond sur ce topic sur le broker NanoPi)
         ("daly-bms-shelly/rpc".to_string(), QoS::AtMostOnce),
-        // Tasmota / Tongou : mesures énergie et état relais publiés sur NanoPi
+        // Tasmota / Tongou : tele/{id}/SENSOR et stat/{id}/POWER depuis NanoPi
         ("tele/#".to_string(), QoS::AtMostOnce),
         ("stat/#".to_string(), QoS::AtMostOnce),
     ]


### PR DESCRIPTION
…oucle

BOGUE CRITIQUE : santuario/# était dans nanopi_to_local_subscriptions(). Comme Pi5 publie TOUS les santuario/* vers NanoPi (local→nanopi), NanoPi renvoyait ces messages au bridge nanopi→local, qui les republish sur Pi5, qui les renvoyait à NanoPi... → boucle infinie → flood MQTT → BMS et pvinverter flashant dans VRM (apparaissent/disparaissent toutes les ~5s).

Fix : retrait de ("santuario/#") de nanopi_to_local_subscriptions(). NanoPi ne publie RIEN en santuario/* — tous ces topics viennent de Pi5.

Ajout commentaires bloc anti-boucle en tête de bridge.rs.

CLAUDE.md : section 6 complétée avec règles bridge, tableau ATS/Tongou mqtt_index, tableau commandes Tasmota, problèmes courants bridge.

Règles bridge correctes (anti-boucle) :
  local→nanopi : santuario/#, W/{portal}/#, R/{portal}/#, cmnd/#,
                 shellypro2pm-.../rpc
  nanopi→local : N/{portal}/#, tele/#, stat/#,
                 shellypro2pm-ec62608840a4/#, daly-bms-shelly/rpc

https://claude.ai/code/session_01M1WjaLsCxHwbvh5KBot4Lx