### PR TITLE
fix(mosquitto): add shellypro2pm/info to bridge INGRESS

### DIFF
--- a/contrib/mosquitto/mosquitto.conf
+++ b/contrib/mosquitto/mosquitto.conf
@@ -123,10 +123,11 @@ topic tele/# in 0 "" ""
 # Tasmota / Tongou — état relais
 topic stat/# in 0 "" ""
 
-# Shelly Pro 2PM — status canaux + heartbeat + events (PAS /rpc qui est OUT)
+# Shelly Pro 2PM — status canaux + heartbeat + events + info (PAS /rpc qui est OUT)
 topic shellypro2pm-ec62608840a4/status/# in 0 "" ""
 topic shellypro2pm-ec62608840a4/online    in 0 "" ""
 topic shellypro2pm-ec62608840a4/events/#  in 0 "" ""
+topic shellypro2pm-ec62608840a4/info      in 0 "" ""
 
 # Réponses RPC Shelly (topic distinct du request — pas de chevauchement)
 topic daly-bms-shelly/rpc in 0 "" ""


### PR DESCRIPTION
daly-bms-server subscribes to {shelly_id}/info for RSSI tracking. The topic was missing from the bridge INGRESS patterns, preventing the Pi5 broker from receiving WiFi signal strength data.

https://claude.ai/code/session_01Rjq5X5HeEB4gWuJTfu3bFn