### PR TITLE
fix(mosquitto): remove directives invalid in Mosquitto 2.0

### DIFF
--- a/contrib/mosquitto/mosquitto.conf
+++ b/contrib/mosquitto/mosquitto.conf
@@ -4,10 +4,6 @@
 # Date : mai 2026
 # =============================================================================
 
-# --- Général ---
-# Identifiant du broker (utile pour le debugging)
-broker_id pi5-mosquitto
-
 # --- Listener MQTT TCP :1883 ---
 listener 1883 0.0.0.0
 # Pas d'authentification (LAN privé de confiance uniquement)
@@ -48,10 +44,6 @@ persistence_file mosquitto.db
 # --- Performance ---
 # Intervalle de nettoyage des sessions expirées
 persistent_client_expiration 1d
-# Intervalle entre les checks de keepalive
-retry_interval 20
-# Timeout des messages QoS 1/2 non acquittés
-message_retry_timeout 20
 
 # =============================================================================
 # BRIDGE EGRESS : Pi5 → NanoPi (192.168.1.120:1883)


### PR DESCRIPTION
mosquitto -c ... -t failed on broker_id (line 9). Three directives in contrib/mosquitto/mosquitto.conf do not exist in Mosquitto 2.0:

- broker_id : never existed as a global option
- retry_interval : removed in 1.4
- message_retry_timeout : removed in 1.4

Their removal does not change broker behavior — defaults are equivalent.

https://claude.ai/code/session_01Rjq5X5HeEB4gWuJTfu3bFn