### PR TITLE
feat(victoriametrics): migrate storage to NVMe with 2y retention

### DIFF
--- a/contrib/victoriametrics.service
+++ b/contrib/victoriametrics.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=VictoriaMetrics Time Series Database
+After=network-online.target mnt-nvme.mount
+Requires=mnt-nvme.mount
+
+[Service]
+Type=simple
+User=victoriametrics
+Group=victoriametrics
+ExecStart=/usr/local/bin/victoria-metrics-prod \
+  -storageDataPath=/mnt/nvme/victoria-metrics \
+  -retentionPeriod=2y \
+  -httpListenAddr=:8428 \
+  -selfScrapeInterval=0 \
+  -maxLabelsPerTimeseries=30 \
+  -search.maxQueryDuration=30s \
+  -search.maxConcurrentRequests=4
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -29,15 +29,16 @@ step "Déploiement Config.toml → /etc/daly-bms/config.toml…"
 sudo cp Config.toml /etc/daly-bms/config.toml
 info "Config.toml déployée"
 
-# ── 4. Répertoire VictoriaMetrics ────────────────────────────────────────────
-VM_DIR="/var/lib/victoria-metrics"
+# ── 4. Répertoire VictoriaMetrics (NVMe) ─────────────────────────────────────
+VM_DIR="/mnt/nvme/victoria-metrics"
 # Récupère l'utilisateur qui exécute le service (ExecStart user, pas root)
 SERVICE_USER=$(systemctl show victoriametrics --property=User --value 2>/dev/null)
 SERVICE_USER="${SERVICE_USER:-victoriametrics}"
-step "Vérification répertoire VictoriaMetrics (${VM_DIR}) → owner=${SERVICE_USER}…"
+step "Vérification NVMe monté et répertoire VictoriaMetrics (${VM_DIR}) → owner=${SERVICE_USER}…"
+mountpoint -q /mnt/nvme || { warn "/mnt/nvme non monté — vérifier /etc/fstab et relancer"; }
 sudo mkdir -p "${VM_DIR}"
 sudo chown "${SERVICE_USER}:${SERVICE_USER}" "${VM_DIR}"
-info "Répertoire VictoriaMetrics OK (owner=${SERVICE_USER})"
+info "Répertoire VictoriaMetrics OK sur NVMe (owner=${SERVICE_USER})"
 
 # ── 5. Déploiement daly-bms-server ───────────────────────────────────────────
 step "Déploiement daly-bms-server…"

--- a/scripts/migrate-vm-to-nvme.sh
+++ b/scripts/migrate-vm-to-nvme.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Migration VictoriaMetrics → NVMe (/mnt/nvme/victoria-metrics)
+# Exécuter UNE SEULE FOIS sur le Pi5 en tant que root ou avec sudo
+# Usage : sudo bash scripts/migrate-vm-to-nvme.sh
+
+set -euo pipefail
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[OK]${NC} $*"; }
+step()  { echo -e "${YELLOW}[>>]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[!!]${NC} $*"; }
+error() { echo -e "${RED}[!!]${NC} $*" >&2; exit 1; }
+
+OLD_DIR="/var/lib/victoria-metrics"
+NEW_DIR="/mnt/nvme/victoria-metrics"
+SERVICE="victoriametrics"
+SERVICE_FILE="/etc/systemd/system/victoriametrics.service"
+
+# ── Vérifications préalables ──────────────────────────────────────────────────
+[[ $EUID -eq 0 ]] || error "Ce script doit être exécuté en root (sudo)"
+
+step "Vérification du montage NVMe…"
+mountpoint -q /mnt/nvme || error "/mnt/nvme n'est pas monté — vérifier /etc/fstab"
+NVME_FREE=$(df -BG /mnt/nvme | awk 'NR==2{print $4}' | tr -d 'G')
+[[ "${NVME_FREE}" -ge 10 ]] || warn "Espace NVMe < 10 Go disponibles (${NVME_FREE} Go)"
+info "NVMe monté, ${NVME_FREE} Go libres"
+
+# ── 1. Arrêt du service ───────────────────────────────────────────────────────
+step "Arrêt de VictoriaMetrics…"
+systemctl stop "${SERVICE}" 2>/dev/null || warn "Service déjà arrêté"
+sleep 2
+info "Service arrêté"
+
+# ── 2. Création du répertoire cible ──────────────────────────────────────────
+step "Création de ${NEW_DIR}…"
+mkdir -p "${NEW_DIR}"
+VM_USER=$(stat -c '%U' "${OLD_DIR}" 2>/dev/null || echo "victoriametrics")
+chown "${VM_USER}:${VM_USER}" "${NEW_DIR}"
+info "Répertoire créé (owner=${VM_USER})"
+
+# ── 3. Migration des données ──────────────────────────────────────────────────
+if [[ -d "${OLD_DIR}" ]] && [[ -n "$(ls -A "${OLD_DIR}" 2>/dev/null)" ]]; then
+    OLD_SIZE=$(du -sh "${OLD_DIR}" 2>/dev/null | cut -f1)
+    step "Copie des données ${OLD_DIR} → ${NEW_DIR} (taille: ${OLD_SIZE})…"
+    rsync -aH --info=progress2 "${OLD_DIR}/" "${NEW_DIR}/"
+    info "Données copiées"
+
+    step "Vérification de l'intégrité (comptage fichiers)…"
+    OLD_COUNT=$(find "${OLD_DIR}" -type f | wc -l)
+    NEW_COUNT=$(find "${NEW_DIR}" -type f | wc -l)
+    [[ "${OLD_COUNT}" -eq "${NEW_COUNT}" ]] || \
+        error "Comptage différent : ${OLD_COUNT} (source) vs ${NEW_COUNT} (cible) — NE PAS supprimer l'ancienne"
+    info "Intégrité OK : ${NEW_COUNT} fichiers copiés"
+else
+    warn "Aucune donnée dans ${OLD_DIR} — démarrage à vide sur NVMe"
+fi
+
+# ── 4. Mise à jour du service systemd ────────────────────────────────────────
+step "Déploiement nouveau fichier service…"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_SERVICE="${SCRIPT_DIR}/../contrib/victoriametrics.service"
+
+if [[ -f "${REPO_SERVICE}" ]]; then
+    cp "${REPO_SERVICE}" "${SERVICE_FILE}"
+    info "Service déployé depuis contrib/victoriametrics.service"
+else
+    # Mise à jour directe si fichier contrib absent
+    warn "contrib/victoriametrics.service introuvable — mise à jour directe du service"
+    sed -i \
+        -e "s|-storageDataPath=.*|-storageDataPath=${NEW_DIR} \\\\|" \
+        -e "s|-retentionPeriod=.*|-retentionPeriod=2y \\\\|" \
+        "${SERVICE_FILE}"
+fi
+
+systemctl daemon-reload
+info "Systemd rechargé"
+
+# ── 5. Démarrage et vérification ─────────────────────────────────────────────
+step "Démarrage de VictoriaMetrics sur NVMe…"
+systemctl start "${SERVICE}"
+sleep 5
+
+if systemctl is-active --quiet "${SERVICE}"; then
+    info "VictoriaMetrics actif sur ${NEW_DIR}"
+else
+    error "VictoriaMetrics n'a pas démarré — journalctl -u victoriametrics -n 30"
+fi
+
+# Test de l'API
+if curl -sf 'http://localhost:8428/-/healthy' >/dev/null 2>&1; then
+    info "API VictoriaMetrics accessible (:8428)"
+else
+    warn "API non accessible — attendre quelques secondes et vérifier"
+fi
+
+# ── 6. Sauvegarde de l'ancienne données (optionnel) ──────────────────────────
+echo ""
+echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
+echo -e "${YELLOW}  Ancien répertoire conservé : ${OLD_DIR}${NC}"
+echo -e "${YELLOW}  Supprimer manuellement si tout est OK :${NC}"
+echo -e "${YELLOW}  sudo rm -rf ${OLD_DIR}${NC}"
+echo -e "${YELLOW}═══════════════════════════════════════════════════════${NC}"
+echo ""
+
+step "Vérification finale…"
+echo "Service    : $(systemctl is-active ${SERVICE})"
+echo "Données    : ${NEW_DIR}"
+echo "Retention  : 2 ans"
+USED=$(du -sh "${NEW_DIR}" 2>/dev/null | cut -f1 || echo "N/A")
+echo "Taille     : ${USED}"
+echo ""
+info "Migration terminée avec succès"

--- a/victoriametrics.md
+++ b/victoriametrics.md
@@ -7,21 +7,22 @@
 | Fichier | Chemin | Rôle |
 |---------|--------|------|
 | **Service systemd** | `/etc/systemd/system/victoriametrics.service` | Définit comment démarrer/stopper le service, l'utilisateur, les arguments de démarrage |
-| *(Ancien fichier supprimé)* | ~~`/etc/victoriametrics/victoriametrics.conf`~~ | ~~Fichier de variables d'environnement (bug, supprimé)~~ |
+| **Fichier source service** | `contrib/victoriametrics.service` | Version de référence dans le dépôt — à déployer via `sudo cp` |
 
-**Contenu actuel du service** (`/etc/systemd/system/victoriametrics.service`) :
+**Contenu actuel du service** (`contrib/victoriametrics.service` → `/etc/systemd/system/victoriametrics.service`) :
 ```ini
 [Unit]
 Description=VictoriaMetrics Time Series Database
-After=network-online.target
+After=network-online.target mnt-nvme.mount
+Requires=mnt-nvme.mount
 
 [Service]
 Type=simple
 User=victoriametrics
 Group=victoriametrics
 ExecStart=/usr/local/bin/victoria-metrics-prod \
-  -storageDataPath=/var/lib/victoria-metrics \
-  -retentionPeriod=30d \
+  -storageDataPath=/mnt/nvme/victoria-metrics \
+  -retentionPeriod=2y \
   -httpListenAddr=:8428 \
   -selfScrapeInterval=0 \
   -maxLabelsPerTimeseries=30 \
@@ -42,8 +43,35 @@ WantedBy=multi-user.target
 | Répertoire | Chemin | Contenu |
 |------------|--------|---------|
 | **Binaire** | `/usr/local/bin/victoria-metrics-prod` | Exécutable principal (lien symbolique `victoria-metrics` → `victoria-metrics-prod`) |
-| **Données TSDB** | `/var/lib/victoria-metrics/` | Toutes les données temporelles (chunks, index, métadonnées) |
+| **Données TSDB** | `/mnt/nvme/victoria-metrics/` | Toutes les données temporelles (chunks, index, métadonnées) — sur NVMe 256 Go |
 | **Logs systemd** | `journalctl -u victoriametrics` | Logs en mémoire/journal systemd (pas de fichier log dédié) |
+
+> **Disque NVMe** : `/dev/nvme0n1p1` (238 Go) monté sur `/mnt/nvme`.
+> Rétention configurée à **2 ans** — capacité largement suffisante (~1–5 Mo/jour pour ~200 séries).
+
+---
+
+## 🚀 Première installation / migration depuis la SD
+
+Si VictoriaMetrics tournait sur la carte SD (`/var/lib/victoria-metrics`), utiliser le script de migration :
+
+```bash
+# Depuis ~/Daly-BMS-Rust sur le Pi5
+sudo bash scripts/migrate-vm-to-nvme.sh
+```
+
+Le script :
+1. Vérifie que `/mnt/nvme` est monté
+2. Arrête le service VictoriaMetrics
+3. Copie les données existantes (`rsync`) vers `/mnt/nvme/victoria-metrics/`
+4. Vérifie l'intégrité (comptage fichiers)
+5. Déploie `contrib/victoriametrics.service` vers `/etc/systemd/system/`
+6. Redémarre le service et vérifie l'API
+
+Après migration, supprimer l'ancienne donnée SD si tout est OK :
+```bash
+sudo rm -rf /var/lib/victoria-metrics
+```
 
 ---
 
@@ -51,29 +79,32 @@ WantedBy=multi-user.target
 
 ```bash
 # Voir la structure du stockage
-sudo ls -la /var/lib/victoria-metrics/
+sudo ls -la /mnt/nvme/victoria-metrics/
 
 # Taille totale des données
-sudo du -sh /var/lib/victoria-metrics/
+sudo du -sh /mnt/nvme/victoria-metrics/
 
 # Détail par sous-répertoire
-sudo du -h /var/lib/victoria-metrics/ | sort -h
+sudo du -h /mnt/nvme/victoria-metrics/ | sort -h
 
 # Voir les logs
 sudo journalctl -u victoriametrics -n 50
 
 # Voir la config du service
 sudo systemctl cat victoriametrics
+
+# Vérification santé API
+curl -sf http://localhost:8428/-/healthy
 ```
 
 ---
 
-## 📊 Structure interne de `/var/lib/victoria-metrics/`
+## 📊 Structure interne de `/mnt/nvme/victoria-metrics/`
 
-Après quelques heures/d'jours d'utilisation, vous verrez :
+Après quelques heures/jours d'utilisation, vous verrez :
 
 ```
-/var/lib/victoria-metrics/
+/mnt/nvme/victoria-metrics/
 ├── data/
 │   ├── small/
 │   │   ├── 2026_04/          → Parties récentes (données fraîches)
@@ -93,13 +124,14 @@ Après quelques heures/d'jours d'utilisation, vous verrez :
 
 ## 🛠️ Modifier la configuration
 
-Pour changer un paramètre (ex: passer à 90 jours de retention) :
+Pour changer un paramètre (ex: passer à 5 ans de retention) :
 
 ```bash
-# 1. Éditer le service
-sudo systemctl edit --full victoriametrics
+# 1. Éditer le fichier source dans le dépôt
+#    contrib/victoriametrics.service → -retentionPeriod=5y
 
-# 2. Modifier la ligne -retentionPeriod=30d → -retentionPeriod=90d
+# 2. Déployer sur le Pi5
+sudo cp contrib/victoriametrics.service /etc/systemd/system/victoriametrics.service
 
 # 3. Recharger et redémarrer
 sudo systemctl daemon-reload
@@ -108,12 +140,33 @@ sudo systemctl restart victoriametrics
 
 ---
 
+## 💾 Vérification du montage NVMe au démarrage
+
+Le service systemd dépend de `mnt-nvme.mount`. Vérifier que le NVMe est bien dans `/etc/fstab` :
+
+```bash
+# Vérifier le montage automatique
+grep nvme /etc/fstab
+
+# Format attendu (UUID recommandé)
+# UUID=<uuid>  /mnt/nvme  ext4  defaults,noatime  0  2
+
+# Obtenir l'UUID du NVMe
+sudo blkid /dev/nvme0n1p1
+
+# Tester le montage fstab sans reboot
+sudo mount -a
+```
+
+---
+
 ## 📝 Récap visuel
 
 ```
 /etc/systemd/system/victoriametrics.service  ←  CONFIGURATION (arguments)
+  (source: contrib/victoriametrics.service dans le dépôt)
 /usr/local/bin/victoria-metrics-prod          ←  BINAIRE
-/var/lib/victoria-metrics/                    ←  DONNÉES TSDB
+/mnt/nvme/victoria-metrics/                   ←  DONNÉES TSDB (NVMe 256 Go, rétention 2 ans)
 journalctl -u victoriametrics                 ←  LOGS
 ```
 


### PR DESCRIPTION
Move VictoriaMetrics data path from /var/lib/victoria-metrics to /mnt/nvme/victoria-metrics to leverage the 256GB NVMe disk. Increase retention from 30d to 2y. Add migration script and service unit file.

- contrib/victoriametrics.service: new service unit targeting NVMe, depends on mnt-nvme.mount, retentionPeriod=2y
- scripts/migrate-vm-to-nvme.sh: one-shot migration script (rsync + integrity check + service swap)
- scripts/deploy-pi5.sh: update VM_DIR to /mnt/nvme/victoria-metrics, add NVMe mount check
- victoriametrics.md: update all paths, retention, add migration and fstab sections

https://claude.ai/code/session_015G9dYqjFALEdtcLXbeLDjT