### PR TITLE
fix(metrics): plug remaining gaps in MPPT max-power + ATS scalar aliases

### DIFF
--- a/crates/daly-bms-server/src/redb_writes.rs
+++ b/crates/daly-bms-server/src/redb_writes.rs
@@ -434,6 +434,23 @@ pub fn write_ats(writer: &Writer, rl: &RateLimiter, snap: &AtsSnapshot) {
          Sample::new("ats_sw1_closed", ts, snap.sw1_closed as i32 as f64), "ats_sw1_closed");
     push(writer, rl, MIN_WRITE_INTERVAL,
          Sample::new("ats_sw2_closed", ts, snap.sw2_closed as i32 as f64), "ats_sw2_closed");
+
+    // Alias scalaires de la source active (utilisés par certains dashboards
+    // Grafana qui ne discriminent pas la phase). On expose la valeur de la
+    // source actuellement sélectionnée par l'ATS — pas une moyenne arbitraire.
+    // Source1=0 (Onduleur) → v1*/freq1, Source2=1 (Réseau) → v2*/freq2.
+    // Neutral (2) ou inconnu : on retombe par défaut sur la source 2 (Réseau).
+    let (av_a, av_b, av_c, af_hz) = match snap.active_source as i32 {
+        0 => (snap.v1a, snap.v1b, snap.v1c, snap.freq1_hz.unwrap_or(0)),
+        _ => (snap.v2a, snap.v2b, snap.v2c, snap.freq2_hz.unwrap_or(0)),
+    };
+    let ats_voltage_v = ((av_a as f64) + (av_b as f64) + (av_c as f64)) / 3.0;
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("ats_voltage_v", ts, ats_voltage_v),
+         "ats_voltage_v");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("ats_freq_hz", ts, af_hz as f64),
+         "ats_freq_hz");
 }
 
 // =============================================================================
@@ -514,6 +531,10 @@ pub fn write_solar_total(writer: &Writer, rl: &RateLimiter, solar_total_w: f32) 
     push(writer, rl, MIN_WRITE_INTERVAL,
          Sample::new("solar_total_w", ts, solar_total_w as f64),
          "solar_total_w");
+    // Alias attendu par les dashboards Grafana drilldown.
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("total_solar_power", ts, solar_total_w as f64),
+         "total_solar_power");
 }
 
 /// Composants de la puissance solaire (publiés par energy-manager via POST).
@@ -581,6 +602,9 @@ pub fn write_monitor(writer: &Writer, rl: &RateLimiter, snap: &crate::state::Mon
     push(writer, rl, MIN_WRITE_INTERVAL,
          Sample::new("pi5_net_tx_bps", ts, snap.net_tx_bps as f64),
          "pi5_net_tx_bps");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_uptime_secs", ts, snap.uptime_secs as f64),
+         "pi5_uptime_secs");
     if let Some(t) = snap.cpu_temp_c {
         push(writer, rl, TEMP_WRITE_INTERVAL,
              Sample::new("pi5_cpu_temp_c", ts, t as f64),

--- a/crates/energy-manager/src/logic/meteo/mod.rs
+++ b/crates/energy-manager/src/logic/meteo/mod.rs
@@ -69,6 +69,7 @@ pub async fn publish_all(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
                 "DcCurrent": s.mppt_273.dc_current_a,
                 "Power":     s.mppt_273.power_w,
                 "YieldToday": s.mppt_273.yield_today_kwh,
+                "MaxPowerToday": s.mppt_273.max_power_today_w,
             },
             {
                 "Instance": 289u32,
@@ -77,6 +78,7 @@ pub async fn publish_all(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
                 "DcCurrent": s.mppt_289.dc_current_a,
                 "Power":     s.mppt_289.power_w,
                 "YieldToday": s.mppt_289.yield_today_kwh,
+                "MaxPowerToday": s.mppt_289.max_power_today_w,
             },
         ],
     });

--- a/crates/energy-manager/src/logic/solar_power/mod.rs
+++ b/crates/energy-manager/src/logic/solar_power/mod.rs
@@ -49,6 +49,8 @@ async fn mqtt_task(
     let t_pv_energy = format!("N/{pid}/pvinverter/{pv}/Ac/Energy/Forward");
     let t_m1_yield  = format!("N/{pid}/solarcharger/{m1}/History/Daily/0/Yield");
     let t_m2_yield  = format!("N/{pid}/solarcharger/{m2}/History/Daily/0/Yield");
+    let t_m1_maxpw  = format!("N/{pid}/solarcharger/{m1}/History/Daily/0/MaxPower");
+    let t_m2_maxpw  = format!("N/{pid}/solarcharger/{m2}/History/Daily/0/MaxPower");
     let t_m1_state  = format!("N/{pid}/solarcharger/{m1}/State");
     let t_m2_state  = format!("N/{pid}/solarcharger/{m2}/State");
     let t_m1_pv_v   = format!("N/{pid}/solarcharger/{m1}/Pv/V");
@@ -124,6 +126,10 @@ async fn mqtt_task(
                 s.mppt_273.yield_today_kwh = msg.victron_value::<f64>();
             } else if *t == t_m2_yield {
                 s.mppt_289.yield_today_kwh = msg.victron_value::<f64>();
+            } else if *t == t_m1_maxpw {
+                s.mppt_273.max_power_today_w = msg.victron_value::<f64>();
+            } else if *t == t_m2_maxpw {
+                s.mppt_289.max_power_today_w = msg.victron_value::<f64>();
             } else if *t == t_m1_state {
                 s.mppt_273.state = msg.victron_value::<i64>();
             } else if *t == t_m2_state {

--- a/crates/energy-manager/src/mqtt/topics.rs
+++ b/crates/energy-manager/src/mqtt/topics.rs
@@ -55,6 +55,7 @@ pub fn all_subscriptions(portal_id: &str, vebus: u32, mppt1: u32, mppt2: u32, pv
         // --- MPPT 1 ---
         n(pid, &format!("solarcharger/{mppt1}/Yield/Power")),
         n(pid, &format!("solarcharger/{mppt1}/History/Daily/0/Yield")),
+        n(pid, &format!("solarcharger/{mppt1}/History/Daily/0/MaxPower")),
         n(pid, &format!("solarcharger/{mppt1}/State")),
         n(pid, &format!("solarcharger/{mppt1}/Pv/V")),
         n(pid, &format!("solarcharger/{mppt1}/Dc/0/Current")),
@@ -62,6 +63,7 @@ pub fn all_subscriptions(portal_id: &str, vebus: u32, mppt1: u32, mppt2: u32, pv
         // --- MPPT 2 ---
         n(pid, &format!("solarcharger/{mppt2}/Yield/Power")),
         n(pid, &format!("solarcharger/{mppt2}/History/Daily/0/Yield")),
+        n(pid, &format!("solarcharger/{mppt2}/History/Daily/0/MaxPower")),
         n(pid, &format!("solarcharger/{mppt2}/State")),
         n(pid, &format!("solarcharger/{mppt2}/Pv/V")),
         n(pid, &format!("solarcharger/{mppt2}/Dc/0/Current")),

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -221,6 +221,7 @@ pub struct MpptState {
     pub pv_voltage_v: Option<f64>,
     pub dc_current_a: Option<f64>,
     pub yield_today_kwh: Option<f64>,
+    pub max_power_today_w: Option<f64>,
     pub state: Option<i64>,
 }
 

--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -223,16 +223,19 @@ N_SERIES=$(curl -s http://localhost:8080/api/v1/redb/series 2>/dev/null | jq '.d
 info "Nb séries en base : $N_SERIES"
 
 NEW_METRICS=(
-    bms_capacity_ah bms_temp_min bms_charge_mos bms_cell_voltage
+    bms_capacity_ah bms_temp_min bms_charge_mos bms_cell_voltage bms_power
     et112_apparent_power_va et112_frequency_hz et112_power_factor
     venus_mppt_power_w venus_mppt_yield_today_kwh venus_mppt_dc_current_a
-    venus_shunt_soc_percent venus_shunt_energy_in_kwh
+    venus_mppt_max_power_today_w
+    venus_shunt_soc_percent venus_shunt_energy_in_kwh venus_shunt_energy_out_kwh
     venus_inverter_ac_output_power_w venus_inverter_ac_output_voltage_v
-    venus_heatpump_power_w venus_heatpump_temp_c
+    venus_inverter_ac_output_current_a venus_inverter_ac_freq_hz
+    venus_heatpump_power_w venus_heatpump_temp_c venus_heatpump_energy_kwh
     shelly_current_a shelly_output shelly_energy_wh
-    pi5_cpu_percent pi5_memory_percent pi5_cpu_temp_c
+    pi5_cpu_percent pi5_memory_percent pi5_cpu_temp_c pi5_uptime_secs
     em_cpu_percent em_memory_percent
-    dc_pv_power_w pvinv_power_w solar_yield_kwh
+    dc_pv_power_w pvinv_power_w solar_yield_kwh solar_total_wh
+    ats_voltage_v ats_freq_hz total_solar_power
 )
 SERIES_JSON=$(curl -s http://localhost:8080/api/v1/redb/series 2>/dev/null || echo '{}')
 PRESENT=0; MISSING=()


### PR DESCRIPTION
Continues the restore-grafana-metrics work after the screenshots showed several panels still empty.

Sources fixed:
- energy-manager solar_power subscribes to N/.../solarcharger/{id}/History/Daily/0/MaxPower and stores the value in MpptState.max_power_today_w. Without this the meteo aggregator could not propagate the field downstream, so daly-bms always saw None for venus_mppt_max_power_today_w.
- The meteo publisher now serialises MaxPowerToday inside the Mppts array on santuario/meteo/venus. daly-bms already parses the key, so the metric flows end-to-end.

New aliases written to redb (from existing snapshots, no extra source):
- ats_voltage_v   = arithmetic mean of the active source's three phase
                    voltages (v1a/b/c or v2a/b/c)
- ats_freq_hz     = freq1_hz or freq2_hz depending on active_source
- total_solar_power = solar_total_w (alias used by the Grafana drilldown)
- pi5_uptime_secs = snap.uptime_secs from on_monitor_snapshot

The deploy-pi5.sh audit list is extended with the new names so the script's post-deploy check covers them.