### PR TITLE
feat(scripts): refonte deploy-pi5.sh + nouveau test-api.sh

### DIFF
--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -1,14 +1,41 @@
 #!/usr/bin/env bash
-# Déploiement complet Pi5 — daly-bms-server + energy-manager
-# Usage (depuis ~/Daly-BMS-Rust sur le Pi5) : bash scripts/deploy-pi5.sh
+# Déploiement Pi5 — daly-bms-server + energy-manager + validation
+#
+# Usage (depuis ~/Daly-BMS-Rust sur le Pi5) :
+#   bash scripts/deploy-pi5.sh                  # full deploy + validation
+#   bash scripts/deploy-pi5.sh --no-build       # skip make build-arm
+#   bash scripts/deploy-pi5.sh --no-validate    # skip script test-api.sh
+#
+# Architecture post-migration redb (cf. docs/plan_migration_vm_redb.md) :
+# - metrics-store (redb à /mnt/nvme/daly-bms/metrics.redb) est la TSDB
+#   primaire, sert toutes les lectures via le dispatcher PromQL local
+#   (`/api/v1/query[_range]`, `/api/v1/chart/*`, `/api/v1/history/*`,
+#    `/api/v1/dashboards/*`, `/api/v1/redb/*`).
+# - VictoriaMetrics est optionnel (dual-write si encore activé dans
+#   Config.toml `[victoriametrics] enabled = true`).
+# - Le dashboard custom `/dashboard/history` passe par le dispatcher
+#   donc suit le toggle `[metrics_store].default_backend`.
 
 set -euo pipefail
 
-GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; CYAN='\033[0;36m'; NC='\033[0m'
 info()  { echo -e "${GREEN}[OK]${NC} $*"; }
-step()  { echo -e "${YELLOW}[>>]${NC} $*"; }
+step()  { echo -e "${CYAN}[>>]${NC} $*"; }
 warn()  { echo -e "${YELLOW}[!!]${NC} $*"; }
-error() { echo -e "${RED}[!!]${NC} $*" >&2; exit 1; }
+error() { echo -e "${RED}[XX]${NC} $*" >&2; exit 1; }
+
+DO_BUILD=true
+DO_VALIDATE=true
+for arg in "$@"; do
+    case "$arg" in
+        --no-build)    DO_BUILD=false ;;
+        --no-validate) DO_VALIDATE=false ;;
+        -h|--help)
+            sed -n '/^# Usage/,/^$/p' "$0" | sed 's/^# //'
+            exit 0
+            ;;
+    esac
+done
 
 # ── 1. Récupération du code ───────────────────────────────────────────────────
 step "Synchronisation du dépôt…"
@@ -16,55 +43,91 @@ make sync || error "make sync a échoué"
 info "Code à jour"
 
 # ── 2. Compilation croisée aarch64 ───────────────────────────────────────────
-step "Compilation daly-bms-server (aarch64)…"
-make build-arm || error "make build-arm a échoué"
-info "daly-bms-server compilé"
+if $DO_BUILD; then
+    step "Compilation daly-bms-server (aarch64)…"
+    make build-arm || error "make build-arm a échoué"
+    info "daly-bms-server compilé"
 
-step "Compilation energy-manager (aarch64)…"
-make build-energy-arm || error "make build-energy-arm a échoué"
-info "energy-manager compilé"
+    step "Compilation energy-manager (aarch64)…"
+    make build-energy-arm || error "make build-energy-arm a échoué"
+    info "energy-manager compilé"
+else
+    warn "Build skippé (--no-build)"
+fi
 
-# ── 3. Mise à jour de la configuration ──────────────────────────────────────
+# ── 3. Déploiement Config.toml (préserve default_backend de l'existant) ─────
 step "Déploiement Config.toml → /etc/daly-bms/config.toml…"
+EXISTING_BACKEND=""
+if [[ -f /etc/daly-bms/config.toml ]]; then
+    EXISTING_BACKEND=$(grep -E '^default_backend' /etc/daly-bms/config.toml 2>/dev/null | head -1 || true)
+fi
 sudo cp Config.toml /etc/daly-bms/config.toml
-info "Config.toml déployée"
+if [[ -n "$EXISTING_BACKEND" ]]; then
+    # Restaure la valeur déployée précédemment (évite de reverter à "vm"
+    # si l'opérateur avait basculé en redb)
+    sudo sed -i "s|^default_backend = .*|$EXISTING_BACKEND|" /etc/daly-bms/config.toml
+    info "Config.toml déployée (default_backend préservé : $EXISTING_BACKEND)"
+else
+    info "Config.toml déployée"
+fi
 
-# ── 4. Répertoire VictoriaMetrics (NVMe) ─────────────────────────────────────
-VM_DIR="/mnt/nvme/victoria-metrics"
-# Récupère l'utilisateur qui exécute le service (ExecStart user, pas root)
-SERVICE_USER=$(systemctl show victoriametrics --property=User --value 2>/dev/null)
-SERVICE_USER="${SERVICE_USER:-victoriametrics}"
-step "Vérification NVMe monté et répertoire VictoriaMetrics (${VM_DIR}) → owner=${SERVICE_USER}…"
-mountpoint -q /mnt/nvme || { warn "/mnt/nvme non monté — vérifier /etc/fstab et relancer"; }
-sudo mkdir -p "${VM_DIR}"
-sudo chown "${SERVICE_USER}:${SERVICE_USER}" "${VM_DIR}"
-info "Répertoire VictoriaMetrics OK sur NVMe (owner=${SERVICE_USER})"
+# ── 4. Répertoires runtime ───────────────────────────────────────────────────
+step "Vérification répertoires runtime…"
+mountpoint -q /mnt/nvme || warn "/mnt/nvme non monté — vérifier /etc/fstab"
 
-# ── 5. Déploiement daly-bms-server ───────────────────────────────────────────
+# metrics-store redb
+REDB_PATH=$(grep -E '^db_path' /etc/daly-bms/config.toml 2>/dev/null \
+    | sed -E 's/.*=\s*"([^"]+)".*/\1/' | head -1)
+REDB_PATH="${REDB_PATH:-/mnt/nvme/daly-bms/metrics.redb}"
+REDB_DIR=$(dirname "$REDB_PATH")
+DALY_USER=$(systemctl show daly-bms --property=User --value 2>/dev/null || echo dalybms)
+DALY_USER="${DALY_USER:-dalybms}"
+sudo mkdir -p "$REDB_DIR"
+sudo chown "$DALY_USER:$DALY_USER" "$REDB_DIR"
+info "Répertoire redb : $REDB_DIR (owner=$DALY_USER)"
+
+# VictoriaMetrics (optionnel) — initialisé seulement si activé dans Config.toml
+VM_ENABLED=$(awk '/^\[victoriametrics\]/,/^\[/' /etc/daly-bms/config.toml \
+    | grep -E '^enabled' | sed -E 's/.*=\s*(true|false).*/\1/' | head -1)
+if [[ "$VM_ENABLED" == "true" ]]; then
+    VM_DIR="/mnt/nvme/victoria-metrics"
+    VM_USER=$(systemctl show victoriametrics --property=User --value 2>/dev/null || echo victoriametrics)
+    VM_USER="${VM_USER:-victoriametrics}"
+    sudo mkdir -p "$VM_DIR"
+    sudo chown "$VM_USER:$VM_USER" "$VM_DIR" 2>/dev/null || true
+    info "Répertoire VictoriaMetrics : $VM_DIR (owner=$VM_USER) [dual-write activé]"
+else
+    info "VictoriaMetrics désactivé dans Config.toml (mode redb seul)"
+fi
+
+# ── 5. systemd unit (si modifié dans le repo, redéployer) ───────────────────
+if ! sudo diff -q contrib/daly-bms.service /etc/systemd/system/daly-bms.service >/dev/null 2>&1; then
+    step "Mise à jour /etc/systemd/system/daly-bms.service…"
+    sudo cp contrib/daly-bms.service /etc/systemd/system/
+    sudo systemctl daemon-reload
+    info "Unit systemd mis à jour"
+fi
+
+# ── 6. Déploiement daly-bms-server ───────────────────────────────────────────
 step "Déploiement daly-bms-server…"
 sudo systemctl stop daly-bms
 sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
 sudo systemctl start daly-bms
-sleep 3
+sleep 4
 
 if ! systemctl is-active --quiet daly-bms; then
     error "daly-bms n'a pas démarré — vérifier : journalctl -u daly-bms -n 50"
 fi
 info "daly-bms actif"
 
-# Vérification VictoriaMetrics
-sleep 2
-VM_LOG=$(journalctl -u daly-bms --since "30 seconds ago" 2>/dev/null | grep -i victoriametrics | head -3)
-if echo "${VM_LOG}" | grep -q "activé"; then
-    info "VictoriaMetrics initialisé : ${VM_DIR}"
-elif echo "${VM_LOG}" | grep -q "échoué\|error\|Error"; then
-    warn "VictoriaMetrics init a échoué — voir : journalctl -u daly-bms -n 30 | grep -i victoriametrics"
-else
-    warn "VictoriaMetrics : aucun message de démarrage détecté (vérifier la config)"
-fi
+# Inspection des logs de boot
+BOOT_LOG=$(journalctl -u daly-bms --since "30 seconds ago" --no-pager 2>/dev/null)
+echo "$BOOT_LOG" | grep -q 'metrics-store ouvert'     && info "metrics-store ouvert ✓"      || warn "metrics-store : init non détectée"
+echo "$BOOT_LOG" | grep -q 'VictoriaMetrics activé'  && info "VictoriaMetrics activé ✓"   || true
+echo "$BOOT_LOG" | grep -q 'dual-write metrics-store' && info "dual-write activé ✓"        || true
 
-# ── 6. Déploiement energy-manager ────────────────────────────────────────────
-sleep 3
+# ── 7. Déploiement energy-manager ────────────────────────────────────────────
+sleep 2
 step "Déploiement energy-manager…"
 sudo systemctl stop energy-manager
 sudo cp target/aarch64-unknown-linux-gnu/release/energy-manager /usr/local/bin/
@@ -76,15 +139,32 @@ else
     error "energy-manager n'a pas démarré — vérifier : journalctl -u energy-manager -n 50"
 fi
 
-# ── 7. Résumé ─────────────────────────────────────────────────────────────────
+# ── 8. Validation API ────────────────────────────────────────────────────────
+if $DO_VALIDATE; then
+    echo ""
+    step "Validation des endpoints API (test-api.sh)…"
+    if [[ -x scripts/test-api.sh ]]; then
+        if bash scripts/test-api.sh; then
+            info "Validation API : tous les tests passent ✓"
+        else
+            warn "Validation API : 1+ test(s) en échec — voir sortie ci-dessus"
+        fi
+    else
+        warn "scripts/test-api.sh manquant ou non exécutable — skip validation"
+    fi
+fi
+
+# ── 9. Résumé ─────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}═══════════════════════════════════════${NC}"
-echo -e "${GREEN}  Déploiement terminé avec succès ✓${NC}"
+echo -e "${GREEN}  Déploiement terminé ✓${NC}"
 echo -e "${GREEN}═══════════════════════════════════════${NC}"
 echo ""
-systemctl status daly-bms energy-manager --no-pager -l | grep -E "Active:|Loaded:" || true
+systemctl status daly-bms energy-manager --no-pager 2>/dev/null \
+    | grep -E "^●|Active:" || true
 echo ""
-step "Vérification VictoriaMetrics via API…"
-sleep 1
-curl -sf 'http://localhost:8428/-/healthy' 2>/dev/null || \
-    warn "Endpoint VictoriaMetrics non accessible"
+if [[ -x scripts/grafana-redb-switch.sh ]]; then
+    step "État backends de lecture :"
+    sudo scripts/grafana-redb-switch.sh status 2>/dev/null \
+        | grep -E "default_backend|url =|Services|Health" || true
+fi

--- a/scripts/test-api.sh
+++ b/scripts/test-api.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Tests d'intégration API daly-bms-server (post-déploiement).
+#
+# Couvre tous les endpoints critiques utilisés par :
+# - Grafana (dispatcher /api/v1/query, /api/v1/query_range, /api/v1/labels)
+# - Dashboard custom interne (/api/v1/chart/*, /api/v1/history/*, /api/v1/dashboards/*)
+# - Endpoints redb directs (/api/v1/redb/*, /-/healthy)
+#
+# Exit code 0 = tous les tests passent. Non-zero = au moins un échec.
+#
+# Usage :
+#   bash scripts/test-api.sh              # tests prod (127.0.0.1:8080)
+#   bash scripts/test-api.sh HOST:PORT    # cible alternative
+#   bash scripts/test-api.sh -v           # verbose (affiche payloads)
+
+set -uo pipefail   # PAS -e : on veut continuer même si un test fail
+                   # pour compter tous les échecs
+
+HOST="${1:-127.0.0.1:8080}"
+case "$HOST" in
+    -v|--verbose) VERBOSE=true; HOST="127.0.0.1:8080" ;;
+    *) VERBOSE=false ;;
+esac
+[[ "${2:-}" == "-v" || "${2:-}" == "--verbose" ]] && VERBOSE=true
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; CYAN='\033[0;36m'; NC='\033[0m'
+
+PASS=0
+FAIL=0
+SKIP=0
+FAIL_NAMES=()
+
+ok()   { echo -e "  ${GREEN}✓${NC} $*"; PASS=$((PASS + 1)); }
+ko()   { echo -e "  ${RED}✗${NC} $*"; FAIL=$((FAIL + 1)); FAIL_NAMES+=("$1"); }
+skip() { echo -e "  ${YELLOW}↷${NC} $* (skip)"; SKIP=$((SKIP + 1)); }
+section() { echo ""; echo -e "${CYAN}── $* ──${NC}"; }
+
+# Helper : curl avec timeout + capture status + body
+http() {
+    local path="$1"; shift
+    local out
+    out=$(curl -s -o /tmp/test-api.body -w '%{http_code}' --max-time 10 \
+        "http://${HOST}${path}" "$@" 2>/dev/null || echo "000")
+    echo "$out"
+}
+
+# Helper : assert status code + JSON path non-vide / égal
+assert_200() {
+    local name="$1" path="$2"
+    local code; code=$(http "$path")
+    if [[ "$code" == "200" ]]; then
+        ok "$name → 200"
+        $VERBOSE && head -c 200 /tmp/test-api.body && echo
+    else
+        ko "$name" "$path → HTTP $code"
+    fi
+}
+
+assert_json_field() {
+    local name="$1" path="$2" jq_expr="$3" expected="$4"
+    local code; code=$(http "$path")
+    if [[ "$code" != "200" ]]; then
+        ko "$name" "$path → HTTP $code (attendu 200)"
+        return
+    fi
+    local value; value=$(jq -r "$jq_expr" /tmp/test-api.body 2>/dev/null || echo "PARSE_ERROR")
+    if [[ "$value" == "$expected" ]]; then
+        ok "$name → $jq_expr = $expected"
+    else
+        ko "$name" "$path : $jq_expr = '$value' (attendu '$expected')"
+        $VERBOSE && head -c 300 /tmp/test-api.body && echo
+    fi
+}
+
+assert_json_nonempty() {
+    local name="$1" path="$2" jq_expr="$3"
+    local code; code=$(http "$path")
+    if [[ "$code" != "200" ]]; then
+        ko "$name" "$path → HTTP $code"
+        return
+    fi
+    local count; count=$(jq -r "$jq_expr" /tmp/test-api.body 2>/dev/null || echo 0)
+    if [[ "$count" =~ ^[0-9]+$ ]] && [[ "$count" -gt 0 ]]; then
+        ok "$name → $jq_expr = $count (non-vide)"
+    else
+        ko "$name" "$path : $jq_expr = $count (attendu >0)"
+        $VERBOSE && head -c 300 /tmp/test-api.body && echo
+    fi
+}
+
+# ── Pré-requis ────────────────────────────────────────────────────────────────
+section "Pré-requis"
+command -v jq >/dev/null 2>&1 || { echo "jq requis (sudo apt install jq)"; exit 2; }
+ok "jq disponible"
+
+# ── 1. Healthchecks ──────────────────────────────────────────────────────────
+section "1. Healthchecks"
+assert_200 "GET /health"                  "/health"
+assert_200 "GET /-/healthy"               "/-/healthy"
+assert_200 "GET /api/v1/redb/healthy"     "/api/v1/redb/healthy"
+
+# ── 2. Catalogue redb ────────────────────────────────────────────────────────
+section "2. Catalogue redb (series + labels)"
+assert_json_nonempty "GET /api/v1/redb/series"               "/api/v1/redb/series"             '.data | length'
+assert_json_nonempty "GET /api/v1/redb/labels"               "/api/v1/redb/labels"             '.data | length'
+assert_json_nonempty "GET /api/v1/redb/label/__name__/values" "/api/v1/redb/label/__name__/values" '.data | length'
+assert_json_nonempty "GET /api/v1/series"                    "/api/v1/series"                  '.data | length'
+assert_json_nonempty "GET /api/v1/labels"                    "/api/v1/labels"                  '.data | length'
+
+# ── 3. Dispatcher PromQL — GET ───────────────────────────────────────────────
+section "3. Dispatcher PromQL (GET — Grafana-facing)"
+QUERY_BMS="bms_voltage"
+QUERY_SOLAR="solar_total_w"
+
+assert_json_field "GET /api/v1/query?query=$QUERY_BMS"   \
+    "/api/v1/query?query=${QUERY_BMS}" '.status' 'success'
+
+assert_json_nonempty "GET /api/v1/query (résultat non-vide)" \
+    "/api/v1/query?query=${QUERY_BMS}" '.data.result | length'
+
+NOW=$(date +%s)
+FROM=$((NOW - 3600))
+assert_json_field "GET /api/v1/query_range?query=$QUERY_BMS (1h)" \
+    "/api/v1/query_range?query=${QUERY_BMS}&start=${FROM}&end=${NOW}&step=60" '.status' 'success'
+
+assert_json_nonempty "GET /api/v1/query_range (résultat non-vide, 1h)" \
+    "/api/v1/query_range?query=${QUERY_BMS}&start=${FROM}&end=${NOW}&step=60" '.data.result | length'
+
+# ── 4. Dispatcher PromQL — POST (Grafana httpMethod=POST par défaut) ────────
+section "4. Dispatcher PromQL (POST)"
+code=$(curl -s -o /tmp/test-api.body -w '%{http_code}' --max-time 10 \
+    -X POST "http://${HOST}/api/v1/query" \
+    --data-urlencode "query=${QUERY_BMS}" 2>/dev/null || echo "000")
+if [[ "$code" == "200" ]]; then
+    status=$(jq -r '.status' /tmp/test-api.body 2>/dev/null)
+    if [[ "$status" == "success" ]]; then
+        ok "POST /api/v1/query → status=success"
+    else
+        ko "POST /api/v1/query" "status='$status' au lieu de 'success'"
+    fi
+else
+    ko "POST /api/v1/query" "HTTP $code"
+fi
+
+code=$(curl -s -o /tmp/test-api.body -w '%{http_code}' --max-time 10 \
+    -X POST "http://${HOST}/api/v1/query_range" \
+    --data-urlencode "query=${QUERY_SOLAR}" \
+    --data-urlencode "start=${FROM}" \
+    --data-urlencode "end=${NOW}" \
+    --data-urlencode "step=60" 2>/dev/null || echo "000")
+if [[ "$code" == "200" ]]; then
+    status=$(jq -r '.status' /tmp/test-api.body 2>/dev/null)
+    [[ "$status" == "success" ]] \
+        && ok "POST /api/v1/query_range → status=success" \
+        || ko "POST /api/v1/query_range" "status='$status'"
+else
+    ko "POST /api/v1/query_range" "HTTP $code"
+fi
+
+# ── 5. Dashboard custom interne ──────────────────────────────────────────────
+section "5. Routes dashboard interne (/dashboard/history)"
+assert_json_nonempty "GET /api/v1/chart/history?minutes=60" \
+    "/api/v1/chart/history?minutes=60" '.solar | length'
+assert_json_field "GET /api/v1/chart/history?minutes=60 (.ok)" \
+    "/api/v1/chart/history?minutes=60" '.ok // true' 'true'
+
+assert_json_field "GET /api/v1/history/energy?period=day" \
+    "/api/v1/history/energy?period=day" '.ok // true' 'true'
+
+# ── 6. PromQL avec label matcher (Grafana panels) ───────────────────────────
+section "6. PromQL avec label matchers"
+QM=$(printf '%s' 'bms_voltage{bms_id="0x01"}' | jq -sRr @uri 2>/dev/null)
+assert_json_nonempty "GET /api/v1/query?query=bms_voltage{bms_id=\"0x01\"}" \
+    "/api/v1/query?query=${QM}" '.data.result | length'
+
+QM=$(printf '%s' 'increase(et112_energy_export_wh{address="0x09"}[1h])' | jq -sRr @uri 2>/dev/null)
+NOW=$(date +%s); FROM=$((NOW - 7200))
+assert_json_field "GET /api/v1/query_range (increase 1h, 2h window)" \
+    "/api/v1/query_range?query=${QM}&start=${FROM}&end=${NOW}&step=300" '.status' 'success'
+
+# ── 7. PromQL erreur attendue (vérifie que le shim rejette correctement) ────
+section "7. Rejet de constructions non supportées"
+QM=$(printf '%s' 'histogram_quantile(0.95, foo)' | jq -sRr @uri 2>/dev/null)
+code=$(http "/api/v1/query?query=${QM}")
+status=$(jq -r '.status' /tmp/test-api.body 2>/dev/null || echo none)
+errtype=$(jq -r '.errorType // .error_type // "?"' /tmp/test-api.body 2>/dev/null)
+if [[ "$status" == "error" && "$errtype" == "bad_data" ]]; then
+    ok "histogram_quantile() correctement rejeté ($status / $errtype)"
+else
+    ko "rejet histogram_quantile" "HTTP $code status='$status' errorType='$errtype'"
+fi
+
+# ── 8. Health checks redb backend ────────────────────────────────────────────
+section "8. Sanity backend redb"
+DB_PATH=$(grep -E '^db_path' /etc/daly-bms/config.toml 2>/dev/null \
+    | sed -E 's/.*=\s*"([^"]+)".*/\1/' | head -1)
+DB_PATH="${DB_PATH:-/mnt/nvme/daly-bms/metrics.redb}"
+if [[ -f "$DB_PATH" ]]; then
+    SIZE=$(du -sh "$DB_PATH" | cut -f1)
+    AGE=$(stat -c '%Y' "$DB_PATH")
+    NOW=$(date +%s)
+    DELTA=$((NOW - AGE))
+    ok "Base redb $DB_PATH existe ($SIZE)"
+    if [[ "$DELTA" -lt 300 ]]; then
+        ok "Base redb mtime récent (${DELTA}s) — writer actif"
+    else
+        ko "redb mtime" "fichier pas écrit depuis ${DELTA}s — writer mort ?"
+    fi
+else
+    skip "Base redb $DB_PATH introuvable"
+fi
+
+# ── Résumé ────────────────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════════════"
+TOTAL=$((PASS + FAIL + SKIP))
+if [[ $FAIL -eq 0 ]]; then
+    echo -e "${GREEN}  Résultat : $PASS/$TOTAL OK ✓${NC}  (skip: $SKIP)"
+    exit 0
+else
+    echo -e "${RED}  Résultat : $FAIL/$TOTAL échec(s) ✗${NC}  (ok: $PASS, skip: $SKIP)"
+    echo ""
+    echo -e "${RED}Tests en échec :${NC}"
+    for n in "${FAIL_NAMES[@]}"; do
+        echo "  - $n"
+    done
+    exit 1
+fi


### PR DESCRIPTION
deploy-pi5.sh refondu pour l'architecture post-migration redb :
- Détecte si [victoriametrics] enabled (dual-write) ou non
- Préserve la valeur de default_backend déjà déployée (évite de reverter à 'vm' si l'opérateur avait basculé en 'redb')
- Crée le répertoire redb (db_path lu depuis Config.toml)
- Redéploie le systemd unit si modifié dans contrib/
- Inspecte les logs de boot pour confirmer metrics-store ouvert
- Flags : --no-build (skip cargo build), --no-validate (skip test-api)
- Invoque scripts/test-api.sh à la fin pour validation

scripts/test-api.sh (nouveau) — validation post-deploy structurée :
  1. Healthchecks (/health, /-/healthy, /api/v1/redb/healthy)
  2. Catalogue redb (series, labels, label values) — non-vide
  3. Dispatcher PromQL GET (/api/v1/query, /api/v1/query_range)
  4. Dispatcher PromQL POST (mode Grafana httpMethod=POST)
  5. Routes dashboard custom (/api/v1/chart/history, /api/v1/history/energy)
  6. PromQL avec label matchers (panels Grafana)
  7. Rejet correct de constructions non supportées (histogram_quantile)
  8. Sanity base redb (existe + mtime récent → writer actif)

Exit code 0 si tous OK. Compte tests passed/failed/skipped + liste les échecs à la fin. Utilisable :
  - Manuellement après chaque deploy
  - En CI/CD ultérieurement
  - Par deploy-pi5.sh automatiquement

À l'usage sur Pi5 :
  bash scripts/deploy-pi5.sh                    # full
  bash scripts/test-api.sh                      # standalone
  bash scripts/test-api.sh 127.0.0.1:8080 -v    # verbose