### PR TITLE
fix(energy-manager): isole la puissance SmartShunt des fallbacks VEBus

### DIFF
--- a/crates/energy-manager/src/logic/smartshunt/mod.rs
+++ b/crates/energy-manager/src/logic/smartshunt/mod.rs
@@ -93,7 +93,11 @@ async fn handle(
     let is_sys_state   = t.ends_with("Battery/State")    && t.contains("/system/0/");
     let is_sys_ttg     = t.ends_with("Battery/TimeToGo") && t.contains("/system/0/");
     let is_vebus_v     = t.ends_with("/Dc/0/Voltage")    && t.contains("/vebus/");
-    let is_vebus_pw    = t.ends_with("/Dc/0/Power")      && t.contains("/vebus/");
+    // NOTE: vebus/Dc/0/Power is intentionally NOT used as a fallback for battery_power_w.
+    // The VEBus DC power measures only what flows through the Multiplus inverter,
+    // which is a different physical quantity from the net battery power measured
+    // by the SmartShunt at the battery terminals. It is captured into dc_power_w
+    // by the `inverter` module instead.
 
     let is_charged    = t.ends_with("/History/ChargedEnergy")    && t.contains("/battery/");
     let is_discharged = t.ends_with("/History/DischargedEnergy") && t.contains("/battery/");
@@ -102,17 +106,29 @@ async fn handle(
         info!("SmartShunt energy counter topic: {t}");
     }
 
-    let is_shunt = t == t_voltage || t == t_current || t == t_power
-        || t == t_soc || t == t_ttg || t == t_state
-        || is_charged || is_discharged;
+    let is_shunt_direct = t == t_voltage || t == t_current || t == t_power
+        || t == t_soc || t == t_ttg || t == t_state;
+    let is_shunt = is_shunt_direct || is_charged || is_discharged;
 
     if !is_shunt && !is_sys_soc && !is_sys_current && !is_sys_state
-        && !is_sys_ttg && !is_vebus_v && !is_vebus_pw {
+        && !is_sys_ttg && !is_vebus_v {
         return None;
     }
 
     let mut s = state.write().await;
     let now = Utc::now();
+
+    // Fallbacks (vebus / system aggregates) only apply when no direct SmartShunt
+    // topic has been received recently. STALE_AFTER bounds how long we keep
+    // trusting cached shunt values before falling back.
+    const STALE_AFTER: chrono::Duration = chrono::Duration::seconds(10);
+    let shunt_fresh = s.shunt_last_seen_ts
+        .map(|ts| now.signed_duration_since(ts) < STALE_AFTER)
+        .unwrap_or(false);
+
+    if is_shunt_direct {
+        s.shunt_last_seen_ts = Some(now);
+    }
 
     if t == t_voltage {
         if let Some(v) = msg.victron_value::<f64>() { s.battery_voltage_v = Some(v); }
@@ -173,21 +189,23 @@ async fn handle(
                    s.shunt_discharged_today_kwh);
         }
 
-    } else if is_sys_soc {
+    } else if is_sys_soc && !shunt_fresh {
         if let Some(v) = msg.victron_value::<f64>() { s.soc_pct = Some(v); }
-    } else if is_sys_current {
+    } else if is_sys_current && !shunt_fresh {
         if let Some(v) = msg.victron_value::<f64>() {
             integrate_ah(&mut s, v, now);
             s.battery_current_a = Some(v);
         }
-    } else if is_sys_state {
+    } else if is_sys_state && !shunt_fresh {
         if let Some(v) = msg.victron_value::<i64>() { s.battery_state = Some(v); }
-    } else if is_sys_ttg {
+    } else if is_sys_ttg && !shunt_fresh {
         if let Some(v) = msg.victron_value::<i64>() { s.time_to_go_sec = Some(v); }
-    } else if is_vebus_v {
+    } else if is_vebus_v && !shunt_fresh {
         if let Some(v) = msg.victron_value::<f64>() { s.battery_voltage_v = Some(v); }
-    } else if is_vebus_pw {
-        if let Some(v) = msg.victron_value::<f64>() { s.battery_power_w = Some(v); }
+    } else {
+        // Topic matched the filter but a fresher shunt value already holds the field.
+        // Suppress the publish_state trigger to avoid republishing unchanged data.
+        return Some(false);
     }
 
     Some(true)

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -128,6 +128,10 @@ pub struct EnergyState {
     pub battery_power_w: Option<f64>,
     pub battery_state: Option<i64>,
     pub time_to_go_sec: Option<i64>,
+    // Timestamp of the last direct SmartShunt topic (battery/{shunt}/Dc/0/*, /Soc, /TimeToGo, /State).
+    // Used to gate fallbacks from VEBus / system aggregates: while shunt data is fresh,
+    // those secondary sources must not overwrite the authoritative shunt values.
+    pub shunt_last_seen_ts: Option<DateTime<Utc>>,
 
     // --- Grid / AC ---
     pub ac_ignore: Option<i64>,         // IgnoreAcIn1: 0=grid, 1=off-grid


### PR DESCRIPTION
Le module smartshunt traitait inconditionnellement les topics vebus/Dc/0/* et system/0/Dc/Battery/* comme des fallbacks, alors qu'ils sont publiés en permanence par Venus OS. battery_power_w oscillait donc entre la puissance nette mesurée par le SmartShunt (battery/{shunt}/Dc/0/Power) et la puissance DC de l'onduleur Multiplus (vebus/{vebus}/Dc/0/Power), qui sont deux grandeurs physiques différentes — d'où la valeur "Power" inexacte sur /dashboard/visualization.

- Supprime le mapping vebus/Dc/0/Power -> battery_power_w (déjà capturé comme dc_power_w par le module inverter).
- Ajoute shunt_last_seen_ts dans EnergyState et conditionne les fallbacks vebus_v / system_* à un seuil de staleness (10 s).
- Suppression du republish quand un fallback est ignoré (évite la republication MQTT inutile).