### PR TITLE
feat(api): routes internes /chart, /history, /dashboards dispatchent …

### DIFF
--- a/crates/daly-bms-server/src/api/chart.rs
+++ b/crates/daly-bms-server/src/api/chart.rs
@@ -36,19 +36,20 @@ pub async fn get_chart_history(
 ) -> impl IntoResponse {
     let minutes = q.minutes.unwrap_or(60).clamp(1, 720) as i64;
 
-    let vm = match &state.vm {
-        Some(v) => v,
-        None => return Json(json!({"solar": [], "soc": [], "load": [], "ok": false, "reason": "vm_disabled"})),
-    };
+    // Pré-flight : un backend de lecture doit être configuré (VM proxy ou redb).
+    if state.vm.is_none() && state.metrics_store.is_none() {
+        return Json(json!({"solar": [], "soc": [], "load": [], "ok": false, "reason": "no_query_backend"}));
+    }
 
     let now_ms   = Utc::now().timestamp_millis();
     let start_ms = now_ms - minutes * 60 * 1000;
     let step_ms: i64 = if minutes <= 60 { 60_000 } else if minutes <= 360 { 300_000 } else { 600_000 };
 
+    // Dispatcher VM/redb (cf. AppState::dispatched_query_range)
     let (solar_res, soc_res, load_res) = tokio::join!(
-        vm.query_range_json("solar_total_w",                           start_ms, now_ms, step_ms),
-        vm.query_range_json("avg(bms_soc)",                            start_ms, now_ms, step_ms),
-        vm.query_range_json("et112_power_w{address=\"0x08\"}",         start_ms, now_ms, step_ms),
+        state.dispatched_query_range("solar_total_w",                       start_ms, now_ms, step_ms),
+        state.dispatched_query_range("avg(bms_soc)",                        start_ms, now_ms, step_ms),
+        state.dispatched_query_range("et112_power_w{address=\"0x08\"}",     start_ms, now_ms, step_ms),
     );
 
     Json(json!({
@@ -111,10 +112,9 @@ pub async fn get_edge_history(
 ) -> impl IntoResponse {
     let minutes = q.minutes.unwrap_or(360).clamp(1, 1440) as i64;
 
-    let vm = match &state.vm {
-        Some(v) => v,
-        None => return Json(json!({ "ok": false, "series": [], "reason": "vm_disabled" })),
-    };
+    if state.vm.is_none() && state.metrics_store.is_none() {
+        return Json(json!({ "ok": false, "series": [], "reason": "no_query_backend" }));
+    }
 
     let (metric, unit): (&str, &str);
     let metric_owned: String;
@@ -167,7 +167,7 @@ pub async fn get_edge_history(
     let start_ms = now_ms - minutes * 60 * 1000;
     let step_ms: i64 = if minutes <= 60 { 60_000 } else if minutes <= 360 { 180_000 } else { 600_000 };
 
-    let result = vm.query_range_json(&query, start_ms, now_ms, step_ms).await;
+    let result = state.dispatched_query_range(&query, start_ms, now_ms, step_ms).await;
 
     let series: Vec<Value> = match result.ok() {
         Some(v) => {

--- a/crates/daly-bms-server/src/api/dashboards.rs
+++ b/crates/daly-bms-server/src/api/dashboards.rs
@@ -138,12 +138,9 @@ pub async fn get_panel_data(
         }
     };
 
-    let vm = match &state.vm {
-        Some(v) => v.clone(),
-        None => {
-            return Json(json!({"ok": false, "reason": "vm_disabled"}));
-        }
-    };
+    if state.vm.is_none() && state.metrics_store.is_none() {
+        return Json(json!({"ok": false, "reason": "no_query_backend"}));
+    }
 
     let now_ms = Utc::now().timestamp_millis();
     let to_ms   = q.to.unwrap_or(now_ms);
@@ -166,14 +163,16 @@ pub async fn get_panel_data(
         }));
     }
 
-    // Exécute toutes les queries en parallèle
+    // Exécute toutes les queries en parallèle (dispatcher VM/redb)
     let futures = panel.queries.iter().map(|q| {
-        let vm = vm.clone();
+        let state_ref = state.clone();
         let expr = q.expr.clone();
         let ref_id = q.ref_id.clone();
         let legend = q.legend.clone();
         async move {
-            let result = vm.query_range_json(&expr, from_ms, to_ms, step_ms).await;
+            let result = state_ref
+                .dispatched_query_range(&expr, from_ms, to_ms, step_ms)
+                .await;
             (ref_id, legend, expr, result)
         }
     });

--- a/crates/daly-bms-server/src/api/history.rs
+++ b/crates/daly-bms-server/src/api/history.rs
@@ -33,10 +33,9 @@ pub async fn get_energy_history(
 ) -> impl IntoResponse {
     let period = q.period.as_deref().unwrap_or("day");
 
-    let vm = match &state.vm {
-        Some(v) => v,
-        None => return Json(json!({"ok": false, "reason": "vm_disabled"})),
-    };
+    if state.vm.is_none() && state.metrics_store.is_none() {
+        return Json(json!({"ok": false, "reason": "no_query_backend"}));
+    }
 
     let now_ms = Utc::now().timestamp_millis();
 
@@ -62,15 +61,15 @@ pub async fn get_energy_history(
     let (solar_w_r, import_w_r, consumption_w_r,
          solar_energy_r, import_energy_r, export_energy_r, consumption_energy_r,
          charge_ah_r, discharge_ah_r) = tokio::join!(
-        vm.query_range_json(&q_solar_w,        start_ms, now_ms, step_ms),
-        vm.query_range_json(&q_import_w,       start_ms, now_ms, step_ms),
-        vm.query_range_json(&q_consump_w,      start_ms, now_ms, step_ms),
-        vm.query_range_json(&q_solar_energy,   start_ms, now_ms, step_ms),
-        vm.query_range_json(&q_import_energy,  start_ms, now_ms, step_ms),
-        vm.query_range_json(&q_export_energy,  start_ms, now_ms, step_ms),
-        vm.query_range_json(&q_consump_energy, start_ms, now_ms, step_ms),
-        vm.query_range_json(&q_charge_ah,      start_ms, now_ms, step_ms),
-        vm.query_range_json(&q_discharge_ah,   start_ms, now_ms, step_ms),
+        state.dispatched_query_range(&q_solar_w,        start_ms, now_ms, step_ms),
+        state.dispatched_query_range(&q_import_w,       start_ms, now_ms, step_ms),
+        state.dispatched_query_range(&q_consump_w,      start_ms, now_ms, step_ms),
+        state.dispatched_query_range(&q_solar_energy,   start_ms, now_ms, step_ms),
+        state.dispatched_query_range(&q_import_energy,  start_ms, now_ms, step_ms),
+        state.dispatched_query_range(&q_export_energy,  start_ms, now_ms, step_ms),
+        state.dispatched_query_range(&q_consump_energy, start_ms, now_ms, step_ms),
+        state.dispatched_query_range(&q_charge_ah,      start_ms, now_ms, step_ms),
+        state.dispatched_query_range(&q_discharge_ah,   start_ms, now_ms, step_ms),
     );
 
     // ── Extraction ──────────────────────────────────────────────────────────────

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -478,6 +478,137 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Backend de lecture courant pour les routes Grafana-facing et internes.
+    pub fn query_backend(&self) -> &str {
+        if self.config.metrics_store.default_backend.eq_ignore_ascii_case("redb") {
+            "redb"
+        } else {
+            "vm"
+        }
+    }
+
+    /// Exécute une requête PromQL sur plage temporelle, dispatchée entre
+    /// VictoriaMetrics (proxy HTTP historique) et `metrics-store` (shim
+    /// PromQL local redb) selon `config.metrics_store.default_backend`.
+    /// Retourne le format JSON Prometheus standard (compatible avec tous
+    /// les callers existants qui parsaient `vm.query_range_json`).
+    pub async fn dispatched_query_range(
+        &self,
+        query: &str,
+        start_ms: i64,
+        end_ms: i64,
+        step_ms: i64,
+    ) -> anyhow::Result<serde_json::Value> {
+        if self.query_backend() == "redb" {
+            self.redb_query_range_json(query, start_ms, end_ms, step_ms)
+        } else {
+            let vm = self
+                .vm
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("VictoriaMetrics not configured"))?;
+            vm.query_range_json(query, start_ms, end_ms, step_ms).await
+        }
+    }
+
+    /// Variante instant — symétrique de [`dispatched_query_range`].
+    /// Pas de caller actuel ; sera utilisé pour simplifier `api/promql.rs`
+    /// pendant la Phase 4 cleanup.
+    #[allow(dead_code)]
+    pub async fn dispatched_query_instant(
+        &self,
+        query: &str,
+        time_ms: i64,
+    ) -> anyhow::Result<serde_json::Value> {
+        if self.query_backend() == "redb" {
+            self.redb_query_instant_json(query, time_ms)
+        } else {
+            let vm = self
+                .vm
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("VictoriaMetrics not configured"))?;
+            vm.query_instant_json(query, time_ms).await
+        }
+    }
+
+    fn redb_query_range_json(
+        &self,
+        query: &str,
+        start_ms: i64,
+        end_ms: i64,
+        step_ms: i64,
+    ) -> anyhow::Result<serde_json::Value> {
+        use metrics_store::promql::{parse_and_validate, Evaluator};
+        let store = self
+            .metrics_store
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("metrics-store backend not configured"))?;
+        let expr = parse_and_validate(query)
+            .map_err(|e| anyhow::anyhow!("PromQL: {}", e.message()))?;
+        let reader = store.reader();
+        let ev = Evaluator::new(&reader);
+        let series = ev
+            .eval_range(&expr, start_ms, end_ms, step_ms)
+            .map_err(|e| anyhow::anyhow!("PromQL exec: {}", e.message()))?;
+        let result: Vec<serde_json::Value> = series
+            .into_iter()
+            .map(|s| {
+                let values: Vec<serde_json::Value> = s
+                    .samples
+                    .into_iter()
+                    .map(|(ts, v)| serde_json::json!([ts as f64 / 1000.0, fmt_val(v)]))
+                    .collect();
+                serde_json::json!({ "metric": s.labels, "values": values })
+            })
+            .collect();
+        Ok(serde_json::json!({
+            "status": "success",
+            "data": { "resultType": "matrix", "result": result },
+        }))
+    }
+
+    #[allow(dead_code)]
+    fn redb_query_instant_json(
+        &self,
+        query: &str,
+        time_ms: i64,
+    ) -> anyhow::Result<serde_json::Value> {
+        use metrics_store::promql::{parse_and_validate, Evaluator};
+        let store = self
+            .metrics_store
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("metrics-store backend not configured"))?;
+        let expr = parse_and_validate(query)
+            .map_err(|e| anyhow::anyhow!("PromQL: {}", e.message()))?;
+        let reader = store.reader();
+        let ev = Evaluator::new(&reader);
+        let samples = ev
+            .eval_instant(&expr, time_ms)
+            .map_err(|e| anyhow::anyhow!("PromQL exec: {}", e.message()))?;
+        let result: Vec<serde_json::Value> = samples
+            .into_iter()
+            .map(|s| serde_json::json!({
+                "metric": s.labels,
+                "value": [time_ms as f64 / 1000.0, fmt_val(s.value)],
+            }))
+            .collect();
+        Ok(serde_json::json!({
+            "status": "success",
+            "data": { "resultType": "vector", "result": result },
+        }))
+    }
+}
+
+fn fmt_val(v: f64) -> String {
+    if v.is_nan() {
+        "NaN".into()
+    } else if v.is_infinite() {
+        if v > 0.0 { "+Inf".into() } else { "-Inf".into() }
+    } else {
+        v.to_string()
+    }
+}
+
+impl AppState {
     pub fn new(
         config: AppConfig,
         log_buffer: LogBuffer,


### PR DESCRIPTION
…vm/redb

Phase 3 finale (avant retrait VM) : les 3 routes internes qui appelaient \`vm.query_range_json(...)\` directement passent maintenant par un helper \`AppState::dispatched_query_range\` qui choisit le backend selon \`config.metrics_store.default_backend\`. Cf. plan_migration_vm_redb.md §0.7 (point bloquant pour Phase 4 noté hier soir).

Routes migrées (13 sites d'appel au total) :
- api/chart.rs       : 4 calls (overview + history par BMS/ET112/etc.)
- api/history.rs     : 9 calls (énergie par période, charge/décharge Ah)
- api/dashboards.rs  : 1 call (panel.queries.iter via join_all)

Helper ajouté (state.rs) :
- AppState::query_backend()              — \"vm\" / \"redb\"
- AppState::dispatched_query_range()     — async, retourne le format JSON
                                           Prometheus standard (status,
                                           data.resultType, data.result)
                                           compatible avec tous les callers
                                           existants qui parsaient
                                           vm.query_range_json
- AppState::dispatched_query_instant()   — symétrique, marqué allow(dead_code)
                                           (sera utilisé pour simplifier
                                           api/promql.rs en Phase 4 cleanup)

Implémentation redb (interne, redb_query_range_json) :
- parse_and_validate(query) → AST
- Evaluator::new(reader).eval_range(...) → Vec<RangeSeries>
- Sérialisation au format Prometheus matrix
- Erreurs PromQL propagées en anyhow::Error pour rester compatibles avec le flow existant (les callers font .ok() ou matchent Result).

Pré-flight check uniformisé : chaque route teste maintenant \`state.vm.is_none() && state.metrics_store.is_none()\` (au lieu de juste \`state.vm.is_none()\`) → la réponse \"reason\": \"no_query_backend\" (au lieu de \"vm_disabled\") signale qu'aucun des deux backends n'est dispo.

Conséquence directe : le dashboard custom interne /dashboard/history suit maintenant le toggle default_backend. Avec \`default_backend = \"redb\"\` (état actuel prod), il interroge redb (qui contient l'historique post-import). Avec \`default_backend = \"vm\"\` (rollback), il revient sur VM direct. Cohérence totale entre Grafana et dashboard custom.

\`cargo check --workspace\` OK, \`cargo test -p metrics-store\` 35/35 + 2/2 verts.