### PR TITLE
fix(observability): log les échecs MQTT silencieux et le lag broadcast

### DIFF
--- a/crates/daly-bms-server/src/api/shelly.rs
+++ b/crates/daly-bms-server/src/api/shelly.rs
@@ -94,7 +94,9 @@ pub async fn control_shelly_channel(
 
     let payload_str = rpc_payload.to_string();
     tokio::spawn(async move {
-        let _ = client.publish(&rpc_topic, QoS::AtLeastOnce, false, payload_str.as_bytes()).await;
+        if let Err(e) = client.publish(&rpc_topic, QoS::AtLeastOnce, false, payload_str.as_bytes()).await {
+            tracing::warn!("Shelly RPC publish failed on {rpc_topic}: {e}");
+        }
     });
 
     tracing::info!("[Shelly] {} ch{} → {}", shelly_id, ch, if on { "ON" } else { "OFF" });

--- a/crates/daly-bms-server/src/api/system.rs
+++ b/crates/daly-bms-server/src/api/system.rs
@@ -178,7 +178,9 @@ pub async fn set_mppt_yield(
             let pvinv_val  = *state.pvinv_power_w.read().await;
             let total_w    = *state.solar_total_w.read().await;
             let rows = crate::vm_client::VmClient::solar_rows(total_w, dc_pv_val, pvinv_val, kwh_val);
-            let _ = vm.write_rows(rows).await;
+            if let Err(e) = vm.write_rows(rows).await {
+                tracing::warn!("VictoriaMetrics solar write failed: {e}");
+            }
         }
     }
 

--- a/crates/daly-bms-server/src/api/tasmota.rs
+++ b/crates/daly-bms-server/src/api/tasmota.rs
@@ -118,7 +118,9 @@ pub async fn control_tasmota(
     let cmd_str = cmd.to_string();
     let topic_clone = mqtt_topic.clone();
     tokio::spawn(async move {
-        let _ = client.publish(&topic_clone, QoS::AtLeastOnce, false, cmd_str.as_bytes()).await;
+        if let Err(e) = client.publish(&topic_clone, QoS::AtLeastOnce, false, cmd_str.as_bytes()).await {
+            tracing::warn!("Tasmota command publish failed on {topic_clone}: {e}");
+        }
     });
 
     tracing::info!(

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -373,9 +373,12 @@ async fn publish_snapshot(
 }
 
 async fn publish_str(client: &AsyncClient, topic: &str, value: &str) {
-    let _ = client
+    if let Err(e) = client
         .publish(topic, QoS::AtLeastOnce, false, value.to_string())
-        .await;
+        .await
+    {
+        warn!("MQTT publish failed on {topic}: {e}");
+    }
 }
 
 /// Extrait le numéro entier d'un identifiant de cellule ("C3" → 3, "Cell3" → 3).

--- a/crates/daly-bms-server/src/shelly/mqtt.rs
+++ b/crates/daly-bms-server/src/shelly/mqtt.rs
@@ -74,14 +74,18 @@ where
 
         // Abonnement aux topics status de chaque device configuré + réponses RPC
         let rpc_response_topic = format!("{}/rpc", RPC_SRC);
-        let _ = client.subscribe(&rpc_response_topic, QoS::AtMostOnce).await;
+        if let Err(e) = client.subscribe(&rpc_response_topic, QoS::AtMostOnce).await {
+            warn!("Shelly MQTT subscribe failed ({rpc_response_topic}): {e}");
+        }
         for dev in &devices {
             let t0 = format!("{}/status/switch:0", dev.shelly_id);
             let t1 = format!("{}/status/switch:1", dev.shelly_id);
             let ti = format!("{}/info", dev.shelly_id);
-            let _ = client.subscribe(&t0, QoS::AtMostOnce).await;
-            let _ = client.subscribe(&t1, QoS::AtMostOnce).await;
-            let _ = client.subscribe(&ti, QoS::AtMostOnce).await;
+            for topic in [&t0, &t1, &ti] {
+                if let Err(e) = client.subscribe(topic, QoS::AtMostOnce).await {
+                    warn!("Shelly MQTT subscribe failed ({topic}): {e}");
+                }
+            }
         }
 
         // Tâche de polling périodique (30 s) via RPC Switch.GetStatus.

--- a/crates/daly-bms-server/src/tasmota/mqtt.rs
+++ b/crates/daly-bms-server/src/tasmota/mqtt.rs
@@ -53,8 +53,12 @@ where
         let (client, mut eventloop) = AsyncClient::new(opts, 128);
 
         // Abonnement aux deux wildcards Tasmota
-        let _ = client.subscribe("tele/+/SENSOR", QoS::AtMostOnce).await;
-        let _ = client.subscribe("stat/+/POWER",  QoS::AtMostOnce).await;
+        if let Err(e) = client.subscribe("tele/+/SENSOR", QoS::AtMostOnce).await {
+            warn!("Tasmota MQTT subscribe failed (tele/+/SENSOR): {e}");
+        }
+        if let Err(e) = client.subscribe("stat/+/POWER", QoS::AtMostOnce).await {
+            warn!("Tasmota MQTT subscribe failed (stat/+/POWER): {e}");
+        }
 
         loop {
             match eventloop.poll().await {

--- a/crates/energy-manager/src/logic/inverter/mod.rs
+++ b/crates/energy-manager/src/logic/inverter/mod.rs
@@ -2,7 +2,8 @@
 /// AC power falls back to V×I when the direct measurement topic is absent.
 use serde_json::json;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{broadcast, RwLock};
+use tracing::warn;
 
 use crate::bus::AppBus;
 use crate::config::VictronConfig;
@@ -31,8 +32,12 @@ async fn run(
     let mut rx = bus.subscribe_mqtt();
     loop {
         let msg = match rx.recv().await {
-            Ok(m)  => m,
-            Err(_) => continue,
+            Ok(m) => m,
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                warn!("inverter MQTT subscriber lagged, dropped {n} message(s)");
+                continue;
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
         };
 
         if handle(&msg, &pfx_vebus, &pfx_system, &state).await {

--- a/crates/energy-manager/src/logic/solar_power/mod.rs
+++ b/crates/energy-manager/src/logic/solar_power/mod.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::{interval, Duration};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::bus::AppBus;
 use crate::config::{SolarConfig, VictronConfig};
@@ -207,7 +207,7 @@ async fn writer_task(
             .send()
             .await
         {
-            debug!("Solar API POST error: {e}");
+            warn!("Solar API POST error: {e}");
         }
 
         bus.emit_live(LiveEvent::new("solar", json!({

--- a/crates/energy-manager/src/logic/tasmota/mod.rs
+++ b/crates/energy-manager/src/logic/tasmota/mod.rs
@@ -2,8 +2,8 @@
 /// Parses stat/{id}/POWER and tele/{id}/SENSOR.
 use serde::Deserialize;
 use std::sync::Arc;
-use tokio::sync::RwLock;
-use tracing::debug;
+use tokio::sync::{broadcast, RwLock};
+use tracing::{debug, warn};
 
 use crate::bus::AppBus;
 use crate::config::VictronConfig;
@@ -50,7 +50,11 @@ async fn run(
     loop {
         let msg = match rx.recv().await {
             Ok(m) => m,
-            Err(_) => continue,
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                warn!("tasmota MQTT subscriber lagged, dropped {n} message(s)");
+                continue;
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
         };
         let t = &msg.topic;
         if t == &stat_topic {


### PR DESCRIPTION
Plusieurs chemins critiques utilisaient \`let _ = ...\` pour ignorer les erreurs de publish/subscribe MQTT et d'écriture VictoriaMetrics. Une panne du broker, un timeout ou un déclassement de l'event-loop devenait invisible : les commandes Tasmota/Shelly étaient perdues, les métriques solaires ne remontaient plus, sans aucune trace dans les logs.

daly-bms-server :
- bridges/mqtt.rs:publish_str — log warn sur échec publish BMS cell telemetry
- tasmota/mqtt.rs — log warn sur subscribe tele/+/SENSOR et stat/+/POWER
- shelly/mqtt.rs — log warn sur tous les subscribe RPC + per-device
- api/system.rs — log warn sur écriture VictoriaMetrics solaire
- api/tasmota.rs — log warn sur publish commande relais
- api/shelly.rs — log warn sur publish RPC

energy-manager :
- logic/solar_power — debug! -> warn! sur erreur POST API solaire
- logic/inverter, logic/tasmota — détection explicite RecvError::Lagged (sinon les messages MQTT perdus en cas de backpressure étaient invisibles) et arrêt propre sur RecvError::Closed.