### PR TITLE
feat(daly-bms-server): dual-write metrics-store (Phase 1 code, off pa…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "daly-bms-core",
  "futures",
  "lettre",
+ "metrics-store",
  "reqwest",
  "rs485-bus",
  "rumqttc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ repository  = "https://github.com/thieryus007-cloud/Daly-BMS-Rust"
 
 # ── Crates internes ────────────────────────────────────────────────────────────
 rs485-bus     = { path = "crates/rs485-bus" }
+metrics-store = { path = "crates/metrics-store" }
 
 # ── Async runtime ─────────────────────────────────────────────────────────────
 tokio         = { version = "1",    features = ["full"] }

--- a/Config.toml
+++ b/Config.toml
@@ -413,6 +413,25 @@ url = "http://127.0.0.1:8428"
 timeout_secs = 10
 
 
+# =============================================================================
+# Backend TSDB redb (dual-write avec VictoriaMetrics, Phase 1 migration)
+# Cf. docs/plan_migration_vm_redb.md
+# Désactivé tant que la migration n'est pas en Phase 1 — VM reste seul.
+# =============================================================================
+[metrics_store]
+enabled = false
+db_path = "/mnt/nvme/daly-bms/metrics.redb"
+# Cache pages redb en MiB (défaut 64).
+cache_mb = 64
+# Profondeur de la queue mpsc entre producteurs et writer.
+queue_depth = 10000
+# Intervalle de la passe de compaction tiered (heures, 0 = désactivé).
+maintenance_interval_hours = 6
+raw_retention_days = 30
+hourly_retention_days = 365
+daily_retention_days = 1825   # 5 ans
+
+
 [alerts]
 # Chemin de la base SQLite pour journal des alertes.
 # Laisser vide pour désactiver complètement les alertes.

--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 rs485-bus     = { workspace = true }
 daly-bms-core = { path = "../daly-bms-core" }
+metrics-store = { workspace = true }
 
 tokio          = { workspace = true }
 tokio-serial   = { workspace = true }

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -41,6 +41,11 @@ pub struct AppConfig {
     #[serde(default)]
     pub victoriametrics: VmConfig,
 
+    /// Backend TSDB local redb (dual-write avec VictoriaMetrics).
+    /// Cf. `docs/plan_migration_vm_redb.md`. Désactivé par défaut.
+    #[serde(default)]
+    pub metrics_store: MetricsStoreConfig,
+
     #[serde(default)]
     pub alerts: AlertsConfig,
 
@@ -430,6 +435,65 @@ impl Default for VmConfig {
             enabled:      false,
             url:          "http://127.0.0.1:8428".to_string(),
             timeout_secs: 10,
+        }
+    }
+}
+
+/// Section `[metrics_store]` — dual-write redb pour la migration §10
+/// (plan_migration_vm_redb.md). Une fois `enabled = true` :
+/// - la base redb est ouverte au démarrage à `db_path` ;
+/// - les samples écrits via `VmClient::write_rows` sont fan-outés vers
+///   le writer batché (`try_write`, non bloquant) ;
+/// - la tâche de maintenance (compaction raw→hourly→daily) tourne
+///   selon `maintenance_interval_hours`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MetricsStoreConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Chemin du fichier redb (créé s'il n'existe pas).
+    #[serde(default = "default_metrics_db_path")]
+    pub db_path: String,
+    /// Taille du cache redb en MiB (défaut 64).
+    #[serde(default = "default_metrics_cache_mb")]
+    pub cache_mb: usize,
+    /// Profondeur de la queue mpsc entre producteurs et writer (défaut
+    /// 10 000 ⇒ ~13 min de prod à 12 samples/s).
+    #[serde(default = "default_metrics_queue_depth")]
+    pub queue_depth: usize,
+    /// Intervalle de la passe de compaction tiered en heures (défaut 6 ⇒
+    /// 4 passes/jour). 0 = désactivé.
+    #[serde(default = "default_metrics_maintenance_hours")]
+    pub maintenance_interval_hours: u64,
+    /// Rétention raw (jours).
+    #[serde(default = "default_metrics_raw_days")]
+    pub raw_retention_days: u32,
+    /// Rétention hourly (jours).
+    #[serde(default = "default_metrics_hourly_days")]
+    pub hourly_retention_days: u32,
+    /// Rétention daily (jours).
+    #[serde(default = "default_metrics_daily_days")]
+    pub daily_retention_days: u32,
+}
+
+fn default_metrics_db_path() -> String { "/mnt/nvme/daly-bms/metrics.redb".into() }
+fn default_metrics_cache_mb() -> usize { 64 }
+fn default_metrics_queue_depth() -> usize { 10_000 }
+fn default_metrics_maintenance_hours() -> u64 { 6 }
+fn default_metrics_raw_days() -> u32 { 30 }
+fn default_metrics_hourly_days() -> u32 { 365 }
+fn default_metrics_daily_days() -> u32 { 5 * 365 }
+
+impl Default for MetricsStoreConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            db_path: default_metrics_db_path(),
+            cache_mb: default_metrics_cache_mb(),
+            queue_depth: default_metrics_queue_depth(),
+            maintenance_interval_hours: default_metrics_maintenance_hours(),
+            raw_retention_days: default_metrics_raw_days(),
+            hourly_retention_days: default_metrics_hourly_days(),
+            daily_retention_days: default_metrics_daily_days(),
         }
     }
 }

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -169,6 +169,7 @@ async fn main() -> anyhow::Result<()> {
                 logging:     config::LoggingConfig::default(),
                 mqtt:        config::MqttConfig::default(),
                 victoriametrics: config::VmConfig::default(),
+                metrics_store: config::MetricsStoreConfig::default(),
                 alerts:      config::AlertsConfig::default(),
                 read_only:   config::ReadOnlyConfig::default(),
                 bms:         Vec::new(),
@@ -279,10 +280,55 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
+    // ── metrics-store redb (dual-write Phase 1, `plan_migration_vm_redb.md`) ──
+    let metrics_store = if config.metrics_store.enabled {
+        let opts = metrics_store::Options {
+            cache_bytes: config.metrics_store.cache_mb * 1024 * 1024,
+            writer_queue_depth: config.metrics_store.queue_depth,
+            writer: metrics_store::WriterConfig::default(),
+        };
+        match metrics_store::MetricsStore::open(
+            std::path::Path::new(&config.metrics_store.db_path),
+            opts,
+        ) {
+            Ok(s) => {
+                info!(
+                    db_path = %config.metrics_store.db_path,
+                    "metrics-store ouvert (dual-write activé)"
+                );
+                if config.metrics_store.maintenance_interval_hours > 0 {
+                    let policy = metrics_store::TierPolicy {
+                        raw_retention_days: config.metrics_store.raw_retention_days,
+                        hourly_retention_days: config.metrics_store.hourly_retention_days,
+                        daily_retention_days: config.metrics_store.daily_retention_days,
+                    };
+                    let _ = s.spawn_maintenance(
+                        policy,
+                        config.metrics_store.maintenance_interval_hours,
+                    );
+                    info!(
+                        interval_h = config.metrics_store.maintenance_interval_hours,
+                        "metrics-store: maintenance tiered planifiée"
+                    );
+                }
+                Some(s)
+            }
+            Err(e) => {
+                warn!("metrics-store ouverture échouée : {e} — dual-write désactivé");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // ── VictoriaMetrics (client HTTP stockage time-series) ────────────────────
     let vm_handle = if config.victoriametrics.enabled {
         match vm_client::VmClient::new(&config.victoriametrics) {
-            Ok(h) => {
+            Ok(mut h) => {
+                if let Some(s) = &metrics_store {
+                    h = h.with_metrics_store(s.writer());
+                }
                 info!("VictoriaMetrics activé — url '{}'", config.victoriametrics.url);
                 Some(h)
             }

--- a/crates/daly-bms-server/src/vm_client.rs
+++ b/crates/daly-bms-server/src/vm_client.rs
@@ -5,6 +5,7 @@
 
 use std::fmt::Write as _;
 use std::time::Duration;
+use metrics_store::writer::{Sample, Writer as MetricsWriter};
 use reqwest::Client;
 use serde_json::Value;
 use tracing::{info, warn};
@@ -48,6 +49,17 @@ impl VmRow {
         }
     }
 
+    /// Convertit en `metrics_store::writer::Sample` pour le dual-write redb
+    /// (Phase 1, `docs/plan_migration_vm_redb.md`). Non destructif côté VM.
+    fn to_sample(&self) -> Sample {
+        Sample {
+            metric: self.metric.clone(),
+            labels: self.labels.iter().cloned().collect(),
+            ts_ms: self.timestamp_ms,
+            value: self.value,
+        }
+    }
+
     /// Sérialise en Prometheus text format — timestamp en millisecondes (requis par /api/v1/import/prometheus).
     /// Écrit directement dans un buffer pré-alloué pour éviter les allocations intermédiaires
     /// (sur le chemin chaud write_rows : ~100s/sec en production).
@@ -78,6 +90,9 @@ impl VmRow {
 pub struct VmClient {
     http:     Client,
     base_url: String,
+    /// Dual-write Phase 1 — fan-out best-effort vers redb. `None` tant que
+    /// la section `[metrics_store]` n'est pas activée dans Config.toml.
+    metrics_store: Option<MetricsWriter>,
 }
 
 impl VmClient {
@@ -89,7 +104,16 @@ impl VmClient {
         Ok(Self {
             http,
             base_url: config.url.trim_end_matches('/').to_string(),
+            metrics_store: None,
         })
+    }
+
+    /// Branche un writer `metrics-store` pour le dual-write Phase 1.
+    /// À appeler après `new()`, depuis `main.rs`.
+    pub fn with_metrics_store(mut self, writer: MetricsWriter) -> Self {
+        info!("dual-write metrics-store activé (Phase 1 migration redb)");
+        self.metrics_store = Some(writer);
+        self
     }
 
     // -------------------------------------------------------------------------
@@ -97,10 +121,27 @@ impl VmClient {
     // -------------------------------------------------------------------------
 
     /// Écrit un batch de métriques dans VictoriaMetrics (non-bloquant).
+    /// Si `metrics_store` est branché, fan-oute aussi vers redb (best-effort —
+    /// les erreurs ne font jamais échouer l'écriture VM).
     pub async fn write_rows(&self, rows: Vec<VmRow>) -> anyhow::Result<()> {
         if rows.is_empty() {
             return Ok(());
         }
+
+        // Dual-write redb — try_write non bloquant pour ne jamais pénaliser
+        // le chemin chaud VM. Une queue pleine ⇒ drop du sample + log debug.
+        if let Some(w) = &self.metrics_store {
+            let mut dropped = 0_usize;
+            for row in &rows {
+                if w.try_write(row.to_sample()).is_err() {
+                    dropped += 1;
+                }
+            }
+            if dropped > 0 {
+                warn!(dropped, total = rows.len(), "metrics-store: queue pleine, samples perdus");
+            }
+        }
+
         // Estime ~80 octets/ligne (nom métrique + labels + valeur + timestamp).
         // Une seule allocation pour le buffer entier au lieu de N+1 allocations.
         let mut body = String::with_capacity(rows.len() * 80);

--- a/docs/plan_migration_vm_redb.md
+++ b/docs/plan_migration_vm_redb.md
@@ -28,10 +28,10 @@
 | Purge cardinalité (code) | ✅ label `pid` retiré + agrégation par nom (commit `7e37e7e`) |
 | Purge cardinalité (fantômes en base) | ✅ exécutée 17 mai 2026 : 277 → 209 séries, 0 série avec `pid` (cf. §0.1.2) |
 | Audit PromQL exhaustif | ✅ cf. §6.5 ci-dessous (81 expressions, 7 fonctions, 1 subquery) |
-| Crate `metrics-store` | ❌ pas démarrée |
-| Endpoint `/api/v1/metrics/ingest` | ❌ pas démarré |
-| Shim PromQL → redb | ❌ pas démarré |
-| Dual-write VM+redb | ❌ pas démarré |
+| Crate `metrics-store` | ✅ Phase 0 complète (cf. branche `claude/migration-vm-redb-kqUG8`) |
+| Endpoint `/api/v1/metrics/ingest` | ❌ pas démarré (parser `prom_text` prêt, reste handler HTTP) |
+| Shim PromQL → redb | ✅ parse+validate+exec, golden test 81/81 (panel 43 rejet explicite) |
+| Dual-write VM+redb | ⚠️ **code prêt** dans `daly-bms-server`, **à activer** dans Config.toml + déployer Pi5 (cf. §0.5) |
 | Bascule Grafana | ❌ pas démarrée |
 | Retrait VictoriaMetrics | ❌ pas démarré |
 | **Volume actuel data dir** | `/mnt/nvme/victoria-metrics` (à mesurer en début de session : `du -sh`) |
@@ -245,6 +245,48 @@ ssh pi5 'du -sh /mnt/nvme/victoria-metrics && \
 **Branche de travail recommandée** : `claude/migration-vm-redb-<jour>` —
 **ne pas réutiliser** `claude/detailed-migration-plan-BJxVd` (cette dernière
 contient les ajouts Solar PV et doit rester focalisée dessus).
+
+### 0.5 État d'avancement du code (Mai 2026 — fin Phase 0)
+
+Branche : `claude/migration-vm-redb-kqUG8`. 6 commits, 35 tests verts
+(`cargo test -p metrics-store`), workspace `cargo check` OK.
+
+| Ticket | Livrable | Commit |
+|---|---|---|
+| 0.3 | Squelette crate `metrics-store` (Cargo.toml + module skeleton) | `e48d922` |
+| 0.4-0.5a | `writer.rs` (thread dédié batché 4 fsync/s, cache LRU series_id), `reader.rs` (query_range_raw / query_range_buckets / list_series), `agg.rs` (Avg/Min/Max/Sum/Count/First/Last) | `ecd8d56` |
+| 0.5b | `tiering.rs` : `compact_raw_to_hourly`, `compact_hourly_to_daily`, `spawn_maintenance` périodique, `AggBucketBuilder` chainable raw→hourly→daily | `672972b` |
+| 0.6 | `promql/` : parser via `promql-parser 0.9`, `validate` (whitelist §6.5), `exec::Evaluator` (selector + binops + aggrégations + range fns + tier auto §6.3) + golden test `tests/golden_promql.rs` 81/81 (panel 43 marqué `KNOWN_UNSUPPORTED_PANELS`) | `addf22f` |
+| 0.7 | `prom_text.rs` : parser format Prometheus exposition (commentaires, échappements, virgule terminale, `+inf`/`-inf`/`nan`, lignes en erreur tracées) | `74058e3` |
+| 0.8 | Benches criterion `insert_batch_raw` + `range_scan_raw` ; ~150 Kelem/s insert + ~13 Melem/s scan sur x86 dev | `7e51678` |
+| Phase 1 (code) | `daly-bms-server` : section `[metrics_store]` dans `AppConfig`, hook dual-write dans `VmClient::write_rows` (try_write best-effort), init `MetricsStore` + `spawn_maintenance` dans `main.rs`, ligne `[metrics_store]` ajoutée à `Config.toml` (défaut `enabled = false`) | (commit en cours) |
+
+**Versions notables** : `redb = "4.1"` (bump 2.2 → 4.1 demandé), pas
+de dépendance C, pure-Rust 100 %.
+
+**Reste à faire pour la Phase 1 ops** (intervention humaine Pi5) :
+```bash
+# 1. Activer le dual-write dans Config.toml
+sed -i 's/^enabled = false$/enabled = true/' Config.toml  # section [metrics_store]
+
+# 2. Déployer (cf. §0 du CLAUDE.md)
+make sync
+make build-arm
+sudo systemctl stop daly-bms
+sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
+sudo cp Config.toml /etc/daly-bms/config.toml
+mkdir -p /mnt/nvme/daly-bms      # s'assurer que db_path est writable
+sudo systemctl start daly-bms
+
+# 3. Observer (≥ 24 h)
+journalctl -u daly-bms -f | grep -i 'metrics-store\|dual-write'
+du -sh /mnt/nvme/daly-bms/metrics.redb   # doit croître
+# Pas d'erreurs "queue pleine" en régime nominal.
+```
+
+À noter : la **migration historique** des 48 Mo de VictoriaMetrics
+(décision §0.4-2 : import script) reste à scripter. Elle peut se faire
+en parallèle du dual-write — pas de blocage.
 
 ### 0.4 Décisions prises (17 mai 2026)
 


### PR DESCRIPTION
…r défaut)

Branche le backend redb (`metrics-store`) en dual-write avec VictoriaMetrics. Cf. plan_migration_vm_redb.md §10 Phase 1.

Changements code :
- `Cargo.toml` workspace : ajoute `metrics-store` dans `workspace.dependencies`.
- `crates/daly-bms-server/Cargo.toml` : dep `metrics-store`.
- `config.rs` : section `[metrics_store]` (`MetricsStoreConfig`) ajoutée à `AppConfig`. Champs : `enabled` (défaut `false`), `db_path`, `cache_mb`, `queue_depth`, `maintenance_interval_hours`, `raw_retention_days`, `hourly_retention_days`, `daily_retention_days`.
- `vm_client.rs` :
  * `VmRow::to_sample()` — conversion vers `metrics_store::Sample`.
  * `VmClient::with_metrics_store(writer)` — builder optionnel non destructif (préserve `VmClient::new()` existant).
  * `write_rows()` : fan-out best-effort via `try_write()` AVANT l'écriture VM. Une queue pleine ⇒ drop + warn agrégé (`dropped + total`). Une erreur côté redb ne fait JAMAIS échouer l'écriture VM (sécurité Phase 1).
- `main.rs` :
  * Ouvre `MetricsStore` si `[metrics_store].enabled = true`, démarre `spawn_maintenance` selon la `TierPolicy`.
  * Injecte `writer` dans le `VmClient` via `with_metrics_store()`.
  * Échec d'ouverture redb ⇒ warn + dual-write désactivé (VM continue seul).

Config :
- `Config.toml` : nouvelle section `[metrics_store]` documentée, `enabled = false` ⇒ comportement inchangé pour le déploiement actuel. L'opérateur doit explicitement passer à `true` et créer le répertoire `/mnt/nvme/daly-bms/` pour activer.

Plan §0 mis à jour avec l'inventaire des 6 commits Phase 0 + la procédure opérationnelle pour activer dual-write sur Pi5 (cf. §0.5).

`cargo check --workspace` + `cargo test -p metrics-store` : OK (35 unit tests + 2 golden tests verts).