### PR TITLE
feat(metrics): capture exhaustive de TOUS les champs des devices phys…

### DIFF
--- a/contrib/grafana/dashboards/bms-detail.json
+++ b/contrib/grafana/dashboards/bms-detail.json
@@ -1,6 +1,21 @@
 {
-  "annotations": { "list": [{ "builtIn": 1, "datasource": { "type": "grafana", "uid": "-- Grafana --" }, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard" }] },
-  "description": "BMS approfondi - cellules, MOSFETs, températures",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "BMS approfondi - cellules, MOSFETs, temp\u00e9ratures",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -8,45 +23,1336 @@
   "links": [],
   "liveNow": false,
   "panels": [
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 100, "panels": [], "title": "Vue d'ensemble BMS", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 1 }, "id": 1, "type": "timeseries", "title": "Tension Pack (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_voltage", "legendFormat": "BMS {{bms_id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 1 }, "id": 2, "type": "timeseries", "title": "Courant (A)", "fieldConfig": { "defaults": { "unit": "amp" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_current", "legendFormat": "BMS {{bms_id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 7 }, "id": 3, "type": "timeseries", "title": "SOC (%)", "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_soc", "legendFormat": "BMS {{bms_id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 7 }, "id": 4, "type": "timeseries", "title": "Puissance (W)", "fieldConfig": { "defaults": { "unit": "watt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_power", "legendFormat": "BMS {{bms_id}}", "refId": "A" }] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 }, "id": 101, "panels": [], "title": "Températures & Delta", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 14 }, "id": 5, "type": "timeseries", "title": "BMS 1 - Températures Min/Max", "fieldConfig": { "defaults": { "unit": "celsius" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_temp_max{bms_id=\"1\"}", "legendFormat": "Max", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_temp_min{bms_id=\"1\"}", "legendFormat": "Min", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 14 }, "id": 6, "type": "timeseries", "title": "BMS 2 - Températures Min/Max", "fieldConfig": { "defaults": { "unit": "celsius" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_temp_max{bms_id=\"2\"}", "legendFormat": "Max", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_temp_min{bms_id=\"2\"}", "legendFormat": "Min", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 20 }, "id": 7, "type": "timeseries", "title": "Delta Cellules (mV)", "fieldConfig": { "defaults": { "unit": "mvolt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_cell_delta_mv", "legendFormat": "BMS {{bms_id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 20 }, "id": 8, "type": "stat", "title": "Capacité (Ah)", "fieldConfig": { "defaults": { "unit": "amph" } }, "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_capacity_ah", "legendFormat": "BMS {{bms_id}}", "refId": "A" }] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 }, "id": 102, "panels": [], "title": "MOSFETs", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 27 }, "id": 9, "type": "state-timeline", "title": "BMS 1 - MOSFETs", "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_charge_mos{bms_id=\"1\"}", "legendFormat": "Charge", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_discharge_mos{bms_id=\"1\"}", "legendFormat": "Discharge", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 27 }, "id": 10, "type": "state-timeline", "title": "BMS 2 - MOSFETs", "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_charge_mos{bms_id=\"2\"}", "legendFormat": "Charge", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_discharge_mos{bms_id=\"2\"}", "legendFormat": "Discharge", "refId": "B" }
-      ] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 }, "id": 103, "panels": [], "title": "Tension cellules", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 10, "w": 24, "x": 0, "y": 34 }, "id": 11, "type": "heatmap", "title": "Tension cellules (heatmap)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_cell_voltage", "legendFormat": "BMS {{bms_id}} cell {{cell}}", "refId": "A", "format": "heatmap" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 8, "w": 12, "x": 0, "y": 44 }, "id": 12, "type": "timeseries", "title": "BMS 1 - Toutes cellules (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_cell_voltage{bms_id=\"1\"}", "legendFormat": "Cell {{cell}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 8, "w": 12, "x": 12, "y": 44 }, "id": 13, "type": "timeseries", "title": "BMS 2 - Toutes cellules (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "bms_cell_voltage{bms_id=\"2\"}", "legendFormat": "Cell {{cell}}", "refId": "A" }] }
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Vue d'ensemble BMS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "type": "timeseries",
+      "title": "Tension Pack (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_voltage",
+          "legendFormat": "BMS {{bms_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 2,
+      "type": "timeseries",
+      "title": "Courant (A)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_current",
+          "legendFormat": "BMS {{bms_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 3,
+      "type": "timeseries",
+      "title": "SOC (%)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_soc",
+          "legendFormat": "BMS {{bms_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 4,
+      "type": "timeseries",
+      "title": "Puissance (W)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_power",
+          "legendFormat": "BMS {{bms_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 101,
+      "panels": [],
+      "title": "Temp\u00e9ratures & Delta",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 5,
+      "type": "timeseries",
+      "title": "BMS 1 - Temp\u00e9ratures Min/Max",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_temp_max{bms_id=\"1\"}",
+          "legendFormat": "Max",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_temp_min{bms_id=\"1\"}",
+          "legendFormat": "Min",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 6,
+      "type": "timeseries",
+      "title": "BMS 2 - Temp\u00e9ratures Min/Max",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_temp_max{bms_id=\"2\"}",
+          "legendFormat": "Max",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_temp_min{bms_id=\"2\"}",
+          "legendFormat": "Min",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 7,
+      "type": "timeseries",
+      "title": "Delta Cellules (mV)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mvolt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_cell_delta_mv",
+          "legendFormat": "BMS {{bms_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 8,
+      "type": "stat",
+      "title": "Capacit\u00e9 (Ah)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amph"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_capacity_ah",
+          "legendFormat": "BMS {{bms_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 102,
+      "panels": [],
+      "title": "MOSFETs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 9,
+      "type": "state-timeline",
+      "title": "BMS 1 - MOSFETs",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_charge_mos{bms_id=\"1\"}",
+          "legendFormat": "Charge",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_discharge_mos{bms_id=\"1\"}",
+          "legendFormat": "Discharge",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 10,
+      "type": "state-timeline",
+      "title": "BMS 2 - MOSFETs",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_charge_mos{bms_id=\"2\"}",
+          "legendFormat": "Charge",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_discharge_mos{bms_id=\"2\"}",
+          "legendFormat": "Discharge",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Tension cellules",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 11,
+      "type": "heatmap",
+      "title": "Tension cellules (heatmap)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_cell_voltage",
+          "legendFormat": "BMS {{bms_id}} cell {{cell}}",
+          "refId": "A",
+          "format": "heatmap"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "id": 12,
+      "type": "timeseries",
+      "title": "BMS 1 - Toutes cellules (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_cell_voltage{bms_id=\"1\"}",
+          "legendFormat": "Cell {{cell}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 13,
+      "type": "timeseries",
+      "title": "BMS 2 - Toutes cellules (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_cell_voltage{bms_id=\"2\"}",
+          "legendFormat": "Cell {{cell}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "id": 201,
+      "panels": [],
+      "title": "BMS \u2014 M\u00e9triques \u00e9tendues",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 54
+      },
+      "id": 202,
+      "type": "timeseries",
+      "title": "BMS - \u00c9tat de sant\u00e9 (SOH)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_soh",
+          "refId": "A",
+          "legendFormat": "BMS {{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "id": 203,
+      "type": "timeseries",
+      "title": "BMS - Tension cellules min/max (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_min_cell_voltage",
+          "refId": "A",
+          "legendFormat": "min {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_max_cell_voltage",
+          "refId": "B",
+          "legendFormat": "max {{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 204,
+      "type": "timeseries",
+      "title": "BMS - Temp\u00e9rature MOSFET (\u00b0C)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_mos_temp_c",
+          "refId": "A",
+          "legendFormat": "{{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 72
+      },
+      "id": 205,
+      "type": "timeseries",
+      "title": "BMS - Temps restant d\u00e9charge (s)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_time_to_go_secs",
+          "refId": "A",
+          "legendFormat": "{{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 78
+      },
+      "id": 206,
+      "type": "timeseries",
+      "title": "BMS - Capacit\u00e9 (Ah)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amph"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_capacity_ah",
+          "refId": "A",
+          "legendFormat": "nominal {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_capacity_remaining_ah",
+          "refId": "B",
+          "legendFormat": "restant {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_reported_capacity_ah",
+          "refId": "C",
+          "legendFormat": "reported {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_consumed_ah",
+          "refId": "D",
+          "legendFormat": "consomm\u00e9e {{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 84
+      },
+      "id": 207,
+      "type": "timeseries",
+      "title": "BMS - Cycles de charge",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_charge_cycles",
+          "refId": "A",
+          "legendFormat": "{{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 90
+      },
+      "id": 208,
+      "type": "timeseries",
+      "title": "BMS - Tension min/max historique (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_min_voltage_hist",
+          "refId": "A",
+          "legendFormat": "min hist {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_max_voltage_hist",
+          "refId": "B",
+          "legendFormat": "max hist {{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 96
+      },
+      "id": 209,
+      "type": "timeseries",
+      "title": "BMS - Total Ah d\u00e9charg\u00e9s (Ah)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amph"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_total_ah_drawn",
+          "refId": "A",
+          "legendFormat": "{{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 102
+      },
+      "id": 210,
+      "type": "timeseries",
+      "title": "BMS - Limites charge / d\u00e9charge",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_max_charge_current",
+          "refId": "A",
+          "legendFormat": "I_charge_max {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_max_discharge_current",
+          "refId": "B",
+          "legendFormat": "I_decharge_max {{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 108
+      },
+      "id": 211,
+      "type": "timeseries",
+      "title": "BMS - Limites tension",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_max_charge_voltage",
+          "refId": "A",
+          "legendFormat": "V_pack_max {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_max_charge_cell_voltage",
+          "refId": "B",
+          "legendFormat": "V_cell_max {{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 114
+      },
+      "id": 212,
+      "type": "timeseries",
+      "title": "BMS - Modules online / offline",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_modules_online",
+          "refId": "A",
+          "legendFormat": "online {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_modules_offline",
+          "refId": "B",
+          "legendFormat": "offline {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_modules_blocking_charge",
+          "refId": "C",
+          "legendFormat": "block_charge {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_modules_blocking_discharge",
+          "refId": "D",
+          "legendFormat": "block_discharge {{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 120
+      },
+      "id": 213,
+      "type": "timeseries",
+      "title": "BMS - Chauffage (consigne)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_heating_active",
+          "refId": "A",
+          "legendFormat": "actif {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_heating_current",
+          "refId": "B",
+          "legendFormat": "I (A) {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_heating_power",
+          "refId": "C",
+          "legendFormat": "P (W) {{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 126
+      },
+      "id": 214,
+      "type": "state-timeline",
+      "title": "BMS - Permissions IO",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_balancing_active",
+          "refId": "A",
+          "legendFormat": "balancing {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_system_switch",
+          "refId": "B",
+          "legendFormat": "sys_switch {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_balance_mos",
+          "refId": "C",
+          "legendFormat": "allow_balance {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_heat_mos",
+          "refId": "D",
+          "legendFormat": "allow_heat {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_external_relay",
+          "refId": "E",
+          "legendFormat": "ext_relay {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_charge_request",
+          "refId": "F",
+          "legendFormat": "charge_req {{bms_id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 132
+      },
+      "id": 215,
+      "type": "state-timeline",
+      "title": "BMS - \u00c9quilibrage par cellule",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_cell_balancing",
+          "refId": "A",
+          "legendFormat": "cell {{cell}} ({{bms_id}})"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 138
+      },
+      "id": 216,
+      "type": "state-timeline",
+      "title": "BMS - Alarmes actives (13 flags)",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_low_voltage",
+          "refId": "A",
+          "legendFormat": "LV {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_high_voltage",
+          "refId": "B",
+          "legendFormat": "HV {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_low_soc",
+          "refId": "C",
+          "legendFormat": "LowSOC {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_high_charge_current",
+          "refId": "D",
+          "legendFormat": "HiChgI {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_high_discharge_current",
+          "refId": "E",
+          "legendFormat": "HiDisI {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_high_current",
+          "refId": "F",
+          "legendFormat": "HiI {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_cell_imbalance",
+          "refId": "G",
+          "legendFormat": "Imbal {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_high_charge_temp",
+          "refId": "H",
+          "legendFormat": "HiChgT {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_low_charge_temp",
+          "refId": "I",
+          "legendFormat": "LoChgT {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_low_cell_voltage",
+          "refId": "J",
+          "legendFormat": "LoCellV {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_low_temp",
+          "refId": "K",
+          "legendFormat": "LoT {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_high_temp",
+          "refId": "L",
+          "legendFormat": "HiT {{bms_id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bms_alarm_fuse_blown",
+          "refId": "M",
+          "legendFormat": "Fuse {{bms_id}}"
+        }
+      ]
+    }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["bms", "cells", "mosfet"],
-  "templating": { "list": [{ "current": { "selected": false, "text": "Prometheus", "value": "prometheus" }, "hide": 0, "includeAll": false, "label": "Data Source", "multi": false, "name": "datasource", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" }] },
-  "time": { "from": "now-6h", "to": "now" },
+  "tags": [
+    "bms",
+    "cells",
+    "mosfet"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Europe/Paris",
   "title": "BMS - Detail Cellules & MOSFETs",

--- a/contrib/grafana/dashboards/infrastructure.json
+++ b/contrib/grafana/dashboards/infrastructure.json
@@ -1,5 +1,20 @@
 {
-  "annotations": { "list": [{ "builtIn": 1, "datasource": { "type": "grafana", "uid": "-- Grafana --" }, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard" }] },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "description": "Pi5 + energy-manager system & tokio metrics",
   "editable": true,
   "fiscalYearStartMonth": 0,
@@ -8,61 +23,1049 @@
   "links": [],
   "liveNow": false,
   "panels": [
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 100, "panels": [], "title": "Pi5 - Système", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 }, "id": 1, "type": "stat", "title": "Pi5 CPU %", "fieldConfig": { "defaults": { "unit": "percent" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_cpu_percent", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 }, "id": 2, "type": "stat", "title": "Pi5 Memory %", "fieldConfig": { "defaults": { "unit": "percent" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_memory_percent", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 }, "id": 3, "type": "stat", "title": "Pi5 Disk %", "fieldConfig": { "defaults": { "unit": "percent" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_disk_percent", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 }, "id": 4, "type": "stat", "title": "Pi5 CPU Temp", "fieldConfig": { "defaults": { "unit": "celsius" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_cpu_temp_c", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 5 }, "id": 5, "type": "timeseries", "title": "Pi5 Load Average", "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_load_avg{window=\"1m\"}", "legendFormat": "1m", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_load_avg{window=\"5m\"}", "legendFormat": "5m", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_load_avg{window=\"15m\"}", "legendFormat": "15m", "refId": "C" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 5 }, "id": 6, "type": "timeseries", "title": "Pi5 Memory (MB)", "fieldConfig": { "defaults": { "unit": "decmbytes" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_mem_used_mb", "legendFormat": "Mem used", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_swap_used_mb", "legendFormat": "Swap used", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 11 }, "id": 7, "type": "timeseries", "title": "Pi5 Network (bps)", "fieldConfig": { "defaults": { "unit": "bps" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_net_rx_bps", "legendFormat": "RX", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_net_tx_bps", "legendFormat": "TX", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 11 }, "id": 8, "type": "stat", "title": "Pi5 Uptime", "fieldConfig": { "defaults": { "unit": "s" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "pi5_uptime_secs", "refId": "A" }] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }, "id": 101, "panels": [], "title": "energy-manager - Système", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 6, "x": 0, "y": 18 }, "id": 9, "type": "stat", "title": "EM CPU %", "fieldConfig": { "defaults": { "unit": "percent" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_cpu_percent", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 6, "x": 6, "y": 18 }, "id": 10, "type": "stat", "title": "EM Memory %", "fieldConfig": { "defaults": { "unit": "percent" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_memory_percent", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 6, "x": 12, "y": 18 }, "id": 11, "type": "stat", "title": "EM Disk %", "fieldConfig": { "defaults": { "unit": "percent" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_disk_percent", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 6, "x": 18, "y": 18 }, "id": 12, "type": "stat", "title": "EM CPU Temp", "fieldConfig": { "defaults": { "unit": "celsius" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_cpu_temp_c", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 22 }, "id": 13, "type": "timeseries", "title": "EM Memory (MB)", "fieldConfig": { "defaults": { "unit": "decmbytes" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_mem_used_mb", "legendFormat": "Mem", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_swap_used_mb", "legendFormat": "Swap", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 22 }, "id": 14, "type": "timeseries", "title": "EM Load Average", "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_load_avg{window=\"1m\"}", "legendFormat": "1m", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_load_avg{window=\"5m\"}", "legendFormat": "5m", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_load_avg{window=\"15m\"}", "legendFormat": "15m", "refId": "C" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 28 }, "id": 15, "type": "timeseries", "title": "EM Network (bps)", "fieldConfig": { "defaults": { "unit": "bps" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_net_rx_bps", "legendFormat": "RX", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_net_tx_bps", "legendFormat": "TX", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 28 }, "id": 16, "type": "timeseries", "title": "Top 10 Processes - CPU %", "fieldConfig": { "defaults": { "unit": "percent" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "topk(10, em_process_cpu_percent)", "legendFormat": "{{name}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 34 }, "id": 17, "type": "timeseries", "title": "Top 10 Processes - Memory (MB)", "fieldConfig": { "defaults": { "unit": "decmbytes" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "topk(10, em_process_mem_mb)", "legendFormat": "{{name}}", "refId": "A" }] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 }, "id": 102, "panels": [], "title": "Tokio Runtime", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 8, "x": 0, "y": 41 }, "id": 18, "type": "timeseries", "title": "Tokio Task Polls (rate/s)", "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(em_tokio_task_polls_total[1m])", "legendFormat": "{{task}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 8, "x": 8, "y": 41 }, "id": 19, "type": "timeseries", "title": "Tokio Mean Poll (µs)", "fieldConfig": { "defaults": { "unit": "µs" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_tokio_task_mean_poll_us", "legendFormat": "{{task}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 8, "x": 16, "y": 41 }, "id": 20, "type": "timeseries", "title": "Tokio Mean Scheduled (µs)", "fieldConfig": { "defaults": { "unit": "µs" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "em_tokio_task_mean_scheduled_us", "legendFormat": "{{task}}", "refId": "A" }] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 47 }, "id": 103, "panels": [], "title": "Rules Engine", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 8, "w": 24, "x": 0, "y": 48 }, "id": 21, "type": "timeseries", "title": "Rule Evaluations (rate/s par règle)", "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(rule_eval_total[1m])", "legendFormat": "{{rule}}", "refId": "A" }] }
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Pi5 - Syst\u00e8me",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "type": "stat",
+      "title": "Pi5 CPU %",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_cpu_percent",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 2,
+      "type": "stat",
+      "title": "Pi5 Memory %",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_memory_percent",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "type": "stat",
+      "title": "Pi5 Disk %",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_disk_percent",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 4,
+      "type": "stat",
+      "title": "Pi5 CPU Temp",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_cpu_temp_c",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 5,
+      "type": "timeseries",
+      "title": "Pi5 Load Average",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_load_avg{window=\"1m\"}",
+          "legendFormat": "1m",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_load_avg{window=\"5m\"}",
+          "legendFormat": "5m",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_load_avg{window=\"15m\"}",
+          "legendFormat": "15m",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 6,
+      "type": "timeseries",
+      "title": "Pi5 Memory (MB)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decmbytes"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_mem_used_mb",
+          "legendFormat": "Mem used",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_swap_used_mb",
+          "legendFormat": "Swap used",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 7,
+      "type": "timeseries",
+      "title": "Pi5 Network (bps)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_net_rx_bps",
+          "legendFormat": "RX",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_net_tx_bps",
+          "legendFormat": "TX",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 8,
+      "type": "stat",
+      "title": "Pi5 Uptime",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_uptime_secs",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 101,
+      "panels": [],
+      "title": "energy-manager - Syst\u00e8me",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 18
+      },
+      "id": 9,
+      "type": "stat",
+      "title": "EM CPU %",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_cpu_percent",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "id": 10,
+      "type": "stat",
+      "title": "EM Memory %",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_memory_percent",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 18
+      },
+      "id": 11,
+      "type": "stat",
+      "title": "EM Disk %",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_disk_percent",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 18
+      },
+      "id": 12,
+      "type": "stat",
+      "title": "EM CPU Temp",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_cpu_temp_c",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 13,
+      "type": "timeseries",
+      "title": "EM Memory (MB)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decmbytes"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_mem_used_mb",
+          "legendFormat": "Mem",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_swap_used_mb",
+          "legendFormat": "Swap",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 14,
+      "type": "timeseries",
+      "title": "EM Load Average",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_load_avg{window=\"1m\"}",
+          "legendFormat": "1m",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_load_avg{window=\"5m\"}",
+          "legendFormat": "5m",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_load_avg{window=\"15m\"}",
+          "legendFormat": "15m",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 15,
+      "type": "timeseries",
+      "title": "EM Network (bps)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_net_rx_bps",
+          "legendFormat": "RX",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_net_tx_bps",
+          "legendFormat": "TX",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 16,
+      "type": "timeseries",
+      "title": "Top 10 Processes - CPU %",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, em_process_cpu_percent)",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 17,
+      "type": "timeseries",
+      "title": "Top 10 Processes - Memory (MB)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decmbytes"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, em_process_mem_mb)",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Tokio Runtime",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 41
+      },
+      "id": 18,
+      "type": "timeseries",
+      "title": "Tokio Task Polls (rate/s)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(em_tokio_task_polls_total[1m])",
+          "legendFormat": "{{task}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 41
+      },
+      "id": 19,
+      "type": "timeseries",
+      "title": "Tokio Mean Poll (\u00b5s)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_tokio_task_mean_poll_us",
+          "legendFormat": "{{task}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 41
+      },
+      "id": 20,
+      "type": "timeseries",
+      "title": "Tokio Mean Scheduled (\u00b5s)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "em_tokio_task_mean_scheduled_us",
+          "legendFormat": "{{task}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Rules Engine",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 21,
+      "type": "timeseries",
+      "title": "Rule Evaluations (rate/s par r\u00e8gle)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(rule_eval_total[1m])",
+          "legendFormat": "{{rule}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 201,
+      "panels": [],
+      "title": "Pi5 \u2014 \u00c9tendu (services, processes, port s\u00e9rie)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 202,
+      "type": "timeseries",
+      "title": "Pi5 - M\u00e9moire / Swap total (MB)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mbytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_mem_total_mb",
+          "refId": "A",
+          "legendFormat": "mem_total"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_swap_total_mb",
+          "refId": "B",
+          "legendFormat": "swap_total"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 203,
+      "type": "state-timeline",
+      "title": "Pi5 - Port s\u00e9rie RS485",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_serial_port_ok",
+          "refId": "A",
+          "legendFormat": "/dev/ttyUSB0"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 204,
+      "type": "state-timeline",
+      "title": "Pi5 - Services systemd actifs",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_service_active",
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "id": 205,
+      "type": "state-timeline",
+      "title": "Pi5 - Services r\u00e9seau prob\u00e9s (TCP)",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_network_service_active",
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "id": 206,
+      "type": "timeseries",
+      "title": "Pi5 - Top processus CPU%",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_process_cpu_percent",
+          "refId": "A",
+          "legendFormat": "{{process}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 88
+      },
+      "id": 207,
+      "type": "timeseries",
+      "title": "Pi5 - Top processus m\u00e9moire (MB)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mbytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "pi5_process_mem_mb",
+          "refId": "A",
+          "legendFormat": "{{process}}"
+        }
+      ]
+    }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["infrastructure", "pi5", "energy-manager"],
-  "templating": { "list": [{ "current": { "selected": false, "text": "Prometheus", "value": "prometheus" }, "hide": 0, "includeAll": false, "label": "Data Source", "multi": false, "name": "datasource", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" }] },
-  "time": { "from": "now-6h", "to": "now" },
+  "tags": [
+    "infrastructure",
+    "pi5",
+    "energy-manager"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Europe/Paris",
   "title": "Infrastructure - Pi5 & energy-manager",

--- a/contrib/grafana/dashboards/network-ats.json
+++ b/contrib/grafana/dashboards/network-ats.json
@@ -1,6 +1,21 @@
 {
-  "annotations": { "list": [{ "builtIn": 1, "datasource": { "type": "grafana", "uid": "-- Grafana --" }, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard" }] },
-  "description": "ATS CHINT + ET112 (réseau électrique)",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "ATS CHINT + ET112 (r\u00e9seau \u00e9lectrique)",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -8,44 +23,816 @@
   "links": [],
   "liveNow": false,
   "panels": [
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 100, "panels": [], "title": "ATS CHINT", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 }, "id": 1, "type": "stat", "title": "Source Active", "fieldConfig": { "defaults": { "mappings": [
-          { "type": "value", "options": { "0": { "text": "Onduleur", "color": "blue" }, "1": { "text": "Réseau", "color": "green" }, "2": { "text": "Neutre", "color": "orange" } } }
-        ] } }, "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "background" }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_active_source", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 4, "w": 18, "x": 6, "y": 1 }, "id": 2, "type": "state-timeline", "title": "État Switches ATS", "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_sw1_closed", "legendFormat": "SW1", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_sw2_closed", "legendFormat": "SW2", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 5 }, "id": 3, "type": "timeseries", "title": "Source 1 - Tensions phases (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_v1a", "legendFormat": "V1A", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_v1b", "legendFormat": "V1B", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_v1c", "legendFormat": "V1C", "refId": "C" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 5 }, "id": 4, "type": "timeseries", "title": "Source 2 - Tensions phases (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_v2a", "legendFormat": "V2A", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_v2b", "legendFormat": "V2B", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_v2c", "legendFormat": "V2C", "refId": "C" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 11 }, "id": 5, "type": "timeseries", "title": "Fréquences Source1 / Source2 (Hz)", "fieldConfig": { "defaults": { "unit": "hertz" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_freq1_hz", "legendFormat": "Source 1", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_freq2_hz", "legendFormat": "Source 2", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 11 }, "id": 6, "type": "timeseries", "title": "ATS Aggregate (Voltage / Freq)", "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_voltage_v", "legendFormat": "Voltage (V)", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "ats_freq_hz", "legendFormat": "Freq (Hz)", "refId": "B" }
-      ] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }, "id": 101, "panels": [], "title": "ET112 - Compteurs", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 18 }, "id": 7, "type": "timeseries", "title": "ET112 - Puissance Apparente (VA) par address", "fieldConfig": { "defaults": { "unit": "voltamp" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "et112_apparent_power_va", "legendFormat": "addr {{address}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 18 }, "id": 8, "type": "timeseries", "title": "ET112 - Power Factor par address", "fieldConfig": { "defaults": { "min": -1, "max": 1 } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "et112_power_factor", "legendFormat": "addr {{address}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 24, "x": 0, "y": 24 }, "id": 9, "type": "timeseries", "title": "ET112 - Courant (A) par address", "fieldConfig": { "defaults": { "unit": "amp" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "et112_current_a", "legendFormat": "addr {{address}}", "refId": "A" }] }
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "ATS CHINT",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "type": "stat",
+      "title": "Source Active",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Onduleur",
+                  "color": "blue"
+                },
+                "1": {
+                  "text": "R\u00e9seau",
+                  "color": "green"
+                },
+                "2": {
+                  "text": "Neutre",
+                  "color": "orange"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_active_source",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 18,
+        "x": 6,
+        "y": 1
+      },
+      "id": 2,
+      "type": "state-timeline",
+      "title": "\u00c9tat Switches ATS",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_sw1_closed",
+          "legendFormat": "SW1",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_sw2_closed",
+          "legendFormat": "SW2",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 3,
+      "type": "timeseries",
+      "title": "Source 1 - Tensions phases (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_v1a",
+          "legendFormat": "V1A",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_v1b",
+          "legendFormat": "V1B",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_v1c",
+          "legendFormat": "V1C",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 4,
+      "type": "timeseries",
+      "title": "Source 2 - Tensions phases (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_v2a",
+          "legendFormat": "V2A",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_v2b",
+          "legendFormat": "V2B",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_v2c",
+          "legendFormat": "V2C",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 5,
+      "type": "timeseries",
+      "title": "Fr\u00e9quences Source1 / Source2 (Hz)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "hertz"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_freq1_hz",
+          "legendFormat": "Source 1",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_freq2_hz",
+          "legendFormat": "Source 2",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 6,
+      "type": "timeseries",
+      "title": "ATS Aggregate (Voltage / Freq)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_voltage_v",
+          "legendFormat": "Voltage (V)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_freq_hz",
+          "legendFormat": "Freq (Hz)",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 101,
+      "panels": [],
+      "title": "ET112 - Compteurs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 7,
+      "type": "timeseries",
+      "title": "ET112 - Puissance Apparente (VA) par address",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "voltamp"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "et112_apparent_power_va",
+          "legendFormat": "addr {{address}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 8,
+      "type": "timeseries",
+      "title": "ET112 - Power Factor par address",
+      "fieldConfig": {
+        "defaults": {
+          "min": -1,
+          "max": 1
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "et112_power_factor",
+          "legendFormat": "addr {{address}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 9,
+      "type": "timeseries",
+      "title": "ET112 - Courant (A) par address",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "et112_current_a",
+          "legendFormat": "addr {{address}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 201,
+      "panels": [],
+      "title": "ATS \u2014 \u00c9tendu (faults / phases / runtime)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 202,
+      "type": "timeseries",
+      "title": "ATS - Code de d\u00e9faut",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_fault",
+          "refId": "A",
+          "legendFormat": "fault code"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 203,
+      "type": "state-timeline",
+      "title": "ATS - Modes (sw_mode/remote/middle_off)",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_sw_mode",
+          "refId": "A",
+          "legendFormat": "sw_mode (Auto=1)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_remote",
+          "refId": "B",
+          "legendFormat": "remote"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_middle_off",
+          "refId": "C",
+          "legendFormat": "middle_off"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 204,
+      "type": "state-timeline",
+      "title": "ATS - Statut par phase (Source 1)",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_phase_s1a",
+          "refId": "A",
+          "legendFormat": "S1A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_phase_s1b",
+          "refId": "B",
+          "legendFormat": "S1B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_phase_s1c",
+          "refId": "C",
+          "legendFormat": "S1C"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 205,
+      "type": "state-timeline",
+      "title": "ATS - Statut par phase (Source 2)",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_phase_s2a",
+          "refId": "A",
+          "legendFormat": "S2A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_phase_s2b",
+          "refId": "B",
+          "legendFormat": "S2B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_phase_s2c",
+          "refId": "C",
+          "legendFormat": "S2C"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 206,
+      "type": "timeseries",
+      "title": "ATS - Compteurs commutations",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_cnt1",
+          "refId": "A",
+          "legendFormat": "S1\u2192S2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_cnt2",
+          "refId": "B",
+          "legendFormat": "S2\u2192S1"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 207,
+      "type": "stat",
+      "title": "ATS - Runtime (h)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_runtime_h",
+          "refId": "A",
+          "legendFormat": "runtime_h"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 68
+      },
+      "id": 208,
+      "type": "timeseries",
+      "title": "ATS - Tensions max historiques",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_max1_v",
+          "refId": "A",
+          "legendFormat": "max source 1"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ats_max2_v",
+          "refId": "B",
+          "legendFormat": "max source 2"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "id": 209,
+      "type": "timeseries",
+      "title": "ET112 - Puissance r\u00e9active (VAr)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "voltampreact"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "et112_reactive_power_var",
+          "refId": "A",
+          "legendFormat": "addr {{address}}"
+        }
+      ]
+    }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["ats", "et112", "grid"],
-  "templating": { "list": [{ "current": { "selected": false, "text": "Prometheus", "value": "prometheus" }, "hide": 0, "includeAll": false, "label": "Data Source", "multi": false, "name": "datasource", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" }] },
-  "time": { "from": "now-6h", "to": "now" },
+  "tags": [
+    "ats",
+    "et112",
+    "grid"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Europe/Paris",
   "title": "Reseau Electrique & ATS",

--- a/contrib/grafana/dashboards/smart-devices.json
+++ b/contrib/grafana/dashboards/smart-devices.json
@@ -1,6 +1,21 @@
 {
-  "annotations": { "list": [{ "builtIn": 1, "datasource": { "type": "grafana", "uid": "-- Grafana --" }, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard" }] },
-  "description": "Tasmota & Shelly smart devices - puissance, tension, courant, énergie, état",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Tasmota & Shelly smart devices - puissance, tension, courant, \u00e9nergie, \u00e9tat",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -8,27 +23,617 @@
   "links": [],
   "liveNow": false,
   "panels": [
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 100, "panels": [], "title": "Tasmota", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 1 }, "id": 1, "type": "timeseries", "title": "Tasmota - Puissance (W)", "fieldConfig": { "defaults": { "unit": "watt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "tasmota_power_w", "legendFormat": "{{id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 1 }, "id": 2, "type": "timeseries", "title": "Tasmota - Tension (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "tasmota_voltage_v", "legendFormat": "{{id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 7 }, "id": 3, "type": "timeseries", "title": "Tasmota - Courant (A)", "fieldConfig": { "defaults": { "unit": "amp" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "tasmota_current_a", "legendFormat": "{{id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 7 }, "id": 4, "type": "timeseries", "title": "Tasmota - Énergie du Jour (kWh)", "fieldConfig": { "defaults": { "unit": "kwatth" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "tasmota_energy_today_kwh", "legendFormat": "{{id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 24, "x": 0, "y": 13 }, "id": 5, "type": "state-timeline", "title": "Tasmota - État ON/OFF", "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "tasmota_power_on", "legendFormat": "{{id}}", "refId": "A" }] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 19 }, "id": 101, "panels": [], "title": "Shelly", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 20 }, "id": 6, "type": "timeseries", "title": "Shelly - Puissance Totale (W)", "fieldConfig": { "defaults": { "unit": "watt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "shelly_power_w", "legendFormat": "{{id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 20 }, "id": 7, "type": "timeseries", "title": "Shelly - Tension (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "shelly_voltage_v", "legendFormat": "{{id}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 26 }, "id": 8, "type": "timeseries", "title": "Shelly - Puissance par Canal (W)", "fieldConfig": { "defaults": { "unit": "watt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "shelly_channel_power_w", "legendFormat": "{{id}} ch{{channel}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 26 }, "id": 9, "type": "timeseries", "title": "Shelly - Courant par Canal (A)", "fieldConfig": { "defaults": { "unit": "amp" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "shelly_current_a", "legendFormat": "{{id}} ch{{channel}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 32 }, "id": 10, "type": "timeseries", "title": "Shelly - Énergie par Canal (Wh)", "fieldConfig": { "defaults": { "unit": "watth" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "shelly_energy_wh", "legendFormat": "{{id}} ch{{channel}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 32 }, "id": 11, "type": "state-timeline", "title": "Shelly - Sortie par Canal", "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "shelly_output", "legendFormat": "{{id}} ch{{channel}}", "refId": "A" }] }
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Tasmota",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "type": "timeseries",
+      "title": "Tasmota - Puissance (W)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_power_w",
+          "legendFormat": "{{id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 2,
+      "type": "timeseries",
+      "title": "Tasmota - Tension (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_voltage_v",
+          "legendFormat": "{{id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 3,
+      "type": "timeseries",
+      "title": "Tasmota - Courant (A)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_current_a",
+          "legendFormat": "{{id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 4,
+      "type": "timeseries",
+      "title": "Tasmota - \u00c9nergie du Jour (kWh)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_energy_today_kwh",
+          "legendFormat": "{{id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 5,
+      "type": "state-timeline",
+      "title": "Tasmota - \u00c9tat ON/OFF",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_power_on",
+          "legendFormat": "{{id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 101,
+      "panels": [],
+      "title": "Shelly",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 6,
+      "type": "timeseries",
+      "title": "Shelly - Puissance Totale (W)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "shelly_power_w",
+          "legendFormat": "{{id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 7,
+      "type": "timeseries",
+      "title": "Shelly - Tension (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "shelly_voltage_v",
+          "legendFormat": "{{id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 8,
+      "type": "timeseries",
+      "title": "Shelly - Puissance par Canal (W)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "shelly_channel_power_w",
+          "legendFormat": "{{id}} ch{{channel}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 9,
+      "type": "timeseries",
+      "title": "Shelly - Courant par Canal (A)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "shelly_current_a",
+          "legendFormat": "{{id}} ch{{channel}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 10,
+      "type": "timeseries",
+      "title": "Shelly - \u00c9nergie par Canal (Wh)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watth"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "shelly_energy_wh",
+          "legendFormat": "{{id}} ch{{channel}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 11,
+      "type": "state-timeline",
+      "title": "Shelly - Sortie par Canal",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "shelly_output",
+          "legendFormat": "{{id}} ch{{channel}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 201,
+      "panels": [],
+      "title": "Smart devices \u2014 M\u00e9triques \u00e9tendues",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 202,
+      "type": "timeseries",
+      "title": "Tasmota - Puissance apparente / Facteur",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_apparent_power_va",
+          "refId": "A",
+          "legendFormat": "VA {{id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_power_factor",
+          "refId": "B",
+          "legendFormat": "PF {{id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 203,
+      "type": "timeseries",
+      "title": "Tasmota - \u00c9nergie cumul\u00e9e",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_energy_yesterday_kwh",
+          "refId": "A",
+          "legendFormat": "hier {{id}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_energy_total_kwh",
+          "refId": "B",
+          "legendFormat": "total {{id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 204,
+      "type": "timeseries",
+      "title": "Tasmota - Signal WiFi (dBm)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dBm"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tasmota_rssi",
+          "refId": "A",
+          "legendFormat": "{{id}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 205,
+      "type": "timeseries",
+      "title": "Shelly - Facteur de puissance par canal",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "shelly_power_factor",
+          "refId": "A",
+          "legendFormat": "{{id}}/ch{{channel}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 206,
+      "type": "timeseries",
+      "title": "Shelly - \u00c9nergie retourn\u00e9e au r\u00e9seau (Wh)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watth"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "shelly_returned_wh",
+          "refId": "A",
+          "legendFormat": "{{id}}/ch{{channel}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 207,
+      "type": "timeseries",
+      "title": "Shelly - Signal WiFi (dBm)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dBm"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "shelly_rssi",
+          "refId": "A",
+          "legendFormat": "{{id}}"
+        }
+      ]
+    }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["tasmota", "shelly", "smart-devices"],
-  "templating": { "list": [{ "current": { "selected": false, "text": "Prometheus", "value": "prometheus" }, "hide": 0, "includeAll": false, "label": "Data Source", "multi": false, "name": "datasource", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" }] },
-  "time": { "from": "now-6h", "to": "now" },
+  "tags": [
+    "tasmota",
+    "shelly",
+    "smart-devices"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Europe/Paris",
   "title": "Smart Devices - Tasmota & Shelly",

--- a/contrib/grafana/dashboards/venus-detail.json
+++ b/contrib/grafana/dashboards/venus-detail.json
@@ -1,5 +1,20 @@
 {
-  "annotations": { "list": [{ "builtIn": 1, "datasource": { "type": "grafana", "uid": "-- Grafana --" }, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard" }] },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "description": "Venus OS - MPPT, SmartShunt, Inverter, Heatpumps et chauffe-eau",
   "editable": true,
   "fiscalYearStartMonth": 0,
@@ -8,49 +23,968 @@
   "links": [],
   "liveNow": false,
   "panels": [
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 100, "panels": [], "title": "MPPT", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 1 }, "id": 1, "type": "timeseries", "title": "MPPT - Tension PV (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_mppt_pv_voltage_v", "legendFormat": "inst {{instance}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 1 }, "id": 2, "type": "timeseries", "title": "MPPT - Courant DC (A)", "fieldConfig": { "defaults": { "unit": "amp" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_mppt_dc_current_a", "legendFormat": "inst {{instance}}", "refId": "A" }] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 }, "id": 101, "panels": [], "title": "SmartShunt", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 8, "x": 0, "y": 8 }, "id": 3, "type": "timeseries", "title": "SmartShunt - Tension (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_shunt_voltage_v", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 8, "x": 8, "y": 8 }, "id": 4, "type": "timeseries", "title": "SmartShunt - Énergie In (kWh)", "fieldConfig": { "defaults": { "unit": "kwatth" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_shunt_energy_in_kwh", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 8, "x": 16, "y": 8 }, "id": 5, "type": "timeseries", "title": "SmartShunt - Énergie Out (kWh)", "fieldConfig": { "defaults": { "unit": "kwatth" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_shunt_energy_out_kwh", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 24, "x": 0, "y": 14 }, "id": 6, "type": "timeseries", "title": "SmartShunt - Ah Chargé/Déchargé Aujourd'hui", "fieldConfig": { "defaults": { "unit": "amph" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_shunt_ah_charged_today", "legendFormat": "Chargé", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_shunt_ah_discharged_today", "legendFormat": "Déchargé", "refId": "B" }
-      ] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 }, "id": 102, "panels": [], "title": "Inverter", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 21 }, "id": 7, "type": "timeseries", "title": "Inverter - Courant DC (A)", "fieldConfig": { "defaults": { "unit": "amp" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_inverter_current_a", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 21 }, "id": 8, "type": "timeseries", "title": "Inverter - Tension AC Sortie (V)", "fieldConfig": { "defaults": { "unit": "volt" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_inverter_ac_output_voltage_v", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 27 }, "id": 9, "type": "timeseries", "title": "Inverter - Courant AC Sortie (A)", "fieldConfig": { "defaults": { "unit": "amp" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_inverter_ac_output_current_a", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 27 }, "id": 10, "type": "timeseries", "title": "Inverter - Fréquence AC (Hz)", "fieldConfig": { "defaults": { "unit": "hertz" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_inverter_ac_freq_hz", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 33 }, "id": 11, "type": "state-timeline", "title": "Inverter - AC Input Ignore", "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_inverter_ac_in_ignore", "legendFormat": "ac_in_ignore", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 33 }, "id": 105, "type": "timeseries", "title": "Inverter - Puissance DC (W)", "fieldConfig": { "defaults": { "unit": "watt" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_inverter_power_w", "legendFormat": "inverter DC", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_inverter_ac_output_power_w", "legendFormat": "AC sortie", "refId": "B" }
-      ] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 }, "id": 103, "panels": [], "title": "Environnement & Heatpumps", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 40 }, "id": 12, "type": "timeseries", "title": "Humidité (%)", "fieldConfig": { "defaults": { "unit": "humidity", "min": 0, "max": 100 } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_humidity_percent", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 40 }, "id": 13, "type": "timeseries", "title": "Heatpump - Énergie (kWh)", "fieldConfig": { "defaults": { "unit": "kwatth" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_heatpump_energy_kwh", "legendFormat": "mqtt_{{mqtt_index}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 46 }, "id": 14, "type": "timeseries", "title": "Heatpump - Target Temp (°C)", "fieldConfig": { "defaults": { "unit": "celsius" } }, "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_heatpump_target_temp_c", "legendFormat": "mqtt_{{mqtt_index}}", "refId": "A" }] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 46 }, "id": 15, "type": "state-timeline", "title": "Heatpump - État", "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "venus_heatpump_state", "legendFormat": "mqtt_{{mqtt_index}}", "refId": "A" }] },
-
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 52 }, "id": 104, "panels": [], "title": "Chauffe-eau", "type": "row" },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 0, "y": 53 }, "id": 16, "type": "timeseries", "title": "Chauffe-eau - Température (°C)", "fieldConfig": { "defaults": { "unit": "celsius" } }, "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "wh_current_temp_c", "legendFormat": "Actuelle", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "wh_target_temp_c", "legendFormat": "Cible", "refId": "B" }
-      ] },
-    { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "gridPos": { "h": 6, "w": 12, "x": 12, "y": 53 }, "id": 17, "type": "state-timeline", "title": "Chauffe-eau - Mode", "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "wh_mode", "legendFormat": "mode", "refId": "A" }] }
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "MPPT",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "type": "timeseries",
+      "title": "MPPT - Tension PV (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_mppt_pv_voltage_v",
+          "legendFormat": "inst {{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 2,
+      "type": "timeseries",
+      "title": "MPPT - Courant DC (A)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_mppt_dc_current_a",
+          "legendFormat": "inst {{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 101,
+      "panels": [],
+      "title": "SmartShunt",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "type": "timeseries",
+      "title": "SmartShunt - Tension (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_shunt_voltage_v",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 4,
+      "type": "timeseries",
+      "title": "SmartShunt - \u00c9nergie In (kWh)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_shunt_energy_in_kwh",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 5,
+      "type": "timeseries",
+      "title": "SmartShunt - \u00c9nergie Out (kWh)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_shunt_energy_out_kwh",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 6,
+      "type": "timeseries",
+      "title": "SmartShunt - Ah Charg\u00e9/D\u00e9charg\u00e9 Aujourd'hui",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amph"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_shunt_ah_charged_today",
+          "legendFormat": "Charg\u00e9",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_shunt_ah_discharged_today",
+          "legendFormat": "D\u00e9charg\u00e9",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Inverter",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 7,
+      "type": "timeseries",
+      "title": "Inverter - Courant DC (A)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_inverter_current_a",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 8,
+      "type": "timeseries",
+      "title": "Inverter - Tension AC Sortie (V)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_inverter_ac_output_voltage_v",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 9,
+      "type": "timeseries",
+      "title": "Inverter - Courant AC Sortie (A)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_inverter_ac_output_current_a",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 10,
+      "type": "timeseries",
+      "title": "Inverter - Fr\u00e9quence AC (Hz)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "hertz"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_inverter_ac_freq_hz",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 11,
+      "type": "state-timeline",
+      "title": "Inverter - AC Input Ignore",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_inverter_ac_in_ignore",
+          "legendFormat": "ac_in_ignore",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 105,
+      "type": "timeseries",
+      "title": "Inverter - Puissance DC (W)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_inverter_power_w",
+          "legendFormat": "inverter DC",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_inverter_ac_output_power_w",
+          "legendFormat": "AC sortie",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Environnement & Heatpumps",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 12,
+      "type": "timeseries",
+      "title": "Humidit\u00e9 (%)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "humidity",
+          "min": 0,
+          "max": 100
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_humidity_percent",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 13,
+      "type": "timeseries",
+      "title": "Heatpump - \u00c9nergie (kWh)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_heatpump_energy_kwh",
+          "legendFormat": "mqtt_{{mqtt_index}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "id": 14,
+      "type": "timeseries",
+      "title": "Heatpump - Target Temp (\u00b0C)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_heatpump_target_temp_c",
+          "legendFormat": "mqtt_{{mqtt_index}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "id": 15,
+      "type": "state-timeline",
+      "title": "Heatpump - \u00c9tat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_heatpump_state",
+          "legendFormat": "mqtt_{{mqtt_index}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 104,
+      "panels": [],
+      "title": "Chauffe-eau",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 16,
+      "type": "timeseries",
+      "title": "Chauffe-eau - Temp\u00e9rature (\u00b0C)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "wh_current_temp_c",
+          "legendFormat": "Actuelle",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "wh_target_temp_c",
+          "legendFormat": "Cible",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 17,
+      "type": "state-timeline",
+      "title": "Chauffe-eau - Mode",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "wh_mode",
+          "legendFormat": "mode",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "id": 201,
+      "panels": [],
+      "title": "Venus \u2014 \u00c9tats / connexion / pression",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "id": 202,
+      "type": "state-timeline",
+      "title": "Venus MPPT - \u00c9tat chargeur (code 0..11)",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_mppt_state",
+          "refId": "A",
+          "legendFormat": "instance {{instance}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 67
+      },
+      "id": 203,
+      "type": "timeseries",
+      "title": "Venus SmartShunt - \u00c9tat batterie + temps restant",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_shunt_state",
+          "refId": "A",
+          "legendFormat": "state (0=Idle 1=Chg 2=Dis)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_shunt_time_to_go_min",
+          "refId": "B",
+          "legendFormat": "time_to_go (min)"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 204,
+      "type": "state-timeline",
+      "title": "Venus Inverter - State / Mode",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_inverter_state",
+          "refId": "A",
+          "legendFormat": "state"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_inverter_mode",
+          "refId": "B",
+          "legendFormat": "mode"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 79
+      },
+      "id": 205,
+      "type": "timeseries",
+      "title": "Venus M\u00e9t\u00e9o - Pression (mbar)",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pressurembar"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_pressure_mbar",
+          "refId": "A",
+          "legendFormat": "instance {{instance}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      },
+      "id": 206,
+      "type": "state-timeline",
+      "title": "Venus - Connexion appareils",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_connected",
+          "refId": "A",
+          "legendFormat": "{{device_type}}/{{instance}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_heatpump_connected",
+          "refId": "B",
+          "legendFormat": "heatpump {{mqtt_index}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 91
+      },
+      "id": 207,
+      "type": "state-timeline",
+      "title": "Venus Heatpump - Position",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "venus_heatpump_position",
+          "refId": "A",
+          "legendFormat": "mqtt_index {{mqtt_index}}"
+        }
+      ]
+    }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["venus", "victron", "mppt", "smartshunt", "inverter", "heatpump", "water-heater"],
-  "templating": { "list": [{ "current": { "selected": false, "text": "Prometheus", "value": "prometheus" }, "hide": 0, "includeAll": false, "label": "Data Source", "multi": false, "name": "datasource", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" }] },
-  "time": { "from": "now-6h", "to": "now" },
+  "tags": [
+    "venus",
+    "victron",
+    "mppt",
+    "smartshunt",
+    "inverter",
+    "heatpump",
+    "water-heater"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Europe/Paris",
   "title": "Venus OS - Detail MPPT/SmartShunt/Inverter & Chauffe-eau",

--- a/crates/daly-bms-server/src/ats/mod.rs
+++ b/crates/daly-bms-server/src/ats/mod.rs
@@ -25,5 +25,5 @@
 pub mod types;
 pub mod poll;
 
-pub use types::{AtsCommand, AtsSnapshot};
+pub use types::{AtsCommand, AtsSnapshot, PhaseStatus};
 pub use poll::{execute_ats_command, run_ats_poll_loop};

--- a/crates/daly-bms-server/src/redb_writes.rs
+++ b/crates/daly-bms-server/src/redb_writes.rs
@@ -150,6 +150,172 @@ pub fn write_bms(writer: &Writer, rl: &RateLimiter, snap: &BmsSnapshot) {
                  .with_label("cell", cell_idx.to_string()),
              &format!("bms_cell_voltage:{}:{}", bms_id, cell_idx));
     }
+
+    // État d'équilibrage par cellule (Balances Cell1..N → 0/1).
+    for (key, &active) in snap.balances.iter() {
+        let cell_idx = key.trim_start_matches("Cell");
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("bms_cell_balancing", ts, active as f64)
+                 .with_label("bms_id", bms_id.clone())
+                 .with_label("cell", cell_idx.to_string()),
+             &format!("bms_cell_balancing:{}:{}", bms_id, cell_idx));
+    }
+
+    // ── État de santé & temps restant ────────────────────────────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_soh", ts, snap.soh as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_soh:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_time_to_go_secs", ts, snap.time_to_go as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_time_to_go_secs:{}", bms_id));
+
+    // ── États bool/flag ──────────────────────────────────────────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_balancing_active", ts, snap.balancing as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_balancing_active:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_system_switch", ts, snap.system_switch as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_system_switch:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_heating_active", ts, snap.heating as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_heating_active:{}", bms_id));
+
+    // ── Tensions / température DC ───────────────────────────────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_min_cell_voltage", ts, snap.system.min_cell_voltage as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_min_cell_voltage:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_max_cell_voltage", ts, snap.system.max_cell_voltage as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_max_cell_voltage:{}", bms_id));
+    push(writer, rl, TEMP_WRITE_INTERVAL,
+         Sample::new("bms_mos_temp_c", ts, snap.system.mos_temperature as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_mos_temp_c:{}", bms_id));
+
+    // ── Capacités (Ah) ───────────────────────────────────────────────────────
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("bms_consumed_ah", ts, snap.consumed_amphours as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_consumed_ah:{}", bms_id));
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("bms_capacity_remaining_ah", ts, snap.capacity as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_capacity_remaining_ah:{}", bms_id));
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("bms_reported_capacity_ah", ts, snap.bms_reported_capacity_ah as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_reported_capacity_ah:{}", bms_id));
+
+    // ── Modules ──────────────────────────────────────────────────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_modules_online", ts, snap.system.nr_of_modules_online as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_modules_online:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_modules_offline", ts, snap.system.nr_of_modules_offline as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_modules_offline:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_modules_blocking_charge", ts, snap.system.nr_of_modules_blocking_charge as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_modules_blocking_charge:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_modules_blocking_discharge", ts, snap.system.nr_of_modules_blocking_discharge as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_modules_blocking_discharge:{}", bms_id));
+
+    // ── Alarmes (13 flags) ──────────────────────────────────────────────────
+    let alarms: [(&str, u8); 13] = [
+        ("bms_alarm_low_voltage",            snap.alarms.low_voltage),
+        ("bms_alarm_high_voltage",           snap.alarms.high_voltage),
+        ("bms_alarm_low_soc",                snap.alarms.low_soc),
+        ("bms_alarm_high_charge_current",    snap.alarms.high_charge_current),
+        ("bms_alarm_high_discharge_current", snap.alarms.high_discharge_current),
+        ("bms_alarm_high_current",           snap.alarms.high_current),
+        ("bms_alarm_cell_imbalance",         snap.alarms.cell_imbalance),
+        ("bms_alarm_high_charge_temp",       snap.alarms.high_charge_temperature),
+        ("bms_alarm_low_charge_temp",        snap.alarms.low_charge_temperature),
+        ("bms_alarm_low_cell_voltage",       snap.alarms.low_cell_voltage),
+        ("bms_alarm_low_temp",               snap.alarms.low_temperature),
+        ("bms_alarm_high_temp",              snap.alarms.high_temperature),
+        ("bms_alarm_fuse_blown",             snap.alarms.fuse_blown),
+    ];
+    for (name, v) in alarms {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new(name, ts, v as f64).with_label("bms_id", bms_id.clone()),
+             &format!("{}:{}", name, bms_id));
+    }
+
+    // ── Historique de vie ────────────────────────────────────────────────────
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("bms_charge_cycles", ts, snap.history.charge_cycles as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_charge_cycles:{}", bms_id));
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("bms_min_voltage_hist", ts, snap.history.minimum_voltage as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_min_voltage_hist:{}", bms_id));
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("bms_max_voltage_hist", ts, snap.history.maximum_voltage as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_max_voltage_hist:{}", bms_id));
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("bms_total_ah_drawn", ts, snap.history.total_ah_drawn as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_total_ah_drawn:{}", bms_id));
+
+    // ── Limites de charge ───────────────────────────────────────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_charge_request", ts, snap.info.charge_request as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_charge_request:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_max_charge_voltage", ts, snap.info.max_charge_voltage as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_max_charge_voltage:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_max_charge_current", ts, snap.info.max_charge_current as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_max_charge_current:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_max_discharge_current", ts, snap.info.max_discharge_current as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_max_discharge_current:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_max_charge_cell_voltage", ts, snap.info.max_charge_cell_voltage as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_max_charge_cell_voltage:{}", bms_id));
+
+    // ── IO permissions (autorisations BMS) ──────────────────────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_balance_mos", ts, snap.io.allow_to_balance as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_balance_mos:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_heat_mos", ts, snap.io.allow_to_heat as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_heat_mos:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_external_relay", ts, snap.io.external_relay as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_external_relay:{}", bms_id));
+
+    // ── Chauffage (consigne / consommation) ─────────────────────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_heating_current", ts, snap.info.heating_current as f64)
+             .with_label("bms_id", bms_id.clone()),
+         &format!("bms_heating_current:{}", bms_id));
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("bms_heating_power", ts, snap.info.heating_power as f64)
+             .with_label("bms_id", bms_id),
+         &format!("bms_heating_power:{:02x}", snap.address));
 }
 
 // =============================================================================
@@ -189,6 +355,11 @@ pub fn write_et112(writer: &Writer, rl: &RateLimiter, snap: &Et112Snapshot) {
          Sample::new("et112_frequency_hz", ts, snap.frequency_hz as f64)
              .with_label("address", addr.clone()),
          &format!("et112_frequency_hz:{}", addr));
+
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("et112_reactive_power_var", ts, snap.reactive_power_var as f64)
+             .with_label("address", addr.clone()),
+         &format!("et112_reactive_power_var:{}", addr));
 
     // Énergie cumulée en Wh (convention VictoriaMetrics historique).
     push(writer, rl, ENERGY_WRITE_INTERVAL,
@@ -246,6 +417,36 @@ pub fn write_venus_mppt(writer: &Writer, rl: &RateLimiter, mppt: &VenusMppt) {
              Sample::new("venus_mppt_dc_current_a", ts, i as f64).with_label("instance", instance.clone()),
              &format!("venus_mppt_dc_current_a:{}", instance));
     }
+    // État du chargeur encodé en numérique : 0=Off, 1=Low power, 2=Fault, 3=Bulk,
+    // 4=Absorption, 5=Float, 6=Storage, 7=Equalize, 8=Passthru, 9=Inverting,
+    // 10=Power assist, 11=Power supply. Le `None` (état inconnu) ne produit rien.
+    if let Some(state_code) = mppt.state.as_ref().and_then(|s| mppt_state_to_code(s)) {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_mppt_state", ts, state_code as f64)
+                 .with_label("instance", instance.clone()),
+             &format!("venus_mppt_state:{}", instance));
+    }
+}
+
+/// Inverse du switch dans `handle_meteo_topic` : nom Victron → code numérique.
+fn mppt_state_to_code(label: &str) -> Option<i32> {
+    let code = match label {
+        "Off"          => 0,
+        "Low power"    => 1,
+        "Fault"        => 2,
+        "Bulk"         => 3,
+        "Absorption"   => 4,
+        "Float"        => 5,
+        "Storage"      => 6,
+        "Equalize"     => 7,
+        "Passthru"     => 8,
+        "Inverting"    => 9,
+        "Power assist" => 10,
+        "Power supply" => 11,
+        s if s.starts_with("State ") => s.trim_start_matches("State ").parse().ok()?,
+        _ => return None,
+    };
+    Some(code)
 }
 
 // =============================================================================
@@ -294,6 +495,27 @@ pub fn write_venus_smartshunt(writer: &Writer, rl: &RateLimiter, shunt: &VenusSm
         push(writer, rl, MIN_WRITE_INTERVAL,
              Sample::new("venus_shunt_ah_discharged_today", ts, v as f64),
              "venus_shunt_ah_discharged_today");
+    }
+    // Temps restant en minutes (None si en charge ou inconnu).
+    if let Some(v) = shunt.time_to_go_min {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_shunt_time_to_go_min", ts, v as f64),
+             "venus_shunt_time_to_go_min");
+    }
+    // État batterie : 0=Idle, 1=Charging, 2=Discharging, 3=Unknown.
+    if let Some(code) = shunt.state.as_ref().map(|s| shunt_state_to_code(s)) {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_shunt_state", ts, code as f64),
+             "venus_shunt_state");
+    }
+}
+
+fn shunt_state_to_code(label: &str) -> i32 {
+    match label {
+        "Idle"        => 0,
+        "Charging"    => 1,
+        "Discharging" => 2,
+        _             => 3,
     }
 }
 
@@ -347,6 +569,37 @@ pub fn write_venus_inverter(writer: &Writer, rl: &RateLimiter, inv: &VenusInvert
              Sample::new("venus_inverter_ac_in_ignore", ts, v as i32 as f64),
              "venus_inverter_ac_in_ignore");
     }
+    // États encodés en numérique (string → code).
+    let st_code = inverter_state_to_code(&inv.state);
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("venus_inverter_state", ts, st_code as f64),
+         "venus_inverter_state");
+    let mode_code = inverter_mode_to_code(&inv.mode);
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("venus_inverter_mode", ts, mode_code as f64),
+         "venus_inverter_mode");
+}
+
+/// État inverter Victron : 0=off, 1=on, 2=inverting, 3=charger, 4=passthrough, 5=other.
+fn inverter_state_to_code(label: &str) -> i32 {
+    match label.to_lowercase().as_str() {
+        "off"         => 0,
+        "on"          => 1,
+        "inverting"   => 2,
+        "charger"     => 3,
+        "passthrough" => 4,
+        _             => 5,
+    }
+}
+
+/// Mode inverter Victron : 0=charger, 1=inverter, 2=passthrough, 3=other.
+fn inverter_mode_to_code(label: &str) -> i32 {
+    match label.to_lowercase().as_str() {
+        "charger"     => 0,
+        "inverter"    => 1,
+        "passthrough" => 2,
+        _             => 3,
+    }
 }
 
 // =============================================================================
@@ -364,9 +617,20 @@ pub fn write_venus_temperature(writer: &Writer, rl: &RateLimiter, temp: &VenusTe
     }
     if let Some(h) = temp.humidity_percent {
         push(writer, rl, TEMP_WRITE_INTERVAL,
-             Sample::new("venus_humidity_percent", ts, h as f64).with_label("instance", instance),
+             Sample::new("venus_humidity_percent", ts, h as f64).with_label("instance", instance.clone()),
              &format!("venus_humidity_percent:{}", temp.instance));
     }
+    if let Some(p) = temp.pressure_mbar {
+        push(writer, rl, TEMP_WRITE_INTERVAL,
+             Sample::new("venus_pressure_mbar", ts, p as f64).with_label("instance", instance.clone()),
+             &format!("venus_pressure_mbar:{}", temp.instance));
+    }
+    // Bool de connexion : 0 = déconnecté, 1 = en ligne.
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("venus_connected", ts, temp.connected as i32 as f64)
+             .with_label("instance", instance)
+             .with_label("device_type", "temperature".to_string()),
+         &format!("venus_connected:temp:{}", temp.instance));
 }
 
 // =============================================================================
@@ -396,9 +660,19 @@ pub fn write_venus_heatpump(writer: &Writer, rl: &RateLimiter, hp: &VenusHeatpum
     }
     if let Some(t) = hp.target_temperature {
         push(writer, rl, TEMP_WRITE_INTERVAL,
-             Sample::new("venus_heatpump_target_temp_c", ts, t as f64).with_label("mqtt_index", idx),
+             Sample::new("venus_heatpump_target_temp_c", ts, t as f64).with_label("mqtt_index", idx.clone()),
              &format!("venus_heatpump_target_temp_c:{}", hp.mqtt_index));
     }
+    // Position : 0=AC Output, 1=AC Input.
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("venus_heatpump_position", ts, hp.position as f64)
+             .with_label("mqtt_index", idx.clone()),
+         &format!("venus_heatpump_position:{}", hp.mqtt_index));
+    // Connected (bool).
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("venus_heatpump_connected", ts, hp.connected as i32 as f64)
+             .with_label("mqtt_index", idx),
+         &format!("venus_heatpump_connected:{}", hp.mqtt_index));
 }
 
 // =============================================================================
@@ -451,6 +725,56 @@ pub fn write_ats(writer: &Writer, rl: &RateLimiter, snap: &AtsSnapshot) {
     push(writer, rl, MIN_WRITE_INTERVAL,
          Sample::new("ats_freq_hz", ts, af_hz as f64),
          "ats_freq_hz");
+
+    // ── Code de défaut (0 = aucun, 1..7 = défauts variés) ───────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("ats_fault", ts, snap.fault as i32 as f64),
+         "ats_fault");
+
+    // ── Modes / flags ATS ───────────────────────────────────────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("ats_sw_mode", ts, snap.sw_mode as i32 as f64),
+         "ats_sw_mode");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("ats_remote", ts, snap.remote as i32 as f64),
+         "ats_remote");
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("ats_middle_off", ts, snap.middle_off as i32 as f64),
+         "ats_middle_off");
+
+    // ── Statut par phase (0=Normal, 1=UnderVoltage, 2=OverVoltage, 3=Error) ─
+    let phases: [(&str, crate::ats::PhaseStatus); 6] = [
+        ("ats_phase_s1a", snap.s1a),
+        ("ats_phase_s1b", snap.s1b),
+        ("ats_phase_s1c", snap.s1c),
+        ("ats_phase_s2a", snap.s2a),
+        ("ats_phase_s2b", snap.s2b),
+        ("ats_phase_s2c", snap.s2c),
+    ];
+    for (name, status) in phases {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new(name, ts, status as i32 as f64),
+             name);
+    }
+
+    // ── Compteurs de commutation et runtime ─────────────────────────────────
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("ats_cnt1", ts, snap.cnt1 as f64),
+         "ats_cnt1");
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("ats_cnt2", ts, snap.cnt2 as f64),
+         "ats_cnt2");
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("ats_runtime_h", ts, snap.runtime_h as f64),
+         "ats_runtime_h");
+
+    // ── Tensions max historiques ────────────────────────────────────────────
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("ats_max1_v", ts, snap.max1_v as f64),
+         "ats_max1_v");
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("ats_max2_v", ts, snap.max2_v as f64),
+         "ats_max2_v");
 }
 
 // =============================================================================
@@ -481,6 +805,33 @@ pub fn write_tasmota(writer: &Writer, rl: &RateLimiter, snap: &TasmotaSnapshot) 
          Sample::new("tasmota_power_on", ts, snap.power_on as i32 as f64)
              .with_label("id", snap.id.to_string()),
          &format!("tasmota_power_on:{}", snap.id));
+
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("tasmota_apparent_power_va", ts, snap.apparent_power_va as f64)
+             .with_label("id", snap.id.to_string()),
+         &format!("tasmota_apparent_power_va:{}", snap.id));
+
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("tasmota_power_factor", ts, snap.power_factor as f64)
+             .with_label("id", snap.id.to_string()),
+         &format!("tasmota_power_factor:{}", snap.id));
+
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("tasmota_energy_yesterday_kwh", ts, snap.energy_yesterday_kwh as f64)
+             .with_label("id", snap.id.to_string()),
+         &format!("tasmota_energy_yesterday_kwh:{}", snap.id));
+
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("tasmota_energy_total_kwh", ts, snap.energy_total_kwh as f64)
+             .with_label("id", snap.id.to_string()),
+         &format!("tasmota_energy_total_kwh:{}", snap.id));
+
+    if let Some(rssi) = snap.rssi {
+        push(writer, rl, TEMP_WRITE_INTERVAL,
+             Sample::new("tasmota_rssi", ts, rssi as f64)
+                 .with_label("id", snap.id.to_string()),
+             &format!("tasmota_rssi:{}", snap.id));
+    }
 }
 
 // =============================================================================
@@ -517,8 +868,21 @@ pub fn write_shelly(writer: &Writer, rl: &RateLimiter, snap: &ShellyEmSnapshot) 
              &format!("shelly_output:{}:{}", id, ch_idx));
         push(writer, rl, ENERGY_WRITE_INTERVAL,
              Sample::new("shelly_energy_wh", ts, ch.energy_wh)
-                 .with_label("id", id.clone()).with_label("channel", ch_label),
+                 .with_label("id", id.clone()).with_label("channel", ch_label.clone()),
              &format!("shelly_energy_wh:{}:{}", id, ch_idx));
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("shelly_power_factor", ts, ch.power_factor as f64)
+                 .with_label("id", id.clone()).with_label("channel", ch_label.clone()),
+             &format!("shelly_power_factor:{}:{}", id, ch_idx));
+        push(writer, rl, ENERGY_WRITE_INTERVAL,
+             Sample::new("shelly_returned_wh", ts, ch.returned_wh)
+                 .with_label("id", id.clone()).with_label("channel", ch_label),
+             &format!("shelly_returned_wh:{}:{}", id, ch_idx));
+    }
+    if let Some(rssi) = snap.rssi {
+        push(writer, rl, TEMP_WRITE_INTERVAL,
+             Sample::new("shelly_rssi", ts, rssi as f64).with_label("id", id),
+             &format!("shelly_rssi:{}", snap.id));
     }
 }
 
@@ -609,6 +973,49 @@ pub fn write_monitor(writer: &Writer, rl: &RateLimiter, snap: &crate::state::Mon
         push(writer, rl, TEMP_WRITE_INTERVAL,
              Sample::new("pi5_cpu_temp_c", ts, t as f64),
              "pi5_cpu_temp_c");
+    }
+
+    // ── Totaux mémoire / swap (manquaient — utiles pour pourcentage calculé) ─
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("pi5_mem_total_mb", ts, snap.mem_total_mb as f64),
+         "pi5_mem_total_mb");
+    push(writer, rl, ENERGY_WRITE_INTERVAL,
+         Sample::new("pi5_swap_total_mb", ts, snap.swap_total_mb as f64),
+         "pi5_swap_total_mb");
+
+    // ── État port série RS485 ───────────────────────────────────────────────
+    push(writer, rl, MIN_WRITE_INTERVAL,
+         Sample::new("pi5_serial_port_ok", ts, snap.serial_port_ok as i32 as f64),
+         "pi5_serial_port_ok");
+
+    // ── État des services systemd (active=1, inactive=0) ────────────────────
+    for svc in &snap.services {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("pi5_service_active", ts, svc.active as i32 as f64)
+                 .with_label("name", svc.name.clone()),
+             &format!("pi5_service_active:{}", svc.name));
+    }
+    for svc in &snap.network_services {
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("pi5_network_service_active", ts, svc.active as i32 as f64)
+                 .with_label("name", svc.name.clone()),
+             &format!("pi5_network_service_active:{}", svc.name));
+    }
+
+    // ── Top processus par CPU% (cardinalité contrôlée par les filtres dans
+    //    monitor.rs — typiquement < 15 noms agrégés). ──────────────────────────
+    for proc in &snap.processes {
+        if proc.cpu_percent < 0.1 && proc.mem_rss_mb < 5.0 {
+            continue; // ignore bruit
+        }
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("pi5_process_cpu_percent", ts, proc.cpu_percent as f64)
+                 .with_label("process", proc.name.clone()),
+             &format!("pi5_process_cpu_percent:{}", proc.name));
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("pi5_process_mem_mb", ts, proc.mem_rss_mb as f64)
+                 .with_label("process", proc.name.clone()),
+             &format!("pi5_process_mem_mb:{}", proc.name));
     }
 }
 

--- a/docs/metrics-inventory.csv
+++ b/docs/metrics-inventory.csv
@@ -105,3 +105,86 @@ rule_eval_total,rule,count,energy-manager rule engine,rust-rule-engine (.grl eva
 wh_current_temp_c,,°C,LG ThinQ Cloud API,LG Therma V chauffe-eau,LG ThinQ API → energy-manager lg_thinq::spawn_poller() → santuario/em/water_heater → write_wh_metrics(),daly-bms-server,60s,aucun consommateur (orphelin — doublon de venus_heatpump_temp_c),Température eau actuelle
 wh_target_temp_c,,°C,LG ThinQ Cloud API,LG Therma V chauffe-eau,LG ThinQ API → energy-manager → santuario/em/water_heater → write_wh_metrics(),daly-bms-server,60s,aucun consommateur (orphelin — doublon de venus_heatpump_target_temp_c),Consigne température
 wh_mode,,int,LG ThinQ Cloud API,LG Therma V chauffe-eau,LG ThinQ API → energy-manager → santuario/em/water_heater → write_wh_metrics(),daly-bms-server,5s,aucun consommateur (orphelin — doublon de venus_heatpump_state),Mode chauffe-eau
+bms_alarm_low_voltage,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sous-tension pack
+bms_alarm_high_voltage,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sur-tension pack
+bms_alarm_low_soc,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,SOC trop bas
+bms_alarm_high_charge_current,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sur-courant charge
+bms_alarm_high_discharge_current,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sur-courant décharge
+bms_alarm_high_current,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sur-courant générique
+bms_alarm_cell_imbalance,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Déséquilibre cellules
+bms_alarm_high_charge_temp,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sur-température charge
+bms_alarm_low_charge_temp,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sous-température charge
+bms_alarm_low_cell_voltage,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sous-tension cellule
+bms_alarm_low_temp,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sous-température globale
+bms_alarm_high_temp,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Sur-température globale
+bms_alarm_fuse_blown,bms_id,bool,RS485 /dev/ttyUSB0,Daly BMS 0x01 (360Ah) / 0x02 (320Ah),RS485 cmd 0x98 → BmsSnapshot.alarms.* → state.on_bms_snapshot() → write_bms(),daly-bms-server,5s,Grafana bms-detail.json (Alarmes) | /dashboard/bms/:id,Fusible grillé
+bms_soh,bms_id,%,RS485,Daly BMS,RS485 cmd 0x90 → BmsSnapshot.soh,daly-bms-server,5s,Grafana bms-detail | /dashboard/bms,État de santé (dégradation pack)
+bms_time_to_go_secs,bms_id,s,RS485,Daly BMS,RS485 → BmsSnapshot.time_to_go,daly-bms-server,5s,Grafana bms-detail,Temps estimé restant décharge
+bms_balancing_active,bms_id,bool,RS485,Daly BMS,BmsSnapshot.balancing,daly-bms-server,5s,Grafana bms-detail,Équilibrage actif global
+bms_system_switch,bms_id,bool,RS485,Daly BMS,BmsSnapshot.system_switch,daly-bms-server,5s,Grafana bms-detail,Interrupteur principal
+bms_heating_active,bms_id,bool,RS485,Daly BMS,BmsSnapshot.heating,daly-bms-server,5s,Grafana bms-detail,Chauffage actif
+bms_min_cell_voltage,bms_id,V,RS485,Daly BMS,BmsSnapshot.system.min_cell_voltage,daly-bms-server,5s,Grafana bms-detail,Tension cellule min
+bms_max_cell_voltage,bms_id,V,RS485,Daly BMS,BmsSnapshot.system.max_cell_voltage,daly-bms-server,5s,Grafana bms-detail,Tension cellule max
+bms_mos_temp_c,bms_id,°C,RS485,Daly BMS,BmsSnapshot.system.mos_temperature,daly-bms-server,60s,Grafana bms-detail,Température MOSFET principal
+bms_consumed_ah,bms_id,Ah,RS485,Daly BMS,BmsSnapshot.consumed_amphours,daly-bms-server,30s,Grafana bms-detail,Ah consommés depuis pleine charge
+bms_capacity_remaining_ah,bms_id,Ah,RS485,Daly BMS,BmsSnapshot.capacity,daly-bms-server,30s,Grafana bms-detail,Capacité restante (estimation)
+bms_reported_capacity_ah,bms_id,Ah,RS485,Daly BMS,BmsSnapshot.bms_reported_capacity_ah (cmd 0x93),daly-bms-server,30s,Grafana bms-detail,Coulométrie BMS
+bms_cell_balancing,bms_id;cell,bool,RS485,Daly BMS,BmsSnapshot.balances (cmd 0x97) par cellule,daly-bms-server,5s,Grafana bms-detail,Équilibrage par cellule
+bms_modules_online,bms_id,cnt,RS485,Daly BMS,BmsSnapshot.system.nr_of_modules_online,daly-bms-server,5s,Grafana bms-detail,Modules en ligne
+bms_modules_offline,bms_id,cnt,RS485,Daly BMS,BmsSnapshot.system.nr_of_modules_offline,daly-bms-server,5s,Grafana bms-detail,Modules hors ligne
+bms_modules_blocking_charge,bms_id,cnt,RS485,Daly BMS,BmsSnapshot.system.nr_of_modules_blocking_charge,daly-bms-server,5s,Grafana bms-detail,Modules bloquant la charge
+bms_modules_blocking_discharge,bms_id,cnt,RS485,Daly BMS,BmsSnapshot.system.nr_of_modules_blocking_discharge,daly-bms-server,5s,Grafana bms-detail,Modules bloquant la décharge
+bms_charge_cycles,bms_id,cnt,RS485,Daly BMS,BmsSnapshot.history.charge_cycles,daly-bms-server,30s,Grafana bms-detail,Nombre de cycles charge effectués
+bms_min_voltage_hist,bms_id,V,RS485,Daly BMS,BmsSnapshot.history.minimum_voltage,daly-bms-server,30s,Grafana bms-detail,Tension min historique
+bms_max_voltage_hist,bms_id,V,RS485,Daly BMS,BmsSnapshot.history.maximum_voltage,daly-bms-server,30s,Grafana bms-detail,Tension max historique
+bms_total_ah_drawn,bms_id,Ah,RS485,Daly BMS,BmsSnapshot.history.total_ah_drawn,daly-bms-server,30s,Grafana bms-detail,Cumul Ah déchargés à vie
+bms_charge_request,bms_id,bool,RS485,Daly BMS,BmsSnapshot.info.charge_request,daly-bms-server,5s,Grafana bms-detail,Demande de charge active
+bms_max_charge_voltage,bms_id,V,RS485,Daly BMS,BmsSnapshot.info.max_charge_voltage,daly-bms-server,5s,Grafana bms-detail,Tension charge max autorisée
+bms_max_charge_current,bms_id,A,RS485,Daly BMS,BmsSnapshot.info.max_charge_current,daly-bms-server,5s,Grafana bms-detail,Courant charge max autorisé
+bms_max_discharge_current,bms_id,A,RS485,Daly BMS,BmsSnapshot.info.max_discharge_current,daly-bms-server,5s,Grafana bms-detail,Courant décharge max autorisé
+bms_max_charge_cell_voltage,bms_id,V,RS485,Daly BMS,BmsSnapshot.info.max_charge_cell_voltage,daly-bms-server,5s,Grafana bms-detail,Tension max cellule
+bms_balance_mos,bms_id,bool,RS485,Daly BMS,BmsSnapshot.io.allow_to_balance,daly-bms-server,5s,Grafana bms-detail,Autorisation équilibrage
+bms_heat_mos,bms_id,bool,RS485,Daly BMS,BmsSnapshot.io.allow_to_heat,daly-bms-server,5s,Grafana bms-detail,Autorisation chauffage
+bms_external_relay,bms_id,bool,RS485,Daly BMS,BmsSnapshot.io.external_relay,daly-bms-server,5s,Grafana bms-detail,Relais externe
+bms_heating_current,bms_id,A,RS485,Daly BMS,BmsSnapshot.info.heating_current,daly-bms-server,5s,Grafana bms-detail,Courant chauffage
+bms_heating_power,bms_id,W,RS485,Daly BMS,BmsSnapshot.info.heating_power,daly-bms-server,5s,Grafana bms-detail,Puissance chauffage
+et112_reactive_power_var,address,VAr,RS485,ET112 0x07/0x08/0x09,Et112Snapshot.reactive_power_var,daly-bms-server,5s,Grafana network-ats,Puissance réactive
+tasmota_apparent_power_va,id,VA,WiFi MQTT,Tasmota plug,TasmotaSnapshot.apparent_power_va,daly-bms-server,5s,Grafana smart-devices,Puissance apparente
+tasmota_power_factor,id,-1..+1,WiFi MQTT,Tasmota plug,TasmotaSnapshot.power_factor,daly-bms-server,5s,Grafana smart-devices,Facteur de puissance
+tasmota_energy_yesterday_kwh,id,kWh,WiFi MQTT,Tasmota plug,TasmotaSnapshot.energy_yesterday_kwh,daly-bms-server,30s,Grafana smart-devices,Énergie hier
+tasmota_energy_total_kwh,id,kWh,WiFi MQTT,Tasmota plug,TasmotaSnapshot.energy_total_kwh,daly-bms-server,30s,Grafana smart-devices,Énergie totale depuis mise en service
+tasmota_rssi,id,dBm,WiFi MQTT,Tasmota plug,TasmotaSnapshot.rssi,daly-bms-server,60s,Grafana smart-devices,Signal WiFi
+shelly_power_factor,id;channel,-1..+1,WiFi MQTT,Shelly Pro 2PM,ShellyChannelData.power_factor,daly-bms-server,5s,Grafana smart-devices,Facteur de puissance par canal
+shelly_returned_wh,id;channel,Wh,WiFi MQTT,Shelly Pro 2PM,ShellyChannelData.returned_wh,daly-bms-server,30s,Grafana smart-devices,Énergie retournée au réseau
+shelly_rssi,id,dBm,WiFi MQTT,Shelly Pro 2PM,ShellyEmSnapshot.rssi,daly-bms-server,60s,Grafana smart-devices,Signal WiFi
+ats_fault,,code,RS485,ATS CHINT,AtsSnapshot.fault (FaultCode enum),daly-bms-server,5s,Grafana network-ats,Code de défaut 0..7
+ats_sw_mode,,bool,RS485,ATS CHINT,AtsSnapshot.sw_mode (Auto/Manuel),daly-bms-server,5s,Grafana network-ats,Mode commutation (1=Auto)
+ats_remote,,bool,RS485,ATS CHINT,AtsSnapshot.remote,daly-bms-server,5s,Grafana network-ats,Télécommande activée
+ats_middle_off,,bool,RS485,ATS CHINT,AtsSnapshot.middle_off,daly-bms-server,5s,Grafana network-ats,Position centrale (double déclenché)
+ats_phase_s1a,,code,RS485,ATS CHINT,AtsSnapshot.s1a (PhaseStatus),daly-bms-server,5s,Grafana network-ats,Statut phase S1A : 0=Normal 1=UV 2=OV 3=Err
+ats_phase_s1b,,code,RS485,ATS CHINT,AtsSnapshot.s1b (PhaseStatus),daly-bms-server,5s,Grafana network-ats,Statut phase S1B : 0=Normal 1=UV 2=OV 3=Err
+ats_phase_s1c,,code,RS485,ATS CHINT,AtsSnapshot.s1c (PhaseStatus),daly-bms-server,5s,Grafana network-ats,Statut phase S1C : 0=Normal 1=UV 2=OV 3=Err
+ats_phase_s2a,,code,RS485,ATS CHINT,AtsSnapshot.s2a (PhaseStatus),daly-bms-server,5s,Grafana network-ats,Statut phase S2A : 0=Normal 1=UV 2=OV 3=Err
+ats_phase_s2b,,code,RS485,ATS CHINT,AtsSnapshot.s2b (PhaseStatus),daly-bms-server,5s,Grafana network-ats,Statut phase S2B : 0=Normal 1=UV 2=OV 3=Err
+ats_phase_s2c,,code,RS485,ATS CHINT,AtsSnapshot.s2c (PhaseStatus),daly-bms-server,5s,Grafana network-ats,Statut phase S2C : 0=Normal 1=UV 2=OV 3=Err
+ats_cnt1,,cnt,RS485,ATS CHINT,AtsSnapshot.cnt1,daly-bms-server,30s,Grafana network-ats,Compteur commutations S1→S2
+ats_cnt2,,cnt,RS485,ATS CHINT,AtsSnapshot.cnt2,daly-bms-server,30s,Grafana network-ats,Compteur commutations S2→S1
+ats_runtime_h,,h,RS485,ATS CHINT,AtsSnapshot.runtime_h,daly-bms-server,30s,Grafana network-ats,Heures de fonctionnement
+ats_max1_v,,V,RS485,ATS CHINT,AtsSnapshot.max1_v,daly-bms-server,30s,Grafana network-ats,Tension max historique source 1
+ats_max2_v,,V,RS485,ATS CHINT,AtsSnapshot.max2_v,daly-bms-server,30s,Grafana network-ats,Tension max historique source 2
+venus_mppt_state,instance,code,D-Bus,Victron MPPT,VenusMppt.state → code 0..11,daly-bms-server,5s,Grafana venus-detail,État chargeur MPPT
+venus_shunt_state,,code,D-Bus,Victron SmartShunt,VenusSmartShunt.state,daly-bms-server,5s,Grafana venus-detail,État batterie (0=Idle 1=Charging 2=Discharging)
+venus_shunt_time_to_go_min,,min,D-Bus,Victron SmartShunt,VenusSmartShunt.time_to_go_min,daly-bms-server,5s,Grafana venus-detail,Temps restant décharge
+venus_inverter_state,,code,D-Bus,Victron Inverter,VenusInverter.state,daly-bms-server,5s,Grafana venus-detail,État onduleur (0=off..5=other)
+venus_inverter_mode,,code,D-Bus,Victron Inverter,VenusInverter.mode,daly-bms-server,5s,Grafana venus-detail,Mode onduleur
+venus_pressure_mbar,instance,mbar,D-Bus,D-Bus Venus via MQTT (NanoPi 192.168.1.120),VenusTemperature.pressure_mbar,daly-bms-server,60s,Grafana venus-detail,Pression atmosphérique
+venus_connected,instance;device_type,bool,D-Bus,D-Bus Venus via MQTT (NanoPi 192.168.1.120),VenusTemperature.connected,daly-bms-server,5s,Grafana venus-detail,État de connexion appareil Venus
+venus_heatpump_position,mqtt_index,code,D-Bus,ET112 PAC / LG ThinQ,VenusHeatpump.position,daly-bms-server,5s,Grafana venus-detail,Position 0=AC Output 1=AC Input
+venus_heatpump_connected,mqtt_index,bool,D-Bus,ET112 PAC / LG ThinQ,VenusHeatpump.connected,daly-bms-server,5s,Grafana venus-detail,Connecté
+pi5_mem_total_mb,,MB,host Pi5,Pi5 host,MonitorSnapshot.mem_total_mb,daly-bms-server,30s,Grafana infrastructure,Mémoire totale
+pi5_swap_total_mb,,MB,host Pi5,Pi5 host,MonitorSnapshot.swap_total_mb,daly-bms-server,30s,Grafana infrastructure,Swap total
+pi5_serial_port_ok,,bool,host Pi5,Pi5 host,MonitorSnapshot.serial_port_ok,daly-bms-server,5s,Grafana infrastructure,RS485 disponible (/dev/ttyUSB0)
+pi5_service_active,name,bool,host Pi5,Pi5 host,MonitorSnapshot.services[].active,daly-bms-server,5s,Grafana infrastructure,systemctl is-active par service
+pi5_network_service_active,name,bool,host Pi5,Pi5 host,MonitorSnapshot.network_services[].active,daly-bms-server,5s,Grafana infrastructure,Probe TCP par service réseau
+pi5_process_cpu_percent,process,%,host Pi5,Pi5 host,MonitorSnapshot.processes[].cpu_percent,daly-bms-server,5s,Grafana infrastructure,CPU par processus (top-N)
+pi5_process_mem_mb,process,MB,host Pi5,Pi5 host,MonitorSnapshot.processes[].mem_rss_mb,daly-bms-server,5s,Grafana infrastructure,Mémoire RSS par processus


### PR DESCRIPTION
…iques (189 séries)

Audit complet réalisé en remontant aux sources physiques (BmsSnapshot, Et112Snapshot, AtsSnapshot, ShellyChannelData, TasmotaSnapshot, MonitorSnapshot, VenusMppt/Shunt/Inverter/Temperature/Heatpump) et non plus à l'inventaire CSV. Identifié 83 champs produits par les devices mais jamais écrits dans redb.

### BMS (RS485 Daly 0x01/0x02) — 33 nouvelles séries
- bms_soh : état de santé (%) ⚠️ critique
- 13 alarmes (bms_alarm_low_voltage, _high_voltage, _low_soc, _high_charge_current, _high_discharge_current, _high_current, _cell_imbalance, _high_charge_temp, _low_charge_temp, _low_cell_voltage, _low_temp, _high_temp, _fuse_blown)
- bms_time_to_go_secs, bms_balancing_active, bms_system_switch, bms_heating_active
- bms_min_cell_voltage, bms_max_cell_voltage, bms_mos_temp_c
- bms_consumed_ah, bms_capacity_remaining_ah, bms_reported_capacity_ah
- bms_cell_balancing (par cellule)
- bms_modules_online, _offline, _blocking_charge, _blocking_discharge
- bms_charge_cycles, bms_min/max_voltage_hist, bms_total_ah_drawn
- bms_charge_request, bms_max_charge_voltage/current, bms_max_discharge_current, bms_max_charge_cell_voltage
- bms_balance_mos, bms_heat_mos, bms_external_relay
- bms_heating_current, bms_heating_power

### ET112 — 1 nouvelle
- et112_reactive_power_var

### Tasmota (WiFi MQTT) — 5 nouvelles
- tasmota_apparent_power_va, _power_factor
- tasmota_energy_yesterday_kwh, _energy_total_kwh, _rssi

### Shelly Pro 2PM — 3 nouvelles
- shelly_power_factor (par canal)
- shelly_returned_wh (par canal, énergie retournée au réseau)
- shelly_rssi

### ATS CHINT (RS485) — 15 nouvelles
- ats_fault (code défaut 0..7)
- ats_sw_mode (Auto/Manuel), ats_remote, ats_middle_off
- 6 statuts phase (ats_phase_s1a/b/c, s2a/b/c)
- ats_cnt1, ats_cnt2, ats_runtime_h
- ats_max1_v, ats_max2_v

### Venus (D-Bus via NanoPi) — 9 nouvelles
- venus_mppt_state (encodage Off/Bulk/Float/... → code 0..11)
- venus_shunt_state, venus_shunt_time_to_go_min
- venus_inverter_state, venus_inverter_mode
- venus_pressure_mbar (météo)
- venus_connected (état connexion appareil)
- venus_heatpump_position, venus_heatpump_connected

### Pi5 monitoring — 7 nouvelles
- pi5_mem_total_mb, pi5_swap_total_mb
- pi5_serial_port_ok (RS485 disponible)
- pi5_service_active{name=...} (systemd par service)
- pi5_network_service_active{name=...} (probes TCP)
- pi5_process_cpu_percent{process=...} (top-N)
- pi5_process_mem_mb{process=...} (top-N)

### Couverture finale
| Avant | Après |
|-------|-------|
| 106 métriques | 189 métriques |
| 75 % devices captés | 100 % |
| 5 dashboards Grafana | 5 dashboards (+ 41 nouveaux panels) |

41 nouveaux panels Grafana générés (un par groupe de métriques) : bms-detail (15), network-ats (8), infrastructure (6), smart-devices (6), venus-detail (6) — chacun sous une row dédiée "Étendu".

Validation automatique : 0 métrique de l'inventaire absente de Grafana, 0 panel orphelin (toute expr Grafana correspond à une série produite).

docs/metrics-inventory.csv mis à jour (189 lignes).

https://claude.ai/code/session_0162nnTNLAWGXFE2YoX5apom