### PR TITLE
fix(mosquitto): kill 16k msg/s shellypro2pm/rpc loop

### DIFF
--- a/contrib/mosquitto/mosquitto.conf
+++ b/contrib/mosquitto/mosquitto.conf
@@ -46,26 +46,31 @@ persistence_file mosquitto.db
 persistent_client_expiration 1d
 
 # =============================================================================
-# BRIDGE EGRESS : Pi5 → NanoPi (192.168.1.120:1883)
+# BRIDGE Pi5 ↔ NanoPi (192.168.1.120:1883) — connexion UNIQUE
 #
-# ⚠ RÈGLE ABSOLUE : Ces topics ne doivent PAS être dans le bridge INGRESS.
-#   Tous les topics santuario/* viennent de Pi5, JAMAIS de NanoPi.
+# ⚠ RÈGLE ABSOLUE 1 : Une seule `connection` pour un broker distant donné.
+#   Sinon le mécanisme anti-loop de Mosquitto (`try_private` + bridge re-publish
+#   avoidance) est neutralisé : deux connexions = deux clients distincts pour le
+#   distant, et un message reçu via une connexion peut être ré-émis via l'autre.
+#
+# ⚠ RÈGLE ABSOLUE 2 : Aucun topic OUT ne doit être capté par un pattern IN.
+#   Tester avec `verify-no-loop.sh` qui détecte les chevauchements de wildcards.
 # =============================================================================
-connection pi5-to-nanopi
+connection pi5-nanopi-bridge
 address 192.168.1.120:1883
 bridge_protocol_version mqttv311
-# Démarrage automatique
 start_type automatic
-# Notification de l'état du bridge
 notifications true
-notification_topic $SYS/broker/bridge/pi5-to-nanopi/state
-# Essayer de signaler au broker distant qu'on est un bridge
-# (évite les boucles si le distant est aussi un bridge)
+notification_topic $SYS/broker/bridge/pi5-nanopi/state
 try_private true
+cleansession false
+bridge_attempt_unsubscribe false
+restart_timeout 10 30
+keepalive_interval 60
 
-# --- Topics EGRESS ---
-# Format : topic <pattern> <direction> <qos> <local-prefix> <remote-prefix>
-
+# -----------------------------------------------------------------------------
+# Topics EGRESS (Pi5 → NanoPi)
+# -----------------------------------------------------------------------------
 # BMS → battery.mqtt_1 / battery.mqtt_2
 topic santuario/bms/# out 1 "" ""
 
@@ -103,33 +108,12 @@ topic R/c0619ab9929a/# out 1 "" ""
 topic cmnd/# out 1 "" ""
 
 # Commandes RPC Shelly (energy-manager → Shelly via NanoPi)
+# ⚠ Le INGRESS shellypro2pm DOIT exclure /rpc (cf. boucle 16k msg/s du 13/05/2026)
 topic shellypro2pm-ec62608840a4/rpc out 0 "" ""
 
-# --- Options bridge EGRESS ---
-# Ne pas tenter de se désabonner à la déconnexion
-bridge_attempt_unsubscribe false
-# Reconnexion automatique
-restart_timeout 10 30
-# Keepalive
-keepalive_interval 60
-
-# =============================================================================
-# BRIDGE INGRESS : NanoPi → Pi5 (192.168.1.120:1883)
-#
-# ⚠ RÈGLE ABSOLUE : Ces topics doivent être ABSENTS du bridge EGRESS.
-#   NanoPi publie : N/{portal}/#, tele/#, stat/#, shellypro2pm/#, daly-bms-shelly/rpc
-#   Pi5 publie   : santuario/*, cmnd/*, W/*, R/*, shellypro2pm.../rpc
-# =============================================================================
-connection nanopi-to-pi5
-address 192.168.1.120:1883
-bridge_protocol_version mqttv311
-start_type automatic
-notifications true
-notification_topic $SYS/broker/bridge/nanopi-to-pi5/state
-try_private true
-
-# --- Topics INGRESS ---
-
+# -----------------------------------------------------------------------------
+# Topics INGRESS (NanoPi → Pi5)
+# -----------------------------------------------------------------------------
 # Venus OS télémétriques (Cerbo GX)
 topic N/c0619ab9929a/# in 0 "" ""
 
@@ -139,16 +123,13 @@ topic tele/# in 0 "" ""
 # Tasmota / Tongou — état relais
 topic stat/# in 0 "" ""
 
-# Shelly Pro 2PM — status + events
-topic shellypro2pm-ec62608840a4/# in 0 "" ""
+# Shelly Pro 2PM — status canaux + heartbeat + events (PAS /rpc qui est OUT)
+topic shellypro2pm-ec62608840a4/status/# in 0 "" ""
+topic shellypro2pm-ec62608840a4/online    in 0 "" ""
+topic shellypro2pm-ec62608840a4/events/#  in 0 "" ""
 
-# Réponses RPC Shelly
+# Réponses RPC Shelly (topic distinct du request — pas de chevauchement)
 topic daly-bms-shelly/rpc in 0 "" ""
-
-# --- Options bridge INGRESS ---
-bridge_attempt_unsubscribe false
-restart_timeout 10 30
-keepalive_interval 60
 
 # =============================================================================
 # SÉCURITÉ (LAN privé — ajustez si exposition publique)

--- a/contrib/mosquitto/verify-no-loop.sh
+++ b/contrib/mosquitto/verify-no-loop.sh
@@ -1,34 +1,123 @@
 #!/bin/bash
-# verify-no-loop.sh
-# Vérifie qu'aucun topic n'est présent à la fois en IN et en OUT
+# =============================================================================
+# verify-no-loop.sh — Détecte les chevauchements OUT/IN dans mosquitto.conf
+#
+# Détecte :
+#   1. Chaînes textuellement identiques (ex: OUT foo/bar + IN foo/bar)
+#   2. Chevauchements via wildcards MQTT (`+` et `#`) :
+#      - `foo/#` matche foo, foo/bar, foo/bar/baz
+#      - `foo/+/baz` matche foo/X/baz
+#      - Donc OUT `foo/bar` + IN `foo/#` = chevauchement = risque boucle
+#
+# Sortie : exit 0 si OK, exit 1 si chevauchement détecté.
+# =============================================================================
 
-CONFIG="/etc/mosquitto/mosquitto.conf"
+set -euo pipefail
+
+CONFIG="${1:-/etc/mosquitto/mosquitto.conf}"
 
 if [ ! -f "$CONFIG" ]; then
-    echo "ERREUR : $CONFIG introuvable"
+    echo "ERREUR : $CONFIG introuvable" >&2
     exit 1
 fi
 
-echo "=== Topics EGRESS (out) ==="
-OUT_TOPICS=$(grep -E '^\s*topic\s+\S+\s+out\s' "$CONFIG" | awk '{print $2}' | sort -u)
-echo "$OUT_TOPICS"
-
-echo ""
-echo "=== Topics INGRESS (in) ==="
-IN_TOPICS=$(grep -E '^\s*topic\s+\S+\s+in\s' "$CONFIG" | awk '{print $2}' | sort -u)
-echo "$IN_TOPICS"
-
-echo ""
-echo "=== INTERSECTION (DANGER — topics en double) ==="
-INTERSECTION=$(comm -12 <(echo "$OUT_TOPICS") <(echo "$IN_TOPICS"))
-
-if [ -n "$INTERSECTION" ]; then
-    echo "❌ ERREUR FATALE : Topics présents dans les deux directions :"
-    echo "$INTERSECTION"
-    echo ""
-    echo "Cela créera une BOUCLE INFINIE. Corriger mosquitto.conf immédiatement."
+command -v python3 >/dev/null 2>&1 || {
+    echo "ERREUR : python3 requis pour le matching wildcard MQTT" >&2
     exit 1
-else
-    echo "✅ OK : Aucun topic en double. Pas de risque de boucle."
-    exit 0
-fi
+}
+
+python3 - "$CONFIG" << 'PYEOF'
+import re, sys
+
+def parse_topics(path):
+    out, inc = [], []
+    rx = re.compile(r'^\s*topic\s+(\S+)\s+(in|out|both)(?:\s+(\d+))?')
+    with open(path) as f:
+        for ln_no, line in enumerate(f, 1):
+            s = line.strip()
+            if not s or s.startswith('#'):
+                continue
+            m = rx.match(s)
+            if not m:
+                continue
+            t, d = m.group(1), m.group(2)
+            if d in ('out', 'both'):
+                out.append((t, ln_no))
+            if d in ('in', 'both'):
+                inc.append((t, ln_no))
+    return out, inc
+
+def mqtt_match(pattern, topic):
+    """Vrai si pattern MQTT (avec +, #) matche le topic concret."""
+    if pattern == topic:
+        return True
+    p = pattern.split('/')
+    t = topic.split('/')
+    i = 0
+    while i < len(p):
+        seg = p[i]
+        if seg == '#':
+            return True
+        if i >= len(t):
+            return False
+        if seg == '+':
+            i += 1
+            continue
+        if seg != t[i]:
+            return False
+        i += 1
+    return i == len(t)
+
+def overlap(pat_a, pat_b):
+    """Vrai si deux patterns MQTT peuvent matcher un même topic réel."""
+    if pat_a == pat_b:
+        return True
+    a, b = pat_a.split('/'), pat_b.split('/')
+    def concretize(p):
+        return '/'.join('X' if s in ('+', '#') else s for s in p)
+    if mqtt_match(pat_b, concretize(a)):
+        return True
+    if mqtt_match(pat_a, concretize(b)):
+        return True
+    # `#` peut matcher 0 segment : tester sans le dernier
+    if a and a[-1] == '#' and len(a) > 1:
+        if mqtt_match(pat_b, '/'.join(a[:-1])):
+            return True
+    if b and b[-1] == '#' and len(b) > 1:
+        if mqtt_match(pat_a, '/'.join(b[:-1])):
+            return True
+    return False
+
+path = sys.argv[1]
+out, inc = parse_topics(path)
+
+print("=== Topics EGRESS (out) ===")
+for t, ln in sorted(out):
+    print(f"  L{ln:<4} {t}")
+print()
+print("=== Topics INGRESS (in) ===")
+for t, ln in sorted(inc):
+    print(f"  L{ln:<4} {t}")
+print()
+
+print("=== Analyse des chevauchements (wildcard-aware) ===")
+problems = []
+for ot, oln in out:
+    for it, iln in inc:
+        if overlap(ot, it):
+            problems.append((ot, oln, it, iln))
+
+if problems:
+    print()
+    print("❌ DANGER — Chevauchements détectés (risque de BOUCLE) :")
+    for ot, oln, it, iln in problems:
+        kind = "IDENTIQUE" if ot == it else "WILDCARD "
+        print(f"   {kind}  OUT(L{oln}) {ot}  ∩  IN(L{iln}) {it}")
+    print()
+    print("Pour fixer : resserrer le pattern IN pour exclure les topics OUT,")
+    print("ou réorganiser les topics OUT pour éviter les wildcards IN trop larges.")
+    sys.exit(1)
+else:
+    print("✅ OK : Aucun chevauchement OUT/IN. Pas de risque de boucle bridge.")
+    sys.exit(0)
+PYEOF


### PR DESCRIPTION
Production diagnostic on 2026-05-13 07:30 captured a feedback storm: 33205 of 33793 sampled messages (98.3%) were on shellypro2pm-ec62608840a4/rpc, broker processing ~17k msg/s and pushing 30-42 Mbps to NanoPi.

Root cause: two independent bridge connections (pi5-to-nanopi and nanopi-to-pi5) towards the same remote broker, combined with the INGRESS wildcard shellypro2pm-ec62608840a4/# which captures the OUT topic shellypro2pm-ec62608840a4/rpc. Mosquitto's try_private/loop-avoidance operates per-connection, so messages traversing one bridge get re-emitted through the other.

Changes:
- mosquitto.conf: merge the two `connection` blocks into a single pi5-nanopi-bridge so try_private and the built-in bridge re-publish guard work; tighten INGRESS for Shelly to status/#, online, events/# only (excludes /rpc which is OUT-only); add cleansession false at bridge level for explicit persistent semantics.
- verify-no-loop.sh: rewrite with MQTT wildcard-aware overlap detection in Python (handles + and #). The previous textual-equality check silently accepted the buggy config because the strings did not match literally. The new version reports line numbers for both endpoints and is run automatically by deploy-mosquitto-native.sh.

https://claude.ai/code/session_01Rjq5X5HeEB4gWuJTfu3bFn