### PR TITLE
feat(dashboards): catalogue panels Grafana + endpoints data (Phase 1)

### DIFF
--- a/crates/daly-bms-server/src/api/dashboards.rs
+++ b/crates/daly-bms-server/src/api/dashboards.rs
@@ -1,0 +1,230 @@
+//! Endpoints catalogue de panels & exécution des requêtes panel.
+//!
+//! - `GET /api/v1/dashboards/catalog`         → liste des panels disponibles
+//! - `GET /api/v1/dashboards/panel/:id/data`  → exécute les PromQL du panel
+//!
+//! Le catalogue est chargé une seule fois au démarrage (cf. `dashboards::Catalog`)
+//! et stocké dans `AppState.dashboard_catalog`.
+
+use axum::{
+    extract::{Path, Query, State},
+    response::IntoResponse,
+    Json,
+};
+use chrono::Utc;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::dashboards::{Panel, PanelKind};
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/dashboards/catalog
+// ---------------------------------------------------------------------------
+
+/// Retourne la liste des panels disponibles.
+/// Filtre optionnel `?kind=stat|timeseries|...` pour ne retourner qu'un type.
+#[derive(Deserialize)]
+pub struct CatalogParams {
+    pub kind: Option<String>,
+    /// Si `true`, inclut les rows (sections). Défaut: false (les rows ne sont pas
+    /// utiles à proposer dans la modale "Ajouter panel").
+    pub include_rows: Option<bool>,
+}
+
+pub async fn get_catalog(
+    State(state): State<AppState>,
+    Query(q):     Query<CatalogParams>,
+) -> impl IntoResponse {
+    let include_rows = q.include_rows.unwrap_or(false);
+    let kind_filter = q.kind.as_deref().map(PanelKind::from_grafana);
+
+    let panels: Vec<&Panel> = state.dashboard_catalog.panels().iter()
+        .filter(|p| include_rows || p.kind != PanelKind::Row)
+        .filter(|p| match &kind_filter {
+            Some(k) => &p.kind == k,
+            None    => true,
+        })
+        .collect();
+
+    Json(json!({
+        "ok":    true,
+        "count": panels.len(),
+        "panels": panels,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/dashboards/panel/:id/data
+// ---------------------------------------------------------------------------
+
+/// Paramètres de requête pour exécuter un panel.
+#[derive(Deserialize)]
+pub struct PanelDataParams {
+    /// Début de fenêtre en epoch ms. Défaut: now - 1h.
+    pub from: Option<i64>,
+    /// Fin de fenêtre en epoch ms. Défaut: now.
+    pub to: Option<i64>,
+    /// Pas de la requête en secondes. Défaut: auto (≈ 200 points sur la fenêtre).
+    pub step: Option<i64>,
+}
+
+/// Exécute les requêtes PromQL d'un panel et retourne les séries.
+///
+/// Format de réponse :
+/// ```json
+/// {
+///   "ok": true,
+///   "panel": { "id": "...", "title": "...", "kind": "timeseries", "unit": "watt" },
+///   "from_ms": ..., "to_ms": ..., "step_ms": ...,
+///   "series": [
+///     { "ref_id": "A", "legend": "PV", "labels": {...}, "ts_ms": [...], "values": [...] },
+///     ...
+///   ]
+/// }
+/// ```
+pub async fn get_panel_data(
+    State(state): State<AppState>,
+    Path(id):     Path<String>,
+    Query(q):     Query<PanelDataParams>,
+) -> impl IntoResponse {
+    let panel = match state.dashboard_catalog.find(&id) {
+        Some(p) => p.clone(),
+        None => {
+            return Json(json!({
+                "ok":     false,
+                "reason": "panel_not_found",
+                "id":     id,
+            }));
+        }
+    };
+
+    let vm = match &state.vm {
+        Some(v) => v.clone(),
+        None => {
+            return Json(json!({"ok": false, "reason": "vm_disabled"}));
+        }
+    };
+
+    let now_ms = Utc::now().timestamp_millis();
+    let to_ms   = q.to.unwrap_or(now_ms);
+    let from_ms = q.from.unwrap_or(to_ms - 3_600_000); // défaut 1h
+    let span_s  = ((to_ms - from_ms).max(1) / 1000) as f64;
+    // Pas auto : ~200 points dans la fenêtre, borné à 5s min / 1d max
+    let auto_step_s = (span_s / 200.0).clamp(5.0, 86_400.0) as i64;
+    let step_s = q.step.unwrap_or(auto_step_s).max(1);
+    let step_ms = step_s * 1000;
+
+    // Rows n'ont pas de queries → réponse vide
+    if panel.queries.is_empty() {
+        return Json(json!({
+            "ok":      true,
+            "panel":   panel,
+            "from_ms": from_ms,
+            "to_ms":   to_ms,
+            "step_ms": step_ms,
+            "series":  Vec::<Value>::new(),
+        }));
+    }
+
+    // Exécute toutes les queries en parallèle
+    let futures = panel.queries.iter().map(|q| {
+        let vm = vm.clone();
+        let expr = q.expr.clone();
+        let ref_id = q.ref_id.clone();
+        let legend = q.legend.clone();
+        async move {
+            let result = vm.query_range_json(&expr, from_ms, to_ms, step_ms).await;
+            (ref_id, legend, expr, result)
+        }
+    });
+    let results: Vec<_> = futures::future::join_all(futures).await;
+
+    let mut series = Vec::new();
+    for (ref_id, legend, expr, result) in results {
+        match result {
+            Ok(json_val) => {
+                let extracted = extract_series(&json_val);
+                for (labels, ts, values) in extracted {
+                    series.push(json!({
+                        "ref_id": ref_id,
+                        "legend": format_legend(legend.as_deref(), &labels),
+                        "expr":   expr,
+                        "labels": labels,
+                        "ts_ms":  ts,
+                        "values": values,
+                    }));
+                }
+            }
+            Err(e) => {
+                tracing::warn!(panel = %panel.id, ref_id = %ref_id, expr = %expr, error = %e,
+                    "panel query failed");
+            }
+        }
+    }
+
+    Json(json!({
+        "ok":      true,
+        "panel":   panel,
+        "from_ms": from_ms,
+        "to_ms":   to_ms,
+        "step_ms": step_ms,
+        "series":  series,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extrait toutes les séries du JSON VM range_query.
+/// Retourne `Vec<(labels, ts_ms, values)>` — une entrée par série Prometheus.
+fn extract_series(result: &Value) -> Vec<(serde_json::Map<String, Value>, Vec<i64>, Vec<f64>)> {
+    let empty = vec![];
+    let list = result.pointer("/data/result").and_then(|v| v.as_array()).unwrap_or(&empty);
+    let mut out = Vec::with_capacity(list.len());
+
+    for s in list {
+        let labels = s.get("metric")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_default();
+        let values = s.get("values").and_then(|v| v.as_array());
+        let Some(values) = values else { continue };
+        let mut ts = Vec::with_capacity(values.len());
+        let mut vs = Vec::with_capacity(values.len());
+        for entry in values {
+            let ts_secs = entry.get(0).and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let val: f64 = entry.get(1)
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(f64::NAN);
+            ts.push((ts_secs * 1000.0) as i64);
+            vs.push(round4(val));
+        }
+        out.push((labels, ts, vs));
+    }
+    out
+}
+
+/// Remplace `{label}` dans un format de légende Grafana par la valeur du label.
+/// Si pas de format, retourne `__name__` ou la concaténation des labels.
+fn format_legend(format: Option<&str>, labels: &serde_json::Map<String, Value>) -> String {
+    if let Some(fmt) = format {
+        let mut result = fmt.to_string();
+        for (k, v) in labels {
+            let placeholder = format!("{{{{{}}}}}", k); // Grafana utilise {{label}}
+            if let Some(val) = v.as_str() {
+                result = result.replace(&placeholder, val);
+            }
+        }
+        return result;
+    }
+    labels.get("__name__").and_then(|v| v.as_str()).unwrap_or("").to_string()
+}
+
+#[inline]
+fn round4(v: f64) -> f64 {
+    if v.is_nan() { return v; }
+    (v * 10000.0).round() / 10000.0
+}

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -7,6 +7,7 @@ pub mod bms;
 pub mod ats;
 pub mod alerts;
 pub mod console;
+pub mod dashboards;
 pub mod et112;
 pub mod tasmota;
 pub mod shelly;
@@ -103,6 +104,10 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/chart/history",           get(chart::get_chart_history))
         .route("/api/v1/chart/edge-history",      get(chart::get_edge_history))
         .route("/api/v1/history/energy",          get(history::get_energy_history))
+
+        // ── Dashboards (catalogue panels Grafana + data) ──────────────────────
+        .route("/api/v1/dashboards/catalog",         get(dashboards::get_catalog))
+        .route("/api/v1/dashboards/panel/:id/data",  get(dashboards::get_panel_data))
 
         // ── Tasmota ──────────────────────────────────────────────────────────
         .route("/api/v1/tasmota",                 get(tasmota::list_tasmota))

--- a/crates/daly-bms-server/src/dashboards/grafana.rs
+++ b/crates/daly-bms-server/src/dashboards/grafana.rs
@@ -1,0 +1,145 @@
+//! Parser Grafana JSON → liste de `Panel` normalisés.
+//!
+//! On extrait uniquement les champs nécessaires à l'affichage :
+//! id, title, type, gridPos, targets[].expr, fieldConfig.defaults.unit.
+//!
+//! Les panels imbriqués dans un row collapsed (`panels: [...]`) sont
+//! aplatis dans la liste principale.
+
+use super::{GridPos, Panel, PanelKind, PanelQuery};
+use serde_json::Value;
+
+/// Parse un JSON Grafana et retourne la liste de panels.
+pub fn parse_dashboard(json: &str) -> anyhow::Result<Vec<Panel>> {
+    let root: Value = serde_json::from_str(json)?;
+    let raw_panels = root.get("panels")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow::anyhow!("dashboard JSON: champ 'panels' absent ou non-array"))?;
+
+    let mut out = Vec::with_capacity(raw_panels.len());
+    for p in raw_panels {
+        collect_panel(p, &mut out);
+    }
+    Ok(out)
+}
+
+/// Ajoute le panel + ses sous-panels (cas row collapsed) à `out`.
+fn collect_panel(p: &Value, out: &mut Vec<Panel>) {
+    if let Some(panel) = parse_one(p) {
+        out.push(panel);
+    }
+    if let Some(sub) = p.get("panels").and_then(|v| v.as_array()) {
+        for child in sub {
+            collect_panel(child, out);
+        }
+    }
+}
+
+fn parse_one(p: &Value) -> Option<Panel> {
+    let id = p.get("id")?.as_u64().map(|n| n.to_string())?;
+    let title = p.get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let raw_type = p.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    let kind = PanelKind::from_grafana(raw_type);
+
+    let grid_pos = p.get("gridPos")
+        .map(parse_gridpos)
+        .unwrap_or_default();
+
+    // Unit : fieldConfig.defaults.unit
+    let unit = p
+        .pointer("/fieldConfig/defaults/unit")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let decimals = p
+        .pointer("/fieldConfig/defaults/decimals")
+        .and_then(|v| v.as_u64())
+        .map(|n| n.min(10) as u8);
+
+    let queries = p.get("targets")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(parse_target).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    Some(Panel {
+        id,
+        title,
+        kind,
+        grid_pos,
+        unit,
+        queries,
+        decimals,
+    })
+}
+
+fn parse_gridpos(v: &Value) -> GridPos {
+    GridPos {
+        x: v.get("x").and_then(|n| n.as_u64()).unwrap_or(0) as u32,
+        y: v.get("y").and_then(|n| n.as_u64()).unwrap_or(0) as u32,
+        w: v.get("w").and_then(|n| n.as_u64()).unwrap_or(12) as u32,
+        h: v.get("h").and_then(|n| n.as_u64()).unwrap_or(8) as u32,
+    }
+}
+
+fn parse_target(t: &Value) -> Option<PanelQuery> {
+    let expr = t.get("expr").and_then(|v| v.as_str())?.to_string();
+    if expr.is_empty() {
+        return None;
+    }
+    let ref_id = t.get("refId").and_then(|v| v.as_str()).unwrap_or("A").to_string();
+    let legend = t.get("legendFormat")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    Some(PanelQuery { ref_id, expr, legend })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal() {
+        let json = r#"{
+            "panels": [
+                {
+                    "id": 1,
+                    "title": "Solar",
+                    "type": "timeseries",
+                    "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
+                    "fieldConfig": {"defaults": {"unit": "watt"}},
+                    "targets": [
+                        {"refId": "A", "expr": "solar_total_w", "legendFormat": "PV"}
+                    ]
+                }
+            ]
+        }"#;
+        let panels = parse_dashboard(json).unwrap();
+        assert_eq!(panels.len(), 1);
+        assert_eq!(panels[0].id, "1");
+        assert_eq!(panels[0].title, "Solar");
+        assert_eq!(panels[0].kind, PanelKind::TimeSeries);
+        assert_eq!(panels[0].unit, "watt");
+        assert_eq!(panels[0].queries.len(), 1);
+        assert_eq!(panels[0].queries[0].expr, "solar_total_w");
+    }
+
+    #[test]
+    fn parse_real_grafana_ess() {
+        const SRC: &str = include_str!("../../../../docs/grafana-ess_dashboard.json");
+        let panels = parse_dashboard(SRC).expect("parse échoué");
+        assert!(panels.len() >= 20, "trop peu de panels parsés: {}", panels.len());
+        // Doit contenir au moins un row, un stat et un timeseries
+        assert!(panels.iter().any(|p| p.kind == PanelKind::Row));
+        assert!(panels.iter().any(|p| p.kind == PanelKind::Stat));
+        assert!(panels.iter().any(|p| p.kind == PanelKind::TimeSeries));
+    }
+}

--- a/crates/daly-bms-server/src/dashboards/mod.rs
+++ b/crates/daly-bms-server/src/dashboards/mod.rs
@@ -1,0 +1,120 @@
+//! Module dashboards — catalogue de panels importés depuis Grafana.
+//!
+//! Architecture :
+//! - `grafana::parse_dashboard()` lit un dashboard Grafana JSON et en extrait
+//!   une liste normalisée de panels (`Panel`).
+//! - Le catalogue est chargé une seule fois au démarrage via `Catalog::load_default()`
+//!   qui inclut le JSON Grafana au build (`include_str!`).
+//! - Exposé via `GET /api/v1/dashboards/catalog`.
+//! - Exécution des PromQL d'un panel via `GET /api/v1/dashboards/panel/:id/data`.
+
+pub mod grafana;
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Type de panel normalisé (subset de Grafana suffisant pour notre UI).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PanelKind {
+    Row,
+    Stat,
+    TimeSeries,
+    BarChart,
+    Gauge,
+    BarGauge,
+    Table,
+    Unknown,
+}
+
+impl PanelKind {
+    pub fn from_grafana(s: &str) -> Self {
+        match s {
+            "row"        => PanelKind::Row,
+            "stat"       => PanelKind::Stat,
+            "timeseries" => PanelKind::TimeSeries,
+            "barchart"   => PanelKind::BarChart,
+            "gauge"      => PanelKind::Gauge,
+            "bargauge"   => PanelKind::BarGauge,
+            "table"      => PanelKind::Table,
+            _            => PanelKind::Unknown,
+        }
+    }
+}
+
+/// Position et taille initiale d'un panel (grille Grafana 24 colonnes).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GridPos {
+    pub x: u32,
+    pub y: u32,
+    pub w: u32,
+    pub h: u32,
+}
+
+/// Une requête PromQL associée à un panel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PanelQuery {
+    /// Identifiant interne (A, B, C... — vient de Grafana `refId`).
+    pub ref_id: String,
+    /// Expression PromQL.
+    pub expr:   String,
+    /// Format de légende (peut contenir des `{label}` Grafana).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legend: Option<String>,
+}
+
+/// Panel normalisé — prêt à être consommé côté UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Panel {
+    /// Identifiant stable (id Grafana, ex: "27").
+    pub id:       String,
+    pub title:    String,
+    pub kind:     PanelKind,
+    pub grid_pos: GridPos,
+    /// Unité Grafana (ex: "watt", "percent", "celsius") — peut être vide.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub unit:     String,
+    /// Liste des requêtes PromQL (vide pour les rows).
+    #[serde(default)]
+    pub queries:  Vec<PanelQuery>,
+    /// Nombre de décimales d'affichage (Grafana `decimals`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decimals: Option<u8>,
+}
+
+/// Catalogue chargé en mémoire au démarrage.
+#[derive(Debug, Clone)]
+pub struct Catalog {
+    panels: Arc<Vec<Panel>>,
+}
+
+impl Catalog {
+    /// Construit un catalogue vide (fallback si parsing échoue).
+    pub fn empty() -> Self {
+        Self { panels: Arc::new(Vec::new()) }
+    }
+
+    /// Charge le dashboard Grafana embarqué dans le binaire.
+    /// Le fichier est inclus au build via `include_str!`.
+    pub fn load_default() -> Self {
+        const GRAFANA_JSON: &str = include_str!("../../../../docs/grafana-ess_dashboard.json");
+        match grafana::parse_dashboard(GRAFANA_JSON) {
+            Ok(panels) => {
+                tracing::info!(count = panels.len(), "Catalogue de panels chargé depuis grafana-ess_dashboard.json");
+                Self { panels: Arc::new(panels) }
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Échec parsing grafana-ess_dashboard.json — catalogue vide");
+                Self::empty()
+            }
+        }
+    }
+
+    pub fn panels(&self) -> &[Panel] {
+        &self.panels
+    }
+
+    pub fn find(&self, id: &str) -> Option<&Panel> {
+        self.panels.iter().find(|p| p.id == id)
+    }
+}

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -21,6 +21,7 @@ mod vm_client;
 mod api;
 mod bridges;
 mod dashboard;
+mod dashboards;
 mod monitor;
 
 use crate::bridges::{alerts, mqtt};

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -449,6 +449,9 @@ pub struct AppState {
     /// Client VictoriaMetrics (None si désactivé dans la config).
     pub vm: Option<Arc<VmClient>>,
 
+    /// Catalogue de panels (importés depuis docs/grafana-ess_dashboard.json au démarrage).
+    pub dashboard_catalog: crate::dashboards::Catalog,
+
     /// Timestamps de la dernière écriture VM par catégorie (epoch secondes).
     /// Throttle le débit d'écriture pour éviter de surcharger VM.
     /// Chaque source a son propre timer — ne jamais partager entre sources différentes.
@@ -525,6 +528,7 @@ impl AppState {
             shelly_client: Arc::new(tokio::sync::Mutex::new(None)),
             alert_engine,
             vm: vm.map(Arc::new),
+            dashboard_catalog: crate::dashboards::Catalog::load_default(),
             vm_last_bms_write:      Arc::new(AtomicU64::new(0)),
             vm_last_shunt_write:    Arc::new(AtomicU64::new(0)),
             vm_last_inverter_write: Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION
Foundation pour dashboard custom remplaçant /dashboard/history :
- Parser docs/grafana-ess_dashboard.json → liste de panels normalisés (types: row, stat, timeseries, barchart, gauge, bargauge, table)
- Chargement en mémoire au démarrage via include_str! (zéro I/O runtime)
- GET /api/v1/dashboards/catalog → liste les panels disponibles (filtre ?kind=... et ?include_rows=true)
- GET /api/v1/dashboards/panel/:id/data?from&to&step → exécute les PromQL du panel en parallèle et renvoie séries formatées pour ECharts

Tests inclus : parsing minimal + parsing du vrai grafana-ess_dashboard.json (vérifie présence de row/stat/timeseries).

Phase suivante : UI dashboard_history.html avec rendu ECharts + modale "Ajouter panel" + SQLite layouts + export PDF.