### PR TITLE
fix(perses): remplacer toutes les unités invalides par decimal

### DIFF
--- a/contrib/perses/dashboards/ess-overview.yaml
+++ b/contrib/perses/dashboards/ess-overview.yaml
@@ -26,7 +26,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#6e6e6e"
@@ -59,7 +59,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#F2495C"
@@ -94,7 +94,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#73BF69"
@@ -125,7 +125,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#73BF69"
@@ -234,7 +234,7 @@ spec:
               areaOpacity: 0.08
             yAxis:
               format:
-                unit: watts
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -354,7 +354,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: volts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#F2495C"
@@ -387,7 +387,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: milliseconds
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#73BF69"
@@ -475,7 +475,7 @@ spec:
               areaOpacity: 0.08
             yAxis:
               format:
-                unit: amperes
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -524,7 +524,7 @@ spec:
               lineWidth: 2
             yAxis:
               format:
-                unit: volts
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -601,7 +601,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: short
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#F2495C"
@@ -630,7 +630,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: short
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#F2495C"
@@ -663,7 +663,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#6e6e6e"
@@ -694,7 +694,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#6e6e6e"
@@ -725,7 +725,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#6e6e6e"
@@ -756,7 +756,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: "W/m²"
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#6e6e6e"
@@ -795,7 +795,7 @@ spec:
               areaOpacity: 0.1
             yAxis:
               format:
-                unit: watts
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -863,7 +863,7 @@ spec:
               areaOpacity: 0.15
             yAxis:
               format:
-                unit: "W/m²"
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -886,7 +886,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -908,7 +908,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -930,7 +930,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -952,7 +952,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -978,7 +978,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#6e6e6e"
@@ -1009,7 +1009,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -1032,7 +1032,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -1054,7 +1054,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#73BF69"
@@ -1084,7 +1084,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#6e6e6e"
@@ -1151,7 +1151,7 @@ spec:
               display: bar
             yAxis:
               format:
-                unit: watt-hours
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -1185,7 +1185,7 @@ spec:
               areaOpacity: 0.08
             yAxis:
               format:
-                unit: watts
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -1233,7 +1233,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: volts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#F2495C"
@@ -1268,7 +1268,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: hertz
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#F2495C"
@@ -1303,7 +1303,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: short
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#73BF69"
@@ -1366,7 +1366,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#6e6e6e"
@@ -1397,7 +1397,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -1420,7 +1420,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: volts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#F2495C"

--- a/contrib/perses/dashboards/pv-solar-5y.yaml
+++ b/contrib/perses/dashboards/pv-solar-5y.yaml
@@ -22,7 +22,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
             thresholds:
               steps:
                 - color: "#73BF69"
@@ -52,7 +52,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -74,7 +74,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watts
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -96,7 +96,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -118,7 +118,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -167,7 +167,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: watt-hours
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -256,7 +256,7 @@ spec:
               lineWidth: 2
             yAxis:
               format:
-                unit: watts
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -304,7 +304,7 @@ spec:
               lineWidth: 2
             yAxis:
               format:
-                unit: volts
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -342,7 +342,7 @@ spec:
               lineWidth: 2
             yAxis:
               format:
-                unit: amperes
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -375,7 +375,7 @@ spec:
           spec:
             calculation: last-number
             format:
-              unit: "W/m²"
+              unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -402,7 +402,7 @@ spec:
               areaOpacity: 0.15
             yAxis:
               format:
-                unit: "W/m²"
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -427,7 +427,7 @@ spec:
               display: bar
             yAxis:
               format:
-                unit: watt-hours
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -456,7 +456,7 @@ spec:
               areaOpacity: 0
             yAxis:
               format:
-                unit: watt-hours
+                unit: "decimal"
         queries:
           - kind: TimeSeriesQuery
             spec:


### PR DESCRIPTION
Le schéma CUE de Perses 0.53 ne supporte aucune unité électrique. Unités valides : percent, celsius, decimal, bytes, durées, devises.

Remplacé dans ess-overview.yaml et pv-solar-5y.yaml :
  watts, volts, amperes, hertz, watt-hours, "W/m²", short, milliseconds
  → "decimal"

Unités conservées : percent (SOC, variation), celsius (température).

https://claude.ai/code/session_016Si94ssN9biZiRx4X44jxw