### PR TITLE
feat(api): endpoints /api/v1/redb/* Prometheus-compat (Phase 2 migrat…

### DIFF
--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -14,6 +14,7 @@ pub mod shelly;
 pub mod chart;
 pub mod history;
 pub mod promql;
+pub mod redb;
 pub mod health;
 
 use crate::dashboard;
@@ -128,6 +129,14 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/query",          get(promql::query_instant))
         .route("/api/v1/query_range",    get(promql::query_range))
         .route("/api/v1/labels",         get(promql::list_metrics))
+
+        // ── Endpoints redb (Phase 2 migration, cf. plan §10) ───────────────
+        .route("/api/v1/redb/query",                  get(redb::query_instant))
+        .route("/api/v1/redb/query_range",            get(redb::query_range))
+        .route("/api/v1/redb/series",                 get(redb::list_series))
+        .route("/api/v1/redb/labels",                 get(redb::list_labels))
+        .route("/api/v1/redb/label/:name/values",     get(redb::label_values))
+        .route("/api/v1/redb/healthy",                get(redb::healthy))
 
         // ── Alertes (journal SQLite) ──────────────────────────────────────────
         .route("/api/v1/alerts/list",              get(alerts::list_alerts))

--- a/crates/daly-bms-server/src/api/redb.rs
+++ b/crates/daly-bms-server/src/api/redb.rs
@@ -1,0 +1,266 @@
+//! Endpoints HTTP `/api/v1/redb/*` — interroge le backend `metrics-store`
+//! (redb) directement via le shim PromQL. Cf. plan_migration_vm_redb.md
+//! Phase 2.
+//!
+//! Format de réponse : compatible Prometheus HTTP API
+//! (`status=success` + `data.{resultType, result}`).
+//!
+//! Endpoints exposés :
+//! - `GET /api/v1/redb/query`            — instant
+//! - `GET /api/v1/redb/query_range`      — plage temporelle
+//! - `GET /api/v1/redb/series`           — catalogue de séries
+//! - `GET /api/v1/redb/labels`           — noms de labels distincts
+//! - `GET /api/v1/redb/label/:name/values` — valeurs distinctes d'un label
+//! - `GET /api/v1/redb/healthy`          — health-check datasource Grafana
+
+use std::collections::BTreeSet;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use metrics_store::promql::{parse_and_validate, Evaluator, InstantSample, PromQlError, RangeSeries};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::state::AppState;
+
+// =============================================================================
+// Helpers : conversion erreur → réponse JSON Prometheus
+// =============================================================================
+
+fn err_response(err: PromQlError) -> Response {
+    let status = match &err {
+        PromQlError::ParseError(_) | PromQlError::Unsupported(_) => StatusCode::BAD_REQUEST,
+        PromQlError::Execution(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    let body = Json(json!({
+        "status": "error",
+        "errorType": err.error_type(),
+        "error": err.message(),
+    }));
+    (status, body).into_response()
+}
+
+fn not_configured() -> Response {
+    let body = Json(json!({
+        "status": "error",
+        "errorType": "bad_data",
+        "error": "metrics-store backend is not enabled (Config.toml [metrics_store])",
+    }));
+    (StatusCode::SERVICE_UNAVAILABLE, body).into_response()
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Format Prometheus : timestamps en secondes (avec décimales ms), valeurs en
+/// strings.
+fn ts_secs(ms: i64) -> serde_json::Value {
+    json!(ms as f64 / 1000.0)
+}
+
+fn val_str(v: f64) -> String {
+    if v.is_nan() {
+        "NaN".to_string()
+    } else if v.is_infinite() {
+        if v > 0.0 { "+Inf".to_string() } else { "-Inf".to_string() }
+    } else {
+        v.to_string()
+    }
+}
+
+// =============================================================================
+// /api/v1/redb/query — instant
+// =============================================================================
+
+#[derive(Deserialize)]
+pub struct InstantParams {
+    pub query: String,
+    /// Timestamp en millisecondes (défaut : maintenant). Prometheus standard
+    /// accepte des secondes mais notre frontend pousse déjà en ms — on garde.
+    pub time: Option<i64>,
+}
+
+pub async fn query_instant(
+    State(state): State<AppState>,
+    Query(params): Query<InstantParams>,
+) -> Response {
+    let Some(store) = state.metrics_store.clone() else {
+        return not_configured();
+    };
+    let expr = match parse_and_validate(&params.query) {
+        Ok(e) => e,
+        Err(e) => return err_response(e),
+    };
+    let t = params.time.unwrap_or_else(now_ms);
+    let reader = store.reader();
+    let ev = Evaluator::new(&reader);
+    let result: Vec<InstantSample> = match ev.eval_instant(&expr, t) {
+        Ok(v) => v,
+        Err(e) => return err_response(e),
+    };
+    let result_json: Vec<Value> = result
+        .into_iter()
+        .map(|s| {
+            json!({
+                "metric": s.labels,
+                "value": [ts_secs(t), val_str(s.value)],
+            })
+        })
+        .collect();
+    Json(json!({
+        "status": "success",
+        "data": { "resultType": "vector", "result": result_json },
+    }))
+    .into_response()
+}
+
+// =============================================================================
+// /api/v1/redb/query_range — plage temporelle
+// =============================================================================
+
+#[derive(Deserialize)]
+pub struct RangeParams {
+    pub query: String,
+    pub start: i64, // ms
+    pub end: i64,   // ms
+    pub step: i64,  // ms
+}
+
+pub async fn query_range(
+    State(state): State<AppState>,
+    Query(params): Query<RangeParams>,
+) -> Response {
+    let Some(store) = state.metrics_store.clone() else {
+        return not_configured();
+    };
+    let expr = match parse_and_validate(&params.query) {
+        Ok(e) => e,
+        Err(e) => return err_response(e),
+    };
+    let reader = store.reader();
+    let ev = Evaluator::new(&reader);
+    let series: Vec<RangeSeries> = match ev.eval_range(&expr, params.start, params.end, params.step) {
+        Ok(v) => v,
+        Err(e) => return err_response(e),
+    };
+    let result_json: Vec<Value> = series
+        .into_iter()
+        .map(|s| {
+            let values: Vec<Value> = s
+                .samples
+                .into_iter()
+                .map(|(ts, v)| json!([ts_secs(ts), val_str(v)]))
+                .collect();
+            json!({ "metric": s.labels, "values": values })
+        })
+        .collect();
+    Json(json!({
+        "status": "success",
+        "data": { "resultType": "matrix", "result": result_json },
+    }))
+    .into_response()
+}
+
+// =============================================================================
+// /api/v1/redb/series — catalogue de séries
+// =============================================================================
+
+pub async fn list_series(State(state): State<AppState>) -> Response {
+    let Some(store) = state.metrics_store.clone() else {
+        return not_configured();
+    };
+    let reader = store.reader();
+    let series = match reader.list_series() {
+        Ok(v) => v,
+        Err(e) => return err_response(PromQlError::Execution(e.to_string())),
+    };
+    let result: Vec<Value> = series
+        .into_iter()
+        .map(|(_id, meta)| {
+            let mut labels: serde_json::Map<String, Value> =
+                serde_json::from_str(&meta.labels_json).unwrap_or_default();
+            labels.insert("__name__".into(), Value::String(meta.metric));
+            Value::Object(labels)
+        })
+        .collect();
+    Json(json!({ "status": "success", "data": result })).into_response()
+}
+
+// =============================================================================
+// /api/v1/redb/labels — noms de labels distincts
+// =============================================================================
+
+pub async fn list_labels(State(state): State<AppState>) -> Response {
+    let Some(store) = state.metrics_store.clone() else {
+        return not_configured();
+    };
+    let reader = store.reader();
+    let series = match reader.list_series() {
+        Ok(v) => v,
+        Err(e) => return err_response(PromQlError::Execution(e.to_string())),
+    };
+    let mut labels: BTreeSet<String> = BTreeSet::new();
+    labels.insert("__name__".into());
+    for (_id, meta) in &series {
+        if let Ok(m) = serde_json::from_str::<serde_json::Map<String, Value>>(&meta.labels_json) {
+            for k in m.keys() {
+                labels.insert(k.clone());
+            }
+        }
+    }
+    let data: Vec<&String> = labels.iter().collect();
+    Json(json!({ "status": "success", "data": data })).into_response()
+}
+
+// =============================================================================
+// /api/v1/redb/label/:name/values
+// =============================================================================
+
+pub async fn label_values(State(state): State<AppState>, Path(name): Path<String>) -> Response {
+    let Some(store) = state.metrics_store.clone() else {
+        return not_configured();
+    };
+    let reader = store.reader();
+    let series = match reader.list_series() {
+        Ok(v) => v,
+        Err(e) => return err_response(PromQlError::Execution(e.to_string())),
+    };
+    let mut values: BTreeSet<String> = BTreeSet::new();
+    for (_id, meta) in &series {
+        if name == "__name__" {
+            values.insert(meta.metric.clone());
+            continue;
+        }
+        if let Ok(m) = serde_json::from_str::<serde_json::Map<String, Value>>(&meta.labels_json) {
+            if let Some(Value::String(v)) = m.get(&name) {
+                values.insert(v.clone());
+            }
+        }
+    }
+    let data: Vec<&String> = values.iter().collect();
+    Json(json!({ "status": "success", "data": data })).into_response()
+}
+
+// =============================================================================
+// /api/v1/redb/healthy — health-check pour la datasource Prometheus de Grafana
+// =============================================================================
+
+pub async fn healthy(State(state): State<AppState>) -> Response {
+    if state.metrics_store.is_some() {
+        (StatusCode::OK, "metrics-store backend is healthy").into_response()
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "metrics-store backend not enabled",
+        )
+            .into_response()
+    }
+}

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -343,7 +343,14 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // ── État partagé ───────────────────────────────────────────────────────────
-    let state = AppState::new(config.clone(), log_buffer, vm_handle, alert_engine.clone());
+    let metrics_store_arc = metrics_store.as_ref().map(|s| std::sync::Arc::new(s.clone()));
+    let state = AppState::new(
+        config.clone(),
+        log_buffer,
+        vm_handle,
+        alert_engine.clone(),
+        metrics_store_arc,
+    );
 
     // ── Bridges en arrière-plan ─────────────────────────────────────────────────
 

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -449,6 +449,11 @@ pub struct AppState {
     /// Client VictoriaMetrics (None si désactivé dans la config).
     pub vm: Option<Arc<VmClient>>,
 
+    /// Backend TSDB redb (None si désactivé). Permet aux endpoints
+    /// `/api/v1/redb/*` d'interroger directement la base locale via le
+    /// shim PromQL (`metrics-store::promql`). Cf. plan Phase 2.
+    pub metrics_store: Option<Arc<metrics_store::MetricsStore>>,
+
     /// Catalogue de panels (importés depuis docs/grafana-ess_dashboard.json au démarrage).
     pub dashboard_catalog: crate::dashboards::Catalog,
 
@@ -473,7 +478,13 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(config: AppConfig, log_buffer: LogBuffer, vm: Option<VmClient>, alert_engine: Option<Arc<AlertEngine>>) -> Self {
+    pub fn new(
+        config: AppConfig,
+        log_buffer: LogBuffer,
+        vm: Option<VmClient>,
+        alert_engine: Option<Arc<AlertEngine>>,
+        metrics_store: Option<Arc<metrics_store::MetricsStore>>,
+    ) -> Self {
         let (ws_tx, _) = broadcast::channel(WS_BROADCAST_CAPACITY);
         let addresses = config.bms_addresses();
         let ring_size = config.serial.ring_buffer_size;
@@ -540,6 +551,7 @@ impl AppState {
             shelly_client: Arc::new(tokio::sync::Mutex::new(None)),
             alert_engine,
             vm: vm.map(Arc::new),
+            metrics_store,
             dashboard_catalog: crate::dashboards::Catalog::load_default(),
             dashboard_storage,
             vm_last_bms_write:      Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION
…ion)

Phase 2 du plan migration VM → redb : nouveaux endpoints HTTP qui interrogent directement le backend `metrics-store` via le shim PromQL (parse + validate + Evaluator), au format JSON Prometheus standard.

Endpoints ajoutés (préfixe `/api/v1/redb/`) :
- `GET /query`                  — instant vector
- `GET /query_range`            — matrix (start, end, step ms)
- `GET /series`                 — catalogue de séries
- `GET /labels`                 — noms de labels distincts
- `GET /label/:name/values`     — valeurs distinctes d'un label
- `GET /healthy`                — health-check datasource Grafana

Si `[metrics_store].enabled = false` → 503 SERVICE_UNAVAILABLE avec message d'erreur clair (Grafana saura router vers VM).

Format de réponse strictement Prometheus :
- `status` : "success" / "error"
- `data.resultType` : "vector" / "matrix"
- `data.result[].metric` : Map<label, value> incluant `__name__`
- `data.result[].value` : [ts_secs_f64, value_str]

Erreurs PromQL (subquery, fonctions hors whitelist, etc.) renvoient `status=error`, `errorType=bad_data` selon spec, 400 BAD_REQUEST.

Changements code :
- `crates/daly-bms-server/src/state.rs` : champ `pub metrics_store: Option<Arc<MetricsStore>>` ajouté à AppState. Signature `AppState::new()` étendue.
- `crates/daly-bms-server/src/main.rs` : passe le MetricsStore (wrappé en Arc) à `AppState::new`. Conservé l'injection writer côté VmClient (dual-write Phase 1 inchangé).
- `crates/daly-bms-server/src/api/redb.rs` (nouveau) : 6 handlers.
- `crates/daly-bms-server/src/api/mod.rs` : 6 routes enregistrées.

Co-existence avec `/api/v1/query*` (proxy VM) inchangée : on peut comparer côte à côte (`curl /api/v1/query?...` vs `curl /api/v1/redb/query?...`) pendant la validation Phase 2.

`cargo check --workspace` + `cargo test -p metrics-store` : OK (35 unit + 2 golden tests verts).