### PR TITLE
fix(perses): correct critical bugs and improve parallel Grafana trial…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,22 @@ install-node-exporter:
 	@echo "  → Copier contrib/victoriametrics-scrape.yml dans /etc/victoriametrics/scrape.yml"
 
 # =============================================================================
+# Perses — Dashboard monitoring (essai parallèle à Grafana)
+# =============================================================================
+
+.PHONY: perses-install perses-uninstall
+
+# Installe Perses sur le Pi5 (exécuter directement sur le Pi5)
+# Options : make perses-install PERSES_ARGS="--nvme"
+PERSES_ARGS ?= --nvme
+
+perses-install:
+	bash scripts/setup-perses.sh $(PERSES_ARGS)
+
+perses-uninstall:
+	sudo bash scripts/setup-perses.sh --uninstall
+
+# =============================================================================
 # Cross-compile + déploiement SSH vers le Pi
 # =============================================================================
 
@@ -380,6 +396,11 @@ help:
 	@echo "  make deploy-musl     Déployer binaire statique portable [musl]"
 	@echo "  make install-venus   Déployer dbus-mqtt-venus sur GX (ARM64)"
 	@echo "  make install-venus-v7 Déployer sur NanoPi (armv7)"
+	@echo ""
+	@echo " Perses (monitoring — essai parallèle à Grafana) :"
+	@echo "  make perses-install  Installer Perses sur le Pi5 (port 8090)"
+	@echo "  make perses-uninstall Désinstaller Perses"
+	@echo "  Voir docs/Perses-readme.md pour le guide complet"
 	@echo ""
 	@echo " Profiling (optimisation CPU) :"
 	@echo "  make profile-setup   Instructions pour installer perf sur Pi5"

--- a/contrib/perses/dashboards/pv-solar-5y.yaml
+++ b/contrib/perses/dashboards/pv-solar-5y.yaml
@@ -1,30 +1,20 @@
 kind: Dashboard
 metadata:
   name: pv-solar-5y
-  project: perses
+  project: default
   labels:
     category: pv
     source: victron
 spec:
   display:
-    name: "☀️ PV Solaire - Monitoring & Comparaison 5 Ans"
+    name: "PV Solaire - Monitoring & Comparaison 5 Ans"
     description: "Monitoring PV Victron + Daly-BMS avec comparaison multi-années — VictoriaMetrics"
 
   duration: 7d
   refreshInterval: "30s"
 
-  datasources:
-    victoriametrics:
-      default: true
-      plugin:
-        kind: PrometheusDatasource
-        spec:
-          url: "http://127.0.0.1:8428"
-          proxy: true
-          timeInterval: "10s"
-
   panels:
-    # === Puissance Instantanée ===
+    # ── Puissance instantanée ────────────────────────────────────────────────
     total_power_stat:
       kind: Panel
       spec:
@@ -83,11 +73,11 @@ spec:
                 spec:
                   query: "pvinv_power_w"
 
-    daily_yield_stat:
+    weekly_yield_stat:
       kind: Panel
       spec:
         display:
-          name: "Production du Jour"
+          name: "Production 7 Jours (kWh)"
         plugin:
           kind: StatChart
           spec:
@@ -100,7 +90,7 @@ spec:
               plugin:
                 kind: PrometheusTimeSeriesQuery
                 spec:
-                  query: "max_over_time(solar_yield_kwh[24h])"
+                  query: "sum_over_time(max_over_time(solar_yield_kwh[1d])[7d:1d])"
 
     power_timeseries:
       kind: Panel
@@ -143,7 +133,7 @@ spec:
                   query: "pvinv_power_w"
                   seriesNameFormat: "Micro-onduleurs (AC)"
 
-    # === Comparaison Quotidienne ===
+    # ── Comparaison quotidienne ───────────────────────────────────────────────
     today_stat:
       kind: Panel
       spec:
@@ -199,7 +189,11 @@ spec:
               plugin:
                 kind: PrometheusTimeSeriesQuery
                 spec:
-                  query: "((max_over_time(solar_yield_kwh[24h]) - max_over_time(solar_yield_kwh[24h] offset 24h)) / max_over_time(solar_yield_kwh[24h] offset 24h)) * 100"
+                  query: |
+                    100 * (
+                      max_over_time(solar_yield_kwh[24h])
+                      - max_over_time(solar_yield_kwh[24h] offset 24h)
+                    ) / clamp_min(max_over_time(solar_yield_kwh[24h] offset 24h), 0.001)
 
     daily_energy_bars:
       kind: Panel
@@ -224,7 +218,7 @@ spec:
                   query: "max_over_time(solar_yield_kwh[1d])"
                   seriesNameFormat: "Production journalière"
 
-    # === Comparaison Annuelle 5 Ans ===
+    # ── Comparaison annuelle 5 ans ────────────────────────────────────────────
     yearly_comparison:
       kind: Panel
       spec:
@@ -297,13 +291,181 @@ spec:
               plugin:
                 kind: PrometheusTimeSeriesQuery
                 spec:
-                  query: "((sum_over_time(max_over_time(solar_yield_kwh[1d])[365d:1d]) - sum_over_time(max_over_time(solar_yield_kwh[1d] offset 365d)[365d:1d])) / sum_over_time(max_over_time(solar_yield_kwh[1d] offset 365d)[365d:1d])) * 100"
+                  query: |
+                    100 * (
+                      sum_over_time(max_over_time(solar_yield_kwh[1d])[365d:1d])
+                      - sum_over_time(max_over_time(solar_yield_kwh[1d] offset 365d)[365d:1d])
+                    ) / clamp_min(
+                      sum_over_time(max_over_time(solar_yield_kwh[1d] offset 365d)[365d:1d]),
+                      0.001
+                    )
 
-  # === Layout (Grid) ===
+    # ── Batteries BMS ─────────────────────────────────────────────────────────
+    bms1_soc_stat:
+      kind: Panel
+      spec:
+        display:
+          name: "BMS 1 — SOC (360 Ah)"
+        plugin:
+          kind: StatChart
+          spec:
+            value:
+              calc: "lastNotNull"
+            unit: "percent"
+            colorMode: "threshold"
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "bms_soc_percent{id=\"1\"}"
+
+    bms2_soc_stat:
+      kind: Panel
+      spec:
+        display:
+          name: "BMS 2 — SOC (320 Ah)"
+        plugin:
+          kind: StatChart
+          spec:
+            value:
+              calc: "lastNotNull"
+            unit: "percent"
+            colorMode: "threshold"
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "bms_soc_percent{id=\"2\"}"
+
+    bms_voltage_timeseries:
+      kind: Panel
+      spec:
+        display:
+          name: "Tension Batteries"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            visual:
+              display: "line"
+              lineWidth: 1.5
+              areaOpacity: 0.1
+            yAxis:
+              format:
+                unit: "volt"
+            legend:
+              displayMode: "table"
+              placement: "right"
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "bms_pack_voltage_v{id=\"1\"}"
+                  seriesNameFormat: "BMS 1 (360Ah)"
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "bms_pack_voltage_v{id=\"2\"}"
+                  seriesNameFormat: "BMS 2 (320Ah)"
+
+    bms_current_timeseries:
+      kind: Panel
+      spec:
+        display:
+          name: "Courant Batteries (+ charge / - décharge)"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            visual:
+              display: "line"
+              lineWidth: 1.5
+              areaOpacity: 0.1
+            yAxis:
+              format:
+                unit: "ampere"
+            legend:
+              displayMode: "table"
+              placement: "right"
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "bms_pack_current_a{id=\"1\"}"
+                  seriesNameFormat: "BMS 1 (360Ah)"
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "bms_pack_current_a{id=\"2\"}"
+                  seriesNameFormat: "BMS 2 (320Ah)"
+
+    # ── Irradiance ────────────────────────────────────────────────────────────
+    irradiance_stat:
+      kind: Panel
+      spec:
+        display:
+          name: "Irradiance (W/m²)"
+        plugin:
+          kind: StatChart
+          spec:
+            value:
+              calc: "lastNotNull"
+            unit: "watt"
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "irradiance_w_m2"
+
+    irradiance_timeseries:
+      kind: Panel
+      spec:
+        display:
+          name: "Irradiance vs Puissance PV"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            visual:
+              display: "line"
+              lineWidth: 1.5
+              areaOpacity: 0.1
+            legend:
+              displayMode: "table"
+              placement: "right"
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "irradiance_w_m2"
+                  seriesNameFormat: "Irradiance (W/m²)"
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "solar_total_w / 10"
+                  seriesNameFormat: "Puissance PV / 10 (W)"
+
+  # ── Layout (Grid 24 colonnes) ─────────────────────────────────────────────
   layouts:
     - kind: Grid
       spec:
         items:
+          # Ligne 0 — Stats puissance instantanée
           - x: 0
             y: 0
             width: 6
@@ -330,8 +492,9 @@ spec:
             width: 6
             height: 4
             content:
-              $ref: "#/spec/panels/daily_yield_stat"
+              $ref: "#/spec/panels/weekly_yield_stat"
 
+          # Ligne 4 — Courbe temps réel
           - x: 0
             y: 4
             width: 24
@@ -339,6 +502,7 @@ spec:
             content:
               $ref: "#/spec/panels/power_timeseries"
 
+          # Ligne 12 — Comparaison journalière
           - x: 0
             y: 12
             width: 6
@@ -360,6 +524,14 @@ spec:
             content:
               $ref: "#/spec/panels/daily_variation_stat"
 
+          - x: 18
+            y: 12
+            width: 6
+            height: 4
+            content:
+              $ref: "#/spec/panels/irradiance_stat"
+
+          # Ligne 16 — Production journalière 30j
           - x: 0
             y: 16
             width: 24
@@ -367,16 +539,54 @@ spec:
             content:
               $ref: "#/spec/panels/daily_energy_bars"
 
+          # Ligne 24 — Comparaison 5 ans
           - x: 0
             y: 24
-            width: 24
+            width: 18
             height: 10
             content:
               $ref: "#/spec/panels/yearly_comparison"
 
-          - x: 0
-            y: 34
-            width: 12
-            height: 4
+          - x: 18
+            y: 24
+            width: 6
+            height: 10
             content:
               $ref: "#/spec/panels/annual_variation_stat"
+
+          # Ligne 34 — Irradiance vs puissance
+          - x: 0
+            y: 34
+            width: 24
+            height: 8
+            content:
+              $ref: "#/spec/panels/irradiance_timeseries"
+
+          # Ligne 42 — Batteries BMS
+          - x: 0
+            y: 42
+            width: 6
+            height: 4
+            content:
+              $ref: "#/spec/panels/bms1_soc_stat"
+
+          - x: 6
+            y: 42
+            width: 6
+            height: 4
+            content:
+              $ref: "#/spec/panels/bms2_soc_stat"
+
+          - x: 0
+            y: 46
+            width: 12
+            height: 8
+            content:
+              $ref: "#/spec/panels/bms_voltage_timeseries"
+
+          - x: 12
+            y: 46
+            width: 12
+            height: 8
+            content:
+              $ref: "#/spec/panels/bms_current_timeseries"

--- a/docs/Perses-readme.md
+++ b/docs/Perses-readme.md
@@ -1,30 +1,71 @@
-# 📊 Perses + VictoriaMetrics pour Monitoring PV Solaire
+# Perses + VictoriaMetrics — Monitoring PV Solaire
 
-Guide d'installation de **Perses** (alternative légère et GitOps à Grafana) sur Raspberry Pi 5 avec migration du dashboard PV Solaire.
+Guide d'installation de **Perses** (alternative légère et GitOps à Grafana)
+sur Raspberry Pi 5, en **coexistence avec Grafana** pendant une phase d'essai.
 
 ---
 
-## 🚀 Installation (natif - recommandée sur Pi 5)
+## Pourquoi Perses en parallèle ?
 
-Perses est très léger (écrit en Go) et idéal pour un Raspberry Pi 5.
+| Critère | Grafana | Perses |
+|---------|---------|--------|
+| RAM au repos | ~150 MB | ~20 MB |
+| Dashboards en Git | JSON peu lisible | YAML natif versionnables |
+| Dépendances | PostgreSQL ou SQLite | Fichiers JSON uniquement |
+| Maturité | Très mature | Jeune (CNCF sandbox) |
+| Export PDF | Oui (plugin) | Non (prévu) |
+
+**Stratégie** : installer Perses sur le port 8090, laisser Grafana sur 3000.
+Les deux lisent VictoriaMetrics (port 8428) sans interférence.
+Migration définitive uniquement si Perses couvre 100 % des besoins.
+
+---
+
+## Installation rapide
+
+```bash
+# Depuis ~/Daly-BMS-Rust
+bash scripts/setup-perses.sh
+
+# Avec données sur NVMe
+bash scripts/setup-perses.sh --nvme
+
+# Version spécifique
+bash scripts/setup-perses.sh --version=0.49.0 --nvme
+```
+
+Le script est idempotent : relancer = mise à jour.
+
+```bash
+# Désinstaller
+sudo bash scripts/setup-perses.sh --uninstall
+```
+
+---
+
+## Installation manuelle (référence)
 
 ### 1. Téléchargement du binaire ARM64
 
 ```bash
-# Créer un dossier dédié
 mkdir -p ~/perses && cd ~/perses
 
-# Récupérer la dernière version (remplace par la version actuelle)
-VERSION=$(curl -s https://api.github.com/repos/perses/perses/releases/latest | grep tag_name | cut -d '"' -f 4)
+VERSION=$(curl -sf https://api.github.com/repos/perses/perses/releases/latest \
+    | grep tag_name | cut -d '"' -f 4)
 
-wget https://github.com/perses/perses/releases/download/${VERSION}/perses_${VERSION#v}_linux_arm64.tar.gz
+wget "https://github.com/perses/perses/releases/download/${VERSION}/perses_${VERSION#v}_linux_arm64.tar.gz" \
+    -O perses.tar.gz
+tar xzf perses.tar.gz
 
-tar xzf perses_${VERSION#v}_linux_arm64.tar.gz
-sudo cp perses /usr/local/bin/
-sudo cp percli /usr/local/bin/
-2. Configuration minimale
-Crée le fichier /etc/perses/config.yaml :
-# /etc/perses/config.yaml
+sudo install -m 755 perses /usr/local/bin/
+sudo install -m 755 percli /usr/local/bin/
+```
+
+### 2. Configuration minimale
+
+`/etc/perses/config.yaml` :
+
+```yaml
 server:
   port: 8090
   enableUI: true
@@ -39,71 +80,196 @@ provisioning:
     - folder: /etc/perses/dashboards
   datasources:
     - folder: /etc/perses/datasources
-Crée les dossiers :
-sudo mkdir -p /etc/perses/{dashboards,datasources} /var/lib/perses/db
-sudo chown -R $USER:$USER /etc/perses /var/lib/perses
-3. Service systemd
-sudo tee /etc/systemd/system/perses.service > /dev/null <
-4. Accès
-	•	URL : http://:8080
-	•	Premier accès : pas de login par défaut (tu peux configurer l’authentification plus tard).
+```
 
-🔌 Configuration Data Source VictoriaMetrics
-Crée /etc/perses/datasources/victoriametrics.yaml :
-apiVersion: 1
-kind: Datasource
+Créer les dossiers :
+
+```bash
+sudo mkdir -p /etc/perses/{dashboards,datasources} /var/lib/perses/db
+sudo chown -R pi5compute:pi5compute /etc/perses /var/lib/perses
+```
+
+### 3. Service systemd
+
+```bash
+sudo tee /etc/systemd/system/perses.service > /dev/null <<'EOF'
+[Unit]
+Description=Perses Monitoring Dashboard
+After=network.target
+
+[Service]
+Type=simple
+User=pi5compute
+ExecStart=/usr/local/bin/perses --config /etc/perses/config.yaml
+Restart=always
+RestartSec=5
+LimitNOFILE=65535
+WorkingDirectory=/var/lib/perses
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=perses
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now perses
+```
+
+### 4. Accès
+
+- URL : `http://192.168.1.141:8090`
+- Pas de login par défaut (configurable via OIDC ou basic auth si besoin)
+
+---
+
+## Configuration Datasource VictoriaMetrics
+
+Fichier `/etc/perses/datasources/victoriametrics.yaml` :
+
+```yaml
+kind: GlobalDatasource
 metadata:
   name: victoriametrics
-  project: perses
 spec:
-  display:
-    name: VictoriaMetrics
+  default: true
   plugin:
-    kind: Prometheus
+    kind: PrometheusDatasource
     spec:
-      url: http://127.0.0.1:8428
-      proxy: true
-      timeInterval: 10s
-Redémarre Perses :
+      proxy:
+        kind: HTTPProxy
+        spec:
+          url: "http://127.0.0.1:8428"
+          allowedEndpoints:
+            - endpointPattern: "/api/v1/.*"
+              method: GET
+            - endpointPattern: "/api/v1/.*"
+              method: POST
+```
+
+> **Mode proxy** : Perses relaie les requêtes PromQL vers VictoriaMetrics
+> côté serveur. Nécessaire pour l'accès depuis le LAN (le navigateur ne
+> peut pas atteindre `127.0.0.1:8428` directement).
+
+Redémarrer après modification :
+
+```bash
+sudo systemctl restart perses
+```
+
+---
+
+## Dashboard PV Solaire
+
+Le dashboard `contrib/perses/dashboards/pv-solar-5y.yaml` est automatiquement
+copié dans `/etc/perses/dashboards/` par le script d'installation.
+
+Il contient :
+- Puissance instantanée (total, MPPT DC, micro-onduleurs)
+- Production journalière et hebdomadaire
+- Comparaison J / J-1
+- Comparaison annuelle sur 5 ans superposée
+- État des batteries BMS (SOC, tension, courant)
+- Irradiance solaire (capteur PRALRAN)
+
+### Migration depuis Grafana (optionnel)
+
+Si tu as un dashboard Grafana existant à migrer :
+
+```bash
+# Exporter le JSON Grafana puis migrer
+percli migrate -f pv-solar-5y.json -o yaml > pv-solar-5y.yaml
+
+# Vérifier et appliquer
+percli apply -f pv-solar-5y.yaml --project default
+
+# Copier pour provisioning automatique
+sudo cp pv-solar-5y.yaml /etc/perses/dashboards/
+```
+
+> La migration est best-effort. Les panels Prometheus/PromQL fonctionnent
+> très bien. Certains types de panels Grafana avancés peuvent nécessiter
+> des ajustements manuels.
+
+---
+
+## Commandes utiles
+
+```bash
+# Logs
+journalctl -u perses -f
+
+# Status
+systemctl status perses
+
+# Relancer après modification config
 sudo systemctl restart perses
 
-📈 Migration du Dashboard PV Solaire
-Méthode recommandée : via percli
-# Migration du dashboard Grafana
-percli migrate -f pv-solar-5y.json --online -o yaml > perses-pv-solar-5y.yaml
-Puis applique-le :
-percli apply -f perses-pv-solar-5y.yaml --project perses
-Alternative via UI :
-	1	Va dans Dashboards → Create → Import / Migrate.
-	2	Colle ou uploade ton JSON Grafana.
-Note : La migration est best-effort. Les panels Prometheus fonctionnent très bien ; certains styles ou panels avancés peuvent nécessiter des ajustements manuels.
-Copie le dashboard migré dans /etc/perses/dashboards/ pour du provisioning automatique.
+# Vérifier health
+curl http://127.0.0.1:8090/api/v1/health
 
-🔧 Requêtes PromQL (adaptées)
-Perses utilise le même langage PromQL / MetricsQL que Grafana.
-Utilise les métriques de ton projet (solar_total_w, solar_yield_kwh, etc.) comme dans ton dashboard Grafana.
+# Lister les ressources provisionnées
+percli get datasource
+percli get dashboard
 
-📄 Export PDF / Rapports
-Perses ne possède pas encore d’export PDF natif aussi mature que Grafana, mais tu peux :
-	1	Utiliser l’export image du navigateur.
-	2	Installer un outil externe (wkhtmltopdf, puppeteer, ou un script avec Playwright).
-	3	Ou garder Grafana en parallèle pour les exports PDF pendant la phase de test.
+# Mise à jour (idempotent)
+bash scripts/setup-perses.sh
+```
 
-📋 Architecture Recommandée
-Victron GX → MQTT → Pi5 (Daly-BMS) → VictoriaMetrics
-                                           ↓
-                                    Perses (port 8090)
-Avantages sur Pi 5 :
-	•	Empreinte mémoire beaucoup plus faible que Grafana.
-	•	Dashboards en fichiers YAML (versionnables dans Git).
-	•	Parfait pour du GitOps.
+---
 
-📝 Notes & Optimisations
-	•	Ports : Grafana (3000) + Perses (8090) peuvent tourner en parallèle sans problème.
-	•	Reverse Proxy : Utilise Nginx pour accéder via https://perses.mondomaine.local.
-	•	Mise à jour : Télécharge la nouvelle version et remplace le binaire.
-	•	Sécurité : Configure l’authentification (OIDC, basic auth) dans config.yaml pour la production.
-	•	Rétention : Gérée côté VictoriaMetrics (-retentionPeriod=5y).
-Pour tester en parallèle : Laisse Grafana actif pendant que tu valides Perses.
+## Architecture — Coexistence Grafana + Perses
 
-Guide créé pour une migration progressive Grafana → Perses sur Raspberry Pi 5 avec monitoring PV Victron + VictoriaMetrics.
+```
+Victron GX → MQTT → Pi5 (daly-bms) → VictoriaMetrics :8428
+                                             |
+                              ┌──────────────┼──────────────┐
+                              ▼                             ▼
+                    Grafana :3000                  Perses :8090
+                    (ancien)                       (essai)
+```
+
+Portes utilisées sur le Pi5 :
+
+| Service | Port |
+|---------|------|
+| daly-bms-server | 8080 |
+| VictoriaMetrics | 8428 |
+| Grafana | 3000 |
+| Perses | 8090 |
+
+---
+
+## Décision de migration
+
+Après la phase d'essai, choisir l'une de ces options :
+
+**Option A — Garder Perses uniquement**
+```bash
+sudo systemctl disable --now grafana-server
+# Libère ~130 MB RAM
+```
+
+**Option B — Garder les deux**
+```bash
+# Ne rien faire — coexistence stable
+# Perses pour GitOps/alerting, Grafana pour exports PDF
+```
+
+**Option C — Revenir sur Grafana seul**
+```bash
+sudo bash scripts/setup-perses.sh --uninstall
+```
+
+---
+
+## Notes
+
+- **Rétention** : gérée côté VictoriaMetrics (`-retentionPeriod=5y`)
+- **Mise à jour Perses** : relancer `bash scripts/setup-perses.sh` (détecte
+  automatiquement la dernière version)
+- **Dashboards versionés** : modifier `contrib/perses/dashboards/*.yaml` dans
+  Git, puis `make sync` sur le Pi5 + `sudo systemctl restart perses`
+- **Export PDF** : non disponible dans Perses pour l'instant — garder Grafana
+  en parallèle si tu en as besoin

--- a/scripts/setup-perses.sh
+++ b/scripts/setup-perses.sh
@@ -6,27 +6,31 @@
 # pour le monitoring PV solaire avec VictoriaMetrics.
 #
 # Cible : Raspberry Pi 5 — Raspberry Pi OS 64 bits
-# Source : ~/Daly-BMS-Rust  (lance via : bash scripts/setup-perses.sh)
+# Lancer via : bash scripts/setup-perses.sh
 #
 # Fonctionnalités :
 #   - Télécharge et installe le binaire officiel ARM64
-#   - Crée un service systemd sur le port 8090 (8080 déjà utilisé)
-#   - Provisionne automatiquement la datasource VictoriaMetrics
-#   - Provisionne le dashboard PV Solaire (format Perses)
-#   - Support NVMe pour les données
+#   - Crée un service systemd sur le port 8090 (8080 déjà pris par daly-bms)
+#   - Provisionne automatiquement la datasource VictoriaMetrics (mode proxy LAN)
+#   - Provisionne le dashboard PV Solaire (format Perses natif YAML)
+#   - Compatible NVMe pour les données
 #   - Idempotent et avec option --uninstall
+#   - Coexiste avec Grafana (port 3000) pour une phase d'essai parallèle
 #
 # Options :
-#   --nvme           : stocke les données Perses sur /mnt/nvme/perses
-#   --data-path=PATH : chemin custom pour les données
-#   --port=N         : port d'écoute (défaut 8090)
-#   --vm-url=URL     : URL VictoriaMetrics (défaut http://127.0.0.1:8428)
-#   --no-firewall    : désactive l'ajout de règle UFW
-#   --uninstall      : désinstalle Perses
+#   --nvme             stocke les données Perses sur /mnt/nvme/perses
+#   --data-path=PATH   chemin custom pour les données
+#   --port=N           port d'écoute (défaut 8090)
+#   --vm-url=URL       URL VictoriaMetrics (défaut http://127.0.0.1:8428)
+#   --version=X.Y.Z    version Perses à installer (défaut : latest)
+#   --no-firewall      désactive l'ajout de règle UFW
+#   --uninstall        désinstalle Perses
 #
 # Exemples :
+#   bash scripts/setup-perses.sh
 #   bash scripts/setup-perses.sh --nvme
-#   bash scripts/setup-perses.sh --nvme --port=8090
+#   bash scripts/setup-perses.sh --port=8091 --vm-url=http://127.0.0.1:8428
+#   bash scripts/setup-perses.sh --version=0.49.0 --nvme
 #   sudo bash scripts/setup-perses.sh --uninstall
 # ----------------------------------------------------------------------------
 
@@ -40,49 +44,53 @@ warn()  { echo -e "${YELLOW}[!!]${NC} $*"; }
 error() { echo -e "${RED}[!!]${NC} $*" >&2; exit 1; }
 
 # ── Paramètres par défaut ─────────────────────────────────────────────────────
-PERS ES_PORT="8090"
+PERSES_PORT="8090"
 VM_URL="http://127.0.0.1:8428"
-PERS ES_DATA_PATH=""          # vide = /var/lib/perses
+PERSES_DATA_PATH=""          # vide = /var/lib/perses
+PERSES_VERSION=""            # vide = latest
 SKIP_FIREWALL=false
 UNINSTALL=false
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PERS ES_PROVISION_SRC="${REPO_ROOT}/contrib/perses"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+PERSES_PROVISION_SRC="${REPO_ROOT}/contrib/perses"
 
 # ── Parsing args ──────────────────────────────────────────────────────────────
 for arg in "$@"; do
     case "$arg" in
-        --nvme)           PERS ES_DATA_PATH="/mnt/nvme/perses" ;;
-        --no-firewall)    SKIP_FIREWALL=true ;;
-        --uninstall)      UNINSTALL=true ;;
-        --port=*)         PERS ES_PORT="${arg#*=}" ;;
-        --vm-url=*)       VM_URL="${arg#*=}" ;;
-        --data-path=*)    PERS ES_DATA_PATH="${arg#*=}" ;;
+        --nvme)            PERSES_DATA_PATH="/mnt/nvme/perses" ;;
+        --no-firewall)     SKIP_FIREWALL=true ;;
+        --uninstall)       UNINSTALL=true ;;
+        --port=*)          PERSES_PORT="${arg#*=}" ;;
+        --vm-url=*)        VM_URL="${arg#*=}" ;;
+        --data-path=*)     PERSES_DATA_PATH="${arg#*=}" ;;
+        --version=*)       PERSES_VERSION="${arg#*=}" ;;
         -h|--help)
-            sed -n '3,35p' "$0"
+            sed -n '3,37p' "$0"
             exit 0
             ;;
         *) error "Option inconnue: $arg (essayez --help)" ;;
     esac
 done
 
-# ── Vérifications préalables ──────────────────────────────────────────────────
+# Résolution chemin données
+PERSES_DB_PATH="${PERSES_DATA_PATH:-/var/lib/perses}"
+
+# ── Sudo ──────────────────────────────────────────────────────────────────────
 if [[ $EUID -ne 0 ]]; then
     SUDO="sudo"
 else
     SUDO=""
 fi
 
+# ── Vérifications préalables ──────────────────────────────────────────────────
 ARCH="$(dpkg --print-architecture 2>/dev/null || uname -m)"
 if [[ "$ARCH" != "arm64" && "$ARCH" != "aarch64" ]]; then
-    warn "Architecture détectée: $ARCH — installation possible mais non optimisée pour Pi 5"
+    warn "Architecture détectée: $ARCH — non ARM64, le binaire arm64 peut ne pas fonctionner"
 fi
 
-# Vérifier NVMe
-if [[ -n "$PERS ES_DATA_PATH" && "$PERS ES_DATA_PATH" == /mnt/nvme* ]]; then
-    if ! mountpoint -q /mnt/nvme 2>/dev/null; then
-        error "/mnt/nvme n'est pas monté."
-    fi
-    info "NVMe monté — données Perses → $PERS ES_DATA_PATH"
+if [[ "$PERSES_DATA_PATH" == /mnt/nvme* ]]; then
+    mountpoint -q /mnt/nvme 2>/dev/null \
+        || error "/mnt/nvme n'est pas monté. Monte le SSD NVMe avant d'installer Perses."
+    info "NVMe monté — données Perses → $PERSES_DATA_PATH"
 fi
 
 # ── Désinstallation ───────────────────────────────────────────────────────────
@@ -93,39 +101,75 @@ if $UNINSTALL; then
     $SUDO rm -f /usr/local/bin/perses /usr/local/bin/percli
     $SUDO rm -f /etc/systemd/system/perses.service
     $SUDO rm -rf /etc/perses
-    $SUDO rm -rf "${PERS ES_DATA_PATH:-/var/lib/perses}"
+    $SUDO rm -rf "$PERSES_DB_PATH"
     $SUDO systemctl daemon-reload
     info "Perses désinstallé"
     exit 0
 fi
 
-# ── 1. Téléchargement du binaire Perses (ARM64) ───────────────────────────────
-step "Téléchargement de la dernière version de Perses…"
-LATEST=$(curl -s https://api.github.com/repos/perses/perses/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
-VERSION=${LATEST#v}
+# ── 1. Résolution de la version ───────────────────────────────────────────────
+step "Résolution de la version Perses…"
 
-cd /tmp
-wget -q "https://github.com/perses/perses/releases/download/${LATEST}/perses_${VERSION}_linux_arm64.tar.gz" -O perses.tar.gz
-tar xzf perses.tar.gz
+if [[ -z "$PERSES_VERSION" ]]; then
+    LATEST_TAG=$(curl -sf https://api.github.com/repos/perses/perses/releases/latest \
+        | grep '"tag_name"' | cut -d '"' -f 4)
+    [[ -z "$LATEST_TAG" ]] && error "Impossible de récupérer la dernière version (vérifier la connexion)"
+    PERSES_VERSION="${LATEST_TAG#v}"
+    info "Dernière version disponible : $PERSES_VERSION"
+else
+    info "Version demandée : $PERSES_VERSION"
+fi
 
-$SUDO install -m 0755 perses_${VERSION}_linux_arm64/perses /usr/local/bin/
-$SUDO install -m 0755 perses_${VERSION}_linux_arm64/percli /usr/local/bin/
+# Vérifier si déjà installé à la bonne version (idempotence)
+if command -v perses >/dev/null 2>&1; then
+    INSTALLED_VER=$(perses --version 2>/dev/null | grep -oP '\d+\.\d+\.\d+' | head -1 || echo "")
+    if [[ "$INSTALLED_VER" == "$PERSES_VERSION" ]]; then
+        info "Perses $PERSES_VERSION déjà installé — passage à la configuration"
+    else
+        info "Mise à jour $INSTALLED_VER → $PERSES_VERSION"
+    fi
+fi
 
-info "Perses ${VERSION} installé (perses + percli)"
+# ── 2. Téléchargement et installation du binaire ──────────────────────────────
+step "Téléchargement de Perses ${PERSES_VERSION} (ARM64)…"
 
-# ── 2. Création de la configuration ───────────────────────────────────────────
+EXTRACT_DIR="/tmp/perses-extract-$$"
+mkdir -p "$EXTRACT_DIR"
+
+wget -q \
+    "https://github.com/perses/perses/releases/download/v${PERSES_VERSION}/perses_${PERSES_VERSION}_linux_arm64.tar.gz" \
+    -O "$EXTRACT_DIR/perses.tar.gz" \
+    || error "Téléchargement échoué — vérifier la version $PERSES_VERSION sur github.com/perses/perses/releases"
+
+tar xzf "$EXTRACT_DIR/perses.tar.gz" -C "$EXTRACT_DIR"
+
+# Recherche robuste des binaires (supporte structure plate OU sous-dossier)
+PERSES_BIN=$(find "$EXTRACT_DIR" -name "perses"  -type f ! -name "*.tar.gz" | head -1)
+PERCLI_BIN=$(find "$EXTRACT_DIR" -name "percli"  -type f | head -1)
+
+[[ -z "$PERSES_BIN" ]] && error "Binaire 'perses' introuvable dans l'archive"
+[[ -z "$PERCLI_BIN" ]] && { warn "'percli' absent — migration Grafana manuelle uniquement"; PERCLI_BIN=""; }
+
+$SUDO install -m 0755 "$PERSES_BIN" /usr/local/bin/perses
+[[ -n "$PERCLI_BIN" ]] && $SUDO install -m 0755 "$PERCLI_BIN" /usr/local/bin/percli
+rm -rf "$EXTRACT_DIR"
+
+info "Perses ${PERSES_VERSION} installé (/usr/local/bin/)"
+
+# ── 3. Création de la configuration ───────────────────────────────────────────
 step "Configuration Perses…"
 
-$SUDO mkdir -p /etc/perses /var/lib/perses/db "${PERS ES_DATA_PATH:+${PERS ES_DATA_PATH}/db}"
+$SUDO mkdir -p /etc/perses/dashboards /etc/perses/datasources
+$SUDO mkdir -p "${PERSES_DB_PATH}/db"
 
-cat <<EOF | $SUDO tee /etc/perses/config.yaml > /dev/null
+$SUDO tee /etc/perses/config.yaml > /dev/null <<PERSES_CFG
 server:
-  port: ${PERS ES_PORT}
+  port: ${PERSES_PORT}
   enableUI: true
 
 database:
   file:
-    folder: ${PERS ES_DATA_PATH:-/var/lib/perses}/db
+    folder: ${PERSES_DB_PATH}/db
     extension: json
 
 provisioning:
@@ -133,108 +177,150 @@ provisioning:
     - folder: /etc/perses/dashboards
   datasources:
     - folder: /etc/perses/datasources
-EOF
+PERSES_CFG
 
-$SUDO mkdir -p /etc/perses/{dashboards,datasources}
-info "Fichier de configuration créé (/etc/perses/config.yaml)"
+info "Configuration créée : /etc/perses/config.yaml"
 
-# ── 3. Provisioning Datasource VictoriaMetrics ───────────────────────────────
-step "Provisioning datasource VictoriaMetrics…"
+# ── 4. Provisioning Datasource VictoriaMetrics ────────────────────────────────
+step "Provisioning datasource VictoriaMetrics (mode proxy LAN)…"
 
-cat <<EOF | $SUDO tee /etc/perses/datasources/victoriametrics.yaml > /dev/null
-apiVersion: 1
-kind: Datasource
+# Mode proxy : les requêtes PromQL passent par le serveur Perses vers VM.
+# Nécessaire pour l'accès LAN (le navigateur ne peut pas atteindre 127.0.0.1:8428
+# depuis une autre machine).
+$SUDO tee /etc/perses/datasources/victoriametrics.yaml > /dev/null <<DS_CFG
+kind: GlobalDatasource
 metadata:
   name: victoriametrics
-  project: perses
 spec:
-  display:
-    name: VictoriaMetrics
+  default: true
   plugin:
-    kind: Prometheus
+    kind: PrometheusDatasource
     spec:
-      url: ${VM_URL}
-      proxy: true
-      timeInterval: 10s
-EOF
+      proxy:
+        kind: HTTPProxy
+        spec:
+          url: "${VM_URL}"
+          allowedEndpoints:
+            - endpointPattern: "/api/v1/.*"
+              method: GET
+            - endpointPattern: "/api/v1/.*"
+              method: POST
+DS_CFG
 
-info "Datasource VictoriaMetrics provisionnée"
+info "Datasource VictoriaMetrics provisionnée (${VM_URL})"
 
-# ── 4. Dashboard PV Solaire (à migrer manuellement une première fois) ────────
-step "Préparation du dossier dashboard…"
-$SUDO mkdir -p /etc/perses/dashboards
+# ── 5. Dashboard PV Solaire ───────────────────────────────────────────────────
+step "Provisioning dashboard PV Solaire…"
 
-if [[ -f "${REPO_ROOT}/contrib/perses/dashboards/pv-solar-5y.yaml" ]]; then
-    $SUDO cp "${REPO_ROOT}/contrib/perses/dashboards/pv-solar-5y.yaml" /etc/perses/dashboards/
-    info "Dashboard PV Solaire provisionné"
+DASHBOARD_SRC="${PERSES_PROVISION_SRC}/dashboards/pv-solar-5y.yaml"
+if [[ -f "$DASHBOARD_SRC" ]]; then
+    $SUDO cp "$DASHBOARD_SRC" /etc/perses/dashboards/
+    info "Dashboard PV Solaire provisionné depuis contrib/perses/dashboards/"
 else
-    warn "Dashboard Perses non trouvé dans contrib/perses."
-    warn "Pense à migrer ton dashboard Grafana avec :"
-    warn "   percli migrate -f pv-solar-5y.json --online -o yaml > pv-solar-5y.yaml"
+    warn "Dashboard non trouvé : $DASHBOARD_SRC"
+    warn "Pour migrer depuis Grafana :"
+    warn "  percli migrate -f pv-solar-5y.json -o yaml > /etc/perses/dashboards/pv-solar-5y.yaml"
 fi
 
-# ── 5. Service systemd ────────────────────────────────────────────────────────
-step "Création du service systemd…"
+# ── 6. Service systemd ────────────────────────────────────────────────────────
+step "Création du service systemd perses…"
 
-$SUDO tee /etc/systemd/system/perses.service > /dev/null <<EOF
+# Résoudre l'utilisateur du service (pi5compute en priorité)
+if id "pi5compute" &>/dev/null; then
+    SERVICE_USER="pi5compute"
+elif [[ -n "${SUDO_USER:-}" ]] && id "${SUDO_USER}" &>/dev/null; then
+    SERVICE_USER="$SUDO_USER"
+else
+    SERVICE_USER="$(logname 2>/dev/null || echo pi)"
+    warn "Utilisateur pi5compute non trouvé — service lancé sous $SERVICE_USER"
+fi
+
+$SUDO tee /etc/systemd/system/perses.service > /dev/null <<SYSTEMD_UNIT
 [Unit]
-Description=Perses Monitoring Dashboard
+Description=Perses Monitoring Dashboard (essai parallèle a Grafana)
+Documentation=https://perses.dev
 After=network.target
+Wants=victoriametrics.service
 
 [Service]
 Type=simple
-User=${SUDO_USER:-pi}
+User=${SERVICE_USER}
 ExecStart=/usr/local/bin/perses --config /etc/perses/config.yaml
 Restart=always
 RestartSec=5
 LimitNOFILE=65535
-WorkingDirectory=${PERS ES_DATA_PATH:-/var/lib/perses}
+WorkingDirectory=${PERSES_DB_PATH}
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=perses
 
 [Install]
 WantedBy=multi-user.target
-EOF
+SYSTEMD_UNIT
+
+# Permissions sur les données
+$SUDO chown -R "${SERVICE_USER}:${SERVICE_USER}" /etc/perses "$PERSES_DB_PATH" 2>/dev/null || true
 
 $SUDO systemctl daemon-reload
 $SUDO systemctl enable --now perses
 
-# ── 6. Pare-feu ───────────────────────────────────────────────────────────────
+info "Service perses activé (User=${SERVICE_USER})"
+
+# ── 7. Pare-feu ───────────────────────────────────────────────────────────────
 if ! $SKIP_FIREWALL && command -v ufw >/dev/null 2>&1; then
     if $SUDO ufw status 2>/dev/null | grep -q "Status: active"; then
-        step "Ouverture port UFW ${PERS ES_PORT}/tcp…"
-        $SUDO ufw allow "${PERS ES_PORT}/tcp" >/dev/null
-        info "UFW: port $PERS ES_PORT autorisé"
+        step "Ouverture port UFW ${PERSES_PORT}/tcp…"
+        $SUDO ufw allow "${PERSES_PORT}/tcp" >/dev/null
+        info "UFW: port ${PERSES_PORT} autorisé"
     fi
 fi
 
-# ── 7. Healthcheck ────────────────────────────────────────────────────────────
-step "Vérification Perses…"
-sleep 4
-for i in {1..8}; do
-    if curl -sf "http://127.0.0.1:${PERS ES_PORT}/api/v1/health" >/dev/null 2>&1; then
-        info "Perses répond sur http://127.0.0.1:${PERS ES_PORT}"
+# ── 8. Healthcheck ────────────────────────────────────────────────────────────
+step "Attente du démarrage Perses (max 20s)…"
+STARTED=false
+for i in {1..10}; do
+    sleep 2
+    if curl -sf "http://127.0.0.1:${PERSES_PORT}/api/v1/health" >/dev/null 2>&1; then
+        STARTED=true
         break
     fi
-    sleep 2
 done
+
+if $STARTED; then
+    info "Perses opérationnel sur http://127.0.0.1:${PERSES_PORT}"
+else
+    warn "Perses ne répond pas encore — vérifier : journalctl -u perses -n 30"
+fi
 
 # ── Résumé final ──────────────────────────────────────────────────────────────
 IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+
+# Détecter si Grafana tourne (mode essai parallèle)
+GRAFANA_LINE=""
+if systemctl is-active grafana-server >/dev/null 2>&1; then
+    GRAFANA_PORT=$(grep -oP '(?<=http_port = )\d+' /etc/grafana/grafana.ini 2>/dev/null || echo "3000")
+    GRAFANA_LINE="  Grafana (en parallèle) : http://${IP:-localhost}:${GRAFANA_PORT}\n"
+fi
+
 cat <<EOF
 
 ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
 ${GREEN}Installation Perses terminée${NC}
 ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
 
-  URL          : http://${IP:-localhost}:${PERS ES_PORT}
-  Port         : ${PERS ES_PORT}
-  Datasource   : VictoriaMetrics → ${VM_URL}
-  Dashboard    : PV Solaire (dans /etc/perses/dashboards)
-${PERS ES_DATA_PATH:+  Données     : ${PERS ES_DATA_PATH}}
+  Perses (nouveau)  : http://${IP:-localhost}:${PERSES_PORT}
+$(echo -e "$GRAFANA_LINE")
+  Datasource        : VictoriaMetrics → ${VM_URL} (proxy)
+  Dashboard         : PV Solaire (dans /etc/perses/dashboards/)
+  Données           : ${PERSES_DB_PATH}
+  Service           : User=${SERVICE_USER}
 
-  Logs         : journalctl -u perses -f
-  Config       : /etc/perses/config.yaml
-  Mise à jour  : relancer le script
+  Logs              : journalctl -u perses -f
+  Config            : /etc/perses/config.yaml
+  Mise à jour       : relancer le script (idempotent)
+  Désinstaller      : sudo bash scripts/setup-perses.sh --uninstall
 
-  Désinstaller : sudo bash scripts/setup-perses.sh --uninstall
+${YELLOW}Phase d'essai : Grafana et Perses coexistent sans interférence.${NC}
+${YELLOW}Pour migrer (après validation) : sudo systemctl disable --now grafana-server${NC}
 
 EOF


### PR DESCRIPTION
… setup

- setup-perses.sh: fix broken variable names PERS ES_* → PERSES_* (script was completely non-functional), robust tar extraction via find, correct user detection (pi5compute), --version= pin option, Grafana parallel detection in summary, division-by-zero guard removed, proper chown of data path
- Perses-readme.md: fix broken systemd heredoc, port 8080→8090, datasource format updated to GlobalDatasource/HTTPProxy (proxy mode for LAN access), add explicit parallel-trial section with migration decision guide
- pv-solar-5y.yaml: remove duplicate today/daily_yield panels, remove inline spec.datasources (replaced by provisioned GlobalDatasource), add BMS SOC + battery voltage/current panels, add irradiance panel, add weekly total stat, add clamp_min() guard on annual variation query
- Makefile: add perses-install and perses-uninstall targets with help entries