### PR TITLE
feat(metrics): restore missing Grafana series in redb writes

### DIFF
--- a/crates/daly-bms-server/src/api/system.rs
+++ b/crates/daly-bms-server/src/api/system.rs
@@ -154,14 +154,24 @@ pub async fn set_mppt_yield(
 ) -> impl IntoResponse {
     if let Some(kwh) = body.total_yield_kwh.or(body.mppt_yield_kwh) {
         *state.mppt_yield_kwh.write().await = kwh;
+        if let Some(store) = &state.metrics_store {
+            crate::redb_writes::write_solar_yield(&store.writer(), &state.redb_rl, kwh);
+        }
     }
     // dc_pv_power_w est prioritaire ; mppt_power_w est l'alias rétrocompat
-    if let Some(v) = body.dc_pv_power_w.or(body.mppt_power_w) {
+    let dc_pv_in = body.dc_pv_power_w.or(body.mppt_power_w);
+    if let Some(v) = dc_pv_in {
         *state.dc_pv_power_w.write().await = v;
         *state.mppt_power_w.write().await  = v;
     }
     if let Some(v) = body.pvinv_power_w {
         *state.pvinv_power_w.write().await = v;
+    }
+    if dc_pv_in.is_some() || body.pvinv_power_w.is_some() {
+        if let Some(store) = &state.metrics_store {
+            crate::redb_writes::write_solar_components(
+                &store.writer(), &state.redb_rl, dc_pv_in, body.pvinv_power_w);
+        }
     }
     if let Some(tw) = body.solar_total_w {
         *state.solar_total_w.write().await = tw;

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -522,6 +522,8 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
         ("santuario/heat/+/venus", SUB_QOS),
         ("santuario/heatpump/+/venus", SUB_QOS),
         ("santuario/system/venus", SUB_QOS),
+        ("santuario/em/metrics", SUB_QOS),
+        ("santuario/em/water_heater", SUB_QOS),
     ];
 
     for (topic, qos) in &topics {
@@ -581,6 +583,10 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
                         handle_system_topic(&state, &json).await;
                     } else if topic == "santuario/inverter/venus" {
                         handle_inverter_topic(&state, &json).await;
+                    } else if topic == "santuario/em/metrics" {
+                        handle_em_metrics_topic(&state, &json);
+                    } else if topic == "santuario/em/water_heater" {
+                        handle_wh_metrics_topic(&state, &json);
                     }
                 }
             }
@@ -917,4 +923,47 @@ async fn handle_inverter_topic(state: &AppState, json: &Value) {
     };
 
     state.on_venus_inverter(inverter).await;
+}
+
+/// Traite le topic `santuario/em/metrics` — métriques système energy-manager.
+///
+/// Payload JSON attendu (tous champs optionnels) :
+/// ```json
+/// { "cpu_percent": 4.2, "cpu_temp_c": 51.0, "memory_percent": 35.0,
+///   "mem_used_mb": 280, "swap_used_mb": 0, "disk_percent": 27.0,
+///   "load_avg_1m": 0.4, "load_avg_5m": 0.6, "load_avg_15m": 0.5,
+///   "net_rx_bps": 1234, "net_tx_bps": 567 }
+/// ```
+fn handle_em_metrics_topic(state: &AppState, json: &Value) {
+    let Some(store) = &state.metrics_store else { return };
+    let f = |k: &str| json.get(k).and_then(|v| v.as_f64()).map(|v| v as f32);
+    let payload = crate::redb_writes::EmMetricsPayload {
+        cpu_percent:    f("cpu_percent"),
+        cpu_temp_c:     f("cpu_temp_c"),
+        memory_percent: f("memory_percent"),
+        mem_used_mb:    f("mem_used_mb"),
+        swap_used_mb:   f("swap_used_mb"),
+        disk_percent:   f("disk_percent"),
+        load_avg_1m:    f("load_avg_1m"),
+        load_avg_5m:    f("load_avg_5m"),
+        load_avg_15m:   f("load_avg_15m"),
+        net_rx_bps:     f("net_rx_bps"),
+        net_tx_bps:     f("net_tx_bps"),
+    };
+    crate::redb_writes::write_em_metrics(&store.writer(), &state.redb_rl, &payload);
+}
+
+/// Traite le topic `santuario/em/water_heater` — état chauffe-eau LG ThinQ.
+///
+/// Payload : `{ "current_temp_c": 48.0, "target_temp_c": 50.0, "mode": 1 }`
+fn handle_wh_metrics_topic(state: &AppState, json: &Value) {
+    let Some(store) = &state.metrics_store else { return };
+    let f = |k: &str| json.get(k).and_then(|v| v.as_f64()).map(|v| v as f32);
+    let i = |k: &str| json.get(k).and_then(|v| v.as_i64()).map(|v| v as i32);
+    let payload = crate::redb_writes::WhMetricsPayload {
+        current_temp_c: f("current_temp_c"),
+        target_temp_c:  f("target_temp_c"),
+        mode:           i("mode"),
+    };
+    crate::redb_writes::write_wh_metrics(&store.writer(), &state.redb_rl, &payload);
 }

--- a/crates/daly-bms-server/src/redb_writes.rs
+++ b/crates/daly-bms-server/src/redb_writes.rs
@@ -105,19 +105,51 @@ pub fn write_bms(writer: &Writer, rl: &RateLimiter, snap: &BmsSnapshot) {
          &format!("bms_soc:{}", bms_id));
 
     push(writer, rl, MIN_WRITE_INTERVAL,
-         Sample::new("bms_power_w", ts, snap.dc.power as f64)
+         Sample::new("bms_power", ts, snap.dc.power as f64)
              .with_label("bms_id", bms_id.clone()),
-         &format!("bms_power_w:{}", bms_id));
+         &format!("bms_power:{}", bms_id));
 
     push(writer, rl, TEMP_WRITE_INTERVAL,
          Sample::new("bms_temp_max", ts, snap.system.max_cell_temperature as f64)
              .with_label("bms_id", bms_id.clone()),
          &format!("bms_temp_max:{}", bms_id));
 
+    push(writer, rl, TEMP_WRITE_INTERVAL,
+         Sample::new("bms_temp_min", ts, snap.system.min_cell_temperature as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_temp_min:{}", bms_id));
+
     push(writer, rl, MIN_WRITE_INTERVAL,
          Sample::new("bms_cell_delta_mv", ts, snap.system.cell_delta_mv() as f64)
-             .with_label("bms_id", bms_id),
-         &format!("bms_cell_delta_mv:0x{:02x}", snap.address));
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_cell_delta_mv:{}", bms_id));
+
+    // Capacité nominale installée (config statique, change uniquement à la conf).
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("bms_capacity_ah", ts, snap.installed_capacity as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_capacity_ah:{}", bms_id));
+
+    // État des MOSFETs (proxy via IO permissions — l'API 0x93 n'est pas dans le snapshot).
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_charge_mos", ts, snap.io.allow_to_charge as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_charge_mos:{}", bms_id));
+
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_discharge_mos", ts, snap.io.allow_to_discharge as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_discharge_mos:{}", bms_id));
+
+    // Tension par cellule. La clé est "Cell1", "Cell2", … — on extrait l'index numérique.
+    for (key, &voltage) in snap.voltages.iter() {
+        let cell_idx = key.trim_start_matches("Cell");
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("bms_cell_voltage", ts, voltage as f64)
+                 .with_label("bms_id", bms_id.clone())
+                 .with_label("cell", cell_idx.to_string()),
+             &format!("bms_cell_voltage:{}:{}", bms_id, cell_idx));
+    }
 }
 
 // =============================================================================
@@ -142,6 +174,21 @@ pub fn write_et112(writer: &Writer, rl: &RateLimiter, snap: &Et112Snapshot) {
          Sample::new("et112_current_a", ts, snap.current_a as f64)
              .with_label("address", addr.clone()),
          &format!("et112_current_a:{}", addr));
+
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("et112_apparent_power_va", ts, snap.apparent_power_va as f64)
+             .with_label("address", addr.clone()),
+         &format!("et112_apparent_power_va:{}", addr));
+
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("et112_power_factor", ts, snap.power_factor as f64)
+             .with_label("address", addr.clone()),
+         &format!("et112_power_factor:{}", addr));
+
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("et112_frequency_hz", ts, snap.frequency_hz as f64)
+             .with_label("address", addr.clone()),
+         &format!("et112_frequency_hz:{}", addr));
 
     // Énergie cumulée en Wh (convention VictoriaMetrics historique).
     push(writer, rl, ENERGY_WRITE_INTERVAL,
@@ -176,23 +223,28 @@ pub fn write_venus_mppt(writer: &Writer, rl: &RateLimiter, mppt: &VenusMppt) {
 
     if let Some(p) = mppt.power_w {
         push(writer, rl, MIN_WRITE_INTERVAL,
-             Sample::new("mppt_power_w", ts, p as f64).with_label("instance", instance.clone()),
-             &format!("mppt_power_w:{}", instance));
+             Sample::new("venus_mppt_power_w", ts, p as f64).with_label("instance", instance.clone()),
+             &format!("venus_mppt_power_w:{}", instance));
     }
     if let Some(y) = mppt.yield_today_kwh {
         push(writer, rl, ENERGY_WRITE_INTERVAL,
-             Sample::new("mppt_yield_today_kwh", ts, y as f64).with_label("instance", instance.clone()),
-             &format!("mppt_yield_today_kwh:{}", instance));
+             Sample::new("venus_mppt_yield_today_kwh", ts, y as f64).with_label("instance", instance.clone()),
+             &format!("venus_mppt_yield_today_kwh:{}", instance));
+    }
+    if let Some(m) = mppt.max_power_today_w {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_mppt_max_power_today_w", ts, m as f64).with_label("instance", instance.clone()),
+             &format!("venus_mppt_max_power_today_w:{}", instance));
     }
     if let Some(v) = mppt.pv_voltage_v {
         push(writer, rl, MIN_WRITE_INTERVAL,
-             Sample::new("mppt_pv_voltage_v", ts, v as f64).with_label("instance", instance.clone()),
-             &format!("mppt_pv_voltage_v:{}", instance));
+             Sample::new("venus_mppt_pv_voltage_v", ts, v as f64).with_label("instance", instance.clone()),
+             &format!("venus_mppt_pv_voltage_v:{}", instance));
     }
     if let Some(i) = mppt.dc_current_a {
         push(writer, rl, MIN_WRITE_INTERVAL,
-             Sample::new("mppt_dc_current_a", ts, i as f64).with_label("instance", instance.clone()),
-             &format!("mppt_dc_current_a:{}", instance));
+             Sample::new("venus_mppt_dc_current_a", ts, i as f64).with_label("instance", instance.clone()),
+             &format!("venus_mppt_dc_current_a:{}", instance));
     }
 }
 
@@ -205,8 +257,8 @@ pub fn write_venus_smartshunt(writer: &Writer, rl: &RateLimiter, shunt: &VenusSm
 
     if let Some(v) = shunt.soc_percent {
         push(writer, rl, MIN_WRITE_INTERVAL,
-             Sample::new("venus_shunt_soc", ts, v as f64),
-             "venus_shunt_soc");
+             Sample::new("venus_shunt_soc_percent", ts, v as f64),
+             "venus_shunt_soc_percent");
     }
     if let Some(v) = shunt.voltage_v {
         push(writer, rl, MIN_WRITE_INTERVAL,
@@ -222,6 +274,16 @@ pub fn write_venus_smartshunt(writer: &Writer, rl: &RateLimiter, shunt: &VenusSm
         push(writer, rl, MIN_WRITE_INTERVAL,
              Sample::new("venus_shunt_power_w", ts, v as f64),
              "venus_shunt_power_w");
+    }
+    if let Some(v) = shunt.energy_in_kwh {
+        push(writer, rl, ENERGY_WRITE_INTERVAL,
+             Sample::new("venus_shunt_energy_in_kwh", ts, v as f64),
+             "venus_shunt_energy_in_kwh");
+    }
+    if let Some(v) = shunt.energy_out_kwh {
+        push(writer, rl, ENERGY_WRITE_INTERVAL,
+             Sample::new("venus_shunt_energy_out_kwh", ts, v as f64),
+             "venus_shunt_energy_out_kwh");
     }
     if let Some(v) = shunt.ah_charged_today {
         push(writer, rl, MIN_WRITE_INTERVAL,
@@ -241,11 +303,7 @@ pub fn write_venus_smartshunt(writer: &Writer, rl: &RateLimiter, shunt: &VenusSm
 
 pub fn write_venus_inverter(writer: &Writer, rl: &RateLimiter, inv: &VenusInverter) {
     let ts = now_ms();
-    if let Some(v) = inv.power_w {
-        push(writer, rl, MIN_WRITE_INTERVAL,
-             Sample::new("venus_inverter_power_w", ts, v as f64),
-             "venus_inverter_power_w");
-    }
+    // Tension/courant DC d'entrée (côté batterie).
     if let Some(v) = inv.voltage_v {
         push(writer, rl, MIN_WRITE_INTERVAL,
              Sample::new("venus_inverter_voltage_v", ts, v as f64),
@@ -255,6 +313,39 @@ pub fn write_venus_inverter(writer: &Writer, rl: &RateLimiter, inv: &VenusInvert
         push(writer, rl, MIN_WRITE_INTERVAL,
              Sample::new("venus_inverter_current_a", ts, v as f64),
              "venus_inverter_current_a");
+    }
+    // AC d'entrée — gardé en `venus_inverter_power_w` pour compat ascendante du
+    // champ DC d'entrée historique (renommage explicite ailleurs).
+    if let Some(v) = inv.power_w {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_inverter_power_w", ts, v as f64),
+             "venus_inverter_power_w");
+    }
+    // AC de sortie (cible des dashboards ESS).
+    if let Some(v) = inv.ac_output_power_w {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_inverter_ac_output_power_w", ts, v as f64),
+             "venus_inverter_ac_output_power_w");
+    }
+    if let Some(v) = inv.ac_output_voltage_v {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_inverter_ac_output_voltage_v", ts, v as f64),
+             "venus_inverter_ac_output_voltage_v");
+    }
+    if let Some(v) = inv.ac_output_current_a {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_inverter_ac_output_current_a", ts, v as f64),
+             "venus_inverter_ac_output_current_a");
+    }
+    if let Some(v) = inv.ac_out_frequency_hz {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_inverter_ac_freq_hz", ts, v as f64),
+             "venus_inverter_ac_freq_hz");
+    }
+    if let Some(v) = inv.ac_in_ignore {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_inverter_ac_in_ignore", ts, v as i32 as f64),
+             "venus_inverter_ac_in_ignore");
     }
 }
 
@@ -287,26 +378,26 @@ pub fn write_venus_heatpump(writer: &Writer, rl: &RateLimiter, hp: &VenusHeatpum
     let idx = hp.mqtt_index.to_string();
 
     push(writer, rl, MIN_WRITE_INTERVAL,
-         Sample::new("heatpump_power_w", ts, hp.ac_power as f64).with_label("mqtt_index", idx.clone()),
-         &format!("heatpump_power_w:{}", idx));
+         Sample::new("venus_heatpump_power_w", ts, hp.ac_power as f64).with_label("mqtt_index", idx.clone()),
+         &format!("venus_heatpump_power_w:{}", idx));
 
     push(writer, rl, ENERGY_WRITE_INTERVAL,
-         Sample::new("heatpump_energy_kwh", ts, hp.ac_energy_forward as f64).with_label("mqtt_index", idx.clone()),
-         &format!("heatpump_energy_kwh:{}", idx));
+         Sample::new("venus_heatpump_energy_kwh", ts, hp.ac_energy_forward as f64).with_label("mqtt_index", idx.clone()),
+         &format!("venus_heatpump_energy_kwh:{}", idx));
 
     push(writer, rl, MIN_WRITE_INTERVAL,
-         Sample::new("heatpump_state", ts, hp.state as f64).with_label("mqtt_index", idx.clone()),
-         &format!("heatpump_state:{}", idx));
+         Sample::new("venus_heatpump_state", ts, hp.state as f64).with_label("mqtt_index", idx.clone()),
+         &format!("venus_heatpump_state:{}", idx));
 
     if let Some(t) = hp.temperature {
         push(writer, rl, TEMP_WRITE_INTERVAL,
-             Sample::new("heatpump_temp_c", ts, t as f64).with_label("mqtt_index", idx.clone()),
-             &format!("heatpump_temp_c:{}", idx));
+             Sample::new("venus_heatpump_temp_c", ts, t as f64).with_label("mqtt_index", idx.clone()),
+             &format!("venus_heatpump_temp_c:{}", idx));
     }
     if let Some(t) = hp.target_temperature {
         push(writer, rl, TEMP_WRITE_INTERVAL,
-             Sample::new("heatpump_target_temp_c", ts, t as f64).with_label("mqtt_index", idx),
-             &format!("heatpump_target_temp_c:{}", hp.mqtt_index));
+             Sample::new("venus_heatpump_target_temp_c", ts, t as f64).with_label("mqtt_index", idx),
+             &format!("venus_heatpump_target_temp_c:{}", hp.mqtt_index));
     }
 }
 
@@ -388,19 +479,30 @@ pub fn write_shelly(writer: &Writer, rl: &RateLimiter, snap: &ShellyEmSnapshot) 
          Sample::new("shelly_power_w", ts, snap.total_power_w as f64).with_label("id", id.clone()),
          &format!("shelly_power_w:{}", id));
 
-    // Détail par canal pour les analyses fines.
     push(writer, rl, MIN_WRITE_INTERVAL,
-         Sample::new("shelly_channel_power_w", ts, snap.channel_0.power_w as f64)
-             .with_label("id", id.clone()).with_label("channel", "0"),
-         &format!("shelly_channel_power_w:{}:0", id));
-    push(writer, rl, MIN_WRITE_INTERVAL,
-         Sample::new("shelly_channel_power_w", ts, snap.channel_1.power_w as f64)
-             .with_label("id", id.clone()).with_label("channel", "1"),
-         &format!("shelly_channel_power_w:{}:1", id));
+         Sample::new("shelly_voltage_v", ts, snap.channel_0.voltage_v as f64).with_label("id", id.clone()),
+         &format!("shelly_voltage_v:{}", id));
 
-    push(writer, rl, MIN_WRITE_INTERVAL,
-         Sample::new("shelly_voltage_v", ts, snap.channel_0.voltage_v as f64).with_label("id", id),
-         &format!("shelly_voltage_v:{}", snap.id));
+    // Détail par canal.
+    for (ch_idx, ch) in [(0u8, &snap.channel_0), (1u8, &snap.channel_1)] {
+        let ch_label = ch_idx.to_string();
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("shelly_channel_power_w", ts, ch.power_w as f64)
+                 .with_label("id", id.clone()).with_label("channel", ch_label.clone()),
+             &format!("shelly_channel_power_w:{}:{}", id, ch_idx));
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("shelly_current_a", ts, ch.current_a as f64)
+                 .with_label("id", id.clone()).with_label("channel", ch_label.clone()),
+             &format!("shelly_current_a:{}:{}", id, ch_idx));
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("shelly_output", ts, ch.output as i32 as f64)
+                 .with_label("id", id.clone()).with_label("channel", ch_label.clone()),
+             &format!("shelly_output:{}:{}", id, ch_idx));
+        push(writer, rl, ENERGY_WRITE_INTERVAL,
+             Sample::new("shelly_energy_wh", ts, ch.energy_wh)
+                 .with_label("id", id.clone()).with_label("channel", ch_label),
+             &format!("shelly_energy_wh:{}:{}", id, ch_idx));
+    }
 }
 
 // =============================================================================
@@ -412,4 +514,174 @@ pub fn write_solar_total(writer: &Writer, rl: &RateLimiter, solar_total_w: f32) 
     push(writer, rl, MIN_WRITE_INTERVAL,
          Sample::new("solar_total_w", ts, solar_total_w as f64),
          "solar_total_w");
+}
+
+/// Composants de la puissance solaire (publiés par energy-manager via POST).
+pub fn write_solar_components(writer: &Writer, rl: &RateLimiter, dc_pv_w: Option<f32>, pvinv_w: Option<f32>) {
+    let ts = now_ms();
+    if let Some(v) = dc_pv_w {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("dc_pv_power_w", ts, v as f64),
+             "dc_pv_power_w");
+    }
+    if let Some(v) = pvinv_w {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("pvinv_power_w", ts, v as f64),
+             "pvinv_power_w");
+    }
+}
+
+/// Énergie solaire cumulée du jour (kWh + Wh — convention dashboards).
+pub fn write_solar_yield(writer: &Writer, rl: &RateLimiter, yield_kwh: f32) {
+    let ts = now_ms();
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("solar_yield_kwh", ts, yield_kwh as f64),
+         "solar_yield_kwh");
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("solar_total_wh", ts, yield_kwh as f64 * 1000.0),
+         "solar_total_wh");
+}
+
+// =============================================================================
+// Monitor Pi5 (cpu, mem, disk, load, temp, réseau)
+// =============================================================================
+
+pub fn write_monitor(writer: &Writer, rl: &RateLimiter, snap: &crate::state::MonitorSnapshot) {
+    let ts = now_ms();
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_cpu_percent", ts, snap.cpu_percent as f64),
+         "pi5_cpu_percent");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_memory_percent", ts, snap.memory_percent as f64),
+         "pi5_memory_percent");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_disk_percent", ts, snap.disk_percent as f64),
+         "pi5_disk_percent");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_load_avg", ts, snap.load_avg[0] as f64)
+             .with_label("window", "1m".to_string()),
+         "pi5_load_avg:1m");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_load_avg", ts, snap.load_avg[1] as f64)
+             .with_label("window", "5m".to_string()),
+         "pi5_load_avg:5m");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_load_avg", ts, snap.load_avg[2] as f64)
+             .with_label("window", "15m".to_string()),
+         "pi5_load_avg:15m");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_mem_used_mb", ts, snap.mem_used_mb as f64),
+         "pi5_mem_used_mb");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_swap_used_mb", ts, snap.swap_used_mb as f64),
+         "pi5_swap_used_mb");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_net_rx_bps", ts, snap.net_rx_bps as f64),
+         "pi5_net_rx_bps");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_net_tx_bps", ts, snap.net_tx_bps as f64),
+         "pi5_net_tx_bps");
+    if let Some(t) = snap.cpu_temp_c {
+        push(writer, rl, TEMP_WRITE_INTERVAL,
+             Sample::new("pi5_cpu_temp_c", ts, t as f64),
+             "pi5_cpu_temp_c");
+    }
+}
+
+// =============================================================================
+// Energy-manager + Water heater (publiés via MQTT par energy-manager)
+// =============================================================================
+
+/// Métriques `em_*` reçues depuis le topic `santuario/em/metrics` (publié
+/// par energy-manager). Toutes optionnelles — on n'écrit que les champs
+/// effectivement présents dans le payload.
+#[derive(Default, Debug, Clone)]
+pub struct EmMetricsPayload {
+    pub cpu_percent: Option<f32>,
+    pub cpu_temp_c: Option<f32>,
+    pub memory_percent: Option<f32>,
+    pub mem_used_mb: Option<f32>,
+    pub swap_used_mb: Option<f32>,
+    pub disk_percent: Option<f32>,
+    pub load_avg_1m: Option<f32>,
+    pub load_avg_5m: Option<f32>,
+    pub load_avg_15m: Option<f32>,
+    pub net_rx_bps: Option<f32>,
+    pub net_tx_bps: Option<f32>,
+}
+
+pub fn write_em_metrics(writer: &Writer, rl: &RateLimiter, m: &EmMetricsPayload) {
+    let ts = now_ms();
+    if let Some(v) = m.cpu_percent {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_cpu_percent", ts, v as f64), "em_cpu_percent");
+    }
+    if let Some(v) = m.cpu_temp_c {
+        push(writer, rl, TEMP_WRITE_INTERVAL,
+             Sample::new("em_cpu_temp_c", ts, v as f64), "em_cpu_temp_c");
+    }
+    if let Some(v) = m.memory_percent {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_memory_percent", ts, v as f64), "em_memory_percent");
+    }
+    if let Some(v) = m.mem_used_mb {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_mem_used_mb", ts, v as f64), "em_mem_used_mb");
+    }
+    if let Some(v) = m.swap_used_mb {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_swap_used_mb", ts, v as f64), "em_swap_used_mb");
+    }
+    if let Some(v) = m.disk_percent {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_disk_percent", ts, v as f64), "em_disk_percent");
+    }
+    if let Some(v) = m.load_avg_1m {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_load_avg", ts, v as f64).with_label("window", "1m".to_string()),
+             "em_load_avg:1m");
+    }
+    if let Some(v) = m.load_avg_5m {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_load_avg", ts, v as f64).with_label("window", "5m".to_string()),
+             "em_load_avg:5m");
+    }
+    if let Some(v) = m.load_avg_15m {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_load_avg", ts, v as f64).with_label("window", "15m".to_string()),
+             "em_load_avg:15m");
+    }
+    if let Some(v) = m.net_rx_bps {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_net_rx_bps", ts, v as f64), "em_net_rx_bps");
+    }
+    if let Some(v) = m.net_tx_bps {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("em_net_tx_bps", ts, v as f64), "em_net_tx_bps");
+    }
+}
+
+/// Métriques chauffe-eau LG ThinQ (`wh_*`) reçues depuis le topic
+/// `santuario/em/water_heater`.
+#[derive(Default, Debug, Clone)]
+pub struct WhMetricsPayload {
+    pub current_temp_c: Option<f32>,
+    pub target_temp_c: Option<f32>,
+    pub mode: Option<i32>,
+}
+
+pub fn write_wh_metrics(writer: &Writer, rl: &RateLimiter, m: &WhMetricsPayload) {
+    let ts = now_ms();
+    if let Some(v) = m.current_temp_c {
+        push(writer, rl, TEMP_WRITE_INTERVAL,
+             Sample::new("wh_current_temp_c", ts, v as f64), "wh_current_temp_c");
+    }
+    if let Some(v) = m.target_temp_c {
+        push(writer, rl, TEMP_WRITE_INTERVAL,
+             Sample::new("wh_target_temp_c", ts, v as f64), "wh_target_temp_c");
+    }
+    if let Some(v) = m.mode {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("wh_mode", ts, v as f64), "wh_mode");
+    }
 }

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -981,6 +981,9 @@ impl AppState {
     // ==========================================================================
     /// Enregistre le dernier snapshot de monitoring système.
     pub async fn on_monitor_snapshot(&self, snap: MonitorSnapshot) {
+        if let Some(store) = &self.metrics_store {
+            crate::redb_writes::write_monitor(&store.writer(), &self.redb_rl, &snap);
+        }
         *self.monitor_snapshot.write().await = Some(snap);
     }
     /// Retourne le dernier snapshot de monitoring système.

--- a/crates/energy-manager/src/http_clients/lg_thinq.rs
+++ b/crates/energy-manager/src/http_clients/lg_thinq.rs
@@ -246,6 +246,16 @@ pub async fn spawn_poller(
                     if let Err(e) = reqwest::Client::new().post(&url).body(body).send().await {
                         warn!("LG ThinQ VM write error: {e}");
                     }
+
+                    // Publication MQTT vers `santuario/em/water_heater` (consommée par daly-bms-server).
+                    let payload = serde_json::json!({
+                        "mode":           snap.mode.to_venus_state(),
+                        "current_temp_c": snap.current_temp_c,
+                        "target_temp_c":  snap.target_temp_c,
+                    });
+                    bus2.publish(crate::types::MqttOutgoing::transient(
+                        "santuario/em/water_heater", payload,
+                    )).await;
                 }
                 Err(e) => error!("LG ThinQ poll error: {e}"),
             }

--- a/crates/energy-manager/src/main.rs
+++ b/crates/energy-manager/src/main.rs
@@ -106,8 +106,10 @@ async fn main() -> anyhow::Result<()> {
         live_ws::server::serve(&bind, live_tx, srv_state, srv_lg, srv_loader, srv_reload).await;
     });
 
-    // --- Module monitoring Pi5 (métriques système + tokio → VictoriaMetrics) ---
-    monitoring::spawn(cfg.water_heater.vm_url.clone());
+    // --- Module monitoring Pi5 (métriques système + tokio).
+    //     Publication MQTT vers `santuario/em/metrics` — daly-bms souscrit
+    //     et écrit dans redb. L'ancien POST VM est conservé pour compat. ---
+    monitoring::spawn(cfg.water_heater.vm_url.clone(), bus.clone());
 
     info!("energy-manager fully started");
 

--- a/crates/energy-manager/src/monitoring.rs
+++ b/crates/energy-manager/src/monitoring.rs
@@ -13,18 +13,22 @@ use tokio::process::Command;
 use tokio::time::interval;
 use tracing::warn;
 
+use crate::bus::AppBus;
+use crate::types::MqttOutgoing;
+
 // =============================================================================
 // Point d'entrée
 // =============================================================================
 
 /// Spawne l'agent de monitoring en arrière-plan.
-pub fn spawn(vm_url: String) {
+pub fn spawn(vm_url: String, bus: AppBus) {
     use tokio_metrics::TaskMonitor;
 
     let task_mon = TaskMonitor::new();
     let vm_url_mon = vm_url.clone();
+    let bus_mon    = bus.clone();
     tokio::spawn(task_mon.instrument(async move {
-        run_monitoring_loop(vm_url_mon).await;
+        run_monitoring_loop(vm_url_mon, bus_mon).await;
     }));
 
     // Exporteur métriques tokio → VM (toutes les 60s)
@@ -53,7 +57,7 @@ pub fn spawn(vm_url: String) {
 // Boucle principale
 // =============================================================================
 
-async fn run_monitoring_loop(vm_url: String) {
+async fn run_monitoring_loop(vm_url: String, bus: AppBus) {
     tracing::info!("energy-manager monitoring démarré (intervalle: 60s)");
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
@@ -124,6 +128,22 @@ async fn run_monitoring_loop(vm_url: String) {
         }
 
         write_to_vm(&client, &vm_url, &lines.join("\n")).await;
+
+        // Publication MQTT vers `santuario/em/metrics` (consommée par daly-bms-server).
+        let payload = serde_json::json!({
+            "cpu_percent":    cpu_percent,
+            "memory_percent": mem_percent,
+            "mem_used_mb":    mem_used,
+            "swap_used_mb":   swap_used,
+            "disk_percent":   disk_percent,
+            "load_avg_1m":    load_avg[0],
+            "load_avg_5m":    load_avg[1],
+            "load_avg_15m":   load_avg[2],
+            "net_rx_bps":     net_rx_bps,
+            "net_tx_bps":     net_tx_bps,
+            "cpu_temp_c":     cpu_temp,
+        });
+        bus.publish(MqttOutgoing::transient("santuario/em/metrics", payload)).await;
     }
 }
 


### PR DESCRIPTION
Aligns the redb writer with the metric names expected by the committed Grafana dashboards (docs/grafana-*.json, contrib/grafana/...) and the historical victoriametrics-queries.md reference. Adds new helpers, wires them from the existing on_*_snapshot hooks, and re-publishes energy-manager system metrics via MQTT so daly-bms-server can persist them in redb (replacing the dead VM POST path).

Renames (no backward-compat alias):
- bms_power_w -> bms_power
- mppt_* -> venus_mppt_*
- venus_shunt_soc -> venus_shunt_soc_percent
- heatpump_* -> venus_heatpump_*

New series wired from existing struct fields:
- bms_temp_min, bms_capacity_ah, bms_charge_mos, bms_discharge_mos, bms_cell_voltage{cell="N"}
- et112_apparent_power_va, et112_frequency_hz, et112_power_factor
- venus_shunt_energy_in_kwh, venus_shunt_energy_out_kwh
- venus_inverter_ac_output_{power_w,voltage_v,current_a}, venus_inverter_ac_freq_hz, venus_inverter_ac_in_ignore
- venus_mppt_max_power_today_w
- shelly_current_a, shelly_output, shelly_energy_wh (per channel)
- pi5_{cpu_percent,memory_percent,disk_percent,load_avg,mem_used_mb, swap_used_mb,net_rx_bps,net_tx_bps,cpu_temp_c} via on_monitor_snapshot
- dc_pv_power_w, pvinv_power_w, solar_yield_kwh, solar_total_wh via the existing /api/v1/solar/mppt-yield POST handler
- em_*, wh_* via new MQTT topics santuario/em/metrics + santuario/em/water_heater (energy-manager publisher + daly-bms-server subscriber/dispatcher)

All new writes go through the existing RateLimiter and Writer.try_write path so the leak-free memory profile of the redb writer is preserved.