### PR TITLE
fix(config): correct SmartShunt instance from 290 to 274

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -555,7 +555,7 @@ shelly_deye_channel  = 0
 tasmota_waterheater_id = "tongou_3BC764"
 # SmartShunt device instance sur Venus OS — vérifier avec :
 #   ssh root@192.168.1.120 "dbus -y | grep battery"
-smartshunt_instance  = 290             # à ajuster selon dbus-spy
+smartshunt_instance  = 274             # VRM ID 274 (Battery Monitor)
 
 # --- Open-Meteo (météo locale) ---
 [energy_manager.open_meteo]

--- a/contrib/mosquitto/mosquitto.conf
+++ b/contrib/mosquitto/mosquitto.conf
@@ -116,7 +116,7 @@ topic shellypro2pm-ec62608840a4/rpc out 0 "" ""
 # -----------------------------------------------------------------------------
 # Venus OS télémétriques (Cerbo GX) — topics spécifiques
 # Source de vérité : crates/energy-manager/src/mqtt/topics.rs::all_subscriptions()
-# Instance mapping : vebus=275, mppt1=273, mppt2=289, pvinv=32, shunt=290
+# Instance mapping : vebus=275, mppt1=273, mppt2=289, pvinv=32, shunt=274
 # GX IO Extender 150 : switch VRM ID 50
 # Mettre à jour ce bloc si Config.toml [energy_manager.victron] change.
 

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -137,7 +137,7 @@ pub struct VictronConfig {
     /// Tasmota device ID for water heater relay (e.g. "tongou_3BC764")
     #[serde(default)]
     pub tasmota_waterheater_id: String,
-    /// SmartShunt device instance on Venus OS (e.g. 290)
+    /// SmartShunt device instance on Venus OS (VRM ID 274)
     #[serde(default = "default_smartshunt_instance")]
     pub smartshunt_instance: u32,
 }
@@ -146,7 +146,7 @@ fn default_vebus_instance() -> u32 { 275 }
 fn default_mppt1_instance() -> u32 { 273 }
 fn default_mppt2_instance() -> u32 { 289 }
 fn default_pvinv_instance() -> u32 { 32 }
-fn default_smartshunt_instance() -> u32 { 290 }
+fn default_smartshunt_instance() -> u32 { 274 }
 
 // ---------------------------------------------------------------------------
 // Open-Meteo

--- a/docs/energy-manager-rules-reference.md
+++ b/docs/energy-manager-rules-reference.md
@@ -451,7 +451,7 @@ Les valeurs `ats_position` et `ats_state` restent à leur défaut (0) dans Energ
 
 **`[energy_manager.victron]`** :
 - portal_id (**obligatoire**)
-- vebus_instance (275), mppt1 (273), mppt2 (289), pvinverter (32), smartshunt (290)
+- vebus_instance (275), mppt1 (273), mppt2 (289), pvinverter (32), smartshunt (274)
 - shelly_deye_id, shelly_deye_channel
 - tasmota_waterheater_id
 


### PR DESCRIPTION
The SmartShunt Battery Monitor has VRM ID 274, not 290. With the wrong instance, the energy-manager subscribed to battery/290/... (no data) and fell back to system/0/Dc/Battery/* aggregates. Direct SmartShunt readings (Voltage, Current, Power, Soc, TimeToGo, State) were never received.

Fixed in: Config.toml, config.rs default, mosquitto.conf comment, and energy-manager-rules-reference.md.

https://claude.ai/code/session_01TZRDiTZR3TG5snKTeur1En