### PR TITLE
fix(memory): guard tous les emit broadcast restants (bridges/mqtt + e…

### DIFF
--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -88,11 +88,13 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
                 .unwrap_or_else(|| snap.address.to_string());
             let topic = format!("{}/bms/{}/venus", cfg.topic_prefix.trim_end_matches('/').rsplit_once('/').map(|(p,_)| p).unwrap_or("santuario"), topic_id);
             let device = if snap.address == 1 { EventDevice::Bms1 } else { EventDevice::Bms2 };
-            state.console_bus.emit(ConsoleEvent::mqtt_out(device, &topic, json!({
-                "Soc": snap.soc,
-                "Voltage": snap.dc.voltage,
-                "Current": snap.dc.current,
-            })));
+            if state.console_bus.receiver_count() > 0 {
+                state.console_bus.emit(ConsoleEvent::mqtt_out(device, &topic, json!({
+                    "Soc": snap.soc,
+                    "Voltage": snap.dc.voltage,
+                    "Current": snap.dc.current,
+                })));
+            }
             if let Err(e) = publish_snapshot(&client, &cfg, snap, &topic_id).await {
                 error!("MQTT publish BMS erreur : {:?}", e);
             }
@@ -504,7 +506,9 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
         match eventloop.poll().await {
             Ok(rumqttc::Event::Incoming(rumqttc::Packet::ConnAck(_))) => {
                 info!("MQTT Venus connecté/reconnecté — réabonnement aux topics");
-                state.console_bus.emit(ConsoleEvent::system("MQTT Venus", "Connecté/reconnecté — réabonnement aux topics"));
+                if state.console_bus.receiver_count() > 0 {
+                    state.console_bus.emit(ConsoleEvent::system("MQTT Venus", "Connecté/reconnecté — réabonnement aux topics"));
+                }
                 for (topic, qos) in &topics {
                     if let Err(e) = client.subscribe(*topic, *qos).await {
                         warn!("MQTT re-subscribe erreur pour {}: {:?}", topic, e);
@@ -519,19 +523,23 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
 
                 // Parser le payload JSON
                 if let Ok(json) = serde_json::from_str::<Value>(payload) {
-                    // Console MQTT IN — device inferred from topic
-                    let ev_device = if topic.contains("/meteo/") {
-                        EventDevice::Solar
-                    } else if topic.contains("/inverter/") {
-                        EventDevice::Inverter
-                    } else if topic.contains("/system/") {
-                        EventDevice::SmartShunt
-                    } else if topic.contains("/heatpump/") {
-                        EventDevice::WaterHeater
-                    } else {
-                        EventDevice::Venus
-                    };
-                    state.console_bus.emit(ConsoleEvent::mqtt_in(ev_device, topic, json.clone()));
+                    // Console MQTT IN — device inferred from topic.
+                    // Skip si pas d'abonné : évite un clone() complet du JSON
+                    // (peut être lourd) à chaque message MQTT entrant.
+                    if state.console_bus.receiver_count() > 0 {
+                        let ev_device = if topic.contains("/meteo/") {
+                            EventDevice::Solar
+                        } else if topic.contains("/inverter/") {
+                            EventDevice::Inverter
+                        } else if topic.contains("/system/") {
+                            EventDevice::SmartShunt
+                        } else if topic.contains("/heatpump/") {
+                            EventDevice::WaterHeater
+                        } else {
+                            EventDevice::Venus
+                        };
+                        state.console_bus.emit(ConsoleEvent::mqtt_in(ev_device, topic, json.clone()));
+                    }
 
                     if topic == "santuario/meteo/venus" {
                         handle_meteo_topic(&state, &json).await;
@@ -569,11 +577,13 @@ async fn handle_meteo_topic(state: &AppState, json: &Value) {
     let irradiance = json.get("Irradiance").and_then(|v| v.as_f64()).map(|v| v as f32).unwrap_or(0.0);
     let yield_kwh  = json.get("TodaysYield").and_then(|v| v.as_f64()).map(|v| v as f32);
     let mppt_power = json.get("MpptPower").and_then(|v| v.as_f64()).map(|v| v as f32);
-    state.console_bus.emit(ConsoleEvent::state(EventDevice::Solar, "Solaire/MPPT update", json!({
-        "irradiance_wm2": irradiance,
-        "yield_today_kwh": yield_kwh,
-        "mppt_power_w": mppt_power,
-    })));
+    if state.console_bus.receiver_count() > 0 {
+        state.console_bus.emit(ConsoleEvent::state(EventDevice::Solar, "Solaire/MPPT update", json!({
+            "irradiance_wm2": irradiance,
+            "yield_today_kwh": yield_kwh,
+            "mppt_power_w": mppt_power,
+        })));
+    }
 
     // Format v2 : tableau Mppts avec données individuelles par chargeur.
     // On remplace toute la map en une seule opération pour purger les entrées
@@ -795,14 +805,16 @@ async fn handle_heatpump_topic(state: &AppState, topic: &str, json: &Value) {
     };
 
     debug!(index = idx, state = hp_state, "Heatpump MQTT reçu");
-    let mode_lbl = match hp_state { 0 => "Vacances", 1 => "HEAT_PUMP", 2 => "TURBO", _ => "Inconnu" };
-    let temp_str = temperature.map(|t| format!(" | {:.1}°C", t)).unwrap_or_default();
-    let tgt_str  = target_temp.map(|t| format!(" → {:.1}°C", t)).unwrap_or_default();
-    state.console_bus.emit(ConsoleEvent::state(EventDevice::WaterHeater, &format!("Chauffe-eau idx={idx} — {mode_lbl}{temp_str}{tgt_str}"), json!({
-        "idx": idx, "state": hp_state, "mode": mode_lbl,
-        "temperature_c": temperature, "target_c": target_temp,
-        "power_w": ac_power, "energy_kwh": ac_energy,
-    })));
+    if state.console_bus.receiver_count() > 0 {
+        let mode_lbl = match hp_state { 0 => "Vacances", 1 => "HEAT_PUMP", 2 => "TURBO", _ => "Inconnu" };
+        let temp_str = temperature.map(|t| format!(" | {:.1}°C", t)).unwrap_or_default();
+        let tgt_str  = target_temp.map(|t| format!(" → {:.1}°C", t)).unwrap_or_default();
+        state.console_bus.emit(ConsoleEvent::state(EventDevice::WaterHeater, &format!("Chauffe-eau idx={idx} — {mode_lbl}{temp_str}{tgt_str}"), json!({
+            "idx": idx, "state": hp_state, "mode": mode_lbl,
+            "temperature_c": temperature, "target_c": target_temp,
+            "power_w": ac_power, "energy_kwh": ac_energy,
+        })));
+    }
     state.on_venus_heatpump(hp).await;
 }
 

--- a/crates/energy-manager/src/bus.rs
+++ b/crates/energy-manager/src/bus.rs
@@ -64,8 +64,16 @@ impl AppBus {
         let _ = self.mqtt_out.send(msg).await;
     }
 
-    /// Broadcast a live event to WebSocket clients
+    /// Broadcast a live event to WebSocket clients.
+    ///
+    /// Skip si aucun client WebSocket n'écoute : évite de retenir un `LiveEvent`
+    /// volumineux (contient un `serde_json::Value`) dans le ring buffer broadcast
+    /// (capacité 64) en permanence. Sans subscriber, chaque event resterait dans
+    /// son slot jusqu'à être écrasé par le prochain — fuite de rétention.
     pub fn emit_live(&self, event: LiveEvent) {
+        if self.live.receiver_count() == 0 {
+            return;
+        }
         let _ = self.live.send(event);
     }
 }


### PR DESCRIPTION
…nergy-manager)

Suite au commit 6ba4171, étend le pattern receiver_count() guard à tous les emit() restants dans le projet, pour éliminer la rétention d'Arc/payloads dans les ring buffers broadcast quand aucun client n'écoute.

crates/daly-bms-server/src/bridges/mqtt.rs (5 emit guardés) :
- ligne 91  : MQTT out BMS snapshots (boucle 1s)
- ligne 507 : MQTT Venus connect/reconnect (rare)
- ligne 534 : MQTT in (CHAQUE message Venus, faisait `json.clone()` complet)
- ligne 572 : Solar/MPPT update (par message meteo)
- ligne 801 : Chauffe-eau update (par message heatpump)

Le guard sur mqtt_in (ligne 534) est le plus impactant : Venus publie en continu, et chaque message déclenchait un clone() du serde_json::Value entier.

crates/energy-manager/src/bus.rs :
- emit_live() : guard interne via receiver_count()==0 → early return (cap broadcast=64, payloads LiveEvent avec serde_json::Value) Évite de patcher chaque call site (solar, inverter, smartshunt, etc.) Le LiveEvent reste alloué côté caller mais est droppé immédiatement au lieu d'être retenu dans le ring jusqu'à 64 sends suivants.

Non-guardés (intentionnel) :
- bus.mqtt_in / bus.rule_reload : tous les modules logiques subscribent en permanence, donc receiver_count() > 0 toujours vrai → guard inutile.
- bus.mqtt_out : c'est un mpsc bounded vers le publisher MQTT, pas un broadcast retentif.

Autres caches audités (sains) :
- LogBuffer : borné à 200 entrées (main.rs:84)
- BmsRingBuffer/Et112RingBuffer/TasmotaRingBuffer : bornés par config
- metrics-store writer::series_cache : cardinalité stable (séries fixes)