### PR TITLE
fix(systemd): tune jemalloc agressif pour libérer les pages au kernel

### DIFF
--- a/contrib/daly-bms.service
+++ b/contrib/daly-bms.service
@@ -20,11 +20,22 @@ Environment=DALY_CONFIG=/etc/daly-bms/config.toml
 Environment=RUST_LOG=info
 
 # Cap les arenas mémoire glibc à 2 (défaut = N_CPU × 8 ≈ 32 sur Pi5).
-# Sans ce cap, chaque thread tokio worker (~5 threads) alloue son propre
-# arena ~1 Mo, ce qui peut gonfler le RSS de 30-40 Mo sans bénéfice
-# réel pour notre workload (single-process, allocations en burst).
-# Cf. https://www.gnu.org/software/libc/manual/html_node/Memory-Allocation-Tunables.html
+# No-op depuis qu'on utilise jemalloc (commit 75b6b84), conservé pour
+# l'historique et au cas où on revient à glibc.
 Environment=MALLOC_ARENA_MAX=2
+
+# Tuning jemalloc (tikv-jemallocator utilise le préfixe `_RJEM_` pour
+# éviter les conflits avec d'autres jemalloc embarqués).
+# Observation prod 18 mai 2026 : un dashboard 30 jours fait grimper
+# VmPeak à 367 Mo (eval_range sur ~270 séries × 43k itérations) et
+# jemalloc retient ~55 Mo après libération avec les defaults (delay 10s
+# avant retour des pages au kernel). Configuration agressive :
+#   dirty_decay_ms:1000   — pages dirty rendues après 1 s (vs 10 s)
+#   muzzy_decay_ms:0      — pages muzzy rendues IMMÉDIATEMENT
+#   background_thread:true — un thread dédié fait le purging en arrière-plan
+# Effet : RSS retombe au baseline ~30-40 Mo après chaque burst, plus
+# de high-water mark.
+Environment=_RJEM_MALLOC_CONF=dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true
 
 ExecStart=/usr/local/bin/daly-bms-server
 


### PR DESCRIPTION
Observation prod 18 mai 2026 (suite commit 75b6b84 jemalloc) :
- BASELINE post-restart : 30 Mo ✓ (vs 87 Mo avec glibc)
- Pendant dashboard historique : VmPeak 367 Mo (eval_range sur 270 séries × 43k itérations sur 30 jours)
- Après dashboard fermé + 2 min de repos : RSS = 85 Mo (stable)

Diagnostic : jemalloc retient les pages dirty/muzzy en pool de réutilisation par défaut (delay 10 s). C'est désiré pour un serveur très chargé qui va vite réallouer, mais inutile pour notre workload (bursts épisodiques sans réallocation immédiate).

Fix : variable d'env _RJEM_MALLOC_CONF (préfixe rjem requis par tikv-jemallocator pour éviter conflit avec d'autres jemallocs) :
  dirty_decay_ms:1000    — pages dirty rendues après 1 s (default 10 s)
  muzzy_decay_ms:0       — pages muzzy rendues IMMÉDIATEMENT (default 10 s)
  background_thread:true — un thread dédié fait le purging en arrière-plan
                           (sans ça, les threads malloc/free font le job
                           ce qui retarde le retour des pages quand le
                           processus est idle)

Effet attendu : RSS retombe à 30-40 Mo après chaque burst dashboard, plus de high-water mark cumulatif.

Coût : ~quelques syscalls madvise(MADV_DONTNEED) supplémentaires par seconde, imperceptible sur Pi5 NVMe.

À déployer côté Pi5 (no rebuild requis — c'est un env var) :
  make sync
  sudo cp contrib/daly-bms.service /etc/systemd/system/
  sudo systemctl daemon-reload
  sudo systemctl restart daly-bms