### PR TITLE
perf(metrics-store): audit robustesse & perf — correctifs R1-R4, P1-P…

### DIFF
--- a/crates/metrics-store/src/lib.rs
+++ b/crates/metrics-store/src/lib.rs
@@ -84,16 +84,35 @@ impl Default for TierPolicy {
 
 struct Inner {
     db: Arc<Database>,
-    writer_tx: parking_lot::Mutex<Option<mpsc::Sender<Sample>>>,
+    writer_tx: parking_lot::Mutex<Option<mpsc::Sender<writer::WriterMsg>>>,
     writer_handle: parking_lot::Mutex<Option<thread::JoinHandle<()>>>,
 }
 
 impl Drop for Inner {
     fn drop(&mut self) {
-        // 1. Ferme le canal en libérant le `Sender` (les `Writer` clones
-        //    encore vivants côté caller maintiennent le canal ouvert ; on
-        //    documente que le store doit être dropé en dernier).
-        self.writer_tx.lock().take();
+        // 1. Signale l'arrêt au thread writer via une sentinelle in-band.
+        //    Contrairement à la simple fermeture du canal, cela arrête le
+        //    writer **même si des `Writer` clones survivent** côté appelant
+        //    (sinon `blocking_recv` ne retournerait jamais `None` et le
+        //    `join()` ci-dessous bloquerait indéfiniment — correctif R2).
+        if let Some(tx) = self.writer_tx.lock().take() {
+            // `try_send` (non bloquant) : `Drop` peut s'exécuter dans un
+            // runtime tokio où `blocking_send` paniquerait. Si la file est
+            // pleine, on laisse au writer le temps de drainer puis on
+            // réessaie (borné à ~100 ms) avant de relâcher le `Sender`.
+            let mut msg = writer::WriterMsg::Shutdown;
+            for _ in 0..50 {
+                match tx.try_send(msg) {
+                    Ok(()) => break,
+                    Err(mpsc::error::TrySendError::Closed(_)) => break,
+                    Err(mpsc::error::TrySendError::Full(m)) => {
+                        msg = m;
+                        thread::sleep(std::time::Duration::from_millis(2));
+                    }
+                }
+            }
+            drop(tx);
+        }
         // 2. Attend la fin du thread writer pour relâcher le lock redb
         //    avant le `Drop` de `Arc<Database>`. Sans ce join, une
         //    réouverture immédiate de la base échouerait avec "Database
@@ -130,7 +149,7 @@ impl MetricsStore {
             tx.commit()?;
         }
 
-        let (writer_tx, writer_rx) = mpsc::channel::<Sample>(opts.writer_queue_depth);
+        let (writer_tx, writer_rx) = mpsc::channel::<writer::WriterMsg>(opts.writer_queue_depth);
         let writer_handle = writer::spawn(db.clone(), writer_rx, opts.writer);
 
         Ok(Self {
@@ -500,6 +519,133 @@ mod tests {
             assert!(id_c >= 3, "id_c={id_c} doit être ≥ 3 (pas de réutilisation)");
         }
 
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// R2 : dropper le store alors qu'un `Writer` clone survit ne doit PAS
+    /// bloquer indéfiniment (sentinelle `Shutdown` in-band).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drop_store_with_live_writer_clone_does_not_hang() {
+        let path = tmp_db_path("r2");
+        let _ = std::fs::remove_file(&path);
+
+        let opts = Options {
+            writer: WriterConfig { batch_max: 4, flush_ms: 20, poll_idle_ms: 2 },
+            ..Options::default()
+        };
+        let store = MetricsStore::open(&path, opts).expect("open");
+        let w = store.writer();
+        w.write(Sample::new("x", 1, 1.0)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        // Drop dans un thread bloquant, borné par timeout : en cas de
+        // régression R2 le `join()` resterait bloqué > 5 s.
+        let res = tokio::time::timeout(
+            Duration::from_secs(5),
+            tokio::task::spawn_blocking(move || drop(store)),
+        )
+        .await;
+        assert!(res.is_ok(), "drop(store) a bloqué malgré un Writer clone vivant — régression R2");
+
+        // Le clone survit et reste utilisable sans paniquer (les writes vont
+        // au néant après arrêt du writer — best-effort).
+        let _ = w.try_write(Sample::new("x", 2, 2.0));
+        drop(w);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// R4 : une seconde passe de compaction sur une heure déjà compactée doit
+    /// FUSIONNER avec le bucket existant, pas l'écraser.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn compaction_merges_existing_bucket_not_overwrite() {
+        use crate::tiering::{compact_raw_to_hourly, HOURLY_MS};
+
+        let path = tmp_db_path("r4");
+        let _ = std::fs::remove_file(&path);
+        {
+            let opts = Options {
+                writer: WriterConfig { batch_max: 1, flush_ms: 20, poll_idle_ms: 2 },
+                ..Options::default()
+            };
+            let store = MetricsStore::open(&path, opts).expect("open");
+            let w = store.writer();
+
+            // 3 points dans l'heure 0.
+            for ts in [0_i64, 1000, 2000] {
+                w.write(Sample::new("p", ts, 10.0)).await.unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(150)).await;
+
+            let s1 = compact_raw_to_hourly(&store.inner.db, 3000).unwrap();
+            assert_eq!(s1.buckets_written, 1);
+            assert_eq!(s1.points_purged, 3);
+
+            // 2 points supplémentaires DANS LA MÊME heure 0, après compaction.
+            w.write(Sample::new("p", 2500, 20.0)).await.unwrap();
+            w.write(Sample::new("p", 2800, 20.0)).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(150)).await;
+
+            let s2 = compact_raw_to_hourly(&store.inner.db, 3000).unwrap();
+            assert_eq!(s2.buckets_written, 1);
+            assert_eq!(s2.points_purged, 2);
+
+            let reader = store.reader();
+            let sid = reader.lookup_series_id("p", "{}").unwrap().unwrap();
+            let hourly = reader
+                .query_range_buckets(sid, 0, HOURLY_MS, Tier::Hourly)
+                .unwrap();
+            assert_eq!(hourly.len(), 1);
+            let b = hourly[0].1;
+            // Fusion : 3 + 2 = 5 points, somme 30 + 40 = 70 (pas écrasé à 2/40).
+            assert_eq!(b.cnt, 5, "bucket écrasé au lieu d'être fusionné (R4)");
+            assert!((b.sum - 70.0).abs() < 1e-9, "sum={}", b.sum);
+            assert_eq!(b.min, 10.0);
+            assert_eq!(b.max, 20.0);
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// M1 : réutiliser un `Evaluator` pour deux requêtes instant différentes
+    /// ne doit pas renvoyer un résultat périmé (cache keyé par pointeur vidé
+    /// au début de chaque évaluation).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn evaluator_reuse_distinct_instant_queries() {
+        use crate::promql::{parse_and_validate, Evaluator};
+
+        let path = tmp_db_path("m1");
+        let _ = std::fs::remove_file(&path);
+        {
+            let opts = Options {
+                writer: WriterConfig { batch_max: 64, flush_ms: 20, poll_idle_ms: 2 },
+                ..Options::default()
+            };
+            let store = MetricsStore::open(&path, opts).expect("open");
+            let w = store.writer();
+            for i in 0..10_i64 {
+                let ts = 100_000 + i * 1_000;
+                w.write(Sample::new("bms_v", ts, 1.0 + i as f64 / 10.0).with_label("bms_id", "1"))
+                    .await
+                    .unwrap();
+                w.write(Sample::new("bms_v", ts, 2.0 + i as f64 / 10.0).with_label("bms_id", "2"))
+                    .await
+                    .unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(150)).await;
+
+            let reader = store.reader();
+            let ev = Evaluator::new(&reader);
+
+            // 1ʳᵉ requête : tous les bms_v → 2 séries.
+            let e1 = parse_and_validate("bms_v").unwrap();
+            let v1 = ev.eval_instant(&e1, 109_000).unwrap();
+            assert_eq!(v1.len(), 2);
+
+            // 2ᵉ requête sur le MÊME Evaluator, sélecteur plus restrictif → 1 série.
+            let e2 = parse_and_validate(r#"bms_v{bms_id="1"}"#).unwrap();
+            let v2 = ev.eval_instant(&e2, 109_000).unwrap();
+            assert_eq!(v2.len(), 1, "résultat périmé du cache pointeur (régression M1)");
+            assert!((v2[0].value - 1.9).abs() < 1e-9);
+        }
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/metrics-store/src/promql/exec.rs
+++ b/crates/metrics-store/src/promql/exec.rs
@@ -140,6 +140,11 @@ impl<'r> Evaluator<'r> {
         if end_ms < start_ms {
             return Err(PromQlError::Execution("end < start".into()));
         }
+        // M1 : le cache est keyé par adresse mémoire de `VectorSelector`.
+        // On le vide avant toute évaluation pour qu'une réutilisation de
+        // l'Evaluator sur une autre expression (dont un nœud aurait été
+        // réalloué à la même adresse) ne renvoie jamais un résultat périmé.
+        self.match_cache.borrow_mut().clear();
         let mut by_labels: BTreeMap<Arc<Labels>, Vec<(i64, f64)>> = BTreeMap::new();
         // Sentinelle pour les valeurs scalaires (labels vides). Partagée
         // sur tous les steps scalaires pour éviter N allocations.
@@ -179,6 +184,10 @@ impl<'r> Evaluator<'r> {
 
     /// Évalue `expr` à un instant unique (équivalent `/api/v1/query`).
     pub fn eval_instant(&self, expr: &Expr, t_ms: i64) -> Result<Vec<InstantSample>, PromQlError> {
+        // M1 : cf. note dans `eval_range` — invalide le cache keyé par
+        // pointeur avant toute évaluation pour éviter un faux positif
+        // d'adresse mémoire réutilisée.
+        self.match_cache.borrow_mut().clear();
         match self.eval_at(expr, t_ms)? {
             Value::Scalar(v) => Ok(vec![InstantSample { labels: Arc::new(Labels::new()), value: v }]),
             Value::Vector(s) => Ok(s),
@@ -233,12 +242,14 @@ impl<'r> Evaluator<'r> {
         let rtx = self.txn()?;
         let mut out = Vec::with_capacity(matched.len());
         for (sid, labels) in matched.iter() {
-            let pts = self
+            // P2 : seul le dernier point de la fenêtre de lookback est
+            // nécessaire — scan inverse au lieu de matérialiser tout le Vec.
+            let last = self
                 .reader
-                .query_range_raw_with_tx(rtx, *sid, t - self.lookback_ms, t)
+                .last_point_in_range_with_tx(rtx, *sid, t - self.lookback_ms, t)
                 .map_err(|e| PromQlError::Execution(e.to_string()))?;
-            if let Some((_, v)) = pts.last() {
-                out.push(InstantSample { labels: labels.clone(), value: *v });
+            if let Some((_, v)) = last {
+                out.push(InstantSample { labels: labels.clone(), value: v });
             }
         }
         Ok(Value::Vector(out))
@@ -328,8 +339,18 @@ impl<'r> Evaluator<'r> {
         let matched = self.match_series(vs)?;
         let rtx = self.txn()?;
         let mut out = Vec::with_capacity(matched.len());
+        // P2 : `increase`/`rate`/`delta`/`last_over_time` n'utilisent que les
+        // bornes de la fenêtre → on évite de charger tous les points.
+        let endpoints_only = matches!(name, "increase" | "rate" | "delta" | "last_over_time");
         for (sid, labels) in matched.iter() {
             let value_opt = match tier {
+                Tier::Raw if endpoints_only => {
+                    let fl = self
+                        .reader
+                        .first_last_in_range_with_tx(rtx, *sid, win_start, t)
+                        .map_err(|e| PromQlError::Execution(e.to_string()))?;
+                    apply_range_fn_endpoints(name, fl, range_ms)
+                }
                 Tier::Raw => {
                     let pts = self
                         .reader
@@ -509,6 +530,23 @@ fn apply_range_fn_raw(name: &str, pts: &[(i64, f64)], range_ms: i64) -> Option<f
     })
 }
 
+/// Variante de [`apply_range_fn_raw`] limitée aux fonctions qui n'ont besoin
+/// que du premier et du dernier point de la fenêtre. Sémantique identique à
+/// `apply_range_fn_raw` pour `increase`/`rate`/`delta`/`last_over_time`.
+fn apply_range_fn_endpoints(
+    name: &str,
+    fl: Option<((i64, f64), (i64, f64))>,
+    range_ms: i64,
+) -> Option<f64> {
+    let ((_, first_v), (_, last_v)) = fl?;
+    Some(match name {
+        "increase" | "delta" => last_v - first_v,
+        "rate" => (last_v - first_v) / (range_ms as f64 / 1000.0),
+        "last_over_time" => last_v,
+        _ => return None,
+    })
+}
+
 fn apply_range_fn_buckets(
     name: &str,
     buckets: &[(i64, AggBucket)],
@@ -560,7 +598,9 @@ fn align_and_op(
             (l, s.value)
         })
         .collect();
-    let mut out = Vec::new();
+    // P4 : pré-dimensionne le résultat (au plus min(|lhs|, |rhs|) paires
+    // alignées) pour éviter les réallocations successives du Vec.
+    let mut out = Vec::with_capacity(lhs.len().min(rhs_idx.len()));
     for s in lhs {
         let mut key = (*s.labels).clone();
         key.remove("__name__");

--- a/crates/metrics-store/src/reader.rs
+++ b/crates/metrics-store/src/reader.rs
@@ -56,6 +56,35 @@ impl Reader {
         query_range_raw_inner(rtx, series_id, from_ms, to_ms)
     }
 
+    /// Dernier point `(ts, value)` de `[from_ms, to_ms]` (le plus récent).
+    ///
+    /// Évite de matérialiser toute la fenêtre quand seul le dernier point
+    /// est nécessaire (instant vector selector PromQL). Scan inverse O(1)
+    /// au lieu d'allouer un `Vec` de toute la fenêtre de lookback.
+    pub fn last_point_in_range_with_tx(
+        &self,
+        rtx: &ReadTransaction,
+        series_id: u32,
+        from_ms: i64,
+        to_ms: i64,
+    ) -> Result<Option<(i64, f64)>> {
+        last_point_in_range_inner(rtx, series_id, from_ms, to_ms)
+    }
+
+    /// Premier et dernier point de `[from_ms, to_ms]`. Utilisé par
+    /// `increase` / `rate` / `delta` / `last_over_time` qui n'ont besoin que
+    /// des deux bornes — évite de charger toute la fenêtre.
+    #[allow(clippy::type_complexity)]
+    pub fn first_last_in_range_with_tx(
+        &self,
+        rtx: &ReadTransaction,
+        series_id: u32,
+        from_ms: i64,
+        to_ms: i64,
+    ) -> Result<Option<((i64, f64), (i64, f64))>> {
+        first_last_in_range_inner(rtx, series_id, from_ms, to_ms)
+    }
+
     /// Range scan sur les tables compactées (hourly/daily). Renvoie les
     /// `AggBucket` désérialisés.
     pub fn query_range_buckets(
@@ -120,6 +149,58 @@ fn query_range_raw_inner(
     Ok(out)
 }
 
+fn last_point_in_range_inner(
+    rtx: &ReadTransaction,
+    series_id: u32,
+    from_ms: i64,
+    to_ms: i64,
+) -> Result<Option<(i64, f64)>> {
+    let t = rtx.open_table(TABLE_RAW)?;
+    let k_lo = enc_skey(series_id, from_ms);
+    let k_hi = enc_skey(series_id, to_ms);
+    let mut range = t.range::<&[u8]>(&k_lo[..]..=&k_hi[..])?;
+    match range.next_back() {
+        Some(entry) => {
+            let (k, v) = entry?;
+            let (_sid, ts) = dec_skey(k.value());
+            Ok(Some((ts, v.value())))
+        }
+        None => Ok(None),
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn first_last_in_range_inner(
+    rtx: &ReadTransaction,
+    series_id: u32,
+    from_ms: i64,
+    to_ms: i64,
+) -> Result<Option<((i64, f64), (i64, f64))>> {
+    let t = rtx.open_table(TABLE_RAW)?;
+    let k_lo = enc_skey(series_id, from_ms);
+    let k_hi = enc_skey(series_id, to_ms);
+    let mut range = t.range::<&[u8]>(&k_lo[..]..=&k_hi[..])?;
+    let first = match range.next() {
+        Some(entry) => {
+            let (k, v) = entry?;
+            let (_sid, ts) = dec_skey(k.value());
+            (ts, v.value())
+        }
+        None => return Ok(None),
+    };
+    // `next_back` sur l'itérateur déjà avancé : renvoie le dernier point
+    // restant, ou `None` s'il n'y avait qu'un seul élément (alors last=first).
+    let last = match range.next_back() {
+        Some(entry) => {
+            let (k, v) = entry?;
+            let (_sid, ts) = dec_skey(k.value());
+            (ts, v.value())
+        }
+        None => first,
+    };
+    Ok(Some((first, last)))
+}
+
 fn query_range_buckets_inner(
     rtx: &ReadTransaction,
     series_id: u32,
@@ -139,8 +220,17 @@ fn query_range_buckets_inner(
     for entry in t.range::<&[u8]>(&k_lo[..]..=&k_hi[..])? {
         let (k, v) = entry?;
         let (_sid, ts) = dec_skey(k.value());
-        let bucket: AggBucket = bincode::deserialize(v.value())?;
-        out.push((ts, bucket));
+        // M2 : un bucket corrompu ne doit pas avorter toute la requête —
+        // on le journalise et on le saute (dégradation gracieuse).
+        match bincode::deserialize::<AggBucket>(v.value()) {
+            Ok(bucket) => out.push((ts, bucket)),
+            Err(e) => tracing::warn!(
+                series_id = _sid,
+                ts,
+                error = %e,
+                "metrics-store: bucket corrompu ignoré"
+            ),
+        }
     }
     Ok(out)
 }
@@ -150,8 +240,16 @@ fn list_series_inner(rtx: &ReadTransaction) -> Result<Vec<(u32, SeriesMeta)>> {
     let mut out = Vec::new();
     for entry in t.iter()? {
         let (k, v) = entry?;
-        let meta: SeriesMeta = bincode::deserialize(v.value())?;
-        out.push((k.value(), meta));
+        // M2 : skip-and-log un meta corrompu plutôt que d'avorter le dump
+        // complet du catalogue.
+        match bincode::deserialize::<SeriesMeta>(v.value()) {
+            Ok(meta) => out.push((k.value(), meta)),
+            Err(e) => tracing::warn!(
+                series_id = k.value(),
+                error = %e,
+                "metrics-store: SeriesMeta corrompu ignoré"
+            ),
+        }
     }
     Ok(out)
 }

--- a/crates/metrics-store/src/tiering.rs
+++ b/crates/metrics-store/src/tiering.rs
@@ -17,7 +17,7 @@ use anyhow::Result;
 use redb::{Database, ReadableDatabase, ReadableTable};
 use tokio::task::JoinHandle;
 
-use crate::encoding::{dec_skey, enc_skey};
+use crate::encoding::{dec_skey, enc_skey, SKEY_LEN};
 use crate::tables::{AggBucket, TABLE_DAILY, TABLE_HOURLY, TABLE_RAW};
 use crate::TierPolicy;
 
@@ -128,8 +128,10 @@ pub struct CompactionStats {
 
 /// `raw → hourly` : agrège tous les points raw `ts < cutoff_ms`.
 pub fn compact_raw_to_hourly(db: &Database, cutoff_ms: i64) -> Result<CompactionStats> {
-    // 1. Phase lecture — agrège en mémoire.
+    // 1. Phase lecture — agrège en mémoire. On mémorise le ts maximum
+    //    réellement lu (`max_ts_read`) pour borner la purge (correctif R3).
     let mut buckets: HashMap<(u32, i64), AggBucketBuilder> = HashMap::new();
+    let mut max_ts_read = i64::MIN;
     {
         let rtx = db.begin_read()?;
         let t_raw = rtx.open_table(TABLE_RAW)?;
@@ -138,6 +140,9 @@ pub fn compact_raw_to_hourly(db: &Database, cutoff_ms: i64) -> Result<Compaction
             let (sid, ts) = dec_skey(k.value());
             if ts >= cutoff_ms {
                 continue;
+            }
+            if ts > max_ts_read {
+                max_ts_read = ts;
             }
             let bucket = bucket_floor(ts, HOURLY_MS);
             buckets
@@ -152,14 +157,21 @@ pub fn compact_raw_to_hourly(db: &Database, cutoff_ms: i64) -> Result<Compaction
         return Ok(CompactionStats::default());
     }
 
-    // 2. Phase écriture des buckets — transaction unique.
+    // 2. Phase écriture des buckets — transaction unique. R4 : si un bucket
+    //    existe déjà à cette clé (compaction partielle antérieure), on le
+    //    fusionne au lieu de l'écraser (sinon perte des données déjà agrégées).
     {
         let wtx = db.begin_write()?;
         {
             let mut t_hour = wtx.open_table(TABLE_HOURLY)?;
-            for ((sid, b), builder) in buckets.into_iter() {
-                let agg = builder.finalize();
+            for ((sid, b), mut builder) in buckets.into_iter() {
                 let key = enc_skey(sid, b);
+                if let Some(existing) = t_hour.get(&key[..])? {
+                    let prev: AggBucket = bincode::deserialize(existing.value())?;
+                    drop(existing);
+                    builder.merge_bucket(&prev, b);
+                }
+                let agg = builder.finalize();
                 let bytes = bincode::serialize(&agg)?;
                 t_hour.insert(&key[..], &bytes[..])?;
             }
@@ -167,9 +179,11 @@ pub fn compact_raw_to_hourly(db: &Database, cutoff_ms: i64) -> Result<Compaction
         wtx.commit()?;
     }
 
-    // 3. Phase purge des raws compactés — transaction séparée pour ne pas
-    //    bloquer trop longtemps les écritures concurrentes.
-    let points_purged = purge_raw_before(db, cutoff_ms)?;
+    // 3. Phase purge — transaction(s) séparée(s), bornée à `max_ts_read`
+    //    (R3 : un point inséré tardivement avec un ts dans
+    //    `]max_ts_read, cutoff[` survit pour la prochaine passe au lieu
+    //    d'être purgé sans avoir été agrégé). Purge par lots (P3).
+    let points_purged = purge_raw_before(db, max_ts_read.saturating_add(1))?;
 
     Ok(CompactionStats { buckets_written, points_purged })
 }
@@ -177,6 +191,7 @@ pub fn compact_raw_to_hourly(db: &Database, cutoff_ms: i64) -> Result<Compaction
 /// `hourly → daily` : agrège tous les buckets horaires `ts < cutoff_ms`.
 pub fn compact_hourly_to_daily(db: &Database, cutoff_ms: i64) -> Result<CompactionStats> {
     let mut buckets: HashMap<(u32, i64), AggBucketBuilder> = HashMap::new();
+    let mut max_ts_read = i64::MIN;
     {
         let rtx = db.begin_read()?;
         let t_hour = rtx.open_table(TABLE_HOURLY)?;
@@ -185,6 +200,9 @@ pub fn compact_hourly_to_daily(db: &Database, cutoff_ms: i64) -> Result<Compacti
             let (sid, ts) = dec_skey(k.value());
             if ts >= cutoff_ms {
                 continue;
+            }
+            if ts > max_ts_read {
+                max_ts_read = ts;
             }
             let bucket = bucket_floor(ts, DAILY_MS);
             let hourly: AggBucket = bincode::deserialize(v.value())?;
@@ -200,13 +218,19 @@ pub fn compact_hourly_to_daily(db: &Database, cutoff_ms: i64) -> Result<Compacti
         return Ok(CompactionStats::default());
     }
 
+    // R4 : fusionne avec le bucket journalier existant le cas échéant.
     {
         let wtx = db.begin_write()?;
         {
             let mut t_day = wtx.open_table(TABLE_DAILY)?;
-            for ((sid, b), builder) in buckets.into_iter() {
-                let agg = builder.finalize();
+            for ((sid, b), mut builder) in buckets.into_iter() {
                 let key = enc_skey(sid, b);
+                if let Some(existing) = t_day.get(&key[..])? {
+                    let prev: AggBucket = bincode::deserialize(existing.value())?;
+                    drop(existing);
+                    builder.merge_bucket(&prev, b);
+                }
+                let agg = builder.finalize();
                 let bytes = bincode::serialize(&agg)?;
                 t_day.insert(&key[..], &bytes[..])?;
             }
@@ -214,37 +238,93 @@ pub fn compact_hourly_to_daily(db: &Database, cutoff_ms: i64) -> Result<Compacti
         wtx.commit()?;
     }
 
-    let points_purged = purge_hourly_before(db, cutoff_ms)?;
+    // R3 + P3 : purge bornée au max lu, par lots.
+    let points_purged = purge_hourly_before(db, max_ts_read.saturating_add(1))?;
 
     Ok(CompactionStats { buckets_written, points_purged })
 }
 
+/// Nombre max de clés supprimées par transaction de purge.
+///
+/// P3 : redb est mono-writer ; une purge en une seule transaction sur des
+/// millions de points gèlerait l'ingestion pendant toute sa durée. On
+/// découpe donc la suppression en lots bornés, en relâchant le write-lock
+/// entre chaque commit pour laisser le thread writer intercaler ses batchs.
+const PURGE_CHUNK: usize = 10_000;
+
+/// Collecte (transaction lecture) les clés `< cutoff_ms`, puis les supprime
+/// par lots bornés (transactions écriture courtes). Évite à la fois de tenir
+/// un write-lock long (P3) et un `extract_if` global.
+fn collect_keys_before(
+    rtx: &redb::ReadTransaction,
+    table: redb::TableDefinition<&[u8], f64>,
+    cutoff_ms: i64,
+) -> Result<Vec<[u8; SKEY_LEN]>> {
+    let t = rtx.open_table(table)?;
+    let mut keys = Vec::new();
+    for entry in t.iter()? {
+        let (k, _v) = entry?;
+        let kb = k.value();
+        let (_, ts) = dec_skey(kb);
+        if ts < cutoff_ms {
+            let mut arr = [0u8; SKEY_LEN];
+            arr.copy_from_slice(kb);
+            keys.push(arr);
+        }
+    }
+    Ok(keys)
+}
+
 fn purge_raw_before(db: &Database, cutoff_ms: i64) -> Result<usize> {
-    let wtx = db.begin_write()?;
-    let removed = {
-        let mut t_raw = wtx.open_table(TABLE_RAW)?;
-        let iter = t_raw.extract_if(|k, _v| {
-            let (_, ts) = dec_skey(k);
-            ts < cutoff_ms
-        })?;
-        iter.count()
+    let keys = {
+        let rtx = db.begin_read()?;
+        collect_keys_before(&rtx, TABLE_RAW, cutoff_ms)?
     };
-    wtx.commit()?;
-    Ok(removed)
+    let total = keys.len();
+    for chunk in keys.chunks(PURGE_CHUNK) {
+        let wtx = db.begin_write()?;
+        {
+            let mut t_raw = wtx.open_table(TABLE_RAW)?;
+            for k in chunk {
+                t_raw.remove(&k[..])?;
+            }
+        }
+        wtx.commit()?;
+    }
+    Ok(total)
 }
 
 fn purge_hourly_before(db: &Database, cutoff_ms: i64) -> Result<usize> {
-    let wtx = db.begin_write()?;
-    let removed = {
-        let mut t_hour = wtx.open_table(TABLE_HOURLY)?;
-        let iter = t_hour.extract_if(|k, _v| {
-            let (_, ts) = dec_skey(k);
-            ts < cutoff_ms
-        })?;
-        iter.count()
+    // Collecte des clés à supprimer (lecture). La valeur de TABLE_HOURLY est
+    // `&[u8]` ; on n'inspecte que la clé, donc on itère directement ici.
+    let keys: Vec<[u8; SKEY_LEN]> = {
+        let rtx = db.begin_read()?;
+        let t = rtx.open_table(TABLE_HOURLY)?;
+        let mut keys = Vec::new();
+        for entry in t.iter()? {
+            let (k, _v) = entry?;
+            let kb = k.value();
+            let (_, ts) = dec_skey(kb);
+            if ts < cutoff_ms {
+                let mut arr = [0u8; SKEY_LEN];
+                arr.copy_from_slice(kb);
+                keys.push(arr);
+            }
+        }
+        keys
     };
-    wtx.commit()?;
-    Ok(removed)
+    let total = keys.len();
+    for chunk in keys.chunks(PURGE_CHUNK) {
+        let wtx = db.begin_write()?;
+        {
+            let mut t_hour = wtx.open_table(TABLE_HOURLY)?;
+            for k in chunk {
+                t_hour.remove(&k[..])?;
+            }
+        }
+        wtx.commit()?;
+    }
+    Ok(total)
 }
 
 fn now_ms() -> i64 {
@@ -263,8 +343,13 @@ pub fn spawn_maintenance(
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let interval = Duration::from_secs(interval_hours.max(1) * 3600);
+        // M4 : première passe peu après le démarrage (60 s, le temps que le
+        // service finisse de booter) au lieu d'attendre un intervalle
+        // complet — sinon un service qui redémarre plus souvent que
+        // `interval_hours` ne compacterait jamais et la table raw croîtrait
+        // sans borne.
+        tokio::time::sleep(Duration::from_secs(60)).await;
         loop {
-            tokio::time::sleep(interval).await;
             let now = now_ms();
             let cutoff_raw = now - policy.raw_retention_days as i64 * DAILY_MS;
             let cutoff_hourly = now - policy.hourly_retention_days as i64 * DAILY_MS;
@@ -298,6 +383,8 @@ pub fn spawn_maintenance(
                 Ok(Err(e)) => tracing::error!(error = %e, "compact hourly→daily failed"),
                 Err(e) => tracing::error!(error = %e, "spawn_blocking hourly→daily panicked"),
             }
+
+            tokio::time::sleep(interval).await;
         }
     })
 }

--- a/crates/metrics-store/src/writer.rs
+++ b/crates/metrics-store/src/writer.rs
@@ -79,32 +79,71 @@ impl Default for WriterConfig {
     }
 }
 
+/// Message interne du canal writer.
+///
+/// `Shutdown` est une sentinelle in-band qui permet d'arrêter proprement le
+/// thread writer **même si des `Writer` clones survivent** côté appelant
+/// (sinon le canal mpsc resterait ouvert et `blocking_recv` ne retournerait
+/// jamais `None` → le `join()` dans `Inner::drop` bloquerait pour toujours).
+/// Cf. correctif R2.
+///
+/// `Sample` n'est volontairement pas boxé : ce serait une allocation par
+/// écriture sur le chemin chaud d'ingestion. La variante `Shutdown` (rare)
+/// justifie l'écart de taille.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum WriterMsg {
+    Sample(Sample),
+    Shutdown,
+}
+
+/// Reconstruit l'erreur publique `SendError<Sample>` à partir de l'erreur
+/// interne, en préservant la signature historique de l'API.
+fn map_send_err(e: mpsc::error::SendError<WriterMsg>) -> mpsc::error::SendError<Sample> {
+    match e.0 {
+        WriterMsg::Sample(s) => mpsc::error::SendError(s),
+        // Inatteignable : `Writer` n'envoie jamais `Shutdown`.
+        WriterMsg::Shutdown => unreachable!("Writer n'émet jamais Shutdown"),
+    }
+}
+
+fn map_try_send_err(
+    e: mpsc::error::TrySendError<WriterMsg>,
+) -> mpsc::error::TrySendError<Sample> {
+    use mpsc::error::TrySendError;
+    match e {
+        TrySendError::Full(WriterMsg::Sample(s)) => TrySendError::Full(s),
+        TrySendError::Closed(WriterMsg::Sample(s)) => TrySendError::Closed(s),
+        // Inatteignable : `Writer` n'envoie jamais `Shutdown`.
+        _ => unreachable!("Writer n'émet jamais Shutdown"),
+    }
+}
+
 /// Handle clonable côté producteur.
 #[derive(Clone)]
 pub struct Writer {
-    pub(crate) tx: mpsc::Sender<Sample>,
+    pub(crate) tx: mpsc::Sender<WriterMsg>,
 }
 
 impl Writer {
     pub async fn write(&self, sample: Sample) -> Result<(), mpsc::error::SendError<Sample>> {
-        self.tx.send(sample).await
+        self.tx.send(WriterMsg::Sample(sample)).await.map_err(map_send_err)
     }
 
     pub fn try_write(&self, sample: Sample) -> Result<(), mpsc::error::TrySendError<Sample>> {
-        self.tx.try_send(sample)
+        self.tx.try_send(WriterMsg::Sample(sample)).map_err(map_try_send_err)
     }
 
     pub fn blocking_write(&self, sample: Sample) -> Result<(), mpsc::error::SendError<Sample>> {
-        self.tx.blocking_send(sample)
+        self.tx.blocking_send(WriterMsg::Sample(sample)).map_err(map_send_err)
     }
 }
 
 /// Démarre le thread writer. Retourne son `JoinHandle` (le caller peut
 /// l'attendre lors d'un shutdown propre ; en pratique le service tourne
 /// jusqu'à `SIGTERM` systemd).
-pub fn spawn(
+pub(crate) fn spawn(
     db: Arc<Database>,
-    rx: mpsc::Receiver<Sample>,
+    rx: mpsc::Receiver<WriterMsg>,
     cfg: WriterConfig,
 ) -> thread::JoinHandle<()> {
     thread::Builder::new()
@@ -119,33 +158,40 @@ pub fn spawn(
         .expect("spawn writer thread")
 }
 
-fn run(db: Arc<Database>, mut rx: mpsc::Receiver<Sample>, cfg: WriterConfig) -> Result<()> {
-    let mut series_cache: LruCache<(String, String), u32> = LruCache::new(
+fn run(db: Arc<Database>, mut rx: mpsc::Receiver<WriterMsg>, cfg: WriterConfig) -> Result<()> {
+    let mut series_cache: LruCache<(String, LabelVec), u32> = LruCache::new(
         NonZeroUsize::new(SERIES_CACHE_CAPACITY).unwrap(),
     );
 
     let mut next_id = load_next_id(&db).context("load_next_id")?;
 
     loop {
-        let batch = drain(&mut rx, &cfg);
+        let (batch, stop) = drain(&mut rx, &cfg);
 
-        if batch.is_empty() {
-            return Ok(()); // channel fermé
+        if !batch.is_empty() {
+            if let Err(e) = commit_batch(&db, &batch, &mut series_cache, &mut next_id) {
+                tracing::error!(error = %e, samples = batch.len(), "commit_batch a échoué");
+            }
         }
 
-        if let Err(e) = commit_batch(&db, &batch, &mut series_cache, &mut next_id) {
-            tracing::error!(error = %e, samples = batch.len(), "commit_batch a échoué");
+        if stop {
+            return Ok(()); // channel fermé ou Shutdown reçu
         }
     }
 }
 
-fn drain(rx: &mut mpsc::Receiver<Sample>, cfg: &WriterConfig) -> Vec<Sample> {
+/// Draine un batch. Retourne `(batch, stop)` où `stop` indique que le canal
+/// est fermé ou qu'un `Shutdown` a été reçu — le batch collecté (les samples
+/// déjà en file) est tout de même commité avant l'arrêt, sans perte.
+fn drain(rx: &mut mpsc::Receiver<WriterMsg>, cfg: &WriterConfig) -> (Vec<Sample>, bool) {
     let mut batch = Vec::with_capacity(cfg.batch_max);
 
-    // Premier sample : on bloque jusqu'à réception (ou shutdown).
+    // Premier message : on bloque jusqu'à réception (sommeil efficace, pas
+    // de busy-poll quand la file est vide).
     match rx.blocking_recv() {
-        Some(s) => batch.push(s),
-        None => return batch,
+        Some(WriterMsg::Sample(s)) => batch.push(s),
+        Some(WriterMsg::Shutdown) => return (batch, true),
+        None => return (batch, true), // canal fermé
     }
 
     let deadline = Instant::now() + Duration::from_millis(cfg.flush_ms);
@@ -153,13 +199,18 @@ fn drain(rx: &mut mpsc::Receiver<Sample>, cfg: &WriterConfig) -> Vec<Sample> {
 
     while batch.len() < cfg.batch_max && Instant::now() < deadline {
         match rx.try_recv() {
-            Ok(s) => batch.push(s),
-            Err(mpsc::error::TryRecvError::Empty) => thread::sleep(idle),
-            Err(mpsc::error::TryRecvError::Disconnected) => break,
+            Ok(WriterMsg::Sample(s)) => batch.push(s),
+            Ok(WriterMsg::Shutdown) => return (batch, true),
+            Err(mpsc::error::TryRecvError::Empty) => {
+                // M3 : ne jamais dormir au-delà de la deadline de flush.
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                thread::sleep(idle.min(remaining));
+            }
+            Err(mpsc::error::TryRecvError::Disconnected) => return (batch, true),
         }
     }
 
-    batch
+    (batch, false)
 }
 
 fn load_next_id(db: &Database) -> Result<u32> {
@@ -174,10 +225,13 @@ fn load_next_id(db: &Database) -> Result<u32> {
 fn commit_batch(
     db: &Database,
     batch: &[Sample],
-    cache: &mut LruCache<(String, String), u32>,
+    cache: &mut LruCache<(String, LabelVec), u32>,
     next_id: &mut u32,
 ) -> Result<()> {
     let wtx = db.begin_write()?;
+    // R1 : on mémorise l'état d'allocation d'ID au début du batch pour
+    // pouvoir restaurer l'état mémoire à l'identique si le commit échoue.
+    let next_id_start = *next_id;
     let mut next_id_dirty = false;
 
     {
@@ -186,17 +240,25 @@ fn commit_batch(
         let mut t_smeta = wtx.open_table(TABLE_SERIES_META)?;
 
         for s in batch {
-            let labels_json = canonical_json(&s.labels);
-            let cache_key = (s.metric.clone(), labels_json.clone());
+            // P1 : clé de cache bon marché — (metric, labels bruts), sans
+            // sérialisation JSON ni BTreeMap. Le `canonical_json` (coûteux)
+            // n'est calculé que sur cache-miss, pour la clé persistée. Deux
+            // ordres de labels différents produisent deux entrées de cache
+            // mais résolvent vers le **même** series_id via la clé canonique
+            // de `series_by_key` — aucun doublon de série possible.
+            let cache_key = (s.metric.clone(), s.labels.clone());
 
             let series_id = if let Some(&id) = cache.get(&cache_key) {
                 id
             } else {
+                let labels_json = canonical_json(&s.labels);
                 let lookup_key = make_lookup_key(&s.metric, &labels_json);
 
                 // Lookup avant insert : on extrait la valeur du guard
                 // immédiatement pour libérer l'emprunt immutable sur `t_skey`
                 // avant d'appeler `.insert()` (sinon borrow checker fail).
+                // NB : au sein de la même write-tx, ce `get` voit les inserts
+                // précédents du batch (déduplication intra-batch correcte).
                 let existing = t_skey.get(&lookup_key[..])?.map(|g| g.value());
 
                 let id = if let Some(id) = existing {
@@ -213,7 +275,7 @@ fn commit_batch(
 
                     let meta = SeriesMeta {
                         metric: s.metric.clone(),
-                        labels_json: labels_json.clone(),
+                        labels_json,
                         first_seen_ms: s.ts_ms,
                         last_seen_ms: s.ts_ms,
                     };
@@ -239,7 +301,17 @@ fn commit_batch(
         }
     }
 
-    wtx.commit()?;
+    // R1 : si le commit échoue, la transaction (inserts series_by_key /
+    // series_meta inclus) est annulée. Le cache contiendrait alors des
+    // series_id jamais persistés → futurs points raw orphelins. On purge
+    // donc le cache et on restaure `next_id` pour rester cohérent avec la
+    // base. Le cache n'est qu'une optimisation : il sera repeuplé depuis la
+    // base au batch suivant.
+    if let Err(e) = wtx.commit() {
+        *next_id = next_id_start;
+        cache.clear();
+        return Err(e.into());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
…4, M1-M4

Implémente l'ensemble des correctifs de l'audit, sans régression (38 tests crate + 2 golden OK, daly-bms-server compile, API publique préservée à l'identique).

Robustesse
- R1 (writer): le cache de séries n'est plus empoisonné si un commit redb échoue — restauration de next_id + purge du cache LRU sur rollback, évitant des points raw orphelins.
- R2 (lib): arrêt propre du thread writer via sentinelle Shutdown in-band ; Inner::drop ne peut plus bloquer indéfiniment quand un Writer clone survit. + test de non-blocage borné par timeout.
- R3 (tiering): la purge est bornée au ts max réellement lu pendant l'agrégation — un sample tardif (ts dans ]max_lu, cutoff[) survit pour la passe suivante au lieu d'être purgé sans agrégation.
- R4 (tiering): fusion (au lieu d'écrasement) d'un bucket hourly/daily déjà existant lors d'une recompaction partielle. + test de merge.

Performance
- P1 (writer): clé de cache bon marché (metric, labels) — canonical_json n'est calculé que sur cache-miss, plus de sérialisation JSON par sample.
- P2 (reader/exec): instant selector et increase/rate/delta/last_over_time n'allouent plus toute la fenêtre — scans last_point / first_last bornés.
- P3 (tiering): purge par lots de 10k (transactions courtes) au lieu d'un extract_if global qui gèle l'ingestion mono-writer.
- P4 (exec): pré-dimensionnement du Vec de sortie de align_and_op.

Divers
- M1 (exec): cache match_series keyé par pointeur vidé au début de chaque eval — plus de faux positif d'adresse réutilisée. + test de réutilisation.
- M2 (reader): un enregistrement bincode corrompu est journalisé et sauté au lieu d'avorter toute la requête / le dump catalogue.
- M3 (writer): le sommeil de batching ne dépasse plus la deadline de flush.
- M4 (tiering): première passe de compaction ~60s après le démarrage.