### PR TITLE
fix(perf): jemalloc à la place de glibc malloc — élimine fragmentatio…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "tokio-metrics",
  "tokio-serial",
@@ -3018,6 +3019,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -43,3 +43,12 @@ askama         = "0.12"
 # ── Monitoring ────────────────────────────────────────────────────────────────
 sd-notify     = { workspace = true }
 tokio-metrics = { workspace = true }
+
+# Allocator jemalloc — remplace glibc malloc pour éliminer la fragmentation
+# heap observée en prod (RSS qui croît à chaque burst dashboard sans
+# redescendre). jemalloc rend agressivement les pages au kernel.
+# Cf. observation 18 mai : malloc_trim libère 18 Mo après une request →
+# fragmentation glibc confirmée. Switch jemalloc résoud le problème
+# sans appel manuel à trim.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -24,6 +24,16 @@ mod dashboard;
 mod dashboards;
 mod monitor;
 
+// Allocator jemalloc à la place de glibc malloc.
+// Cf. commit accompagnant : observation 18 mai 2026 d'une fragmentation
+// heap qui faisait croître le RSS à chaque utilisation du dashboard
+// historique (+15-20 Mo par burst, non libérés). malloc_trim manuel
+// libérait 18 Mo confirmant le diagnostic. jemalloc rend les pages au
+// kernel agressivement → RSS retombe au baseline après chaque burst.
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use crate::bridges::{alerts, mqtt};
 use crate::config::AppConfig;
 use crate::state::{AppState, LogBuffer, LogEntry};


### PR DESCRIPTION
…n heap

Observation prod 18 mai 2026 : le RSS de daly-bms-server croît à chaque utilisation du dashboard historique (/api/v1/chart/history, /api/v1/history/energy) et ne redescend jamais, même au repos. Mesure : 87 Mo baseline → 94 → 108 → 125 Mo après 4 ouvertures du dashboard. Pattern monotone, asymptote vers OOM à terme.

Diagnostic confirmé par malloc_trim() manuel via gdb :
  AVANT request : RSS 125 Mo
  APRÈS request : RSS 125 Mo (idem, pas de retour)
  APRÈS malloc_trim(0) : RSS 107 Mo (-18 Mo libérés immédiatement)

→ glibc retient les pages au high-water mark même quand le heap est libéré (comportement normal mais inadapté à un workload alloc-heavy en bursts comme le shim PromQL eval_range qui peut allouer 50+ Mo pendant une eval 30 jours puis tout libérer).

Solution : remplacement de l'allocateur global par jemalloc via tikv-jemallocator. jemalloc :
- rend les pages au kernel agressivement (madvise(MADV_DONTNEED))
- gère mieux les arenas multi-thread (notre workload tokio worker pool + spawn_blocking)
- éprouvé sur ARM (utilisé par CockroachDB, TiKV, etc.)

Coût : +500 Ko sur le binaire stripped (acceptable, on est à 11 Mo). Pas de changement d'API. Compilation aarch64 testée OK.

À déployer côté Pi5 :
  make sync && make build-arm
  sudo systemctl stop daly-bms
  sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
  sudo systemctl start daly-bms

Effet attendu :
- RSS baseline ~80-90 Mo (idem qu'avant)
- Burst dashboard : pic à ~100-120 Mo PENDANT la request
- POST-burst : retombe à ~80-90 Mo en quelques secondes (vs maintenant où il reste à 120+ indéfiniment)
- Pas d'asymptote vers OOM