### PR TITLE
diag(memory): bascule vers heaptrack — retrait complet dhat + jemallo…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,21 +390,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
 ]
 
 [[package]]
@@ -822,7 +798,6 @@ dependencies = [
  "bytes",
  "chrono",
  "daly-bms-core",
- "dhat",
  "futures",
  "lettre",
  "metrics-store",
@@ -879,22 +854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "dhat"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
-dependencies = [
- "backtrace",
- "lazy_static",
- "mintex",
- "parking_lot",
- "rustc-hash 1.1.0",
- "serde",
- "serde_json",
- "thousands",
 ]
 
 [[package]]
@@ -1279,12 +1238,6 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "half"
@@ -1917,12 +1870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mintex"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
-
-[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,7 +2216,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2289,7 +2236,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2582,18 +2529,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3076,12 +3011,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "thousands"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ check-musl-deps:
 # Compilation — Version optimisée
 # =============================================================================
 
-.PHONY: build build-arm build-arm-debug build-arm-dhat build-arm-jeprof build-arm-musl build-arm-v7 build-venus build-venus-arm build-venus-armv7 build-venus-v7 build-energy build-energy-arm install-energy run-energy
+.PHONY: build build-arm build-arm-debug build-arm-musl build-arm-v7 build-venus build-venus-arm build-venus-armv7 build-venus-v7 build-energy build-energy-arm install-energy run-energy
 
 VENUS_BIN := dbus-mqtt-venus
 
@@ -115,89 +115,6 @@ build-arm-debug: check-arm-deps
 	$(CARGO) build --profile release-debug --target $(TARGET_ARM) --bin $(BINARY)
 	@echo "✓ Binaire ARM avec symboles : $(ARM_DEBUG_DIR)/$(BINARY)"
 	@echo "  → Profiler sur Pi5 : sudo perf record -F 99 -g ./$(BINARY) && sudo perf report"
-
-# Build ARM64 avec profiling jemalloc — IDENTIQUE à build-arm depuis que
-# le feature `profiling` est activé en permanence sur tikv-jemallocator
-# (cf. crates/daly-bms-server/Cargo.toml). Conservé comme alias pour la
-# compat avec scripts/mem-profile.sh.
-build-arm-jeprof: build-arm
-
-# Build ARM64 avec dhat-heap pour traquer une fuite mémoire.
-# Au démarrage, dhat::Alloc remplace jemalloc et trace TOUTES les allocations.
-# À l'arrêt propre (SIGTERM/Ctrl-C), écrit le profil JSON dans :
-#   /var/lib/daly-bms/dhat-heap.json
-#   (créé par systemd StateDirectory=daly-bms, owned par user dalybms)
-# Customisable via env var DHAT_OUTPUT=/autre/chemin.json
-#
-# Procédure complète sur Pi5 :
-#   ┌─────────────────────────────────────────────────────────────────────┐
-#   │ 1. Compiler la variante diagnostic (depuis ton poste de dev) :     │
-#   │      make build-arm-dhat                                            │
-#   │                                                                     │
-#   │ 2. Pousser le code + binaire sur Pi5 (ou make sync + rebuild) :    │
-#   │      git push                                                       │
-#   │      ssh pi5compute@192.168.1.141                                   │
-#   │      cd ~/Daly-BMS-Rust && make sync && make build-arm-dhat         │
-#   │                                                                     │
-#   │ 3. Déployer le binaire (le service tournera ~10x plus lent) :      │
-#   │      ⚠️ NOTE: le profile `release-debug` sort dans release-debug/   │
-#   │         et NON dans release/ — bien utiliser le chemin correct.    │
-#   │      sudo systemctl stop daly-bms                                   │
-#   │      sudo cp target/aarch64-unknown-linux-gnu/release-debug/daly-bms-server /usr/local/bin/ │
-#   │      sudo rm -f /var/lib/daly-bms/dhat-heap.json   # clean state    │
-#   │      sudo systemctl start daly-bms                                  │
-#   │                                                                     │
-#   │ 4. Vérifier que dhat est actif :                                    │
-#   │      sudo journalctl -u daly-bms -n 5 | grep dhat                   │
-#   │      → "[dhat] profiling actif → /var/lib/daly-bms/dhat-heap.json"  │
-#   │                                                                     │
-#   │ 5. Laisser tourner 30-60 min en mode passif (pas de curl, pas de   │
-#   │    dashboard ouvert). Vérifier que le RSS grimpe comme avant via    │
-#   │    rss-tracker.sh                                                   │
-#   │                                                                     │
-#   │ 6. Arrêter PROPREMENT (SIGTERM → écriture du JSON) :                │
-#   │      sudo systemctl stop daly-bms                                   │
-#   │      # Pas de SIGKILL : `kill -9` perd les données dhat             │
-#   │                                                                     │
-#   │ 7. Vérifier que le fichier existe et le récupérer :                 │
-#   │      sudo ls -lh /var/lib/daly-bms/dhat-heap.json                   │
-#   │      sudo cp /var/lib/daly-bms/dhat-heap.json /tmp/                 │
-#   │      sudo chmod 644 /tmp/dhat-heap.json                             │
-#   │      # Depuis ton poste :                                           │
-#   │      scp pi5compute@192.168.1.141:/tmp/dhat-heap.json .             │
-#   │                                                                     │
-#   │ 8. Restaurer le binaire normal (pas de dhat en prod) :              │
-#   │      make build-arm   # rebuild en release/ optimisé (sans dhat)    │
-#   │      sudo systemctl stop daly-bms                                   │
-#   │      sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/ │
-#   │      sudo systemctl start daly-bms                                  │
-#   │                                                                     │
-#   │ 9. Analyser dhat-heap.json :                                        │
-#   │      Option A : navigateur → https://nnethercote.github.io/dh_view/ │
-#   │      Option B : git clone https://github.com/nnethercote/dhat-rs    │
-#   │                 et ouvrir dhat-rs/dh_view.html en local             │
-#   │      → Trier par "t-end bytes" = mémoire LIVE retenue = la fuite    │
-#   │      → La backtrace pointe la fonction qui alloue sans libérer     │
-#   └─────────────────────────────────────────────────────────────────────┘
-#
-# ⚠️ NE PAS LAISSER EN PROD : dhat ralentit ~10x et consomme bcp de RAM.
-build-arm-dhat: check-arm-deps
-	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(CROSS_LINKER_GNU) \
-	RUSTFLAGS="$(ARM_RUSTFLAGS_DEBUG)" \
-	$(CARGO) build --profile release-debug --target $(TARGET_ARM) --bin $(BINARY) \
-		--features dhat-heap
-	@echo "✓ Binaire ARM dhat-heap : $(ARM_DEBUG_DIR)/$(BINARY)"
-	@ls -lh $(ARM_DEBUG_DIR)/$(BINARY) 2>/dev/null || true
-	@echo ""
-	@echo "  Étape suivante — déployer :"
-	@echo "    sudo systemctl stop daly-bms"
-	@echo "    sudo cp $(ARM_DEBUG_DIR)/$(BINARY) /usr/local/bin/"
-	@echo "    sudo rm -f /var/lib/daly-bms/dhat-heap.json"
-	@echo "    sudo systemctl start daly-bms"
-	@echo "    sudo journalctl -u daly-bms -n 10 | grep dhat   # vérifier activation"
-	@echo ""
-	@echo "  ⚠️ Diagnostic uniquement — ne pas laisser en prod (10x plus lent)"
-	@echo "  → Voir Makefile section build-arm-dhat pour la procédure complète"
 
 # Build ARM64 statique (musl) — plus portable, binaire autonome
 build-arm-musl: check-musl-deps

--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -50,32 +50,5 @@ tokio-metrics = { workspace = true }
 # Cf. observation 18 mai : malloc_trim libère 18 Mo après une request →
 # fragmentation glibc confirmée. Switch jemalloc résoud le problème
 # sans appel manuel à trim.
-#
-# Feature `profiling` ACTIVÉE EN PERMANENCE : compile jemalloc avec
-# --enable-prof. Coût ~0% perf tant qu'on ne set pas `prof_active:true`
-# au runtime, mais permet de capturer des heap profiles à la demande
-# via `_RJEM_MALLOC_CONF=prof:true,prof_active:true,...` (cf.
-# scripts/mem-profile.sh). Évite d'avoir à rebuilder pour diagnostiquer
-# une fuite mémoire en prod.
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = ["profiling"] }
-
-# ── Heap profiling (diagnostic fuite mémoire) ────────────────────────────────
-# Build : cargo build --release --features dhat-heap
-#         make build-arm  →  ajouter --features dhat-heap dans la cmd
-#
-# Au démarrage, le profiler dhat remplace l'allocator jemalloc et écrit un
-# fichier `dhat-heap.json` dans CWD à l'arrêt propre du process (SIGTERM /
-# Ctrl-C). Le profil identifie les backtraces qui retiennent de la mémoire
-# — utilisé pour traquer une fuite linéaire ~140 KB/min en mode passif
-# (cf. docs/issue.md). Laisser tourner 30-60 min pour avoir un signal clair.
-#
-# Analyse : ouvrir dhat-heap.json dans https://nnethercote.github.io/dh_view/
-# (le viewer html marche en local aussi). Trier par "t-end bytes" — c'est
-# la mémoire LIVE retenue jusqu'à la fin du run = la fuite.
-[dependencies.dhat]
-version = "0.3"
-optional = true
-
-[features]
-dhat-heap = ["dep:dhat"]
+tikv-jemallocator = "0.6"

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -29,17 +29,9 @@ mod monitor;
 // historique (+15-20 Mo par burst, non libérés). malloc_trim manuel
 // libérait 18 Mo confirmant le diagnostic. jemalloc rend les pages au
 // kernel agressivement → RSS retombe au baseline après chaque burst.
-//
-// En mode profiling heap (--features dhat-heap), on remplace jemalloc par
-// dhat::Alloc pour tracer toutes les allocations et identifier la backtrace
-// d'une fuite. Mutuellement exclusif avec jemalloc.
-#[cfg(all(not(target_env = "msvc"), not(feature = "dhat-heap")))]
+#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-#[cfg(feature = "dhat-heap")]
-#[global_allocator]
-static ALLOC: dhat::Alloc = dhat::Alloc;
 
 use crate::bridges::{alerts, mqtt};
 use crate::config::AppConfig;
@@ -168,26 +160,6 @@ fn cleanup_old_logs(dir: &str, keep_days: u64) {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Démarre le profiler heap dhat AVANT toute allocation. Le guard est
-    // retenu jusqu'à la fin de main() — à l'arrêt il flushe le fichier
-    // dans le chemin spécifié. Pour un arrêt propre via systemd :
-    // `sudo systemctl stop daly-bms` → SIGTERM → main retourne → guard
-    // drop → fichier écrit.
-    //
-    // Chemin déterministe via DHAT_OUTPUT (env) ou fallback /var/lib/daly-bms
-    // (StateDirectory créé par systemd, owned par user dalybms).
-    // Le défaut dhat (CWD = "/") ne fonctionnerait pas — service tourne en
-    // user dalybms non-root sans WorkingDirectory.
-    #[cfg(feature = "dhat-heap")]
-    let _dhat_profiler = {
-        let path = std::env::var("DHAT_OUTPUT")
-            .unwrap_or_else(|_| "/var/lib/daly-bms/dhat-heap.json".to_string());
-        eprintln!("[dhat] profiling actif → {}", path);
-        dhat::Profiler::builder()
-            .file_name(&path)
-            .build()
-    };
-
     let args = ServerArgs::parse();
 
     // ── Configuration ──────────────────────────────────────────────────────────

--- a/scripts/mem-profile.sh
+++ b/scripts/mem-profile.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
-# Profiling mémoire daly-bms-server via jemalloc (--enable-prof).
+# Profiling mémoire daly-bms-server via heaptrack.
 #
 # Process en 2 commandes :
-#   bash scripts/mem-profile.sh start    # build léger + déploie + active prof
+#   bash scripts/mem-profile.sh start    # build debug + déploie + démarre heaptrack
 #   ... attendre 30-60 min en mode passif ...
-#   bash scripts/mem-profile.sh stop     # dump + arrête + analyse + restaure
+#   bash scripts/mem-profile.sh stop     # arrête + analyse + restaure binaire prod
 #
-# Beaucoup plus léger que dhat :
-# - Build identique à `make build-arm` (pas de debuginfo=2 → ~3-5 min sur Pi5)
-# - ~5% overhead runtime (vs 10x pour dhat)
-# - jemalloc déjà l'allocator de prod, on active juste --enable-prof
+# Pourquoi heaptrack et pas dhat ou jemalloc-prof :
+# - heaptrack s'intègre via LD_PRELOAD au démarrage (pas de modification code)
+# - Outil standard Debian (apt install heaptrack heaptrack-gui)
+# - Overhead modéré (~2-3x), peut tourner 1h sans saturer la RAM
+# - Détection automatique des leaks via `heaptrack_print --print-leaks`
+# - dhat-rs : OOM au link sur Pi5 (debuginfo=2 + instrumentation)
+# - jemalloc prof : feature `profiling` ne s'active pas via target-conditional dep
 #
-# Le profil heap (avec backtraces) atterrit dans ./jeprof-heap.txt.
-# Le diff entre 2 snapshots = la fuite.
+# Le binaire DOIT contenir des symboles (debuginfo) pour avoir des backtraces
+# utiles → on utilise `make build-arm-debug` (profile release-debug) qui a
+# `debug=true, strip=none`. Sans symboles, heaptrack montre juste des adresses.
 
 set -euo pipefail
 
@@ -23,235 +27,189 @@ warn()  { echo -e "${YELLOW}[!!]${NC} $*"; }
 error() { echo -e "${RED}[XX]${NC} $*" >&2; exit 1; }
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-BIN_JEPROF="$REPO_DIR/target/aarch64-unknown-linux-gnu/release/daly-bms-server"
+BIN_DEBUG="$REPO_DIR/target/aarch64-unknown-linux-gnu/release-debug/daly-bms-server"
+BIN_PROD="$REPO_DIR/target/aarch64-unknown-linux-gnu/release/daly-bms-server"
 INSTALL_BIN="/usr/local/bin/daly-bms-server"
 DROPIN_DIR="/etc/systemd/system/daly-bms.service.d"
-DROPIN_FILE="$DROPIN_DIR/jeprof.conf"
-PROF_DIR="/var/lib/daly-bms/jeprof"
-PROF_PREFIX="$PROF_DIR/heap"
-OUT_TEXT="$REPO_DIR/jeprof-heap.txt"
-OUT_RAW="$REPO_DIR/jeprof-heap.raw"
+DROPIN_FILE="$DROPIN_DIR/heaptrack.conf"
+TRACE_DIR="/var/lib/daly-bms/heaptrack"
+TRACE_FILE="$TRACE_DIR/daly-bms.gz"
+OUT_LEAKS="$REPO_DIR/heaptrack-leaks.txt"
+OUT_TRACE="$REPO_DIR/heaptrack-trace.gz"
 
 cd "$REPO_DIR"
 
 case "${1:-}" in
 
 # =============================================================================
-# START — build léger + déploie + active profiling
+# START — build debug + deploy + start with heaptrack wrapper
 # =============================================================================
 start)
-    step "1/7 Vérification dépendance jeprof (apt install libjemalloc-dev)…"
-    if ! command -v jeprof >/dev/null 2>&1; then
-        error "jeprof manquant — installe AVANT de lancer :  sudo apt install -y libjemalloc-dev"
+    step "1/7 Vérification dépendance heaptrack…"
+    if ! command -v heaptrack >/dev/null 2>&1; then
+        error "heaptrack manquant — installer :  sudo apt install -y heaptrack"
     fi
-    info "jeprof disponible"
+    HEAPTRACK_BIN="$(command -v heaptrack)"
+    info "heaptrack : $HEAPTRACK_BIN ($(heaptrack --version 2>&1 | head -1))"
 
-    step "2/7 Build avec profiling jemalloc (release normal, ~3-5 min)…"
-    make build-arm
-    [[ -x "$BIN_JEPROF" ]] || error "Binaire absent : $BIN_JEPROF"
+    step "2/7 Build du binaire avec symboles (make build-arm-debug, ~3-5 min)…"
+    make build-arm-debug
+    [[ -x "$BIN_DEBUG" ]] || error "Binaire absent : $BIN_DEBUG"
 
-    # ── FAIL-FAST #1 : vérifier que le binaire a bien les symboles prof
-    # Sans --enable-prof, ces symboles sont absents et MALLOC_CONF=prof:true
-    # est silencieusement ignoré → on attendrait 1h pour rien.
-    if ! nm "$BIN_JEPROF" 2>/dev/null | grep -q "_rjem_prof_"; then
-        echo "----- DIAGNOSTIC -----"
-        nm "$BIN_JEPROF" 2>/dev/null | grep -c "_rjem_" || true
-        echo "----------------------"
-        error "Le binaire ne contient PAS les symboles _rjem_prof_* → jemalloc compilé sans --enable-prof. Vérifier Cargo.toml : tikv-jemallocator doit avoir features=[\"profiling\"]"
+    # FAIL-FAST : vérifier que les symboles sont présents (sans symboles
+    # heaptrack montre des adresses inutilisables)
+    if ! nm "$BIN_DEBUG" 2>/dev/null | head -5 | grep -q "."; then
+        error "Le binaire n'a pas de symboles — vérifier profile release-debug (debug=true, strip=none)"
     fi
-    info "Binaire compilé AVEC profiling jemalloc (_rjem_prof_* présents)"
+    SYM_COUNT=$(nm "$BIN_DEBUG" 2>/dev/null | wc -l)
+    info "Binaire compilé avec $SYM_COUNT symboles"
 
-    step "3/7 Configuration systemd drop-in (env _RJEM_MALLOC_CONF)…"
-    sudo mkdir -p "$DROPIN_DIR" "$PROF_DIR"
-    sudo chown dalybms:dalybms "$PROF_DIR" 2>/dev/null || true
-    sudo rm -f "$PROF_DIR"/heap.* 2>/dev/null || true
+    step "3/7 Préparation du dossier de trace…"
+    sudo mkdir -p "$DROPIN_DIR" "$TRACE_DIR"
+    sudo chown dalybms:dalybms "$TRACE_DIR" 2>/dev/null || true
+    sudo rm -f "$TRACE_DIR"/*.gz 2>/dev/null || true
+    info "Dir trace : $TRACE_DIR"
 
-    # Config jemalloc :
-    #   prof:true             — active le sous-système prof
-    #   prof_active:true      — démarre l'enregistrement immédiatement
-    #   prof_prefix:...       — chemin des fichiers .heap dumpés
-    #   lg_prof_sample:17     — 1 échantillon tous les 128 KB alloués
-    #                           (plus de granularité pour fuite lente)
-    #   prof_final:true       — dump automatique au shutdown du process
+    step "4/7 Configuration systemd drop-in (wrapper heaptrack)…"
+    # heaptrack -o <output> <command> : démarre command sous heaptrack
+    # qui injecte LD_PRELOAD automatiquement. Le wrapper retourne quand le
+    # process enfant termine → systemd voit le wrapper sortir et c'est OK.
     sudo tee "$DROPIN_FILE" >/dev/null <<EOF
 [Service]
 TimeoutStopSec=60
-Environment=_RJEM_MALLOC_CONF=prof:true,prof_active:true,prof_prefix:$PROF_PREFIX,lg_prof_sample:17,prof_final:true
+# Heaptrack capture les allocations et écrit dans /var/lib/daly-bms/heaptrack/
+# Le service tourne ~2-3x plus lent — DIAGNOSTIC UNIQUEMENT.
+ExecStart=
+ExecStart=$HEAPTRACK_BIN -o $TRACE_FILE $INSTALL_BIN
 EOF
     sudo systemctl daemon-reload
     info "Drop-in en place : $DROPIN_FILE"
 
-    step "4/7 Arrêt service + déploiement binaire…"
+    step "5/7 Arrêt service + déploiement binaire debug…"
     sudo systemctl stop daly-bms
-    sudo cp "$BIN_JEPROF" "$INSTALL_BIN"
-    info "Binaire déployé"
+    sudo cp "$BIN_DEBUG" "$INSTALL_BIN"
+    info "Binaire deployé"
 
-    step "5/7 Démarrage service…"
+    step "6/7 Démarrage service sous heaptrack…"
     sudo systemctl start daly-bms
-    sleep 4
+    sleep 5
     if ! systemctl is-active --quiet daly-bms; then
         sudo journalctl -u daly-bms -n 30 --no-pager
         error "Service ne démarre pas — voir logs ci-dessus"
     fi
     info "Service actif"
 
-    # ── FAIL-FAST #2 : aucun warning jemalloc dans les logs
-    step "6/7 Vérification absence d'erreur MALLOC_CONF…"
-    sleep 2
-    if sudo journalctl -u daly-bms --since "30 seconds ago" --no-pager 2>/dev/null | \
-         grep -iE "Invalid conf|jemalloc.*error|Bad system call"; then
-        sudo journalctl -u daly-bms --since "30 seconds ago" --no-pager
-        error "jemalloc rejette la config MALLOC_CONF — voir logs ci-dessus"
-    fi
-    info "Pas d'erreur MALLOC_CONF dans les logs"
-
-    # ── FAIL-FAST #3 : un .heap doit apparaître < 30s
-    step "7/7 Attente du premier dump heap (max 30s)…"
-    for i in $(seq 1 15); do
-        if sudo ls "$PROF_DIR"/heap.*.heap 2>/dev/null | head -1 >/dev/null; then
-            FIRST_HEAP=$(sudo ls -t "$PROF_DIR"/heap.*.heap 2>/dev/null | tail -1)
-            SIZE=$(sudo stat -c%s "$FIRST_HEAP")
-            info "Premier dump détecté après ${i}×2s : $(basename "$FIRST_HEAP") ($SIZE bytes)"
+    # FAIL-FAST : un fichier trace doit apparaître < 15s
+    step "7/7 Vérification de l'apparition du fichier de trace (max 15s)…"
+    for i in $(seq 1 8); do
+        if sudo ls "$TRACE_DIR"/*.gz 2>/dev/null | head -1 >/dev/null; then
+            FILE=$(sudo ls -t "$TRACE_DIR"/*.gz 2>/dev/null | head -1)
+            SIZE=$(sudo stat -c%s "$FILE")
+            info "Trace détectée après ${i}×2s : $(basename "$FILE") ($SIZE bytes)"
             break
         fi
         sleep 2
     done
-    if ! sudo ls "$PROF_DIR"/heap.*.heap 2>/dev/null | head -1 >/dev/null; then
+    if ! sudo ls "$TRACE_DIR"/*.gz 2>/dev/null | head -1 >/dev/null; then
         echo "----- DIAGNOSTIC -----"
-        echo "PROF_DIR = $PROF_DIR"
-        sudo ls -la "$PROF_DIR" 2>&1 || true
-        echo "--- env du process ---"
-        PID=$(pgrep -f 'daly-bms-server$' | head -1)
-        if [[ -n "$PID" ]]; then
-            sudo cat /proc/$PID/environ 2>/dev/null | tr '\0' '\n' | grep -i MALLOC || echo "(pas de var MALLOC dans environ)"
-        fi
+        sudo ls -la "$TRACE_DIR" 2>&1 || true
+        sudo journalctl -u daly-bms --since "30 seconds ago" --no-pager | tail -20
         echo "----------------------"
-        error "Aucun fichier .heap après 30s → profiling pas actif. Ne pas attendre 1h en vain."
+        error "Aucun fichier trace dans $TRACE_DIR après 15s"
     fi
 
     echo ""
     echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
-    echo -e "${GREEN}  Profiling VALIDÉ — laisser tourner 30-60 min en mode passif${NC}"
+    echo -e "${GREEN}  Heaptrack VALIDÉ — laisser tourner 30-60 min en mode passif${NC}"
     echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
     echo ""
-    echo "  Surveiller que la fuite se reproduit (le RSS doit monter linéairement) :"
+    echo "  Surveiller que la fuite se reproduit :"
     echo "    PID=\$(pgrep -f 'daly-bms-server\$' | head -1)"
     echo "    watch -n 60 \"sudo cat /proc/\$PID/status | grep -E '^VmRSS|^RssAnon'\""
     echo ""
-    echo "  Quand RSS a monté de 5-10 MB, lancer :"
+    echo "  Quand RSS a monté de 5-10 MB :"
     echo "    bash scripts/mem-profile.sh stop"
     ;;
 
 # =============================================================================
-# STOP — dump final, analyse, restauration binaire prod
+# STOP — stop service (flushes trace), analyze leaks, restore prod
 # =============================================================================
 stop)
-    step "1/6 Trigger d'un dump final via systemctl stop (prof_final:true)…"
+    step "1/5 Arrêt service (heaptrack flushe la trace)…"
     sudo systemctl stop daly-bms
-    info "Service arrêté → dump heap final écrit"
+    sleep 2
+    info "Service arrêté"
 
-    step "2/6 Listing des fichiers heap capturés…"
-    HEAP_FILES=$(sudo find "$PROF_DIR" -name 'heap.*.heap' 2>/dev/null | sort)
-    if [[ -z "$HEAP_FILES" ]]; then
+    step "2/5 Récupération de la trace heaptrack…"
+    TRACE_GZ=$(sudo ls -t "$TRACE_DIR"/*.gz 2>/dev/null | head -1 || true)
+    if [[ -z "$TRACE_GZ" ]]; then
         echo "----- DIAGNOSTIC -----"
-        sudo ls -la "$PROF_DIR" 2>&1 || true
-        echo "--- logs récents ---"
-        sudo journalctl -u daly-bms --since "1 hour ago" --no-pager 2>/dev/null | \
-            grep -iE "jemalloc|MALLOC_CONF|prof" | head -10 || echo "(rien)"
+        sudo ls -la "$TRACE_DIR" 2>&1 || true
         echo "----------------------"
-        echo ""
-        warn "Profiling n'a JAMAIS écrit de fichier heap pendant le run."
-        warn "→ Relancer 'bash scripts/mem-profile.sh start' qui valide maintenant"
-        warn "  l'activation du profiling AVANT de t'inviter à attendre 1h."
-        # Restaurer quand même le binaire prod pour ne pas laisser le service down
-        warn "Restauration immédiate du binaire prod…"
+        warn "Aucune trace heaptrack trouvée — restauration binaire prod"
         sudo rm -f "$DROPIN_FILE"
         sudo systemctl daemon-reload
-        if [[ -x "target/aarch64-unknown-linux-gnu/release/daly-bms-server" ]]; then
-            sudo cp "target/aarch64-unknown-linux-gnu/release/daly-bms-server" "$INSTALL_BIN"
-        fi
+        [[ -x "$BIN_PROD" ]] && sudo cp "$BIN_PROD" "$INSTALL_BIN"
         sudo systemctl start daly-bms
-        error "Aucun heap capturé — voir diagnostic ci-dessus"
+        error "Pas de trace → relancer 'mem-profile.sh start'"
     fi
-    COUNT=$(echo "$HEAP_FILES" | wc -l)
-    info "$COUNT fichiers heap capturés"
-    echo "$HEAP_FILES" | xargs sudo ls -lh
+    sudo cp "$TRACE_GZ" "$OUT_TRACE"
+    sudo chown "$USER:$USER" "$OUT_TRACE"
+    SIZE=$(du -h "$OUT_TRACE" | cut -f1)
+    info "Trace récupérée : $OUT_TRACE ($SIZE)"
 
-    step "3/6 Récupération du heap final + dépendance jeprof…"
-    LAST_HEAP=$(echo "$HEAP_FILES" | tail -1)
-    FIRST_HEAP=$(echo "$HEAP_FILES" | head -1)
-    sudo cp "$LAST_HEAP" "$OUT_RAW"
-    sudo chown "$USER:$USER" "$OUT_RAW"
-    info "Heap final récupéré : $OUT_RAW"
+    step "3/5 Analyse des leaks (heaptrack_print --print-leaks)…"
+    heaptrack_print --print-leaks "$OUT_TRACE" > "$OUT_LEAKS" 2>/dev/null || \
+        heaptrack_print "$OUT_TRACE" > "$OUT_LEAKS"
+    info "Rapport : $OUT_LEAKS"
 
-    if ! command -v jeprof >/dev/null 2>&1; then
-        warn "jeprof manquant → analyse impossible en local"
-        echo "       sudo apt install -y libjemalloc-dev"
-        echo "       puis : jeprof --text --base=$FIRST_HEAP $INSTALL_BIN $LAST_HEAP"
-    else
-        step "4/6 Génération du rapport texte (diff first → last)…"
-        if [[ "$FIRST_HEAP" == "$LAST_HEAP" ]]; then
-            warn "Un seul snapshot disponible — diff impossible, sortie absolue"
-            sudo jeprof --text --show_bytes --lines "$INSTALL_BIN" "$LAST_HEAP" > "$OUT_TEXT" 2>/dev/null || \
-                sudo jeprof --text --show_bytes "$INSTALL_BIN" "$LAST_HEAP" > "$OUT_TEXT"
-        else
-            # --base = ce qu'on soustrait du final → ne reste QUE la fuite
-            sudo jeprof --text --show_bytes --lines --base="$FIRST_HEAP" \
-                "$INSTALL_BIN" "$LAST_HEAP" > "$OUT_TEXT" 2>/dev/null || \
-            sudo jeprof --text --show_bytes --base="$FIRST_HEAP" \
-                "$INSTALL_BIN" "$LAST_HEAP" > "$OUT_TEXT"
-        fi
-        sudo chown "$USER:$USER" "$OUT_TEXT"
-        info "Rapport généré : $OUT_TEXT"
+    step "4/5 Restauration binaire prod (sans heaptrack)…"
+    if [[ ! -x "$BIN_PROD" ]]; then
+        warn "Binaire prod absent — rebuild en cours…"
+        make build-arm
     fi
-
-    step "5/6 Build + restauration du binaire prod (sans jeprof)…"
-    make build-arm
     sudo rm -f "$DROPIN_FILE"
     sudo systemctl daemon-reload
-    sudo cp "target/aarch64-unknown-linux-gnu/release/daly-bms-server" "$INSTALL_BIN"
+    sudo cp "$BIN_PROD" "$INSTALL_BIN"
     sudo systemctl start daly-bms
     sleep 3
     if systemctl is-active --quiet daly-bms; then
         info "Service prod redémarré normalement"
     else
-        warn "Service ne redémarre pas — voir : sudo journalctl -u daly-bms -n 30"
+        warn "Service ne démarre pas — voir : sudo journalctl -u daly-bms -n 30"
     fi
 
-    step "6/6 Résultats"
+    step "5/5 Top des allocations qui FUITENT"
     echo ""
     echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
-    echo -e "${GREEN}  Profil capturé${NC}"
+    echo -e "${GREEN}  Heaptrack analyse — Top leaks${NC}"
     echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
     echo ""
-    if [[ -f "$OUT_TEXT" ]]; then
-        echo "  Top 20 allocations qui FUITENT (delta first → last) :"
-        echo ""
-        head -40 "$OUT_TEXT" | sed 's/^/    /'
-        echo ""
-        echo "  Rapport complet : $OUT_TEXT"
-    fi
-    echo "  Heap brut       : $OUT_RAW"
+    # Section "MOST CALLS TO ALLOCATION FUNCTIONS" + "PEAK MEMORY CONSUMERS" +
+    # "MEMORY LEAKED" du rapport heaptrack_print
+    grep -A 40 -E "MEMORY LEAKED|PEAK MEMORY CONSUMERS" "$OUT_LEAKS" | head -100 || head -50 "$OUT_LEAKS"
     echo ""
-    echo "  Pour visualisation graphique :"
-    echo "    jeprof --web --base=$FIRST_HEAP $INSTALL_BIN $LAST_HEAP"
-    echo "    jeprof --svg --base=$FIRST_HEAP $INSTALL_BIN $LAST_HEAP > leak.svg"
+    echo "  Rapport complet : $OUT_LEAKS"
+    echo "  Trace brute     : $OUT_TRACE"
+    echo ""
+    echo "  Visualisation graphique (GUI) :"
+    echo "    sudo apt install heaptrack-gui"
+    echo "    heaptrack_gui $OUT_TRACE"
     ;;
 
 # =============================================================================
 *)
     cat <<EOF
 Usage:
-  bash scripts/mem-profile.sh start    # build léger + déploie + démarre profiling
-  bash scripts/mem-profile.sh stop     # dump + analyse + restaure binaire prod
+  bash scripts/mem-profile.sh start    # build debug + déploie + démarre heaptrack
+  bash scripts/mem-profile.sh stop     # arrête + analyse leaks + restaure prod
 
 Process complet :
-  1. bash scripts/mem-profile.sh start
-  2. Attendre 30-60 min en mode passif (vérifier que RSS monte)
-  3. bash scripts/mem-profile.sh stop
-  4. Le rapport ./jeprof-heap.txt liste les allocations qui fuitent
-
-Prérequis : sudo apt install -y libjemalloc-dev   (pour jeprof)
+  1. sudo apt install -y heaptrack   (une fois)
+  2. bash scripts/mem-profile.sh start
+  3. Attendre 30-60 min en mode passif (vérifier que RSS monte)
+  4. bash scripts/mem-profile.sh stop
+  5. Lire ./heaptrack-leaks.txt — top des leaks avec backtraces
 EOF
     exit 1
     ;;


### PR DESCRIPTION
…c-prof

Les deux approches précédentes ont échoué :
- dhat-rs : OOM au link sur Pi5 (debuginfo=2 + instrumentation = pic RAM qui sature les 8 Go, build interrompu après 25 min sans aboutir).
- jemalloc profiling : la feature `profiling` propagée via target-conditional dep `[target.cfg(...).dependencies]` ne s'active pas au build (vérifié par `nm` : 0 symbole `_rjem_prof_*` dans le binaire compilé).

Solution : heaptrack — outil standard Debian (apt install heaptrack), s'intègre via wrapper ExecStart=heaptrack (LD_PRELOAD auto), pas de code modifié, overhead ~2-3x acceptable pour 1h de capture.

Changements :
- Cargo.toml : retour à `tikv-jemallocator = "0.6"` sans feature
- Cargo.toml : suppression complète de la dep `dhat` et du feature `dhat-heap`
- main.rs   : suppression du bloc dhat::Profiler init et de l'alloc switch
              conditionnel (revient au #[cfg(not(target_env = "msvc"))] simple)
- Makefile  : suppression targets `build-arm-dhat` + `build-arm-jeprof`
              + documentation associée. ARM_DEBUG_DIR conservé pour
              `build-arm-debug` qui reste utile (et que heaptrack utilise).
- scripts/mem-profile.sh : réécriture complète pour heaptrack
              - start : make build-arm-debug → deploy debug binary →
                drop-in qui wrap ExecStart avec heaptrack →
                fail-fast si pas de fichier .gz dans 15s
              - stop  : stop service → heaptrack_print --print-leaks →
                ./heaptrack-leaks.txt → restore binaire prod automatique

Process : `bash scripts/mem-profile.sh start` puis attendre 30-60 min puis `bash scripts/mem-profile.sh stop` — le rapport s'affiche en console et est sauvegardé dans ./heaptrack-leaks.txt avec backtraces complètes.