### PR TITLE
fix(energy-manager): détection RecvError::Lagged dans les select! des…

### DIFF
--- a/crates/energy-manager/src/logic/charge_current/mod.rs
+++ b/crates/energy-manager/src/logic/charge_current/mod.rs
@@ -6,8 +6,8 @@ mod rules;
 use chrono::Utc;
 use serde_json::json;
 use std::sync::Arc;
-use tokio::sync::RwLock;
-use tracing::info;
+use tokio::sync::{broadcast, RwLock};
+use tracing::{info, warn};
 
 use crate::bus::AppBus;
 use crate::config::{ChargeCurrent as ChargeCfg, VictronConfig};
@@ -53,7 +53,15 @@ async fn run(
 
     loop {
         tokio::select! {
-            Ok(msg) = rx.recv() => {
+            result = rx.recv() => {
+                let msg = match result {
+                    Ok(m) => m,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("charge_current MQTT subscriber lagged, dropped {n} message(s)");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                };
                 let t = &msg.topic;
                 if t != &topic_ignore && t != &topic_pv_power && t != &topic_consump {
                     continue;

--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -7,9 +7,9 @@ mod rules;
 use chrono::{DateTime, Utc};
 use serde_json::json;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{broadcast, RwLock};
 use tokio::time::{interval, sleep, Duration};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::bus::AppBus;
 use crate::config::{DeyeConfig, VictronConfig};
@@ -122,7 +122,15 @@ async fn run(
 
     loop {
         tokio::select! {
-            Ok(msg) = rx.recv() => {
+            result = rx.recv() => {
+                let msg = match result {
+                    Ok(m) => m,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("deye_command MQTT subscriber lagged, dropped {n} message(s)");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                };
                 let t = &msg.topic;
 
                 if *t == t_freq {

--- a/crates/energy-manager/src/logic/smartshunt/mod.rs
+++ b/crates/energy-manager/src/logic/smartshunt/mod.rs
@@ -13,8 +13,8 @@ mod rules;
 use chrono::{Datelike, Utc};
 use serde_json::json;
 use std::sync::Arc;
-use tokio::sync::RwLock;
-use tracing::{debug, info};
+use tokio::sync::{broadcast, RwLock};
+use tracing::{debug, info, warn};
 
 use crate::bus::AppBus;
 use crate::config::VictronConfig;
@@ -50,7 +50,15 @@ async fn run(vic: Arc<VictronConfig>, bus: AppBus, state: Arc<RwLock<EnergyState
 
     loop {
         tokio::select! {
-            Ok(msg) = rx.recv() => {
+            result = rx.recv() => {
+                let msg = match result {
+                    Ok(m) => m,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("smartshunt MQTT subscriber lagged, dropped {n} message(s)");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                };
                 if let Some(dirty) = handle(
                     &msg, &state, &mut rule_engine,
                     &t_voltage, &t_current, &t_power,

--- a/crates/energy-manager/src/logic/solar_power/mod.rs
+++ b/crates/energy-manager/src/logic/solar_power/mod.rs
@@ -6,7 +6,7 @@ mod rules;
 use chrono::Datelike;
 use serde_json::json;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{broadcast, RwLock};
 use tokio::time::{interval, Duration};
 use tracing::{debug, warn};
 
@@ -70,7 +70,15 @@ async fn mqtt_task(
 
     loop {
         tokio::select! {
-            Ok(msg) = rx.recv() => {
+            result = rx.recv() => {
+                let msg = match result {
+                    Ok(m) => m,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("solar_power MQTT subscriber lagged, dropped {n} message(s)");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                };
         let t = &msg.topic;
 
         let mut publish_baseline: Option<(i32, f64)> = None;


### PR DESCRIPTION
… modules logic

Les 4 modules restants utilisaient le pattern \`Ok(msg) = rx.recv()\` dans tokio::select!, qui ne matche que sur Ok. Quand le broadcast bus tombait en arrière (Lagged), les messages perdus l'étaient silencieusement — impossible de détecter la backpressure sur charge_current, smartshunt, solar_power et deye_command.

Convertit en \`result = rx.recv() => { match result { ... } }\` pour logger explicitement le nombre de messages perdus et break proprement sur Closed. Aligné avec le pattern déjà appliqué dans inverter et tasmota.