### PR TITLE
fix(rs485): corrections suite review Gemini Code Assist (PR #512)

### DIFF
--- a/crates/daly-bms-core/src/bus.rs
+++ b/crates/daly-bms-core/src/bus.rs
@@ -109,7 +109,7 @@ impl DalyPort {
         // Acquérir le verrou exclusif pour toute la transaction
         let mut guard = self.bus.acquire().await;
 
-        guard.flush_rx().await;
+        guard.flush_rx();
         guard.write_all(req_bytes).await?; // std::io::Error → DalyError::Io via #[from]
         guard.inter_frame_delay().await;
 
@@ -205,7 +205,7 @@ impl DalyPort {
         let request = RequestFrame::read(bms_address, cmd);
 
         let mut guard = self.bus.acquire().await;
-        guard.flush_rx().await;
+        guard.flush_rx();
 
         let req_bytes = request.as_bytes();
         trace!(

--- a/crates/daly-bms-core/src/poll.rs
+++ b/crates/daly-bms-core/src/poll.rs
@@ -112,6 +112,8 @@ pub async fn poll_loop<F, E>(
                     on_snapshot(snapshot);
                 }
                 Err(DalyError::Timeout { .. }) => {
+                    // Timeout = port série fonctionnel, juste le BMS qui ne répond pas
+                    consecutive_serial_errors = 0;
                     warn!(
                         bms = format!("{:#04x}", device.address),
                         "Timeout — BMS peut-être hors ligne"
@@ -142,6 +144,8 @@ pub async fn poll_loop<F, E>(
                     break; // sortir de la boucle devices et réessayer le cycle
                 }
                 Err(e) => {
+                    // CRC/trame invalide = port série fonctionnel (bruit ou réponse corrompue)
+                    consecutive_serial_errors = 0;
                     let msg = format!("{:?}", e);
                     warn!(
                         bms = format!("{:#04x}", device.address),

--- a/crates/daly-bms-server/src/ats/poll.rs
+++ b/crates/daly-bms-server/src/ats/poll.rs
@@ -82,7 +82,7 @@ async fn read_reg(bus: &SharedBus, addr: u8, reg: u16, timeout_ms: u64) -> Optio
     tokio::time::sleep(Duration::from_millis(INTER_REG_DELAY_MS)).await;
 
     let mut guard = bus.acquire().await;
-    guard.flush_rx().await;
+    guard.flush_rx();
     guard.write_all(&req).await.ok()?;
     guard.inter_frame_delay().await;
     match guard.read_exact_with_timeout(resp_len, timeout_ms).await {
@@ -153,8 +153,9 @@ where
         "ATS CHINT polling démarré (lecture registre par registre)"
     );
 
-    // Détection du modèle au démarrage
-    let model = detect_model(&bus, addr).await;
+    // Détection du modèle au démarrage (peut retourner "BN" si l'ATS est hors tension).
+    // Sera redétecté dès que l'ATS revient en ligne après une absence prolongée.
+    let mut model = detect_model(&bus, addr).await;
     info!(addr = format!("{:#04x}", addr), model = %model, "Modèle ATS détecté");
 
     let mut consecutive_errors: u32 = 0;
@@ -178,10 +179,11 @@ where
                     "ATS snapshot OK"
                 );
                 if consecutive_errors >= FAST_TIMEOUT_AFTER {
-                    info!(
-                        addr = format!("{:#04x}", addr),
-                        "ATS de nouveau en ligne — timeout restauré à {}ms", FULL_TIMEOUT_MS
-                    );
+                    // L'ATS revient en ligne après une absence — redétecter le modèle
+                    // car detect_model() au démarrage avait peut-être échoué (ATS absent).
+                    info!(addr = format!("{:#04x}", addr), "ATS de nouveau en ligne — redétection du modèle");
+                    model = detect_model(&bus, addr).await;
+                    info!(addr = format!("{:#04x}", addr), model = %model, "Modèle ATS redétecté");
                 }
                 consecutive_errors = 0;
                 on_result(addr, &cfg.name, Ok(()));
@@ -231,7 +233,7 @@ async fn poll_ats(
 ) -> anyhow::Result<AtsSnapshot> {
 
     // ── Tensions source 1 ────────────────────────────────────────────────────
-    let v1a = read_reg(bus, addr, 0x0006, timeout_ms).await.ok_or_else(|| anyhow::anyhow!("Timeout 0x0006 (v1a)"))? as f32;
+    let v1a = read_reg(bus, addr, 0x0006, timeout_ms).await.ok_or_else(|| anyhow::anyhow!("Erreur lecture 0x0006 (v1a)"))? as f32;
     let v1b = read_reg(bus, addr, 0x0007, timeout_ms).await.unwrap_or(0) as f32;
     let v1c = read_reg(bus, addr, 0x0008, timeout_ms).await.unwrap_or(0) as f32;
 

--- a/crates/rs485-bus/src/lib.rs
+++ b/crates/rs485-bus/src/lib.rs
@@ -20,11 +20,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Mutex;
+use tokio_serial::{ClearBuffer, SerialPort};
 use tracing::trace;
-
-/// Timeout du flush RX (drain des octets résiduels avant émission).
-/// 50 ms pour absorber les trames parasites laissées par un appareil hors tension.
-const FLUSH_TIMEOUT_MS: u64 = 50;
 
 // =============================================================================
 // SharedBus
@@ -93,7 +90,7 @@ impl SharedBus {
     /// Pour des transactions complexes (Daly multi-trame), utiliser [`acquire()`].
     pub async fn transact(&self, tx: &[u8], resp_len: usize) -> anyhow::Result<Vec<u8>> {
         let mut guard = self.acquire().await;
-        guard.flush_rx().await;
+        guard.flush_rx();
         guard.write_all(tx).await
             .map_err(|e| anyhow::anyhow!("TX erreur : {}", e))?;
         guard.inter_frame_delay().await;
@@ -121,13 +118,12 @@ pub struct BusGuard<'a> {
 
 impl<'a> BusGuard<'a> {
     /// Vide le buffer RX (drain les octets résiduels d'une transaction précédente).
-    pub async fn flush_rx(&mut self) {
-        let mut tmp = [0u8; 256];
-        let _ = tokio::time::timeout(
-            Duration::from_millis(FLUSH_TIMEOUT_MS),
-            self.port.read(&mut tmp),
-        )
-        .await;
+    ///
+    /// Utilise `clear(ClearBuffer::Input)` — opération noyau non-bloquante (tcflush).
+    /// N'ajoute aucune latence quand le bus est calme, contrairement à une lecture
+    /// avec timeout.
+    pub fn flush_rx(&mut self) {
+        let _ = self.port.clear(ClearBuffer::Input);
     }
 
     /// Écrit tous les octets dans le port + flush.


### PR DESCRIPTION
4 corrections identifiées par code review post-merge :

1. flush_rx non-bloquant (rs485-bus/src/lib.rs) : Remplace la lecture avec timeout (50 ms de latence par transaction) par self.port.clear(ClearBuffer::Input) — ioctl noyau instantané. Supprime ~50 ms de surcharge inutile sur chaque transaction BMS/ET112.

2. Redétection modèle ATS au retour en ligne (ats/poll.rs) : detect_model() peut retourner "BN" si l'ATS est absent au démarrage. Désormais model est mutable et redétecté dès que consecutive_errors repasse à 0 après FAST_TIMEOUT_AFTER échecs — évite de rater les registres MN-spécifiques après reconnexion.

3. Reset consecutive_serial_errors sur Timeout/Other (poll.rs) : Un Timeout ou une erreur CRC prouve que le port série est fonctionnel. On remet consecutive_serial_errors à 0 dans ces branches pour éviter qu'une erreur série ancienne (séparée par des timeouts) déclenche à tort le backoff exponentiel persistant.

4. Message d'erreur générique pour read_reg (ats/poll.rs) : "Timeout 0x0006 (v1a)" → "Erreur lecture 0x0006 (v1a)" car read_reg peut échouer pour d'autres raisons (CRC, exception Modbus).

https://claude.ai/code/session_0141bsKixi8n7fwAzGpeeP88