### PR TITLE
feat(grafana): option --nvme pour stocker DB/logs/plugins sur /mnt/nvme

### DIFF
--- a/scripts/setup-grafana.sh
+++ b/scripts/setup-grafana.sh
@@ -5,30 +5,33 @@
 # Installation et configuration complète de Grafana sur Raspberry Pi 5 (aarch64)
 # pour le monitoring PV solaire avec VictoriaMetrics.
 #
-# Cible :  Raspberry Pi 5 — Debian/Ubuntu 64 bits — user pi5compute
+# Cible :  Raspberry Pi 5 — Raspberry Pi OS 64 bits — user pi5compute
 # Source : ~/Daly-BMS-Rust  (lance via : bash scripts/setup-grafana.sh)
 #
 # Fonctionnalités :
 #   - Installe Grafana OSS depuis le dépôt officiel (ARM64)
 #   - Provisionne automatiquement la datasource VictoriaMetrics
 #   - Provisionne automatiquement le dashboard "PV Solaire 5 ans"
+#   - Option --nvme : stocke les données Grafana sur le NVMe (/mnt/nvme/grafana)
+#     → la SD card ne porte que le binaire (~150 Mo)
 #   - Configure le pare-feu (si UFW actif) et le port 3000
 #   - Vérifie la connectivité à VictoriaMetrics (http://127.0.0.1:8428)
-#   - Optionnellement : installe le plugin grafana-image-renderer
 #   - Idempotent : peut être relancé sans casser une install existante
 #
 # Options :
-#   --renderer   : installe grafana-image-renderer + chromium (~300 Mo)
-#   --port=N     : change le port Grafana (défaut 3000)
+#   --nvme           : stocke DB/logs/plugins sur /mnt/nvme/grafana (recommandé Pi5)
+#   --data-path=PATH : chemin custom pour les données Grafana (remplace --nvme)
+#   --port=N         : change le port Grafana (défaut 3000)
 #   --admin-pwd=PASS : définit le mot de passe admin initial
-#   --vm-url=URL : URL VictoriaMetrics (défaut http://127.0.0.1:8428)
-#   --no-firewall : désactive l'ajout de règle UFW
-#   --uninstall  : désinstalle Grafana et nettoie la configuration
+#   --vm-url=URL     : URL VictoriaMetrics (défaut http://127.0.0.1:8428)
+#   --no-firewall    : désactive l'ajout de règle UFW
+#   --renderer       : installe grafana-image-renderer + chromium (~300 Mo)
+#   --uninstall      : désinstalle Grafana et nettoie la configuration
 #
 # Exemples :
-#   bash scripts/setup-grafana.sh
-#   bash scripts/setup-grafana.sh --renderer --admin-pwd='ChangeMe!2026'
-#   bash scripts/setup-grafana.sh --port=8081
+#   bash scripts/setup-grafana.sh --nvme
+#   bash scripts/setup-grafana.sh --nvme --admin-pwd='ChangeMe!2026'
+#   bash scripts/setup-grafana.sh --port=3000
 #   sudo bash scripts/setup-grafana.sh --uninstall
 # ----------------------------------------------------------------------------
 
@@ -45,6 +48,7 @@ error() { echo -e "${RED}[!!]${NC} $*" >&2; exit 1; }
 GRAFANA_PORT="3000"
 ADMIN_PWD=""
 VM_URL="http://127.0.0.1:8428"
+GRAFANA_DATA_PATH=""          # vide = /var/lib/grafana (défaut Grafana)
 INSTALL_RENDERER=false
 SKIP_FIREWALL=false
 UNINSTALL=false
@@ -54,14 +58,16 @@ GRAFANA_PROVISION_SRC="${REPO_ROOT}/contrib/grafana"
 # ── Parsing args ──────────────────────────────────────────────────────────────
 for arg in "$@"; do
     case "$arg" in
+        --nvme)           GRAFANA_DATA_PATH="/mnt/nvme/grafana" ;;
         --renderer)       INSTALL_RENDERER=true ;;
         --no-firewall)    SKIP_FIREWALL=true ;;
         --uninstall)      UNINSTALL=true ;;
         --port=*)         GRAFANA_PORT="${arg#*=}" ;;
         --admin-pwd=*)    ADMIN_PWD="${arg#*=}" ;;
         --vm-url=*)       VM_URL="${arg#*=}" ;;
+        --data-path=*)    GRAFANA_DATA_PATH="${arg#*=}" ;;
         -h|--help)
-            sed -n '3,32p' "$0"
+            sed -n '3,38p' "$0"
             exit 0
             ;;
         *) error "Option inconnue: $arg (essayez --help)" ;;
@@ -69,18 +75,11 @@ for arg in "$@"; do
 done
 
 # ── Vérifications préalables ──────────────────────────────────────────────────
-require_sudo() {
-    if [[ $EUID -ne 0 ]]; then
-        if ! sudo -n true 2>/dev/null; then
-            step "Élévation sudo requise…"
-        fi
-        SUDO="sudo"
-    else
-        SUDO=""
-    fi
-}
-
-require_sudo
+if [[ $EUID -ne 0 ]]; then
+    SUDO="sudo"
+else
+    SUDO=""
+fi
 
 ARCH="$(dpkg --print-architecture 2>/dev/null || uname -m)"
 case "$ARCH" in
@@ -88,16 +87,27 @@ case "$ARCH" in
     *) warn "Architecture non aarch64 ($ARCH) — installation possible mais non testée" ;;
 esac
 
+# Vérifier que le NVMe est monté si --nvme demandé
+if [[ -n "$GRAFANA_DATA_PATH" && "$GRAFANA_DATA_PATH" == /mnt/nvme* ]]; then
+    if ! mountpoint -q /mnt/nvme 2>/dev/null; then
+        error "/mnt/nvme n'est pas monté. Vérifiez: mount | grep nvme"
+    fi
+    info "NVMe monté — données Grafana → $GRAFANA_DATA_PATH"
+fi
+
 # ── Désinstallation ───────────────────────────────────────────────────────────
 if $UNINSTALL; then
     step "Désinstallation de Grafana…"
     $SUDO systemctl stop grafana-server 2>/dev/null || true
     $SUDO systemctl disable grafana-server 2>/dev/null || true
     $SUDO apt-get remove -y grafana 2>/dev/null || true
-    $SUDO rm -rf /etc/grafana/provisioning/datasources/victoriametrics.yaml
-    $SUDO rm -rf /etc/grafana/provisioning/dashboards/daly-bms.yaml
+    $SUDO rm -f /etc/grafana/provisioning/datasources/victoriametrics.yaml
+    $SUDO rm -f /etc/grafana/provisioning/dashboards/daly-bms.yaml
     $SUDO rm -rf /var/lib/grafana/dashboards
-    info "Grafana désinstallé (les data /var/lib/grafana/grafana.db restent)"
+    if [[ -n "$GRAFANA_DATA_PATH" ]]; then
+        warn "Données NVMe conservées dans $GRAFANA_DATA_PATH (suppression manuelle si besoin)"
+    fi
+    info "Grafana désinstallé"
     exit 0
 fi
 
@@ -119,7 +129,7 @@ SRC_LIST="/etc/apt/sources.list.d/grafana.list"
 if [[ ! -f "$KEYRING" ]]; then
     step "Ajout de la clé GPG Grafana…"
     wget -q -O - https://apt.grafana.com/gpg.key | $SUDO gpg --dearmor -o "$KEYRING"
-    info "Clé GPG installée: $KEYRING"
+    info "Clé GPG installée"
 else
     info "Clé GPG Grafana déjà présente"
 fi
@@ -144,7 +154,58 @@ else
     info "Grafana déjà installé (version $INSTALLED_VER)"
 fi
 
-# ── 4. Vérification accès VictoriaMetrics ────────────────────────────────────
+# ── 4. Stockage des données sur NVMe (optionnel) ─────────────────────────────
+GRAFANA_INI="/etc/grafana/grafana.ini"
+
+if [[ -n "$GRAFANA_DATA_PATH" ]]; then
+    step "Configuration du stockage NVMe → $GRAFANA_DATA_PATH"
+
+    # Créer les sous-dossiers avec le bon propriétaire
+    for subdir in "" data log plugins temp; do
+        DIR="${GRAFANA_DATA_PATH}${subdir:+/$subdir}"
+        $SUDO mkdir -p "$DIR"
+        $SUDO chown grafana:grafana "$DIR"
+        $SUDO chmod 0755 "$DIR"
+    done
+
+    # Patcher la section [paths] dans grafana.ini
+    # On insère/remplace les clés data, logs, plugins
+    patch_ini_path() {
+        local key="$1" val="$2"
+        if $SUDO grep -qE "^${key}\s*=" "$GRAFANA_INI"; then
+            $SUDO sed -i -E "s|^${key}\s*=.*|${key} = ${val}|" "$GRAFANA_INI"
+        elif $SUDO grep -qE "^;${key}\s*=" "$GRAFANA_INI"; then
+            $SUDO sed -i -E "s|^;${key}\s*=.*|${key} = ${val}|" "$GRAFANA_INI"
+        else
+            # Ajouter sous [paths] si la section existe
+            if $SUDO grep -q "^\[paths\]" "$GRAFANA_INI"; then
+                $SUDO sed -i "/^\[paths\]/a ${key} = ${val}" "$GRAFANA_INI"
+            else
+                printf "\n[paths]\n%s = %s\n" "$key" "$val" | $SUDO tee -a "$GRAFANA_INI" >/dev/null
+            fi
+        fi
+    }
+
+    patch_ini_path "data"    "${GRAFANA_DATA_PATH}/data"
+    patch_ini_path "logs"    "${GRAFANA_DATA_PATH}/log"
+    patch_ini_path "plugins" "${GRAFANA_DATA_PATH}/plugins"
+    patch_ini_path "temp_data_lifetime" "24h"
+
+    info "Chemins Grafana configurés sur NVMe:"
+    echo "  • data    → ${GRAFANA_DATA_PATH}/data"
+    echo "  • logs    → ${GRAFANA_DATA_PATH}/log"
+    echo "  • plugins → ${GRAFANA_DATA_PATH}/plugins"
+
+    # Migrer la DB existante si présente
+    if [[ -f /var/lib/grafana/grafana.db && ! -f "${GRAFANA_DATA_PATH}/data/grafana.db" ]]; then
+        step "Migration de la DB existante vers NVMe…"
+        $SUDO cp /var/lib/grafana/grafana.db "${GRAFANA_DATA_PATH}/data/grafana.db"
+        $SUDO chown grafana:grafana "${GRAFANA_DATA_PATH}/data/grafana.db"
+        info "DB migrée vers ${GRAFANA_DATA_PATH}/data/grafana.db"
+    fi
+fi
+
+# ── 5. Vérification accès VictoriaMetrics ────────────────────────────────────
 step "Vérification VictoriaMetrics: $VM_URL …"
 if curl -sf "$VM_URL/health" -o /dev/null --max-time 5; then
     info "VictoriaMetrics répond sur $VM_URL"
@@ -154,17 +215,16 @@ else
     warn "Vérifiez:  systemctl status victoriametrics"
 fi
 
-# ── 5. Provisioning datasource + dashboard ───────────────────────────────────
+# ── 6. Provisioning datasource + dashboard ───────────────────────────────────
 step "Déploiement du provisioning Grafana…"
 
-[[ -d "$GRAFANA_PROVISION_SRC" ]] || error "Dossier ${GRAFANA_PROVISION_SRC} introuvable"
+[[ -d "$GRAFANA_PROVISION_SRC" ]] || error "Dossier ${GRAFANA_PROVISION_SRC} introuvable (make sync ?)"
 
 # Datasource
 $SUDO install -m 0644 -o root -g grafana \
     "${GRAFANA_PROVISION_SRC}/provisioning/datasources/victoriametrics.yaml" \
     /etc/grafana/provisioning/datasources/victoriametrics.yaml
 
-# Si une URL VM différente est demandée, on patche le fichier déployé
 if [[ "$VM_URL" != "http://127.0.0.1:8428" ]]; then
     $SUDO sed -i "s|http://127.0.0.1:8428|${VM_URL}|g" \
         /etc/grafana/provisioning/datasources/victoriametrics.yaml
@@ -176,39 +236,40 @@ $SUDO install -m 0644 -o root -g grafana \
     "${GRAFANA_PROVISION_SRC}/provisioning/dashboards/daly-bms.yaml" \
     /etc/grafana/provisioning/dashboards/daly-bms.yaml
 
-# Dashboards JSON
+# Dossier dashboards (dans /var/lib/grafana — petits fichiers JSON, OK sur SD)
 $SUDO install -d -o grafana -g grafana -m 0755 /var/lib/grafana/dashboards
 $SUDO install -m 0644 -o grafana -g grafana \
     "${GRAFANA_PROVISION_SRC}/dashboards/pv-solar-5y.json" \
     /var/lib/grafana/dashboards/pv-solar-5y.json
 
-info "Provisioning déployé:"
-echo "  • /etc/grafana/provisioning/datasources/victoriametrics.yaml"
-echo "  • /etc/grafana/provisioning/dashboards/daly-bms.yaml"
-echo "  • /var/lib/grafana/dashboards/pv-solar-5y.json"
+info "Provisioning déployé"
 
-# ── 6. Configuration grafana.ini (port, admin) ───────────────────────────────
-GRAFANA_INI="/etc/grafana/grafana.ini"
+# ── 7. Configuration grafana.ini (port, admin) ───────────────────────────────
+patch_ini_key() {
+    local key="$1" val="$2"
+    if $SUDO grep -qE "^${key}\s*=" "$GRAFANA_INI"; then
+        $SUDO sed -i -E "s|^${key}\s*=.*|${key} = ${val}|" "$GRAFANA_INI"
+    elif $SUDO grep -qE "^;${key}\s*=" "$GRAFANA_INI"; then
+        $SUDO sed -i -E "s|^;${key}\s*=.*|${key} = ${val}|" "$GRAFANA_INI"
+    fi
+}
 
 if [[ "$GRAFANA_PORT" != "3000" ]]; then
     step "Configuration du port → $GRAFANA_PORT"
-    if grep -qE "^http_port\s*=" "$GRAFANA_INI"; then
-        $SUDO sed -i -E "s|^http_port\s*=.*|http_port = ${GRAFANA_PORT}|" "$GRAFANA_INI"
-    elif grep -qE "^;http_port\s*=" "$GRAFANA_INI"; then
-        $SUDO sed -i -E "s|^;http_port\s*=.*|http_port = ${GRAFANA_PORT}|" "$GRAFANA_INI"
+    if ! $SUDO grep -q "^\[server\]" "$GRAFANA_INI"; then
+        printf "\n[server]\nhttp_port = %s\n" "$GRAFANA_PORT" | $SUDO tee -a "$GRAFANA_INI" >/dev/null
     else
-        echo -e "\n[server]\nhttp_port = ${GRAFANA_PORT}" | $SUDO tee -a "$GRAFANA_INI" >/dev/null
+        patch_ini_key "http_port" "$GRAFANA_PORT"
     fi
     info "Port défini à $GRAFANA_PORT"
 fi
 
-# Mot de passe admin (uniquement à la 1ʳᵉ install ; ensuite via API)
 if [[ -n "$ADMIN_PWD" ]]; then
-    if [[ ! -f /var/lib/grafana/grafana.db ]]; then
-        step "Définition admin_password initial dans grafana.ini…"
-        if grep -qE "^;?admin_password\s*=" "$GRAFANA_INI"; then
-            $SUDO sed -i -E "s|^;?admin_password\s*=.*|admin_password = ${ADMIN_PWD}|" "$GRAFANA_INI"
-        fi
+    DB_PATH="${GRAFANA_DATA_PATH:+${GRAFANA_DATA_PATH}/data}/grafana.db"
+    DB_PATH="${DB_PATH:-/var/lib/grafana/grafana.db}"
+    if [[ ! -f "$DB_PATH" ]]; then
+        step "Définition admin_password initial…"
+        patch_ini_key "admin_password" "$ADMIN_PWD"
         info "Mot de passe admin initial défini"
     else
         warn "DB Grafana déjà présente — mot de passe non modifié."
@@ -216,26 +277,26 @@ if [[ -n "$ADMIN_PWD" ]]; then
     fi
 fi
 
-# ── 7. Image renderer (optionnel) ────────────────────────────────────────────
+# ── 8. Image renderer (optionnel, lourd) ─────────────────────────────────────
 if $INSTALL_RENDERER; then
-    step "Installation grafana-image-renderer + Chromium…"
+    step "Installation grafana-image-renderer + Chromium (~300 Mo)…"
     $SUDO apt-get install -y -qq chromium chromium-sandbox || \
-        warn "Chromium non disponible — le plugin pourrait nécessiter une install manuelle"
+        warn "Chromium non disponible via apt"
     $SUDO grafana-cli plugins install grafana-image-renderer || \
-        warn "Échec installation grafana-image-renderer (continuer sans)"
+        warn "Échec installation grafana-image-renderer"
     info "Image renderer installé"
 fi
 
-# ── 8. Pare-feu UFW (optionnel) ──────────────────────────────────────────────
+# ── 9. Pare-feu UFW (optionnel) ──────────────────────────────────────────────
 if ! $SKIP_FIREWALL && command -v ufw >/dev/null 2>&1; then
     if $SUDO ufw status 2>/dev/null | grep -q "Status: active"; then
-        step "Ouverture port UFW $GRAFANA_PORT/tcp…"
+        step "Ouverture port UFW ${GRAFANA_PORT}/tcp…"
         $SUDO ufw allow "${GRAFANA_PORT}/tcp" >/dev/null
         info "UFW: port $GRAFANA_PORT autorisé"
     fi
 fi
 
-# ── 9. Activation et démarrage du service ────────────────────────────────────
+# ── 10. Activation et démarrage du service ───────────────────────────────────
 step "Activation et démarrage grafana-server…"
 $SUDO systemctl daemon-reload
 $SUDO systemctl enable grafana-server >/dev/null 2>&1
@@ -248,7 +309,7 @@ else
     error "grafana-server ne démarre pas — voir: journalctl -u grafana-server -n 50"
 fi
 
-# ── 10. Healthcheck final ────────────────────────────────────────────────────
+# ── 11. Healthcheck final ────────────────────────────────────────────────────
 step "Vérification HTTP Grafana…"
 for i in {1..10}; do
     if curl -sf "http://127.0.0.1:${GRAFANA_PORT}/api/health" >/dev/null; then
@@ -261,6 +322,9 @@ done
 
 # ── Résumé ───────────────────────────────────────────────────────────────────
 IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+NVME_NOTE=""
+[[ -n "$GRAFANA_DATA_PATH" ]] && NVME_NOTE="  Données NVMe : ${GRAFANA_DATA_PATH}/
+"
 cat <<EOF
 
 ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
@@ -268,15 +332,14 @@ ${GREEN}Installation Grafana terminée${NC}
 ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
 
   URL          : http://${IP:-localhost}:${GRAFANA_PORT}
-  Login        : admin / admin (à changer à la 1ʳᵉ connexion si non --admin-pwd)
+  Login        : admin / admin  (changer à la 1ʳᵉ connexion)
   Datasource   : VictoriaMetrics → ${VM_URL}  (provisionnée)
-  Dashboard    : "PV Solaire - Monitoring & Comparaison 5 Ans"
-                 dossier "PV Solaire" (provisionné)
-
+  Dashboard    : "PV Solaire - Monitoring & Comparaison 5 Ans" (dossier PV Solaire)
+${NVME_NOTE}
   Logs         : journalctl -u grafana-server -f
   Config       : /etc/grafana/grafana.ini
   Provisioning : /etc/grafana/provisioning/
 
-  Désinstaller : bash scripts/setup-grafana.sh --uninstall
+  Désinstaller : sudo bash scripts/setup-grafana.sh --uninstall
 
 EOF


### PR DESCRIPTION
Évite de saturer la SD card : seul le binaire Grafana (~150 Mo) reste sur la SD, les données runtime vont sur le NVMe.

  --nvme           : données → /mnt/nvme/grafana/{data,log,plugins}
  --data-path=PATH : chemin custom
  Migration automatique de grafana.db si déjà présente.
  Vérification mountpoint avant toute opération NVMe.

Aussi : suppression de software-properties-common (absent sur Raspberry Pi OS), et patch_ini_key factorisé.