### PR TITLE
fix(monitor): replace docker restart with systemctl + polkit rule

### DIFF
--- a/contrib/polkit/50-dalybms-systemd-restart.rules
+++ b/contrib/polkit/50-dalybms-systemd-restart.rules
@@ -1,0 +1,25 @@
+// Autorise l'utilisateur `dalybms` à redémarrer les services
+// systemd que `daly-bms-server` surveille et relance automatiquement
+// depuis `crates/daly-bms-server/src/monitor.rs` (fonction
+// `restart_systemd_service`, sondes TCP + watchdog).
+//
+// Unités couvertes :
+//   - mosquitto-broker.service  (broker MQTT natif, sondé port 1883)
+//   - energy-manager.service    (sondé port 8081 par le watchdog)
+//
+// Installation :
+//   sudo cp 50-dalybms-systemd-restart.rules /etc/polkit-1/rules.d/
+//   sudo systemctl restart polkit
+//
+// Vérification (en tant que dalybms) :
+//   sudo -u dalybms systemctl restart mosquitto-broker
+polkit.addRule(function(action, subject) {
+    if (action.id != "org.freedesktop.systemd1.manage-units") return;
+    if (subject.user != "dalybms") return;
+
+    var unit = action.lookup("unit");
+    if (unit == "mosquitto-broker.service" ||
+        unit == "energy-manager.service") {
+        return polkit.Result.YES;
+    }
+});

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -18,9 +18,9 @@ use tokio::process::Command;
 use tokio::time::interval;
 use tracing::{info, warn};
 
-/// Services réseau à sonder : (label, host, port, conteneur_docker_pour_restart).
+/// Services réseau à sonder : (label, host, port, service_systemd_à_redémarrer).
 const TCP_SERVICES: &[(&str, &str, u16, Option<&str>)] = &[
-    ("mosquitto",      "127.0.0.1",     1883, Some("mosquitto")),
+    ("mosquitto",      "127.0.0.1",     1883, Some("mosquitto-broker")),
     ("energy-manager", "127.0.0.1",     8081, None),
     ("venus-mqtt",     "192.168.1.120", 1883, None),
 ];
@@ -96,28 +96,28 @@ async fn collect_snapshot(_state: &AppState, net_rx_bps: u64, net_tx_bps: u64) -
         } else if em_status.is_empty() { "unknown".to_string() } else { em_status },
     });
 
-    let mosquitto_systemd = check_systemd_service("mosquitto").await == "active";
+    let mosquitto_systemd = check_systemd_service("mosquitto-broker").await == "active";
     services.push(ServiceStatus {
-        name:   "mosquitto".to_string(),
+        name:   "mosquitto-broker".to_string(),
         active: mosquitto_systemd || tcp_probe("127.0.0.1", 1883).await,
         status: if mosquitto_systemd { "active".to_string() } else { "inactive".to_string() },
     });
 
     // ── Sondes TCP ───────────────────────────────────────────────────────────
-    for &(name, host, port, docker_name) in TCP_SERVICES {
+    for &(name, host, port, svc_to_restart) in TCP_SERVICES {
         let reachable = tcp_probe(host, port).await;
 
         if !reachable {
-            if let Some(cname) = docker_name {
-                if restart_docker_container(cname).await {
-                    let msg = format!("Redémarré conteneur Docker: {}", cname);
+            if let Some(svc) = svc_to_restart {
+                if restart_systemd_service(svc).await {
+                    let msg = format!("Redémarré service systemd: {}", svc);
                     info!("{}", msg);
                     auto_actions.push(msg);
                     network_services.push(ServiceStatus {
                         name: name.to_string(), active: false, status: "restarted".to_string(),
                     });
                 } else {
-                    warn!("Échec redémarrage conteneur Docker: {}", cname);
+                    warn!("Échec redémarrage service systemd: {}", svc);
                     network_services.push(ServiceStatus {
                         name: name.to_string(), active: false, status: "down".to_string(),
                     });
@@ -313,13 +313,6 @@ async fn check_systemd_service(name: &str) -> String {
     match Command::new("systemctl").args(["is-active", name]).output().await {
         Ok(o) => String::from_utf8_lossy(&o.stdout).trim().to_string(),
         Err(_) => "unknown".to_string(),
-    }
-}
-
-async fn restart_docker_container(name: &str) -> bool {
-    match Command::new("docker").args(["restart", name]).output().await {
-        Ok(out) => out.status.success(),
-        Err(_)  => false,
     }
 }
 
@@ -530,8 +523,11 @@ pub fn spawn_all(state: AppState) {
     });
 }
 
+/// Redémarre une unité systemd. Nécessite une règle polkit autorisant
+/// l'utilisateur `dalybms` à gérer l'unité concernée (voir
+/// `contrib/polkit/50-dalybms-systemd-restart.rules`).
 async fn restart_systemd_service(name: &str) -> bool {
-    match Command::new("sudo").args(["systemctl", "restart", name]).output().await {
+    match Command::new("systemctl").args(["restart", name]).output().await {
         Ok(out) => {
             if !out.status.success() {
                 warn!("systemctl restart {} → stderr: {}",


### PR DESCRIPTION
Post-Mosquitto migration, monitor.rs still referenced docker restart of the broker container that no longer exists.

- TCP_SERVICES: replace docker container "mosquitto" with systemd unit "mosquitto-broker" as the restart target
- check_systemd_service: probe "mosquitto-broker" (not "mosquitto")
- restart loop: rename `docker_name`/`cname` to `svc_to_restart`/`svc`
- Remove redundant local restart_docker_container function (existing restart_systemd_service handles this)
- Drop sudo from restart_systemd_service — rely on polkit so the dalybms user can restart unprivileged

Add contrib/polkit/50-dalybms-systemd-restart.rules granting `dalybms` the right to restart mosquitto-broker.service and energy-manager.service (the two units monitor.rs auto-restarts).

https://claude.ai/code/session_01Rjq5X5HeEB4gWuJTfu3bFn