### PR TITLE
fix(systemd): cap MALLOC_ARENA_MAX=2 pour réduire le RSS sur Pi5

### DIFF
--- a/contrib/daly-bms.service
+++ b/contrib/daly-bms.service
@@ -19,6 +19,13 @@ Environment=DALY_CONFIG=/etc/daly-bms/config.toml
 # Niveau de log (trace, debug, info, warn, error)
 Environment=RUST_LOG=info
 
+# Cap les arenas mémoire glibc à 2 (défaut = N_CPU × 8 ≈ 32 sur Pi5).
+# Sans ce cap, chaque thread tokio worker (~5 threads) alloue son propre
+# arena ~1 Mo, ce qui peut gonfler le RSS de 30-40 Mo sans bénéfice
+# réel pour notre workload (single-process, allocations en burst).
+# Cf. https://www.gnu.org/software/libc/manual/html_node/Memory-Allocation-Tunables.html
+Environment=MALLOC_ARENA_MAX=2
+
 ExecStart=/usr/local/bin/daly-bms-server
 
 # Redémarrage automatique en cas de crash


### PR DESCRIPTION
Observé en prod : le RSS de daly-bms-server est passé de ~27 Mo (avant migration redb) à ~110 Mo, avec une croissance lente vers ~120 Mo (~10 kB/min décélérant). Le cache redb (64 Mo configuré) + le base tokio/Axum (~15 Mo) suffisent pas à expliquer entièrement cet écart.

Cause identifiée : glibc alloue par défaut N_CPU x 8 arenas mémoire sur Linux (32+ sur Pi5 quad-core), chacune ~1 Mo d'overhead. Sur un processus multi-threadé Rust/tokio (~5 worker threads + spawn_blocking de la review #1 du commit 955123b), c'est entre 20 et 40 Mo de RSS 'fantôme' non-utile pour notre workload.

Le tuning MALLOC_ARENA_MAX=2 (variante classique pour les services single-process en Rust/Go) force glibc à 2 arenas partagés au lieu de N_CPU x 8, ce qui réduit le RSS de 20-40 Mo typiquement sans impact mesurable sur les perfs (notre workload n'a pas de contention lourde sur l'allocateur).

À déployer côté Pi5 :
  sudo cp contrib/daly-bms.service /etc/systemd/system/
  sudo systemctl daemon-reload
  sudo systemctl restart daly-bms

Effet attendu : RSS retombe à 70-80 Mo après quelques minutes de warm-up, plateau autour de 80-90 Mo (au lieu de 120-150 Mo).