### PR TITLE
diag(memory): ajoute support dhat-heap pour profiler la fuite mémoire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +399,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -798,6 +822,7 @@ dependencies = [
  "bytes",
  "chrono",
  "daly-bms-core",
+ "dhat",
  "futures",
  "lettre",
  "metrics-store",
@@ -854,6 +879,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1238,6 +1279,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "half"
@@ -1870,6 +1917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,7 +2269,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2236,7 +2289,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2529,6 +2582,18 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3011,6 +3076,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ check-musl-deps:
 # Compilation — Version optimisée
 # =============================================================================
 
-.PHONY: build build-arm build-arm-debug build-arm-musl build-arm-v7 build-venus build-venus-arm build-venus-armv7 build-venus-v7 build-energy build-energy-arm install-energy run-energy
+.PHONY: build build-arm build-arm-debug build-arm-dhat build-arm-musl build-arm-v7 build-venus build-venus-arm build-venus-armv7 build-venus-v7 build-energy build-energy-arm install-energy run-energy
 
 VENUS_BIN := dbus-mqtt-venus
 
@@ -114,6 +114,31 @@ build-arm-debug: check-arm-deps
 	$(CARGO) build --profile release-debug --target $(TARGET_ARM) --bin $(BINARY)
 	@echo "✓ Binaire ARM avec symboles : $(ARM_RELEASE_DIR)/$(BINARY)"
 	@echo "  → Profiler sur Pi5 : sudo perf record -F 99 -g ./$(BINARY) && sudo perf report"
+
+# Build ARM64 avec dhat-heap pour traquer une fuite mémoire.
+# Au démarrage, dhat::Alloc remplace jemalloc et trace TOUTES les allocations.
+# À l'arrêt propre (SIGTERM/Ctrl-C), écrit dhat-heap.json dans le CWD.
+#
+# Usage sur Pi5 :
+#   1. make build-arm-dhat
+#   2. scp / make sync, puis sudo systemctl stop daly-bms
+#   3. sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/
+#   4. sudo systemctl start daly-bms
+#   5. laisser tourner 30-60 min en mode passif
+#   6. sudo systemctl stop daly-bms  (déclenche l'écriture dhat-heap.json)
+#   7. Récupérer dhat-heap.json depuis le CWD du service (probablement /)
+#   8. Analyser avec https://nnethercote.github.io/dh_view/
+#      → Trier par "t-end bytes" pour voir la mémoire RETENUE = la fuite
+#
+# ⚠️ NE PAS LAISSER EN PROD : dhat ralentit ~10x et consomme bcp de RAM.
+build-arm-dhat: check-arm-deps
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(CROSS_LINKER_GNU) \
+	RUSTFLAGS="$(ARM_RUSTFLAGS_DEBUG)" \
+	$(CARGO) build --profile release-debug --target $(TARGET_ARM) --bin $(BINARY) \
+		--features dhat-heap
+	@echo "✓ Binaire ARM dhat-heap : $(ARM_RELEASE_DIR)/$(BINARY)"
+	@echo "  ⚠️ Diagnostic uniquement — ne pas laisser en prod (10x plus lent)"
+	@echo "  → Voir Makefile section build-arm-dhat pour la procédure complète"
 
 # Build ARM64 statique (musl) — plus portable, binaire autonome
 build-arm-musl: check-musl-deps

--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -52,3 +52,23 @@ tokio-metrics = { workspace = true }
 # sans appel manuel à trim.
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"
+
+# ── Heap profiling (diagnostic fuite mémoire) ────────────────────────────────
+# Build : cargo build --release --features dhat-heap
+#         make build-arm  →  ajouter --features dhat-heap dans la cmd
+#
+# Au démarrage, le profiler dhat remplace l'allocator jemalloc et écrit un
+# fichier `dhat-heap.json` dans CWD à l'arrêt propre du process (SIGTERM /
+# Ctrl-C). Le profil identifie les backtraces qui retiennent de la mémoire
+# — utilisé pour traquer une fuite linéaire ~140 KB/min en mode passif
+# (cf. docs/issue.md). Laisser tourner 30-60 min pour avoir un signal clair.
+#
+# Analyse : ouvrir dhat-heap.json dans https://nnethercote.github.io/dh_view/
+# (le viewer html marche en local aussi). Trier par "t-end bytes" — c'est
+# la mémoire LIVE retenue jusqu'à la fin du run = la fuite.
+[dependencies.dhat]
+version = "0.3"
+optional = true
+
+[features]
+dhat-heap = ["dep:dhat"]

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -29,9 +29,17 @@ mod monitor;
 // historique (+15-20 Mo par burst, non libérés). malloc_trim manuel
 // libérait 18 Mo confirmant le diagnostic. jemalloc rend les pages au
 // kernel agressivement → RSS retombe au baseline après chaque burst.
-#[cfg(not(target_env = "msvc"))]
+//
+// En mode profiling heap (--features dhat-heap), on remplace jemalloc par
+// dhat::Alloc pour tracer toutes les allocations et identifier la backtrace
+// d'une fuite. Mutuellement exclusif avec jemalloc.
+#[cfg(all(not(target_env = "msvc"), not(feature = "dhat-heap")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
 
 use crate::bridges::{alerts, mqtt};
 use crate::config::AppConfig;
@@ -160,6 +168,13 @@ fn cleanup_old_logs(dir: &str, keep_days: u64) {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Démarre le profiler heap dhat AVANT toute allocation. Le guard est
+    // retenu jusqu'à la fin de main() — à l'arrêt il flushe `dhat-heap.json`
+    // dans le CWD. Pour un arrêt propre via systemd : `sudo systemctl stop
+    // daly-bms` → SIGTERM → main retourne → guard drop → fichier écrit.
+    #[cfg(feature = "dhat-heap")]
+    let _dhat_profiler = dhat::Profiler::new_heap();
+
     let args = ServerArgs::parse();
 
     // ── Configuration ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Suite à l'application des guards broadcast (commits 6ba4171 + 921fd72), la fuite RSS persiste à ~700 KB/5min (~8 MB/h) en mode passif. RssAnon grossit en parallèle → c'est bien une allocation Rust live retenue, pas de la fragmentation.

L'audit code-level n'a pas révélé d'accumulation évidente. Tous les ring buffers et HashMap sont bornés ou stables en cardinalité (BmsRingBuffer, Et112RingBuffer, TasmotaRingBuffer, log_buffer, rs485_stats, series_cache, venus_mppts, venus_temperatures, venus_heatpumps, shelly_latest).

Pour identifier la backtrace allocante, on ajoute le profiler dhat-rs derrière une feature flag `dhat-heap` :

- `Cargo.toml` : dhat 0.3 en optional dep + feature `dhat-heap`
- `main.rs`   : swap conditionnel jemalloc → dhat::Alloc + Profiler::new_heap()
                au début de main(). Le guard est tenu jusqu'à la fin → flush
                automatique de `dhat-heap.json` à l'arrêt (SIGTERM systemd).
- `Makefile`  : nouveau target `build-arm-dhat` documenté.

Procédure (sur Pi5) :
  1. make build-arm-dhat
  2. déployer le binaire et redémarrer le service
  3. laisser tourner 30-60 min en mode passif
  4. sudo systemctl stop daly-bms → écrit dhat-heap.json dans CWD du service
  5. analyser sur https://nnethercote.github.io/dh_view/ → trier par "t-end bytes" pour voir la mémoire LIVE retenue à la fin

⚠️ dhat ralentit l'exécution ~10x — diagnostic uniquement, pas pour la prod.

Vérification audit (suspects écartés) :
- ws_tx.send dans on_snapshot : AlertEngine est toujours subscriber → le guard `receiver_count() > 0` ne skip jamais en pratique (commit 6ba4171 reste utile pour skip latest_snapshots().await, gain mineur)
- metrics-store writer : aucun push_sample() dans daly-bms-server, writer thread parqué sur rx (la base 1.2 Go est juste un import VM dormant)
- AlertEngine SQLite : connection partagée + HashMap states bornée
- monitor agent : intervalle 30s, MonitorSnapshot remplacé à chaque cycle
- tasmota/shelly MQTT loops : HashMap<id, ...> bornés par config
- BMS poll_loop : fw_cache HashMap<u8, ...> borné à nb_devices

Suspects restants à investiguer via dhat :
- rumqttc EventLoop interne (buffer de paquets ?)
- BmsSnapshot::clone() par broadcast (allocation steady state ?)
- tracing-appender non_blocking writer (file rotation buffer ?)
- reqwest connection pool (TLS contexts ?)