### PR TITLE
fix(api): adresser review gemini-code-assist sur PR #456

### DIFF
--- a/crates/daly-bms-server/src/api/chart.rs
+++ b/crates/daly-bms-server/src/api/chart.rs
@@ -36,8 +36,10 @@ pub async fn get_chart_history(
 ) -> impl IntoResponse {
     let minutes = q.minutes.unwrap_or(60).clamp(1, 720) as i64;
 
-    // Pré-flight : un backend de lecture doit être configuré (VM proxy ou redb).
-    if state.vm.is_none() && state.metrics_store.is_none() {
+    // Pré-flight : le backend SÉLECTIONNÉ par config doit être disponible
+    // (review gemini #2 sur PR #456 — éviter le faux positif "ok+data vides"
+    // quand default_backend pointe sur un backend non initialisé).
+    if !state.is_query_backend_ready() {
         return Json(json!({"solar": [], "soc": [], "load": [], "ok": false, "reason": "no_query_backend"}));
     }
 
@@ -112,7 +114,7 @@ pub async fn get_edge_history(
 ) -> impl IntoResponse {
     let minutes = q.minutes.unwrap_or(360).clamp(1, 1440) as i64;
 
-    if state.vm.is_none() && state.metrics_store.is_none() {
+    if !state.is_query_backend_ready() {
         return Json(json!({ "ok": false, "series": [], "reason": "no_query_backend" }));
     }
 

--- a/crates/daly-bms-server/src/api/dashboards.rs
+++ b/crates/daly-bms-server/src/api/dashboards.rs
@@ -138,7 +138,7 @@ pub async fn get_panel_data(
         }
     };
 
-    if state.vm.is_none() && state.metrics_store.is_none() {
+    if !state.is_query_backend_ready() {
         return Json(json!({"ok": false, "reason": "no_query_backend"}));
     }
 

--- a/crates/daly-bms-server/src/api/history.rs
+++ b/crates/daly-bms-server/src/api/history.rs
@@ -33,7 +33,7 @@ pub async fn get_energy_history(
 ) -> impl IntoResponse {
     let period = q.period.as_deref().unwrap_or("day");
 
-    if state.vm.is_none() && state.metrics_store.is_none() {
+    if !state.is_query_backend_ready() {
         return Json(json!({"ok": false, "reason": "no_query_backend"}));
     }
 

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -487,11 +487,28 @@ impl AppState {
         }
     }
 
+    /// Indique si le backend de lecture **sélectionné par config** est
+    /// effectivement disponible. À utiliser par les routes pour leur
+    /// pré-flight check (au lieu de tester `vm.is_none() && metrics_store.is_none()`
+    /// qui peut donner un faux positif "ok mais data vides" si la config
+    /// pointe sur un backend non initialisé).
+    pub fn is_query_backend_ready(&self) -> bool {
+        match self.query_backend() {
+            "redb" => self.metrics_store.is_some(),
+            _ => self.vm.is_some(),
+        }
+    }
+
     /// Exécute une requête PromQL sur plage temporelle, dispatchée entre
     /// VictoriaMetrics (proxy HTTP historique) et `metrics-store` (shim
     /// PromQL local redb) selon `config.metrics_store.default_backend`.
-    /// Retourne le format JSON Prometheus standard (compatible avec tous
-    /// les callers existants qui parsaient `vm.query_range_json`).
+    /// Retourne le format JSON Prometheus standard.
+    ///
+    /// Côté redb, le travail synchrone (open reader + eval PromQL + B-tree
+    /// scans) est déporté sur `tokio::task::spawn_blocking` pour ne pas
+    /// monopoliser un worker de l'exécuteur async — particulièrement
+    /// important quand un caller comme `api/history.rs` lance 9 requêtes
+    /// en parallèle via `tokio::join!`.
     pub async fn dispatched_query_range(
         &self,
         query: &str,
@@ -500,7 +517,16 @@ impl AppState {
         step_ms: i64,
     ) -> anyhow::Result<serde_json::Value> {
         if self.query_backend() == "redb" {
-            self.redb_query_range_json(query, start_ms, end_ms, step_ms)
+            let store = self
+                .metrics_store
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("metrics-store backend not configured"))?;
+            let query = query.to_string();
+            tokio::task::spawn_blocking(move || {
+                redb_query_range_inner(&store, &query, start_ms, end_ms, step_ms)
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("redb worker panic: {e}"))?
         } else {
             let vm = self
                 .vm
@@ -520,7 +546,16 @@ impl AppState {
         time_ms: i64,
     ) -> anyhow::Result<serde_json::Value> {
         if self.query_backend() == "redb" {
-            self.redb_query_instant_json(query, time_ms)
+            let store = self
+                .metrics_store
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("metrics-store backend not configured"))?;
+            let query = query.to_string();
+            tokio::task::spawn_blocking(move || {
+                redb_query_instant_inner(&store, &query, time_ms)
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("redb worker panic: {e}"))?
         } else {
             let vm = self
                 .vm
@@ -529,82 +564,115 @@ impl AppState {
             vm.query_instant_json(query, time_ms).await
         }
     }
+}
 
-    fn redb_query_range_json(
-        &self,
-        query: &str,
-        start_ms: i64,
-        end_ms: i64,
-        step_ms: i64,
-    ) -> anyhow::Result<serde_json::Value> {
-        use metrics_store::promql::{parse_and_validate, Evaluator};
-        let store = self
-            .metrics_store
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("metrics-store backend not configured"))?;
-        let expr = parse_and_validate(query)
-            .map_err(|e| anyhow::anyhow!("PromQL: {}", e.message()))?;
-        let reader = store.reader();
-        let ev = Evaluator::new(&reader);
-        let series = ev
-            .eval_range(&expr, start_ms, end_ms, step_ms)
-            .map_err(|e| anyhow::anyhow!("PromQL exec: {}", e.message()))?;
-        let result: Vec<serde_json::Value> = series
-            .into_iter()
-            .map(|s| {
-                let values: Vec<serde_json::Value> = s
-                    .samples
-                    .into_iter()
-                    .map(|(ts, v)| serde_json::json!([ts as f64 / 1000.0, fmt_val(v)]))
-                    .collect();
-                serde_json::json!({ "metric": s.labels, "values": values })
-            })
-            .collect();
-        Ok(serde_json::json!({
-            "status": "success",
-            "data": { "resultType": "matrix", "result": result },
-        }))
-    }
+// Fonctions sync exécutées sous `spawn_blocking` (pool de threads dédié) :
+// la review #1 de gemini-code-assist demande à ne pas bloquer l'executor
+// async avec les ops redb memory-mapped + eval PromQL potentiellement
+// coûteuses. Cf. PR #456 / commit `0839b84` revue.
 
-    #[allow(dead_code)]
-    fn redb_query_instant_json(
-        &self,
-        query: &str,
-        time_ms: i64,
-    ) -> anyhow::Result<serde_json::Value> {
-        use metrics_store::promql::{parse_and_validate, Evaluator};
-        let store = self
-            .metrics_store
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("metrics-store backend not configured"))?;
-        let expr = parse_and_validate(query)
-            .map_err(|e| anyhow::anyhow!("PromQL: {}", e.message()))?;
-        let reader = store.reader();
-        let ev = Evaluator::new(&reader);
-        let samples = ev
-            .eval_instant(&expr, time_ms)
-            .map_err(|e| anyhow::anyhow!("PromQL exec: {}", e.message()))?;
-        let result: Vec<serde_json::Value> = samples
-            .into_iter()
-            .map(|s| serde_json::json!({
+fn redb_query_range_inner(
+    store: &metrics_store::MetricsStore,
+    query: &str,
+    start_ms: i64,
+    end_ms: i64,
+    step_ms: i64,
+) -> anyhow::Result<serde_json::Value> {
+    use metrics_store::promql::{parse_and_validate, Evaluator};
+    let expr = parse_and_validate(query)
+        .map_err(|e| anyhow::anyhow!("PromQL: {}", e.message()))?;
+    let reader = store.reader();
+    let ev = Evaluator::new(&reader);
+    let series = ev
+        .eval_range(&expr, start_ms, end_ms, step_ms)
+        .map_err(|e| anyhow::anyhow!("PromQL exec: {}", e.message()))?;
+    let result: Vec<serde_json::Value> = series
+        .into_iter()
+        .map(|s| {
+            let values: Vec<serde_json::Value> = s
+                .samples
+                .into_iter()
+                .map(|(ts, v)| serde_json::json!([ts as f64 / 1000.0, fmt_val(v)]))
+                .collect();
+            serde_json::json!({ "metric": s.labels, "values": values })
+        })
+        .collect();
+    Ok(serde_json::json!({
+        "status": "success",
+        "data": { "resultType": "matrix", "result": result },
+    }))
+}
+
+#[allow(dead_code)]
+fn redb_query_instant_inner(
+    store: &metrics_store::MetricsStore,
+    query: &str,
+    time_ms: i64,
+) -> anyhow::Result<serde_json::Value> {
+    use metrics_store::promql::{parse_and_validate, Evaluator};
+    let expr = parse_and_validate(query)
+        .map_err(|e| anyhow::anyhow!("PromQL: {}", e.message()))?;
+    let reader = store.reader();
+    let ev = Evaluator::new(&reader);
+    let samples = ev
+        .eval_instant(&expr, time_ms)
+        .map_err(|e| anyhow::anyhow!("PromQL exec: {}", e.message()))?;
+    let result: Vec<serde_json::Value> = samples
+        .into_iter()
+        .map(|s| {
+            serde_json::json!({
                 "metric": s.labels,
                 "value": [time_ms as f64 / 1000.0, fmt_val(s.value)],
-            }))
-            .collect();
-        Ok(serde_json::json!({
-            "status": "success",
-            "data": { "resultType": "vector", "result": result },
-        }))
+            })
+        })
+        .collect();
+    Ok(serde_json::json!({
+        "status": "success",
+        "data": { "resultType": "vector", "result": result },
+    }))
+}
+
+/// Formatage cohérent avec la convention Prometheus (review gemini #4).
+/// `f64::to_string()` natif Rust produit des chaînes du type
+/// `53.900001525878906` (artéfact de la conversion f32→f64), incohérent
+/// avec ce que renvoie VictoriaMetrics (`53.9000015259`). On cap à 6
+/// décimales et on trim les zéros terminaux — bon compromis entre
+/// précision et lisibilité.
+fn fmt_val(v: f64) -> String {
+    if v.is_nan() {
+        return "NaN".into();
+    }
+    if v.is_infinite() {
+        return if v > 0.0 { "+Inf".into() } else { "-Inf".into() };
+    }
+    let s = format!("{v:.6}");
+    let trimmed = s.trim_end_matches('0').trim_end_matches('.');
+    if trimmed.is_empty() || trimmed == "-" {
+        "0".into()
+    } else {
+        trimmed.to_string()
     }
 }
 
-fn fmt_val(v: f64) -> String {
-    if v.is_nan() {
-        "NaN".into()
-    } else if v.is_infinite() {
-        if v > 0.0 { "+Inf".into() } else { "-Inf".into() }
-    } else {
-        v.to_string()
+#[cfg(test)]
+mod fmt_val_tests {
+    use super::fmt_val;
+
+    #[test]
+    fn formats_typical_values() {
+        assert_eq!(fmt_val(53.9), "53.9");
+        // Cas où f32→f64 ajoute du bruit décimal (réel observé en prod)
+        assert_eq!(fmt_val(53.900001525878906), "53.900002");
+        assert_eq!(fmt_val(0.0), "0");
+        assert_eq!(fmt_val(-12.34), "-12.34");
+        assert_eq!(fmt_val(100.0), "100");
+    }
+
+    #[test]
+    fn formats_special_values() {
+        assert_eq!(fmt_val(f64::NAN), "NaN");
+        assert_eq!(fmt_val(f64::INFINITY), "+Inf");
+        assert_eq!(fmt_val(f64::NEG_INFINITY), "-Inf");
     }
 }
 


### PR DESCRIPTION
Review automatique du code, 3 des 4 recommandations adressées :

1/ [HIGH] spawn_blocking pour les ops redb (review #1) Les requêtes redb sont synchrones (memory-mapped + eval PromQL B-tree) et bloquaient un worker de l'exécuteur async. Particulièrement problématique pour api/history.rs qui lance 9 requêtes en parallèle via tokio::join! — elles s'exécutaient en réalité séquentiellement faute de yield-point.

Fix : extraction de fonctions inner sync (redb_query_range_inner, redb_query_instant_inner) déportées sur tokio::task::spawn_blocking. Le MetricsStore est Clone (Arc<Inner>), donc le move dans le closure spawn_blocking ne coûte qu'un refcount++ — pas de duplication données.

Gain attendu mesurable : api/history.rs `/api/v1/history/energy` peut maintenant servir ses 9 queries en vrai parallèle (limité par le pool blocking de tokio, défaut 512 threads — largement suffisant).

2/ [MEDIUM] Pre-flight backend-specific (review #2, #3, #4) Le check `state.vm.is_none() && state.metrics_store.is_none()` peut donner un faux positif "ok: true mais data vides" si default_backend = \"vm\" mais state.vm = None (config partielle).

Fix : nouvelle méthode AppState::is_query_backend_ready() qui teste le backend SÉLECTIONNÉ par config (et pas juste \"au moins un des deux\"). Substitué dans chart.rs (2 sites), history.rs (1 site), dashboards.rs (1 site).

3/ [MEDIUM] fmt_val formatage cohérent vs Prometheus (review #5) f64::to_string() Rust produit \"53.900001525878906\" (artéfact de la conversion f32→f64 des sources BMS), incohérent avec ce que VM renvoie (\"53.9000015259\"). Cosmétique mais bruyait les diffs côte à côte.

Fix : format!(\"{v:.6}\") + trim trailing zeros + trim '.' terminal. Compromis précision/lisibilité (6 décimales suffit pour V/A/W/Wh BMS). 2 tests unitaires ajoutés couvrant les valeurs typiques + NaN/Inf.

Non adressé (volontairement) :
- Review #5 (duplication redb_query_range/instant helpers) : ces helpers vont être supprimés/fusionnés en Phase 5 cleanup quand le dispatcher disparaîtra (un seul backend post-VM). Pas de gain à refactor maintenant.

cargo check OK, cargo test fmt_val_tests 2/2 verts.