### PR TITLE
fix(profile): release-debug → thin LTO + codegen=16 + debug=1 (link r…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,12 +119,18 @@ debug = false
 rpath = false
 incremental = false
 
-# Profile pour le profiling avec perf/flamegraph (symboles conservés)
+# Profile pour le profiling avec perf/flamegraph/heaptrack (symboles conservés)
+# Override des settings release qui rendent le link step très lent sur Pi5 natif :
+# fat LTO + codegen-units=1 + DWARF complet peuvent prendre 10+ min au link
+# pour un binaire de cette taille. Pour un build de DIAGNOSTIC (pas prod),
+# thin LTO donne ~90% du gain perf en 5-10x moins de temps + codegen parallèle.
 [profile.release-debug]
-inherits = "release"
-debug = true                     # Garde les symboles pour perf
-strip = "none"                   # Ne pas strip pour le profiling
-panic = "unwind"                 # Permet backtrace pour debug
+inherits      = "release"
+lto           = "thin"           # vs "fat" en release : 5-10x plus rapide à linker
+codegen-units = 16               # vs 1 en release : exploite les 4 cores Pi5
+debug         = 1                # Line info (suffit pour backtraces) vs DWARF complet
+strip         = "none"           # Garde les symboles
+panic         = "unwind"         # Permet backtrace
 
 # Profile "size" si espace disque critique (optionnel)
 [profile.release-size]


### PR DESCRIPTION
…apide)

Le profile `release-debug` héritait de `release` qui a `lto = "fat"` + `codegen-units = 1` — ces deux paramètres rendent le link step extrêmement long sur Pi5 natif (10+ min pour un binaire de cette taille). Combiné avec `debug = true` (DWARF complet), le link saturait CPU/RAM pendant longtemps.

Or le profile release-debug sert pour le DIAGNOSTIC (perf, flamegraph, heaptrack) — pas pour la prod. On peut donc relaxer ces settings :

- lto = "thin"      : ~90% du gain perf de fat LTO, 5-10x plus rapide au link
- codegen-units = 16 : codegen parallèle exploitant les 4 cores Pi5
- debug = 1         : line info uniquement (suffit pour backtraces) au lieu
                      du DWARF complet qui gonfle le binaire et le link

Build attendu après ce fix : ~2-3 min au lieu de 8-10+ min sur Pi5.
Profile `release` (prod) inchangé : fat LTO + codegen=1 conservés.