### PR TITLE
chore(infra): finalize Mosquitto native migration §10-§11

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -76,8 +76,8 @@ enabled = true
 
 # Windows avec Docker Desktop local → "localhost"
 # Windows avec NanoPi comme broker → "192.168.1.120"
-# Raspberry Pi 5 production        → "localhost" (Mosquitto local) ou IP NanoPi
-host = "192.168.1.120"
+# Raspberry Pi 5 production        → "127.0.0.1" (Mosquitto natif local, bridgé vers NanoPi)
+host = "127.0.0.1"
 port = 1883
 
 # Préfixe des topics (ex: santuario/bms/1/venus)
@@ -526,7 +526,7 @@ device_instance = 152
 
 # --- MQTT ---
 [energy_manager.mqtt]
-host              = "192.168.1.141"   # broker Mosquitto local Pi5
+host              = "127.0.0.1"       # broker Mosquitto natif Pi5 (loopback)
 port              = 1883
 keep_alive_secs   = 60
 reconnect_delay_secs = 10

--- a/contrib/daly-bms.service
+++ b/contrib/daly-bms.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=DalyBMS Server — Rust RS485 BMS monitor
 Documentation=https://github.com/thieryus007-cloud/Daly-BMS-Rust
-After=network.target
+After=network.target mosquitto-broker.service
 Wants=network.target
+Requires=mosquitto-broker.service
 
 [Service]
 Type=notify

--- a/contrib/energy-manager.service
+++ b/contrib/energy-manager.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Energy Manager — Gestionnaire d'énergie Rust (remplace Node-RED)
 Documentation=https://github.com/thieryus007-cloud/Daly-BMS-Rust
-After=network-online.target mosquitto.service
+After=network-online.target mosquitto-broker.service daly-bms.service
 Wants=network-online.target
+Requires=mosquitto-broker.service
 PartOf=daly-bms.service
 
 [Service]


### PR DESCRIPTION
- Config.toml [mqtt].host: 192.168.1.120 → 127.0.0.1 (loopback)
- Config.toml [energy_manager.mqtt].host: 192.168.1.141 → 127.0.0.1
- daly-bms.service: add Requires/After mosquitto-broker.service
- energy-manager.service: replace inexistant mosquitto.service by mosquitto-broker.service, add Requires + After daly-bms.service

Implements steps §10 and §11 of docs/migration-mosquitto-docker-to-native-v2.md. All Pi5-produced traffic now hits the local native broker; bridge handles NanoPi exchange only. No code change in Rust crates required (rumqttc honours [mqtt].host / [energy_manager.mqtt].host at runtime).

https://claude.ai/code/session_01Rjq5X5HeEB4gWuJTfu3bFn