### PR TITLE
fix(perses): archive plate — EXTRACT_DIR pointe sur TMPDIR_PERSES

### DIFF
--- a/scripts/setup-perses.sh
+++ b/scripts/setup-perses.sh
@@ -121,9 +121,9 @@ trap 'rm -rf "$TMPDIR_PERSES"' EXIT
 ARCHIVE_URL="https://github.com/perses/perses/releases/download/${LATEST}/perses_${VERSION}_linux_arm64.tar.gz"
 step "Téléchargement : ${ARCHIVE_URL}"
 curl -fsSL "${ARCHIVE_URL}" -o "${TMPDIR_PERSES}/perses.tar.gz"
+# L'archive est plate (pas de sous-dossier) → extraire directement dans TMPDIR_PERSES
 tar xzf "${TMPDIR_PERSES}/perses.tar.gz" -C "${TMPDIR_PERSES}"
-
-EXTRACT_DIR="${TMPDIR_PERSES}/perses_${VERSION}_linux_arm64"
+EXTRACT_DIR="${TMPDIR_PERSES}"
 
 $SUDO install -m 0755 "${EXTRACT_DIR}/perses"  /usr/local/bin/perses
 $SUDO install -m 0755 "${EXTRACT_DIR}/percli"  /usr/local/bin/percli


### PR DESCRIPTION
L'archive perses_x.y.z_linux_arm64.tar.gz extrait ses fichiers directement à la racine (pas de sous-dossier). Suppression du suffixe /perses_VERSION_linux_arm64 qui n'existe pas.

https://claude.ai/code/session_016Si94ssN9biZiRx4X44jxw