### PR TITLE
feat(api): support POST sur /api/v1/query[_range] (compat Grafana htt…

### DIFF
--- a/crates/daly-bms-server/src/api/mod.rs
+++ b/crates/daly-bms-server/src/api/mod.rs
@@ -127,21 +127,24 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/shelly/:id/channel/:ch/control",     post(shelly::control_shelly_channel))
         // ── PromQL (historique Tsink) ─────────────────────────────────────────
         // ── PromQL Grafana-facing — dispatch vm/redb selon
-        //    `[metrics_store].default_backend` (cf. api/promql.rs) ─────────
-        .route("/api/v1/query",          get(promql::query_instant))
-        .route("/api/v1/query_range",    get(promql::query_range))
+        //    `[metrics_store].default_backend` (cf. api/promql.rs).
+        //    GET + POST tous les deux (Grafana `httpMethod: POST` par défaut)
+        .route("/api/v1/query",
+               get(promql::query_instant).post(promql::query_instant_post))
+        .route("/api/v1/query_range",
+               get(promql::query_range).post(promql::query_range_post))
         .route("/api/v1/labels",         get(promql::list_metrics))
 
         // ── Endpoints Prometheus complémentaires §8.2 (toujours redb) ─────
-        //    /api/v1/series, /api/v1/label/:n/values, /-/healthy n'existaient
-        //    pas côté VM proxy ; servis directement par le shim redb.
         .route("/api/v1/series",                      get(redb::list_series))
         .route("/api/v1/label/:name/values",          get(redb::label_values))
         .route("/-/healthy",                          get(redb::healthy))
 
         // ── Endpoints redb explicites (debug, parité côte-à-côte) ──────────
-        .route("/api/v1/redb/query",                  get(redb::query_instant))
-        .route("/api/v1/redb/query_range",            get(redb::query_range))
+        .route("/api/v1/redb/query",
+               get(redb::query_instant).post(redb::query_instant_post))
+        .route("/api/v1/redb/query_range",
+               get(redb::query_range).post(redb::query_range_post))
         .route("/api/v1/redb/series",                 get(redb::list_series))
         .route("/api/v1/redb/labels",                 get(redb::list_labels))
         .route("/api/v1/redb/label/:name/values",     get(redb::label_values))

--- a/crates/daly-bms-server/src/api/promql.rs
+++ b/crates/daly-bms-server/src/api/promql.rs
@@ -18,7 +18,7 @@ use axum::{
     extract::{Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
+    Form, Json,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -95,12 +95,24 @@ pub async fn query_instant(
     State(state): State<AppState>,
     Query(params): Query<InstantQueryParams>,
 ) -> Response {
+    handle_query_instant(state, params).await
+}
+
+/// `POST /api/v1/query` — Variante POST utilisée par Grafana
+/// (Prometheus datasource avec `httpMethod: POST`). Les paramètres
+/// arrivent dans le body `application/x-www-form-urlencoded`.
+pub async fn query_instant_post(
+    State(state): State<AppState>,
+    Form(params): Form<InstantQueryParams>,
+) -> Response {
+    handle_query_instant(state, params).await
+}
+
+async fn handle_query_instant(state: AppState, params: InstantQueryParams) -> Response {
     if use_redb(&state) {
         let p = redb_api::InstantParams { query: params.query, time: params.time };
         return redb_api::run_query_instant(&state, &p).await;
     }
-
-    // Backend VM (historique)
     let vm = match state.vm.as_ref() {
         Some(v) => v,
         None => return vm_unavailable().into_response(),
@@ -117,6 +129,18 @@ pub async fn query_range(
     State(state): State<AppState>,
     Query(params): Query<RangeQueryParams>,
 ) -> Response {
+    handle_query_range(state, params).await
+}
+
+/// `POST /api/v1/query_range` — variante POST (Grafana POST mode).
+pub async fn query_range_post(
+    State(state): State<AppState>,
+    Form(params): Form<RangeQueryParams>,
+) -> Response {
+    handle_query_range(state, params).await
+}
+
+async fn handle_query_range(state: AppState, params: RangeQueryParams) -> Response {
     if use_redb(&state) {
         let p = redb_api::RangeParams {
             query: params.query,
@@ -126,8 +150,6 @@ pub async fn query_range(
         };
         return redb_api::run_query_range(&state, &p).await;
     }
-
-    // Backend VM (historique) — validations conservées à l'identique
     let vm = match state.vm.as_ref() {
         Some(v) => v,
         None => return vm_unavailable().into_response(),

--- a/crates/daly-bms-server/src/api/redb.rs
+++ b/crates/daly-bms-server/src/api/redb.rs
@@ -19,7 +19,7 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
+    Form, Json,
 };
 use metrics_store::promql::{parse_and_validate, Evaluator, InstantSample, PromQlError, RangeSeries};
 use serde::Deserialize;
@@ -95,6 +95,15 @@ pub async fn query_instant(
     run_query_instant(&state, &params).await
 }
 
+/// Variante POST : Grafana (Prometheus datasource) envoie les paramètres
+/// dans le body application/x-www-form-urlencoded quand `httpMethod: POST`.
+pub async fn query_instant_post(
+    State(state): State<AppState>,
+    Form(params): Form<InstantParams>,
+) -> Response {
+    run_query_instant(&state, &params).await
+}
+
 /// Logique pure (sans extracteurs Axum) — appelable depuis le dispatcher
 /// `api/promql.rs` quand `default_backend = "redb"`.
 pub async fn run_query_instant(state: &AppState, params: &InstantParams) -> Response {
@@ -143,6 +152,13 @@ pub struct RangeParams {
 pub async fn query_range(
     State(state): State<AppState>,
     Query(params): Query<RangeParams>,
+) -> Response {
+    run_query_range(&state, &params).await
+}
+
+pub async fn query_range_post(
+    State(state): State<AppState>,
+    Form(params): Form<RangeParams>,
 ) -> Response {
     run_query_range(&state, &params).await
 }


### PR DESCRIPTION
…pMethod=POST)

Bug observé en prod : après bascule Grafana sur notre dispatcher, tous les panels affichent 'No data'. Cause : Grafana envoie POST avec application/x-www-form-urlencoded body quand 'httpMethod: POST' est configuré dans la datasource (par défaut sur la datasource Prometheus de Grafana). Nos routes étaient déclarées en GET uniquement → 405 Method Not Allowed → No data.

Fix :
- api/redb.rs : ajout des handlers query_instant_post / query_range_post qui utilisent l'extracteur Form<T> au lieu de Query<T>. Les deux variantes appellent le même run_query_*().
- api/promql.rs : idem pour le dispatcher. Factorisation des handle_query_instant / handle_query_range pour partager la logique entre GET et POST.
- api/mod.rs : routes /api/v1/query et /api/v1/query_range déclarées '.get(handler).post(handler_post)' — pareil pour /api/v1/redb/*.

Test attendu (Pi5) :
  curl -X POST -d 'query=up' http://127.0.0.1:8080/api/v1/query # → 200 status:success (au lieu de 405 avant)

En attendant le redéploiement du binaire, workaround Pi5 immédiat :
  sudo sed -i 's/httpMethod: POST/httpMethod: GET/' \
    /etc/grafana/provisioning/datasources/victoriametrics.yaml
  sudo systemctl restart grafana-server
Grafana repasse en mode GET qui marche déjà.