### PR TITLE
feat: dispatch vm/redb + datasource Grafana provisioning (Phase 3)

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -430,6 +430,11 @@ maintenance_interval_hours = 6
 raw_retention_days = 30
 hourly_retention_days = 365
 daily_retention_days = 1825   # 5 ans
+# Backend par défaut pour les routes Grafana-facing /api/v1/query[_range],
+# /api/v1/labels. Valeurs : "vm" (proxy VictoriaMetrics, historique) ou
+# "redb" (shim PromQL local). Les routes /api/v1/redb/* restent toujours
+# redb-backed quelle que soit cette valeur.
+default_backend = "vm"
 
 
 [alerts]

--- a/contrib/grafana/provisioning/datasources/daly-metrics.yaml
+++ b/contrib/grafana/provisioning/datasources/daly-metrics.yaml
@@ -1,0 +1,32 @@
+apiVersion: 1
+
+# Datasource Grafana qui interroge le backend `metrics-store` (redb) via
+# daly-bms-server. Cf. docs/plan_migration_vm_redb.md §8.1 Phase 3.
+#
+# Les endpoints Prometheus-compat exposés par daly-bms-server (/api/v1/query,
+# /api/v1/query_range, /api/v1/labels, /api/v1/series, /api/v1/label/:n/values,
+# /-/healthy) dispatchent vers redb quand `[metrics_store].default_backend =
+# "redb"` dans /etc/daly-bms/config.toml.
+#
+# Pour basculer Grafana :
+#   1. Activer cette datasource (la rendre `isDefault: true`).
+#   2. Désactiver `victoriametrics.yaml` (mettre `isDefault: false`).
+#   3. Restart Grafana : `sudo systemctl restart grafana-server` (ou docker).
+# Les dashboards `.json` existants restent inchangés — le shim PromQL accepte
+# les mêmes expressions (cf. golden test §6.5).
+
+datasources:
+  - name: Daly Metrics (redb)
+    type: prometheus
+    access: proxy
+    url: http://127.0.0.1:8080
+    uid: daly-metrics
+    isDefault: false
+    editable: true
+    jsonData:
+      httpMethod: GET
+      timeInterval: 60s
+      queryTimeout: 30s
+      prometheusType: Prometheus
+      prometheusVersion: 2.40.0
+      manageAlerts: false

--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -126,11 +126,20 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/shelly/:id/status",                  get(shelly::get_shelly_status))
         .route("/api/v1/shelly/:id/channel/:ch/control",     post(shelly::control_shelly_channel))
         // ── PromQL (historique Tsink) ─────────────────────────────────────────
+        // ── PromQL Grafana-facing — dispatch vm/redb selon
+        //    `[metrics_store].default_backend` (cf. api/promql.rs) ─────────
         .route("/api/v1/query",          get(promql::query_instant))
         .route("/api/v1/query_range",    get(promql::query_range))
         .route("/api/v1/labels",         get(promql::list_metrics))
 
-        // ── Endpoints redb (Phase 2 migration, cf. plan §10) ───────────────
+        // ── Endpoints Prometheus complémentaires §8.2 (toujours redb) ─────
+        //    /api/v1/series, /api/v1/label/:n/values, /-/healthy n'existaient
+        //    pas côté VM proxy ; servis directement par le shim redb.
+        .route("/api/v1/series",                      get(redb::list_series))
+        .route("/api/v1/label/:name/values",          get(redb::label_values))
+        .route("/-/healthy",                          get(redb::healthy))
+
+        // ── Endpoints redb explicites (debug, parité côte-à-côte) ──────────
         .route("/api/v1/redb/query",                  get(redb::query_instant))
         .route("/api/v1/redb/query_range",            get(redb::query_range))
         .route("/api/v1/redb/series",                 get(redb::list_series))

--- a/crates/daly-bms-server/src/api/promql.rs
+++ b/crates/daly-bms-server/src/api/promql.rs
@@ -1,8 +1,18 @@
-//! Endpoints PromQL compatibles Prometheus HTTP API.
+//! Endpoints PromQL Prometheus-compat avec **dispatch dynamique** entre
+//! VictoriaMetrics (proxy HTTP historique) et `metrics-store` (shim PromQL
+//! local redb).
 //!
-//! Proxy vers VictoriaMetrics — la réponse JSON est retournée telle quelle.
+//! Le choix de backend est piloté par `[metrics_store].default_backend` :
+//! - `"vm"` (défaut, comportement historique) — proxy vers VM
+//! - `"redb"` — utilise `metrics_store::promql::Evaluator`
+//!
+//! Les routes explicites `/api/v1/redb/*` (cf. `api::redb`) restent toujours
+//! redb-backed indépendamment de ce flag (utile pour debug / parité).
+//!
+//! Routes exposées :
 //!   GET /api/v1/query        — requête instantanée
 //!   GET /api/v1/query_range  — requête sur plage temporelle
+//!   GET /api/v1/labels       — liste métriques (autocomplete frontend)
 
 use axum::{
     extract::{Query, State},
@@ -11,12 +21,13 @@ use axum::{
     Json,
 };
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::json;
 
+use crate::api::redb as redb_api;
 use crate::state::AppState;
 
 // =============================================================================
-// Paramètres de requête
+// Paramètres de requête (alignés avec api::redb pour la cohérence)
 // =============================================================================
 
 #[derive(Deserialize)]
@@ -71,59 +82,89 @@ fn vm_error(e: anyhow::Error) -> ApiError {
     }
 }
 
+fn use_redb(state: &AppState) -> bool {
+    state.config.metrics_store.default_backend.eq_ignore_ascii_case("redb")
+}
+
 // =============================================================================
 // Handlers
 // =============================================================================
 
 /// `GET /api/v1/query` — Requête PromQL instantanée.
-///
-/// Exemple : `/api/v1/query?query=bms_voltage{bms_id="0x01"}&time=1700000000000`
 pub async fn query_instant(
     State(state): State<AppState>,
     Query(params): Query<InstantQueryParams>,
-) -> Result<Json<Value>, ApiError> {
-    let vm = state.vm.as_ref().ok_or_else(vm_unavailable)?;
+) -> Response {
+    if use_redb(&state) {
+        let p = redb_api::InstantParams { query: params.query, time: params.time };
+        return redb_api::run_query_instant(&state, &p).await;
+    }
 
+    // Backend VM (historique)
+    let vm = match state.vm.as_ref() {
+        Some(v) => v,
+        None => return vm_unavailable().into_response(),
+    };
     let time_ms = params.time.unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
-
-    vm.query_instant_json(&params.query, time_ms)
-        .await
-        .map(Json)
-        .map_err(vm_error)
+    match vm.query_instant_json(&params.query, time_ms).await {
+        Ok(json) => Json(json).into_response(),
+        Err(e) => vm_error(e).into_response(),
+    }
 }
 
 /// `GET /api/v1/query_range` — Requête PromQL sur plage temporelle.
-///
-/// Exemple : `/api/v1/query_range?query=bms_soc{bms_id="0x01"}&start=1700000000000&end=1700086400000&step=60000`
 pub async fn query_range(
     State(state): State<AppState>,
     Query(params): Query<RangeQueryParams>,
-) -> Result<Json<Value>, ApiError> {
-    let vm = state.vm.as_ref().ok_or_else(vm_unavailable)?;
+) -> Response {
+    if use_redb(&state) {
+        let p = redb_api::RangeParams {
+            query: params.query,
+            start: params.start,
+            end:   params.end,
+            step:  params.step,
+        };
+        return redb_api::run_query_range(&state, &p).await;
+    }
 
+    // Backend VM (historique) — validations conservées à l'identique
+    let vm = match state.vm.as_ref() {
+        Some(v) => v,
+        None => return vm_unavailable().into_response(),
+    };
     if params.start > params.end {
-        return Err(ApiError {
+        return ApiError {
             status:     "error".into(),
             error:      "start must be before end".into(),
             error_type: Some("bad_data".into()),
-        });
+        }
+        .into_response();
     }
     if params.step <= 0 {
-        return Err(ApiError {
+        return ApiError {
             status:     "error".into(),
             error:      "step must be positive".into(),
             error_type: Some("bad_data".into()),
-        });
+        }
+        .into_response();
     }
-
-    vm.query_range_json(&params.query, params.start, params.end, params.step)
+    match vm
+        .query_range_json(&params.query, params.start, params.end, params.step)
         .await
-        .map(Json)
-        .map_err(vm_error)
+    {
+        Ok(json) => Json(json).into_response(),
+        Err(e) => vm_error(e).into_response(),
+    }
 }
 
-/// `GET /api/v1/labels` — Liste des métriques connues (pour autocomplete frontend).
-pub async fn list_metrics(State(state): State<AppState>) -> Json<Value> {
+/// `GET /api/v1/labels` — Liste des métriques connues.
+///
+/// Backend redb : scan dynamique de `series_meta`.
+/// Backend VM   : liste statique conservée (compat frontend).
+pub async fn list_metrics(State(state): State<AppState>) -> Response {
+    if use_redb(&state) {
+        return redb_api::run_list_labels(&state).await;
+    }
     Json(json!({
         "status": "success",
         "data": if state.vm.is_some() {
@@ -142,4 +183,5 @@ pub async fn list_metrics(State(state): State<AppState>) -> Json<Value> {
             vec![]
         }
     }))
+    .into_response()
 }

--- a/crates/daly-bms-server/src/api/redb.rs
+++ b/crates/daly-bms-server/src/api/redb.rs
@@ -92,6 +92,12 @@ pub async fn query_instant(
     State(state): State<AppState>,
     Query(params): Query<InstantParams>,
 ) -> Response {
+    run_query_instant(&state, &params).await
+}
+
+/// Logique pure (sans extracteurs Axum) — appelable depuis le dispatcher
+/// `api/promql.rs` quand `default_backend = "redb"`.
+pub async fn run_query_instant(state: &AppState, params: &InstantParams) -> Response {
     let Some(store) = state.metrics_store.clone() else {
         return not_configured();
     };
@@ -138,6 +144,10 @@ pub async fn query_range(
     State(state): State<AppState>,
     Query(params): Query<RangeParams>,
 ) -> Response {
+    run_query_range(&state, &params).await
+}
+
+pub async fn run_query_range(state: &AppState, params: &RangeParams) -> Response {
     let Some(store) = state.metrics_store.clone() else {
         return not_configured();
     };
@@ -174,6 +184,10 @@ pub async fn query_range(
 // =============================================================================
 
 pub async fn list_series(State(state): State<AppState>) -> Response {
+    run_list_series(&state).await
+}
+
+pub async fn run_list_series(state: &AppState) -> Response {
     let Some(store) = state.metrics_store.clone() else {
         return not_configured();
     };
@@ -199,6 +213,10 @@ pub async fn list_series(State(state): State<AppState>) -> Response {
 // =============================================================================
 
 pub async fn list_labels(State(state): State<AppState>) -> Response {
+    run_list_labels(&state).await
+}
+
+pub async fn run_list_labels(state: &AppState) -> Response {
     let Some(store) = state.metrics_store.clone() else {
         return not_configured();
     };
@@ -225,6 +243,10 @@ pub async fn list_labels(State(state): State<AppState>) -> Response {
 // =============================================================================
 
 pub async fn label_values(State(state): State<AppState>, Path(name): Path<String>) -> Response {
+    run_label_values(&state, &name).await
+}
+
+pub async fn run_label_values(state: &AppState, name: &str) -> Response {
     let Some(store) = state.metrics_store.clone() else {
         return not_configured();
     };
@@ -240,7 +262,7 @@ pub async fn label_values(State(state): State<AppState>, Path(name): Path<String
             continue;
         }
         if let Ok(m) = serde_json::from_str::<serde_json::Map<String, Value>>(&meta.labels_json) {
-            if let Some(Value::String(v)) = m.get(&name) {
+            if let Some(Value::String(v)) = m.get(name) {
                 values.insert(v.clone());
             }
         }

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -473,6 +473,13 @@ pub struct MetricsStoreConfig {
     /// Rétention daily (jours).
     #[serde(default = "default_metrics_daily_days")]
     pub daily_retention_days: u32,
+    /// Backend par défaut pour les routes Grafana-facing
+    /// (`/api/v1/query`, `/api/v1/query_range`, `/api/v1/labels`).
+    /// Valeurs : `"vm"` (proxy VictoriaMetrics, comportement historique)
+    /// ou `"redb"` (shim PromQL local). Les routes explicites
+    /// `/api/v1/redb/*` restent toujours redb-backed.
+    #[serde(default = "default_metrics_query_backend")]
+    pub default_backend: String,
 }
 
 fn default_metrics_db_path() -> String { "/mnt/nvme/daly-bms/metrics.redb".into() }
@@ -482,6 +489,7 @@ fn default_metrics_maintenance_hours() -> u64 { 6 }
 fn default_metrics_raw_days() -> u32 { 30 }
 fn default_metrics_hourly_days() -> u32 { 365 }
 fn default_metrics_daily_days() -> u32 { 5 * 365 }
+fn default_metrics_query_backend() -> String { "vm".into() }
 
 impl Default for MetricsStoreConfig {
     fn default() -> Self {
@@ -494,6 +502,7 @@ impl Default for MetricsStoreConfig {
             raw_retention_days: default_metrics_raw_days(),
             hourly_retention_days: default_metrics_hourly_days(),
             daily_retention_days: default_metrics_daily_days(),
+            default_backend: default_metrics_query_backend(),
         }
     }
 }

--- a/docs/plan_migration_vm_redb.md
+++ b/docs/plan_migration_vm_redb.md
@@ -31,8 +31,9 @@
 | Crate `metrics-store` | ✅ Phase 0 complète (cf. branche `claude/migration-vm-redb-kqUG8`) |
 | Endpoint `/api/v1/metrics/ingest` | ❌ pas démarré (parser `prom_text` prêt, reste handler HTTP) |
 | Shim PromQL → redb | ✅ parse+validate+exec, golden test 81/81 (panel 43 rejet explicite) |
-| Dual-write VM+redb | ⚠️ **code prêt** dans `daly-bms-server`, **à activer** dans Config.toml + déployer Pi5 (cf. §0.5) |
-| Bascule Grafana | ❌ pas démarrée |
+| Dual-write VM+redb | ✅ déployé Pi5 (17 mai 2026, 191 séries dual-écrites, parité valeur confirmée par diff côte-à-côte) |
+| Endpoint `/api/v1/metrics/ingest` | ❌ pas démarré (parser `prom_text` prêt, reste handler HTTP) |
+| Bascule Grafana | ⚠️ **code prêt** (dispatch `default_backend = "vm"`/`"redb"` + provisioning YAML) — à activer en mettant `default_backend = "redb"` dans `/etc/daly-bms/config.toml` et en faisant pointer Grafana sur la nouvelle datasource (cf. §0.6) |
 | Retrait VictoriaMetrics | ❌ pas démarré |
 | **Volume actuel data dir** | `/mnt/nvme/victoria-metrics` (à mesurer en début de session : `du -sh`) |
 
@@ -287,6 +288,55 @@ du -sh /mnt/nvme/daly-bms/metrics.redb   # doit croître
 À noter : la **migration historique** des 48 Mo de VictoriaMetrics
 (décision §0.4-2 : import script) reste à scripter. Elle peut se faire
 en parallèle du dual-write — pas de blocage.
+
+### 0.6 Bascule Grafana (Phase 3, code livré 17 mai 2026)
+
+Le serveur expose les endpoints Prometheus standard avec un **dispatch
+dynamique** piloté par `[metrics_store].default_backend` :
+
+| Route | `default_backend = "vm"` | `default_backend = "redb"` |
+|---|---|---|
+| `GET /api/v1/query` | proxy VictoriaMetrics | shim PromQL redb |
+| `GET /api/v1/query_range` | proxy VictoriaMetrics | shim PromQL redb |
+| `GET /api/v1/labels` | liste statique | scan dynamique `series_meta` |
+| `GET /api/v1/series` | (toujours redb) | shim |
+| `GET /api/v1/label/:name/values` | (toujours redb) | shim |
+| `GET /-/healthy` | (toujours redb) | shim |
+| `GET /api/v1/redb/*` | (toujours redb) | shim — utile pour parité diff |
+
+Procédure de bascule (réversible — `default_backend = "vm"` rétablit l'état
+antérieur sans toucher au reste) :
+
+```bash
+# 1. Sur le repo (idempotent), confirmer la nouvelle datasource :
+ls contrib/grafana/provisioning/datasources/daly-metrics.yaml
+# (créée par le commit Phase 3 — uid=daly-metrics, isDefault=false)
+
+# 2. Sur Pi5 : déployer le code Phase 3
+make sync && make build-arm
+sudo systemctl stop daly-bms
+sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
+
+# 3. Toggle dans /etc/daly-bms/config.toml :
+sudo sed -i 's/^default_backend = "vm"$/default_backend = "redb"/' /etc/daly-bms/config.toml
+sudo systemctl start daly-bms
+
+# 4. Sanity : redb sert maintenant /api/v1/query
+curl -s "http://127.0.0.1:8080/api/v1/query?query=up" | jq .
+
+# 5. Côté Grafana : si datasource provisioning utilisée
+sudo cp contrib/grafana/provisioning/datasources/daly-metrics.yaml \
+        /etc/grafana/provisioning/datasources/
+# Modifier daly-metrics.yaml pour `isDefault: true` ET
+# victoriametrics.yaml pour `isDefault: false`, puis :
+sudo systemctl restart grafana-server
+# Sinon (UI manuelle) : Grafana > Connections > Data sources > VictoriaMetrics
+# → désactiver "Default" ; ajouter "Daly Metrics (redb)" → activer "Default".
+```
+
+Rollback : remettre `default_backend = "vm"` + restart daly-bms ; tous les
+dashboards reprennent immédiatement leurs réponses depuis VM (qui reste
+alimenté tant que le dual-write Phase 1 tourne).
 
 ### 0.4 Décisions prises (17 mai 2026)
 


### PR DESCRIPTION
Phase 3 de plan_migration_vm_redb.md livrée : le serveur expose maintenant les routes Prometheus standard avec un dispatch dynamique piloté par `[metrics_store].default_backend` ("vm" par défaut, "redb" pour bascule), réversible sans redéploiement de binaire.

Changements code :
- `config.rs` : nouveau champ `default_backend: String` dans `MetricsStoreConfig` (défaut "vm"). Valide "vm" / "redb" case-insensitive.
- `api/promql.rs` : refonte en dispatcher. Les handlers `query_instant` / `query_range` / `list_metrics` testent `use_redb(state)` et délèguent à `api::redb::run_*` ou conservent le proxy VM historique.
- `api/redb.rs` : extraction de la logique métier dans `run_*` (sans extracteurs Axum), permettant l'appel depuis le dispatcher.
- `api/mod.rs` : routes Phase 3.4 §8.2 ajoutées et **toujours** redb-backed :
  * GET /api/v1/series
  * GET /api/v1/label/:name/values
  * GET /-/healthy Les routes /api/v1/redb/* sont conservées pour parité côte-à-côte.

Provisioning Grafana :
- `contrib/grafana/provisioning/datasources/daly-metrics.yaml` (nouveau) : datasource Prometheus pointant sur 127.0.0.1:8080 (notre serveur), uid=daly-metrics, isDefault=false. L'opérateur bascule en éditant ce flag + désactivant victoriametrics.yaml puis restart grafana-server.

Config :
- `Config.toml` : `default_backend = "vm"` ajouté à [metrics_store] (zéro effet en prod tant que la valeur reste "vm").

Doc :
- `docs/plan_migration_vm_redb.md` §0 : statut Phase 3 = code prêt ; nouvelle section §0.6 = procédure de bascule réversible documentée (sed default_backend → "redb" + restart daly-bms ; rollback inverse).

Tests : `cargo check --workspace` OK, `cargo test -p metrics-store` 35/35 unit + 2/2 golden verts.

Vérifs Pi5 attendues après deploy :
  curl 'http://127.0.0.1:8080/api/v1/query?query=up'   # vm (défaut)
  sed ... default_backend = "redb" ...
  curl 'http://127.0.0.1:8080/api/v1/query?query=up'   # redb maintenant
  curl 'http://127.0.0.1:8080/api/v1/series' | jq '.data | length'
  curl 'http://127.0.0.1:8080/-/healthy'