### PR TITLE
feat(metrics-store): squelette crate redb (Phase 0.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1582,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-store"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "parking_lot",
+ "redb",
+ "serde",
+ "smallvec",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2029,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2468,6 +2500,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/daly-bms-server",
     "crates/dbus-mqtt-venus",
     "crates/energy-manager",
+    "crates/metrics-store",
 ]
 
 [workspace.package]

--- a/crates/metrics-store/Cargo.toml
+++ b/crates/metrics-store/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name        = "metrics-store"
+version.workspace     = true
+edition.workspace     = true
+authors.workspace     = true
+license.workspace     = true
+rust-version.workspace = true
+repository.workspace  = true
+
+[dependencies]
+redb        = "2.2"
+anyhow      = { workspace = true }
+tokio       = { workspace = true }
+tracing     = { workspace = true }
+serde       = { workspace = true }
+bincode     = "1.3"
+smallvec    = { version = "1", features = ["serde"] }
+parking_lot = "0.12"

--- a/crates/metrics-store/src/encoding.rs
+++ b/crates/metrics-store/src/encoding.rs
@@ -1,0 +1,65 @@
+//! Encodage des clés composites `(series_id u32, ts_ms i64)` en `[u8; 12]`
+//! big-endian. Cf. plan_migration_vm_redb.md §4.1.
+
+pub const SKEY_LEN: usize = 12;
+const TS_SIGN_FLIP: u64 = 0x8000_0000_0000_0000;
+
+pub fn enc_skey(series_id: u32, ts_ms: i64) -> [u8; SKEY_LEN] {
+    let mut k = [0u8; SKEY_LEN];
+    k[0..4].copy_from_slice(&series_id.to_be_bytes());
+    k[4..12].copy_from_slice(&((ts_ms as u64) ^ TS_SIGN_FLIP).to_be_bytes());
+    k
+}
+
+pub fn dec_skey(k: &[u8]) -> (u32, i64) {
+    debug_assert_eq!(k.len(), SKEY_LEN);
+    let s = u32::from_be_bytes(k[0..4].try_into().unwrap());
+    let raw = u64::from_be_bytes(k[4..12].try_into().unwrap());
+    let ts = (raw ^ TS_SIGN_FLIP) as i64;
+    (s, ts)
+}
+
+/// Construit la clé de l'index inverse `series_by_key` :
+/// `metric + 0x00 + labels_json` (ordre lexicographique stable).
+pub fn make_lookup_key(metric: &str, labels_json: &str) -> Vec<u8> {
+    let mut k = Vec::with_capacity(metric.len() + 1 + labels_json.len());
+    k.extend_from_slice(metric.as_bytes());
+    k.push(0);
+    k.extend_from_slice(labels_json.as_bytes());
+    k
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_basic() {
+        for (s, t) in [(0u32, 0i64), (1, 1), (42, 1_700_000_000_000), (u32::MAX, i64::MAX)] {
+            let k = enc_skey(s, t);
+            assert_eq!(dec_skey(&k), (s, t));
+        }
+    }
+
+    #[test]
+    fn roundtrip_negative_ts() {
+        let k = enc_skey(7, -1);
+        assert_eq!(dec_skey(&k), (7, -1));
+    }
+
+    #[test]
+    fn lexicographic_order_matches_ts_order() {
+        let s = 5;
+        let k1 = enc_skey(s, 100);
+        let k2 = enc_skey(s, 200);
+        let k3 = enc_skey(s, 300);
+        assert!(k1 < k2 && k2 < k3);
+    }
+
+    #[test]
+    fn series_id_dominates_ordering() {
+        let a = enc_skey(1, i64::MAX);
+        let b = enc_skey(2, i64::MIN);
+        assert!(a < b);
+    }
+}

--- a/crates/metrics-store/src/lib.rs
+++ b/crates/metrics-store/src/lib.rs
@@ -1,0 +1,150 @@
+//! `metrics-store` — backend TSDB pure-Rust basé sur [`redb`].
+//!
+//! Cette crate remplacera VictoriaMetrics pour stocker les métriques produites
+//! par `daly-bms-server` et `energy-manager`. Cf. `docs/plan_migration_vm_redb.md`
+//! pour la conception complète :
+//!
+//! - §4 schéma de tables et encodage des clés
+//! - §5 API publique (`MetricsStore`, `Writer`, `Reader`)
+//! - §10 plan de bascule en 4 phases
+//!
+//! État : **squelette** (Phase 0.3). Le writer batché (§5.3), le reader
+//! (§5.4) et les agrégats (§5.5) seront ajoutés dans les tickets suivants.
+
+pub mod encoding;
+pub mod reader;
+pub mod tables;
+pub mod writer;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use redb::{Builder, Database};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+pub use reader::Reader;
+pub use tables::{AggBucket, SeriesMeta, Tier};
+pub use writer::{Sample, Writer};
+
+/// Options d'ouverture. La sémantique exacte des champs sera affinée quand le
+/// writer batché et la maintenance seront branchés.
+#[derive(Debug, Clone)]
+pub struct Options {
+    /// Taille du cache de pages redb (défaut 64 MiB, cf. §4.4).
+    pub cache_bytes: usize,
+    /// Profondeur de la queue mpsc entre producteurs et writer_loop.
+    pub writer_queue_depth: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            cache_bytes: 64 * 1024 * 1024,
+            writer_queue_depth: 10_000,
+        }
+    }
+}
+
+/// Politique de compaction `raw → hourly → daily`. Détails §9.1.
+#[derive(Debug, Clone)]
+pub struct TierPolicy {
+    pub raw_retention_days: u32,
+    pub hourly_retention_days: u32,
+    pub daily_retention_days: u32,
+}
+
+impl Default for TierPolicy {
+    fn default() -> Self {
+        Self {
+            raw_retention_days: 30,
+            hourly_retention_days: 365,
+            daily_retention_days: 5 * 365,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MetricsStore {
+    db: Arc<Database>,
+    writer_tx: mpsc::Sender<Sample>,
+}
+
+impl MetricsStore {
+    /// Ouvre (ou crée) la base et initialise toutes les tables.
+    pub fn open(db_path: &Path, opts: Options) -> Result<Self> {
+        let db = Builder::new()
+            .set_cache_size(opts.cache_bytes)
+            .create(db_path)?;
+        let db = Arc::new(db);
+
+        // Crée les tables si elles n'existent pas (cf. §4.4).
+        {
+            let tx = db.begin_write()?;
+            let _ = tx.open_table(tables::TABLE_SERIES_BY_KEY)?;
+            let _ = tx.open_table(tables::TABLE_SERIES_META)?;
+            let _ = tx.open_table(tables::TABLE_META)?;
+            let _ = tx.open_table(tables::TABLE_RAW)?;
+            let _ = tx.open_table(tables::TABLE_HOURLY)?;
+            let _ = tx.open_table(tables::TABLE_DAILY)?;
+            tx.commit()?;
+        }
+
+        // Queue pour le writer_loop (encore à implémenter, cf. §5.3).
+        let (writer_tx, _writer_rx) = mpsc::channel::<Sample>(opts.writer_queue_depth);
+
+        Ok(Self { db, writer_tx })
+    }
+
+    pub fn writer(&self) -> Writer {
+        Writer { tx: self.writer_tx.clone() }
+    }
+
+    pub fn reader(&self) -> Reader {
+        Reader { db: self.db.clone() }
+    }
+
+    /// Démarre la tâche de maintenance (compaction raw→hourly→daily).
+    /// Stub — l'implémentation arrivera avec le module `tiering.rs` (Phase 0.5).
+    pub fn spawn_maintenance(&self, _policy: TierPolicy) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            tracing::warn!("metrics-store: spawn_maintenance pas encore implémenté");
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_db_path(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        p.push(format!("metrics-store-{name}-{pid}-{nanos}.redb"));
+        p
+    }
+
+    #[test]
+    fn open_creates_all_tables() {
+        let path = tmp_db_path("open");
+        let _ = std::fs::remove_file(&path);
+
+        let store = MetricsStore::open(&path, Options::default()).expect("open");
+
+        let rtx = store.reader().begin_read().expect("read tx");
+        rtx.open_table(tables::TABLE_RAW).expect("raw");
+        rtx.open_table(tables::TABLE_HOURLY).expect("hourly");
+        rtx.open_table(tables::TABLE_DAILY).expect("daily");
+        rtx.open_table(tables::TABLE_SERIES_BY_KEY).expect("series_by_key");
+        rtx.open_table(tables::TABLE_SERIES_META).expect("series_meta");
+        rtx.open_table(tables::TABLE_META).expect("meta");
+        drop(rtx);
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/metrics-store/src/reader.rs
+++ b/crates/metrics-store/src/reader.rs
@@ -1,0 +1,22 @@
+//! Reader skeleton — snapshots MVCC lock-free. Cf. plan §5.4.
+//!
+//! L'implémentation `query_range` arrivera dans le ticket suivant (Phase 0.5),
+//! après que `tables.rs` et `encoding.rs` aient été couverts par des tests
+//! d'intégration. Pour l'instant on fige uniquement la forme du handle.
+
+use std::sync::Arc;
+
+use redb::Database;
+
+#[derive(Clone)]
+pub struct Reader {
+    pub(crate) db: Arc<Database>,
+}
+
+impl Reader {
+    /// Ouvre une transaction de lecture (snapshot MVCC). Exposé pour permettre
+    /// aux tests d'inspecter la base avant que `query_range` ne soit câblé.
+    pub fn begin_read(&self) -> anyhow::Result<redb::ReadTransaction> {
+        Ok(self.db.begin_read()?)
+    }
+}

--- a/crates/metrics-store/src/tables.rs
+++ b/crates/metrics-store/src/tables.rs
@@ -1,0 +1,53 @@
+//! Définitions des tables redb. Cf. plan_migration_vm_redb.md §4.2.
+
+use redb::TableDefinition;
+use serde::{Deserialize, Serialize};
+
+/// Index inverse : `(metric + 0x00 + labels_json)` → `series_id`.
+pub const TABLE_SERIES_BY_KEY: TableDefinition<&[u8], u32> =
+    TableDefinition::new("series_by_key");
+
+/// Métadonnées par série (`SeriesMeta` sérialisée en bincode).
+pub const TABLE_SERIES_META: TableDefinition<u32, &[u8]> =
+    TableDefinition::new("series_meta");
+
+/// Compteur monotone — clé `"next_series_id"`.
+pub const TABLE_META: TableDefinition<&str, u64> = TableDefinition::new("meta");
+
+/// Points bruts : clé = `enc_skey(series_id, ts_ms)`.
+pub const TABLE_RAW: TableDefinition<&[u8], f64> = TableDefinition::new("metrics_raw");
+
+/// Points compactés horaires : clé = `enc_skey(series_id, bucket_ms)`,
+/// valeur = `AggBucket` bincode.
+pub const TABLE_HOURLY: TableDefinition<&[u8], &[u8]> = TableDefinition::new("metrics_hourly");
+
+/// Points compactés journaliers.
+pub const TABLE_DAILY: TableDefinition<&[u8], &[u8]> = TableDefinition::new("metrics_daily");
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeriesMeta {
+    pub metric: String,
+    pub labels_json: String,
+    pub first_seen_ms: i64,
+    pub last_seen_ms: i64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct AggBucket {
+    pub avg: f64,
+    pub min: f64,
+    pub max: f64,
+    pub sum: f64,
+    /// Première valeur de la fenêtre — nécessaire pour `increase()` après compaction.
+    pub first: f64,
+    /// Dernière valeur de la fenêtre — idem.
+    pub last: f64,
+    pub cnt: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tier {
+    Raw,
+    Hourly,
+    Daily,
+}

--- a/crates/metrics-store/src/writer.rs
+++ b/crates/metrics-store/src/writer.rs
@@ -1,0 +1,34 @@
+//! Writer skeleton — implémentation complète en §5.3 du plan.
+//!
+//! Pour cette première étape (squelette de crate) on expose le handle [`Writer`]
+//! et le type [`Sample`] pour figer l'API publique. La boucle `writer_loop` qui
+//! batch les samples et commit toutes les ~250 ms sera ajoutée dans le ticket
+//! suivant (Phase 0.4).
+
+use smallvec::SmallVec;
+use tokio::sync::mpsc;
+
+/// Échantillon de métrique à ingérer.
+#[derive(Debug, Clone)]
+pub struct Sample {
+    pub metric: String,
+    pub labels: SmallVec<[(String, String); 4]>,
+    pub ts_ms: i64,
+    pub value: f64,
+}
+
+/// Handle clonable côté producteur — envoie les samples vers la tâche d'écriture.
+#[derive(Clone)]
+pub struct Writer {
+    pub(crate) tx: mpsc::Sender<Sample>,
+}
+
+impl Writer {
+    pub async fn write(&self, sample: Sample) -> Result<(), mpsc::error::SendError<Sample>> {
+        self.tx.send(sample).await
+    }
+
+    pub fn try_write(&self, sample: Sample) -> Result<(), mpsc::error::TrySendError<Sample>> {
+        self.tx.try_send(sample)
+    }
+}


### PR DESCRIPTION
Démarre la nouvelle crate `metrics-store` selon plan_migration_vm_redb.md §5.1 :

- `encoding.rs` — clés composites `(series_id u32, ts_ms i64)` → `[u8; 12]` big-endian avec sign-flip pour ts négatifs (§4.1). Couvert par 4 tests unitaires : round-trip basique/négatif, ordre lex ↔ ordre numérique, et domination du `series_id` sur l'ordre global.
- `tables.rs` — `TableDefinition` pour `series_by_key`, `series_meta`, `meta`, `metrics_raw`, `metrics_hourly`, `metrics_daily` (§4.2) + types `SeriesMeta`, `AggBucket`, `Tier`.
- `writer.rs` — handle `Writer` + type `Sample` (API publique §5.2 figée). Boucle batch (§5.3) à venir au ticket suivant.
- `reader.rs` — handle `Reader` qui expose `begin_read()` (snapshot MVCC). `query_range`/agrégats §5.4-5.5 à venir.
- `lib.rs` — `MetricsStore::open()` qui crée toutes les tables, plus `Options`/`TierPolicy` par défaut alignés sur §4.4. Test d'intégration qui ouvre la base et vérifie les 6 tables.

Workspace : `crates/metrics-store` ajouté aux `members`. 0 dep C, redb 2.6
pure-Rust. `cargo test -p metrics-store` : 5/5 verts. `cargo check
--workspace` : OK.

Prochain ticket : implémenter le `writer_loop` batché (§5.3) puis `query_range` (§5.4).