### PR TITLE
fix(systemd): déplace StartLimitIntervalSec en section [Unit]

### DIFF
--- a/contrib/daly-bms.service
+++ b/contrib/daly-bms.service
@@ -3,6 +3,8 @@ Description=DalyBMS Server — Rust RS485 BMS monitor
 Documentation=https://github.com/thieryus007-cloud/Daly-BMS-Rust
 After=network.target mosquitto-broker.service
 Wants=network.target mosquitto-broker.service
+# Pas de rate-limit sur les redémarrages (clé Unit, pas Service)
+StartLimitIntervalSec=0
 
 [Service]
 Type=notify
@@ -22,7 +24,6 @@ ExecStart=/usr/local/bin/daly-bms-server
 # Redémarrage automatique en cas de crash
 Restart=on-failure
 RestartSec=5s
-StartLimitIntervalSec=0
 
 # Accès au port série RS485 (/dev/ttyUSB* ou /dev/ttyACM*)
 SupplementaryGroups=dialout

--- a/contrib/energy-manager.service
+++ b/contrib/energy-manager.service
@@ -5,6 +5,8 @@ After=network-online.target mosquitto-broker.service daly-bms.service
 Wants=network-online.target
 Requires=mosquitto-broker.service
 PartOf=daly-bms.service
+# Pas de rate-limit sur les redémarrages (clé Unit, pas Service)
+StartLimitIntervalSec=0
 
 [Service]
 Type=notify
@@ -23,8 +25,6 @@ Environment=ENERGY_CONFIG=/etc/daly-bms/config.toml
 
 Restart=on-failure
 RestartSec=5s
-# Allow unlimited restarts — the service manages its own reconnection logic.
-StartLimitIntervalSec=0
 
 # Resource limits
 LimitNOFILE=65536

--- a/contrib/node-exporter.service
+++ b/contrib/node-exporter.service
@@ -2,6 +2,8 @@
 Description=Prometheus Node Exporter — métriques système Pi5
 Documentation=https://prometheus.io/docs/guides/node-exporter/
 After=network.target
+# Pas de rate-limit sur les redémarrages (clé Unit, pas Service)
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
@@ -15,7 +17,6 @@ ExecStart=/usr/local/bin/node_exporter \
 
 Restart=on-failure
 RestartSec=5s
-StartLimitIntervalSec=0
 
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
systemd émettait l'avertissement :
  Unknown key 'StartLimitIntervalSec' in section [Service]

La clé est documentée dans systemd.unit(5), section [Unit] — pas [Service]. Le placement actuel n'avait aucun effet (le rate-limit restait actif par défaut), mais ne produisait qu'un warning au journald.

Concerne daly-bms.service, energy-manager.service, node-exporter.service.