### PR TITLE
docs: purge all operational Docker references post-Mosquitto migration

### DIFF
--- a/DEBUG_ONDULEUR_SMARTSHUNT.md
+++ b/DEBUG_ONDULEUR_SMARTSHUNT.md
@@ -11,15 +11,15 @@ Exécuter chaque commande **dans l'ordre exact** sur Pi5, noter les résultats.
 ```bash
 # Sur Pi5 — État des services
 systemctl status daly-bms | head -20
-docker ps | grep mosquitto
+systemctl is-active mosquitto-broker
 ```
 
 **Résultat attendu:**
 - daly-bms: `active (running)`
-- mosquitto: container running
+- mosquitto-broker: `active`
 
 **Si NOK:** 
-- Redémarrer: `sudo systemctl restart daly-bms && docker restart mosquitto`
+- Redémarrer: `sudo systemctl restart daly-bms && sudo systemctl restart mosquitto-broker`
 
 ---
 
@@ -47,8 +47,8 @@ journalctl -u daly-bms -n 30 --no-pager
 
 ```bash
 # Sur Pi5 — Vérifier que Mosquitto écoute
-netstat -tlnp | grep 1883
-docker exec mosquitto mosquitto_sub -h localhost -p 1883 -t '$SYS/#' -C 1
+ss -tlnp | grep 1883
+mosquitto_sub -h 127.0.0.1 -p 1883 -t '$SYS/#' -C 1
 ```
 
 **Résultat attendu:**
@@ -56,7 +56,7 @@ docker exec mosquitto mosquitto_sub -h localhost -p 1883 -t '$SYS/#' -C 1
 - `$SYS` topics publiés = broker actif
 
 **Si broker down:**
-- Redémarrer: `docker restart mosquitto`
+- Redémarrer: `sudo systemctl restart mosquitto-broker`
 - Attendre 5s
 - Tester à nouveau
 
@@ -67,7 +67,7 @@ docker exec mosquitto mosquitto_sub -h localhost -p 1883 -t '$SYS/#' -C 1
 ```bash
 # Sur Pi5 — Watch tous les topics santuario pendant 30 secondes
 echo "Watching MQTT for 30 seconds..."
-timeout 30 docker exec mosquitto mosquitto_sub -h localhost -p 1883 -t 'santuario/#' -v 2>&1 | head -100
+timeout 30 mosquitto_sub -h 127.0.0.1 -p 1883 -t 'santuario/#' -v 2>&1 | head -100
 ```
 
 **Résultat attendu:**
@@ -145,7 +145,7 @@ sleep 2
 journalctl -u daly-bms -f &  # Laisser tourner en background
 
 # Dans une autre terminal, déclencher un message MQTT:
-docker exec mosquitto mosquitto_pub -h localhost -p 1883 -t 'santuario/inverter/venus' \
+mosquitto_pub -h 127.0.0.1 -p 1883 -t 'santuario/inverter/venus' \
   -m '{"Voltage": 48.2, "Current": 3.5, "Power": 168.7, "AcVoltage": 229.8, "AcCurrent": 5.6, "AcPower": 1286.0, "State": "on", "Mode": "inverter"}'
 
 # Vérifier si le handler a reçu et parsé le message
@@ -258,7 +258,7 @@ journalctl -u daly-bms -n 10
 
 ```
 □ Services tournent (BMS, Mosquitto, energy-manager)
-  Commande: systemctl status daly-bms && docker ps
+  Commande: systemctl status daly-bms mosquitto-broker energy-manager
 
 □ MQTT topics publiés
   Commande: mosquitto_sub -t 'santuario/#' -v
@@ -295,11 +295,11 @@ Cela permettra de diagnostiquer rapidement.
 ```bash
 # Redémarrer tout
 sudo systemctl restart daly-bms
-docker restart mosquitto
+sudo systemctl restart mosquitto-broker
 sleep 5
 
 # Vérifier MQTT
-timeout 10 docker exec mosquitto mosquitto_sub -h localhost -t 'santuario/#' -v
+timeout 10 mosquitto_sub -h 127.0.0.1 -t 'santuario/#' -v
 
 # Vérifier API
 for ep in inverter smartshunt mppt temperatures; do

--- a/Readme.md
+++ b/Readme.md
@@ -6,8 +6,8 @@ Remplacement total de la stack Python/FastAPI **et** des flows Node-RED par **Ru
 `energy-manager` + `dbus-mqtt-venus`).
 
 > Dashboard intégré **SSR Rust** (Askama + ECharts) — aucun npm.
-> Infrastructure Docker **inchangée** (Mosquitto, VictoriaMetrics ).
-> Déploiement ultra-léger : **un seul binaire statique** (~12–18 Mo).
+> Broker MQTT **natif systemd** (`mosquitto-broker.service`), VictoriaMetrics en binaire natif.
+> Déploiement ultra-léger : **un seul binaire statique** (~12–18 Mo). Aucun Docker requis.
 > Compatible **Windows** (testé) et **Linux/aarch64** (Raspberry Pi).
 
 ---
@@ -182,8 +182,7 @@ Daly-BMS-Rust/
 ├── Cargo.lock
 ├── Config.toml                ← Configuration principale (TOML)
 ├── Makefile                   ← Commandes build/test/deploy
-├── docker-compose.infra.yml   ← Infra Mosquitto (broker MQTT)
-├── .env.docker                ← Template variables d'environnement (à copier en .env)
+├── contrib/mosquitto/mosquitto.conf ← Config broker MQTT natif (deploy → /etc/mosquitto/)
 ├── .gitignore
 │
 ├── crates/
@@ -243,8 +242,6 @@ Daly-BMS-Rust/
 │   ├── victoriametrics-scrape.yml← Config scrape Prometheus pour VM
 │   ├── install-systemd.sh        ← Script d'installation systemd
 │   └── uninstall-systemd.sh      ← Script de désinstallation
-├── docker/
-│   └── mosquitto/config/mosquitto.conf
 ├── docs/                         ← Guides détaillés (energy-manager, ATS, Venus, etc.)
 └── nanoPi/                       ← Config dbus-mqtt-venus (Venus OS)
     ├── config-nanopi.toml        ← Config production dbus-mqtt-venus
@@ -256,18 +253,17 @@ Daly-BMS-Rust/
 
 ### Estimation mémoire
 
-#### Pi5 (master — Docker).  mesure réelle: 20%
+#### Pi5 (master — tout natif systemd).  mesure réelle: 20%
 
 | Service                    | RAM minimale | RAM confortable |
 |----------------------------|-------------|-----------------|
 | daly-bms-server (Rust)     | ~25 MB      | ~50 MB          |
 | energy-manager (Rust)      | ~30 MB      | ~100 MB (LimitMemoryMax=100M) |
-| Mosquitto                  | ~12 MB      | ~20 MB          |
+| mosquitto-broker (natif)   | ~8 MB       | ~15 MB          |
 | VictoriaMetrics 2.x (Go)   | ~150 MB     | ~350 MB         |
 | OS Raspberry Pi OS Lite    | ~150 MB     | ~200 MB         |
-| Docker Engine + overhead   | ~100 MB     | ~150 MB         |
 | Marge tampon / cache       | ~200 MB     | ~400 MB         |
-| **TOTAL**                  | **~667 MB** | **~1270 MB**    |
+| **TOTAL**                  | **~563 MB** | **~1115 MB**    |
 
 #### NanoPi Neo3 (Venus OS — services Rust statiques)
 
@@ -284,8 +280,7 @@ Daly-BMS-Rust/
 | Composant | Version | Usage |
 |-----------|---------|-------|
 | Rust      | 1.80+   | Compilation |
-| Docker    | 24+     | Infra MQTT |
-| Docker Compose v2 | — | `make up` |
+| Mosquitto 2.x | natif apt | Broker MQTT (`mosquitto-broker.service`) |
 | cross     | dernière | Cross-compilation ARM (optionnel) |
 
 > Le dashboard est **SSR (Askama + ECharts)** — Node.js/npm ne sont plus nécessaires.
@@ -307,12 +302,13 @@ Daly-BMS-Rust/
 
 ## Démarrage rapide
 
-### Infrastructure Docker (broker MQTT)
+### Broker MQTT (mosquitto-broker.service)
 
 ```bash
-cp .env.docker .env            # adapter les tokens et mots de passe
-make up                        # Mosquitto:1883
-make ps                        # vérifier l'état des containers
+# Vérifier que le broker est actif
+systemctl status mosquitto-broker
+# Logs
+journalctl -u mosquitto-broker -f
 ```
 
 ### Configuration
@@ -341,10 +337,10 @@ make install        # copie le binaire + installe daly-bms.service
 journalctl -u daly-bms -f
 ```
 
-### Infrastructure broker MQTT
+### Broker MQTT
 
 ```bash
-make up   # démarre Mosquitto via docker-compose.infra.yml
+systemctl status mosquitto-broker   # vérifier l'état
 ```
 
 ---
@@ -415,13 +411,6 @@ Le dashboard est **embarqué dans le binaire** (SSR Askama + ECharts). Aucun npm
 ## Commandes Make
 
 ```bash
-make up            # Démarrer Docker (infra seule)
-make down          # Arrêter Docker
-make restart       # Redémarrer les containers
-make ps            # État des containers
-make logs          # Logs de tous les containers (follow)
-make reset         # Arrêter + supprimer volumes + redémarrer (reset complet)
-
 make build              # Compiler (release, local)
 make build-arm          # Cross-compiler daly-bms-server pour aarch64 (Pi5)
 make build-arm-debug    # Build aarch64 avec symboles (profile release-debug)
@@ -459,35 +448,13 @@ make doc                # cargo doc (workspace, --open)
 
 ## Gestion des logs et rétention des données
 
-### Logs Docker (rotation automatique)
-
-Tous les containers utilisent le driver `json-file` avec rotation automatique :
-
-| Service | Max taille | Fichiers |
-|---------|-----------|---------|
-| dalybms-server | 20 Mo | 5 fichiers |
-| Mosquitto | 10 Mo | 3 fichiers |
-| VictoriaMetrics | 10 Mo | 3 fichiers |
-| energy-manager | 5 Mo | 3 fichiers |
-
-```bash
-# Voir les logs en temps réel
-make logs
-
-# Logs d'un service spécifique
-docker logs dalybms-server -f --tail 100
-docker logs dalybms-VictoriaMetrics -f --tail 100
-docker logs dalybms-mosquitto -f --tail 100
-
-# Taille des fichiers log Docker
-du -sh /var/lib/docker/containers/*/
-```
-
-### Logs systemd (déploiement sans Docker)
+### Logs systemd
 
 ```bash
 # Logs en temps réel
 journalctl -u daly-bms -f
+journalctl -u energy-manager -f
+journalctl -u mosquitto-broker -f
 
 # Logs depuis une date
 journalctl -u daly-bms --since "2026-03-17 00:00:00"
@@ -507,26 +474,19 @@ sudo journalctl --vacuum-size=100M
 
 ### Rétention des données VictoriaMetrics
 
-Par défaut : **30 jours** (720h), configurable dans `.env` :
-
-```bash
-# Dans .env
-DOCKER_VictoriaMetrics_INIT_RETENTION=720h    # 30 jours (défaut)
-# DOCKER_VictoriaMetrics_INIT_RETENTION=2160h  # 90 jours
-# DOCKER_VictoriaMetrics_INIT_RETENTION=0      # Infini (déconseillé sur SD/eMMC)
-```
+Par défaut : **30 jours** (720h), configurable via le flag de démarrage `--retentionPeriod` de VictoriaMetrics.
 
 ### Nettoyage complet (reset usine)
 
 ```bash
-# Arrêter tout + supprimer tous les volumes (DONNÉES PERDUES)
-make reset
+# Arrêter tout
+sudo systemctl stop daly-bms energy-manager mosquitto-broker
 
-# Nettoyer les images Docker inutilisées
-docker system prune -f
+# Supprimer données VictoriaMetrics et broker (DONNÉES PERDUES)
+sudo rm -rf /var/lib/victoria-metrics-data /var/lib/mosquitto/mosquitto.db
 
-# Libérer l'espace disque Docker (images + caches)
-docker system prune -a --volumes
+# Redémarrer
+sudo systemctl start mosquitto-broker energy-manager daly-bms
 ```
 
 > **Note RPi/eMMC** : Sur Raspberry Pi avec carte SD ou eMMC, surveiller l'espace disque.
@@ -599,9 +559,9 @@ sudo usermod -aG dialout $USER  # si permission refusée
 # Logs service systemd
 journalctl -u daly-bms -f
 
-# Logs Docker
-make logs
-docker logs dalybms-server -f --tail 100
+# Logs services
+journalctl -u daly-bms -f
+journalctl -u mosquitto-broker -f
 
 # Test API
 curl http://localhost:8080/api/v1/system/status | jq
@@ -612,12 +572,11 @@ wscat -c ws://localhost:8080/ws/bms/stream
 # Niveau de logs augmenté
 RUST_LOG=debug daly-bms-server
 
-# Vérifier état containers
-make ps
-docker compose -f docker-compose.infra.yml ps
+# Vérifier état services
+systemctl status daly-bms mosquitto-broker energy-manager
 
 # Redémarrer Mosquitto
-docker compose -f docker-compose.infra.yml restart mosquitto
+sudo systemctl restart mosquitto-broker
 ```
 
 ---
@@ -660,7 +619,7 @@ Il affiche pour chaque BMS :
 
 ### Phase 1 — Infrastructure & Intégration ✅
 
-- [x] Infrastructure Mosquitto (Docker)
+- [x] Infrastructure Mosquitto (natif systemd depuis mai 2026, anciennement Docker)
 - [x] Auto-détection port série et adresses BMS
 - [x] Dashboard SSR intégré (Askama + ECharts, sans npm)
 - [x] MQTT publish_interval_sec réduit à 1s (temps réel)
@@ -671,7 +630,7 @@ Il affiche pour chaque BMS :
 
 - [x] RPi5 CM opérationnel — données BMS 0x01 et 0x02 confirmées dans VictoriaMetrics
 - [x] Correction adresses BMS (0x28/0x29 → 0x01/0x02)
-- [x] Rotation logs Docker configurée + rétention VictoriaMetrics 30j
+- [x] Rotation logs systemd configurée + rétention VictoriaMetrics 30j
 - [ ] Validation commandes d'écriture (MOS, SOC, reset) sur hardware réel
 - [ ] Tests intégration 24h stabilité
 
@@ -688,7 +647,7 @@ Il affiche pour chaque BMS :
 ### Phase 4 — Migration & Consolidation 🚧 ✅
 
 - [x] Renommer le crate `daly-bms-venus` → `dbus-mqtt-venus` dans le workspace Rust ✅
-- [ ] Migration flows energy-manager du NanoPi vers le Pi5 (docker-compose.infra.yml) ✅
+- [x] Migration energy-manager du NanoPi vers le Pi5 (service systemd natif) ✅
 - [ ] Nettoyage NanoPi : services Python retirés, seul `dbus-mqtt-venus` reste
 - [ ] Validation stabilité 24h post-migration energy-manager
 

--- a/docs/VENUS-DEVICE-INTEGRATION.md
+++ b/docs/VENUS-DEVICE-INTEGRATION.md
@@ -73,7 +73,7 @@ com.victronenergy.acload (when used as consumer to measure an acload)
 
 | Machine | IP | Rôle |
 |---|---|---|
-| Pi5 (Raspberry Pi 5) | 192.168.1.141 | Docker : Mosquitto, energy-manager |
+| Pi5 (Raspberry Pi 5) | 192.168.1.141 | systemd : mosquitto-broker, daly-bms-server, energy-manager |
 | NanoPi Neo3 | 192.168.1.120 | Venus OS, service Rust dbus-mqtt-venus, D-Bus |
 
 ---
@@ -170,7 +170,7 @@ entre les publications et le device disparaît du VRM.
 
 ## Configuration Mosquitto bridge (Pi5)
 
-Fichier : `docker/mosquitto/config/mosquitto.conf`
+Fichier : `contrib/mosquitto/mosquitto.conf` (déployé vers `/etc/mosquitto/mosquitto.conf`)
 
 ### Direction NanoPi → Pi5 (données publiées par le Rust)
 ```
@@ -302,12 +302,13 @@ ssh root@192.168.1.120 "svc -d /data/etc/sv/dbus-mqtt-venus && \
                         svc -u /data/etc/sv/dbus-mqtt-venus"
 ```
 
-### Étape 5 — Déployer mosquitto.conf si modifié (Pi5 Docker)
+### Étape 5 — Déployer mosquitto.conf si modifié (Pi5)
 
 ```bash
 cd ~/Daly-BMS-Rust
-git pull origin claude/migrate-energy-manager-pi5-91idx
-docker compose restart mosquitto
+make sync
+sudo cp contrib/mosquitto/mosquitto.conf /etc/mosquitto/mosquitto.conf
+sudo systemctl restart mosquitto-broker
 ```
 
 ### Étape 6 — Mettre à jour les flux energy-manager si modifiés
@@ -830,9 +831,8 @@ Le service cible est actif et verrouille le binaire. Faire `svc -d` avant le `sc
 ### git pull échoue (local changes)
 
 ```bash
-# Si fichier appartient à un autre utilisateur (ex: mosquitto Docker)
-sudo chown $(whoami):$(whoami) docker/mosquitto/config/
-sudo chown $(whoami):$(whoami) docker/mosquitto/config/mosquitto.conf
+# Si fichier appartient à root (ex: config déployée via sudo)
+sudo chown $(whoami):$(whoami) contrib/mosquitto/mosquitto.conf
 ```
 
 ### Architecture mismatch (binaire invalide)
@@ -840,11 +840,14 @@ sudo chown $(whoami):$(whoami) docker/mosquitto/config/mosquitto.conf
 NanoPi = ARMv7 32-bit. Le binaire Pi5 (aarch64) ne fonctionne pas.
 Toujours compiler avec `--target armv7-unknown-linux-gnueabihf`.
 
-### Onglet energy-manager vide après docker compose down/up
+### energy-manager ne démarre pas après redémarrage
 
-Les volumes energy-manager sont persistants. Si les flux disparaissent :
-1. Vérifier `docker volume ls | grep energy-manager`
-2. Réimporter depuis `flux-energy-manager/*.json`
+```bash
+systemctl status energy-manager
+journalctl -u energy-manager -n 30
+# Vérifier que Config.toml est présent :
+ls /etc/daly-bms/config.toml
+```
 
 
 ### annexe: Victron switch parameters


### PR DESCRIPTION
Replace every `docker` command with its native systemd / mosquitto_sub equivalent across user-facing documentation:

Readme.md
- Header: "Infrastructure Docker" → "Broker MQTT natif systemd"
- File tree: remove docker-compose.infra.yml, .env.docker, docker/ dir → add contrib/mosquitto/mosquitto.conf
- Memory table: remove Docker Engine overhead row, fix totals
- Prerequisites: remove Docker / Docker Compose rows
- Quick-start: replace "make up" with systemctl status
- Make commands: remove up/down/restart/ps/logs/reset (no longer exist)
- Logs section: drop "Logs Docker" subsection, keep systemd section
- Dépannage: replace docker logs / docker compose with journalctl / systemctl / systemctl restart mosquitto-broker
- Changelog: mark items as systemd-native, fix phase 4 item

DEBUG_ONDULEUR_SMARTSHUNT.md
- All docker ps / docker restart / docker exec mosquitto replaced with systemctl is-active, systemctl restart, mosquitto_sub -h 127.0.0.1
- Checklist: docker ps → systemctl status …

docs/VENUS-DEVICE-INTEGRATION.md
- Infrastructure table: "Docker : Mosquitto, energy-manager" → systemd
- §5 deployment step: docker compose restart → systemctl restart
- mosquitto.conf path: docker/mosquitto/config/ → contrib/mosquitto/
- git pull chown: docker path → contrib path
- energy-manager troubleshooting: docker compose → systemctl

https://claude.ai/code/session_01Rjq5X5HeEB4gWuJTfu3bFn