### PR TITLE
feat(dashboard/history): onglets indépendants par layout + onglet Sol…

### DIFF
--- a/crates/daly-bms-server/src/api/dashboards.rs
+++ b/crates/daly-bms-server/src/api/dashboards.rs
@@ -23,6 +23,40 @@ use crate::state::AppState;
 /// User id par défaut tant qu'il n'y a pas d'auth utilisateur.
 const DEFAULT_USER: &str = "default";
 
+/// Onglet (tab) par défaut quand le client n'en précise pas.
+const DEFAULT_TAB: &str = "default";
+
+/// Compose la clé de stockage (user, tab) → `user_id` SQLite.
+/// Format : `<user>:<tab>` (rétro-compat : `default:default` est mappé à `default` tout court
+/// pour ne pas casser les layouts existants en base avant l'introduction des onglets).
+fn storage_key(tab: &str) -> String {
+    if tab == DEFAULT_TAB { DEFAULT_USER.to_string() }
+    else { format!("{}:{}", DEFAULT_USER, tab) }
+}
+
+/// Valide un identifiant d'onglet : 1..=32 caractères, [a-z0-9_-]. Tout autre
+/// caractère est rejeté pour éviter toute injection ou abus du fichier SQLite.
+fn validate_tab(tab: &str) -> Result<&str, &'static str> {
+    if tab.is_empty() || tab.len() > 32 { return Err("tab length 1..=32"); }
+    if !tab.bytes().all(|b| matches!(b, b'a'..=b'z' | b'0'..=b'9' | b'_' | b'-')) {
+        return Err("tab must match [a-z0-9_-]+");
+    }
+    Ok(tab)
+}
+
+#[derive(Deserialize, Default)]
+pub struct TabQuery {
+    #[serde(default)]
+    pub tab: Option<String>,
+}
+
+impl TabQuery {
+    fn resolve(&self) -> Result<String, &'static str> {
+        let raw = self.tab.as_deref().unwrap_or(DEFAULT_TAB);
+        Ok(storage_key(validate_tab(raw)?))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/v1/dashboards/catalog
 // ---------------------------------------------------------------------------
@@ -272,12 +306,19 @@ fn storage_unavailable() -> Response {
 /// Le contenu du champ `layout` est inséré tel quel depuis la base (sans parse) —
 /// le client le reçoit comme un tableau JSON valide. Si jamais ce qui est en base
 /// n'est pas du JSON valide, on retourne `layout: null`.
-pub async fn get_layout(State(state): State<AppState>) -> Response {
+pub async fn get_layout(
+    State(state): State<AppState>,
+    Query(tq):    Query<TabQuery>,
+) -> Response {
     let Some(storage) = state.dashboard_storage.clone() else {
         return storage_unavailable();
     };
+    let key = match tq.resolve() {
+        Ok(k)  => k,
+        Err(e) => return (StatusCode::BAD_REQUEST, Json(json!({"ok":false,"reason":e}))).into_response(),
+    };
     // I/O SQLite bloquant → spawn_blocking
-    let result = tokio::task::spawn_blocking(move || storage.get(DEFAULT_USER)).await;
+    let result = tokio::task::spawn_blocking(move || storage.get(&key)).await;
     match result {
         Ok(Ok(None))          => raw_json(StatusCode::OK, r#"{"ok":true,"layout":null}"#.to_string()),
         Ok(Ok(Some(layout_json))) => {
@@ -304,10 +345,15 @@ pub async fn get_layout(State(state): State<AppState>) -> Response {
 /// ou directement le tableau `[...]`.
 pub async fn set_layout(
     State(state): State<AppState>,
+    Query(tq):    Query<TabQuery>,
     Json(body):   Json<Value>,
 ) -> Response {
     let Some(storage) = state.dashboard_storage.clone() else {
         return storage_unavailable();
+    };
+    let key = match tq.resolve() {
+        Ok(k)  => k,
+        Err(e) => return (StatusCode::BAD_REQUEST, Json(json!({"ok":false,"reason":e}))).into_response(),
     };
     let layout = match body.get("layout") {
         Some(v) => v.clone(),
@@ -324,7 +370,7 @@ pub async fn set_layout(
             "ok": false, "reason": "layout_too_large"
         }))).into_response();
     }
-    let result = tokio::task::spawn_blocking(move || storage.set(DEFAULT_USER, &layout_json)).await;
+    let result = tokio::task::spawn_blocking(move || storage.set(&key, &layout_json)).await;
     match result {
         Ok(Ok(()))  => (StatusCode::OK, Json(json!({"ok": true}))).into_response(),
         Ok(Err(e))  => db_error_response(e),
@@ -336,11 +382,18 @@ pub async fn set_layout(
 }
 
 /// DELETE /api/v1/dashboards/layout — retour à l'état d'origine côté UI.
-pub async fn delete_layout(State(state): State<AppState>) -> Response {
+pub async fn delete_layout(
+    State(state): State<AppState>,
+    Query(tq):    Query<TabQuery>,
+) -> Response {
     let Some(storage) = state.dashboard_storage.clone() else {
         return storage_unavailable();
     };
-    let result = tokio::task::spawn_blocking(move || storage.delete(DEFAULT_USER)).await;
+    let key = match tq.resolve() {
+        Ok(k)  => k,
+        Err(e) => return (StatusCode::BAD_REQUEST, Json(json!({"ok":false,"reason":e}))).into_response(),
+    };
+    let result = tokio::task::spawn_blocking(move || storage.delete(&key)).await;
     match result {
         Ok(Ok(()))  => (StatusCode::OK, Json(json!({"ok": true}))).into_response(),
         Ok(Err(e))  => db_error_response(e),
@@ -348,5 +401,38 @@ pub async fn delete_layout(State(state): State<AppState>) -> Response {
             tracing::error!(error = %join_e, "spawn_blocking join error");
             (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"ok": false, "reason": "task_join_failed"}))).into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tab_tests {
+    use super::*;
+
+    #[test]
+    fn validate_tab_accepts_valid() {
+        assert!(validate_tab("default").is_ok());
+        assert!(validate_tab("solar_pv").is_ok());
+        assert!(validate_tab("abc-123").is_ok());
+        assert!(validate_tab("a").is_ok());
+        assert!(validate_tab(&"a".repeat(32)).is_ok());
+    }
+
+    #[test]
+    fn validate_tab_rejects_invalid() {
+        assert!(validate_tab("").is_err());
+        assert!(validate_tab(&"a".repeat(33)).is_err());
+        assert!(validate_tab("Default").is_err());          // majuscule
+        assert!(validate_tab("../foo").is_err());            // path traversal
+        assert!(validate_tab("a b").is_err());               // espace
+        assert!(validate_tab("a:b").is_err());               // ':'
+        assert!(validate_tab("a'b").is_err());               // quote SQL
+    }
+
+    #[test]
+    fn storage_key_keeps_default_user_for_default_tab() {
+        // Rétro-compat : layouts existants en base sous "default" ne doivent pas être perdus.
+        assert_eq!(storage_key("default"), "default");
+        assert_eq!(storage_key("solar_pv"), "default:solar_pv");
+        assert_eq!(storage_key("custom-1"), "default:custom-1");
     }
 }

--- a/crates/daly-bms-server/src/dashboards/mod.rs
+++ b/crates/daly-bms-server/src/dashboards/mod.rs
@@ -90,11 +90,6 @@ pub struct Catalog {
 }
 
 impl Catalog {
-    /// Construit un catalogue vide (fallback si parsing échoue).
-    pub fn empty() -> Self {
-        Self { panels: Arc::new(Vec::new()) }
-    }
-
     /// Charge tous les dashboards Grafana embarqués dans le binaire.
     /// Les fichiers sont inclus au build via `include_str!` puis concaténés.
     /// Les IDs de chaque fichier doivent rester disjoints (cf. en-tête de chaque JSON).

--- a/crates/daly-bms-server/templates/history.html
+++ b/crates/daly-bms-server/templates/history.html
@@ -35,6 +35,29 @@
 }
 .dash-period button:hover { background: var(--surface2); color: var(--text); }
 .dash-period button.active { background: var(--accent2); color: #fff; }
+/* ── Onglets (tabs) — chaque onglet a son propre layout sauvegardé ─────── */
+.dash-tabs {
+  display: flex;
+  gap: 0.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.2rem;
+}
+.dash-tabs button {
+  padding: 0.32rem 0.85rem;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: calc(var(--radius-sm) - 2px);
+  font-family: inherit;
+  white-space: nowrap;
+}
+.dash-tabs button:hover { background: var(--surface2); color: var(--text); }
+.dash-tabs button.active { background: var(--accent); color: #fff; }
 .dash-btn {
   padding: 0.42rem 0.95rem;
   border-radius: var(--radius-sm);
@@ -346,6 +369,10 @@
 
 {% block content %}
 <div class="dash-toolbar">
+  <div class="dash-tabs" id="tab-bar">
+    <button data-tab="default"  class="active">📊 Personnalisé</button>
+    <button data-tab="solar_pv">☀️ Solar PV</button>
+  </div>
   <div class="dash-period" id="period-bar">
     <button data-period="1h">1h</button>
     <button data-period="6h">6h</button>
@@ -445,8 +472,15 @@ const STATE = {
   period:      '24h',
   panelData:   new Map(),   // panelId → dernier data (pour re-render print)
   storageMode: 'local',     // 'server' (SQLite) ou 'local' (localStorage fallback)
+  tab:         'default',   // onglet actif ('default' | 'solar_pv' | ...)
 };
-const LS_KEY = 'dash_layout_v1';
+
+// IDs des panels Solar PV importés depuis Grafana Labs (cf. docs/grafana-solar_pv_dashboard.json).
+// Servent à construire le layout par défaut de l'onglet "solar_pv".
+const SOLAR_PV_IDS = ['1001','1002','1003','1004','1005','1006','1007','1008','1009','1010','1011'];
+
+// Clé localStorage par onglet (fallback hors-ligne).
+function lsKey(tab) { return 'dash_layout_v1__' + tab; }
 
 const PERIOD_MS = {
   '1h':   3_600_000,
@@ -489,9 +523,10 @@ async function loadCatalog() {
 }
 
 async function loadLayout() {
-  // 1. Tentative serveur (SQLite)
+  // 1. Tentative serveur (SQLite) — `tab` est passé en query param.
+  const qs = '?tab=' + encodeURIComponent(STATE.tab);
   try {
-    const r = await fetch('/api/v1/dashboards/layout');
+    const r = await fetch('/api/v1/dashboards/layout' + qs);
     if (r.ok) {
       const j = await r.json();
       if (j.ok && Array.isArray(j.layout)) {
@@ -499,7 +534,7 @@ async function loadLayout() {
         STATE.storageMode = 'server';
         return;
       }
-      // ok=true mais layout=null → rien en base, on tombe sur le défaut
+      // ok=true mais layout=null → rien en base, on tombe sur le défaut de l'onglet
       if (j.ok && j.layout === null) {
         STATE.storageMode = 'server';
         STATE.layout = defaultLayout();
@@ -511,8 +546,8 @@ async function loadLayout() {
     console.warn('Layout serveur indisponible, fallback localStorage', e);
     STATE.storageMode = 'local';
   }
-  // 2. Fallback localStorage
-  const raw = localStorage.getItem(LS_KEY);
+  // 2. Fallback localStorage — clé spécifique à l'onglet.
+  const raw = localStorage.getItem(lsKey(STATE.tab));
   if (raw) {
     try { STATE.layout = JSON.parse(raw); return; }
     catch (e) { /* fallthrough */ }
@@ -520,20 +555,36 @@ async function loadLayout() {
   STATE.layout = defaultLayout();
 }
 
+/// Layout par défaut spécifique à l'onglet actif.
+/// - `default` : tous les panels du catalog (sauf ceux de l'onglet solar_pv).
+/// - `solar_pv` : uniquement les 11 panels Solar PV, dans leur gridPos d'origine.
 function defaultLayout() {
-  return STATE.catalog.map(p => ({
-    id: p.id,
-    x: p.grid_pos.x, y: p.grid_pos.y,
-    w: p.grid_pos.w, h: p.grid_pos.h,
-  }));
+  if (STATE.tab === 'solar_pv') {
+    return STATE.catalog
+      .filter(p => SOLAR_PV_IDS.includes(p.id))
+      .map(p => ({
+        id: p.id,
+        x: p.grid_pos.x, y: p.grid_pos.y,
+        w: p.grid_pos.w, h: p.grid_pos.h,
+      }));
+  }
+  // Onglet "default" : tout SAUF les panels Solar PV (ils ont leur propre onglet).
+  return STATE.catalog
+    .filter(p => !SOLAR_PV_IDS.includes(p.id))
+    .map(p => ({
+      id: p.id,
+      x: p.grid_pos.x, y: p.grid_pos.y,
+      w: p.grid_pos.w, h: p.grid_pos.h,
+    }));
 }
 
 async function saveLayout() {
   // Toujours sauver en local en miroir (pour les transitions hors-ligne)
-  try { localStorage.setItem(LS_KEY, JSON.stringify(STATE.layout)); } catch (e) {}
+  try { localStorage.setItem(lsKey(STATE.tab), JSON.stringify(STATE.layout)); } catch (e) {}
   if (STATE.storageMode !== 'server') return;
+  const qs = '?tab=' + encodeURIComponent(STATE.tab);
   try {
-    await fetch('/api/v1/dashboards/layout', {
+    await fetch('/api/v1/dashboards/layout' + qs, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ layout: STATE.layout }),
@@ -544,12 +595,27 @@ async function saveLayout() {
 }
 
 async function deleteServerLayout() {
+  // Reset = retirer le layout courant en base + miroir local de l'onglet actif.
+  try { localStorage.removeItem(lsKey(STATE.tab)); } catch (e) {}
   if (STATE.storageMode !== 'server') return;
-  try { await fetch('/api/v1/dashboards/layout', { method: 'DELETE' }); }
+  const qs = '?tab=' + encodeURIComponent(STATE.tab);
+  try { await fetch('/api/v1/dashboards/layout' + qs, { method: 'DELETE' }); }
   catch (e) { console.warn('delete layout serveur a échoué', e); }
 }
 
 function bindToolbar() {
+  // Onglets : chaque tab a son propre layout sauvegardé côté serveur.
+  document.querySelectorAll('#tab-bar button').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const newTab = btn.dataset.tab;
+      if (newTab === STATE.tab) return;
+      document.querySelectorAll('#tab-bar button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      STATE.tab = newTab;
+      await loadLayout();
+      await renderAll();
+    });
+  });
   document.querySelectorAll('#period-bar button').forEach(btn => {
     btn.addEventListener('click', async () => {
       document.querySelectorAll('#period-bar button').forEach(b => b.classList.remove('active'));
@@ -565,13 +631,12 @@ function bindToolbar() {
     setTimeout(() => window.print(), 200);
   });
   document.getElementById('btn-reset').addEventListener('click', async () => {
-    localStorage.removeItem(LS_KEY);
-    await deleteServerLayout();
+    await deleteServerLayout();    // efface aussi le miroir localStorage de l'onglet
     await loadLayout();
     await renderAll();
   });
   document.getElementById('btn-clear').addEventListener('click', async () => {
-    if (!confirm('Retirer tous les panels du dashboard ?')) return;
+    if (!confirm("Retirer tous les panels de l'onglet courant ?")) return;
     STATE.layout = [];
     await saveLayout();
     await renderAll();


### PR DESCRIPTION
…ar PV

Chaque onglet (Personnalisé / Solar PV) a son propre layout sauvegardé côté serveur, indépendamment des autres. Le storage SQLite existant est réutilisé : la clé devient <user>:<tab> au lieu de <user> seul, sauf pour "default" (rétro-compat — les layouts existants en base ne sont pas perdus).

Backend (api/dashboards.rs) :
- GET/POST/DELETE /api/v1/dashboards/layout acceptent un query param ?tab=solar_pv optionnel
- TabQuery + validate_tab (regex [a-z0-9_-]{1,32}) bloque path traversal, injection SQL et noms trop longs
- 3 tests unitaires (validate_tab_accepts_valid / _rejects_invalid / storage_key_keeps_default_user_for_default_tab)

Frontend (templates/history.html) :
- Rangée d'onglets dans le toolbar (📊 Personnalisé / ☀️ Solar PV)
- STATE.tab tracke l'onglet actif ; tous les fetch passent ?tab=…
- Clé localStorage devient dash_layout_v1__<tab> (miroir hors-ligne)
- defaultLayout() filtre désormais le catalog selon l'onglet :
  * default → tous SAUF les panels Solar PV (IDs 1001..1011)
  * solar_pv → uniquement les 11 panels Solar PV, dans leur gridPos d'origine
- Switch d'onglet : loadLayout + renderAll → 2 layouts coexistent

Cleanup :
- Catalog::empty() retiré (jamais appelé, warning dead_code)

UX : à l'ouverture de l'onglet Solar PV pour la première fois, les 11 panels apparaissent automatiquement dans la disposition d'origine (reprise des gridPos de docs/Solar_PV.json). L'utilisateur peut ensuite réorganiser/retirer ; tout reste persisté entre reboots et redéploiements.

https://claude.ai/code/session_018wJXmbUVXaPLTyaCLqWc8f