### PR TITLE
fix(metrics-store): traite la revue Gemini de la PR #520 (P1, increase/rate reset, anti-panic range)

### DIFF
--- a/crates/metrics-store/src/lib.rs
+++ b/crates/metrics-store/src/lib.rs
@@ -648,4 +648,87 @@ mod tests {
         }
         let _ = std::fs::remove_file(&path);
     }
+
+    /// Revue Gemini : `increase`/`rate` doivent gérer un reset de compteur
+    /// (`last < first`) au lieu de renvoyer une valeur négative.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn increase_rate_handle_counter_reset() {
+        use crate::promql::{parse_and_validate, Evaluator};
+
+        let path = tmp_db_path("reset");
+        let _ = std::fs::remove_file(&path);
+        {
+            let opts = Options {
+                writer: WriterConfig { batch_max: 8, flush_ms: 20, poll_idle_ms: 2 },
+                ..Options::default()
+            };
+            let store = MetricsStore::open(&path, opts).expect("open");
+            let w = store.writer();
+            // Compteur qui se réinitialise : 80 puis 5 (reset matériel).
+            w.write(Sample::new("energy_reset", 100_000, 80.0)).await.unwrap();
+            w.write(Sample::new("energy_reset", 101_000, 5.0)).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(150)).await;
+
+            let reader = store.reader();
+            let ev = Evaluator::new(&reader);
+
+            // increase : reset → on retient `last` (5), pas 5-80 = -75.
+            let e = parse_and_validate("increase(energy_reset[10s])").unwrap();
+            let v = ev.eval_instant(&e, 101_000).unwrap();
+            assert_eq!(v.len(), 1);
+            assert!((v[0].value - 5.0).abs() < 1e-9, "increase reset = {}", v[0].value);
+            assert!(v[0].value >= 0.0, "increase ne doit jamais être négatif");
+
+            // rate : 5 / 10 s = 0.5 (jamais négatif).
+            let e = parse_and_validate("rate(energy_reset[10s])").unwrap();
+            let v = ev.eval_instant(&e, 101_000).unwrap();
+            assert_eq!(v.len(), 1);
+            assert!((v[0].value - 0.5).abs() < 1e-9, "rate reset = {}", v[0].value);
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Revue Gemini : un intervalle inversé (`from > to`) ne doit pas paniquer
+    /// dans `redb::range` — résultat vide / `None`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inverted_interval_does_not_panic() {
+        let path = tmp_db_path("inverted");
+        let _ = std::fs::remove_file(&path);
+        {
+            let opts = Options {
+                writer: WriterConfig { batch_max: 8, flush_ms: 20, poll_idle_ms: 2 },
+                ..Options::default()
+            };
+            let store = MetricsStore::open(&path, opts).expect("open");
+            let w = store.writer();
+            for ts in 1000..1005 {
+                w.write(Sample::new("g", ts, ts as f64)).await.unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(150)).await;
+
+            let reader = store.reader();
+            let sid = reader.lookup_series_id("g", "{}").unwrap().unwrap();
+
+            // Bornes inversées → vide, pas de panic.
+            assert!(reader.query_range_raw(sid, 2000, 1000).unwrap().is_empty());
+
+            let rtx = reader.begin_read().unwrap();
+            assert!(reader
+                .last_point_in_range_with_tx(&rtx, sid, 2000, 1000)
+                .unwrap()
+                .is_none());
+            assert!(reader
+                .first_last_in_range_with_tx(&rtx, sid, 2000, 1000)
+                .unwrap()
+                .is_none());
+            assert!(reader
+                .query_range_buckets_with_tx(&rtx, sid, 2000, 1000, Tier::Hourly)
+                .unwrap()
+                .is_empty());
+
+            // Sanity : intervalle normal renvoie bien les points.
+            assert_eq!(reader.query_range_raw(sid, 1000, 1004).unwrap().len(), 5);
+        }
+        let _ = std::fs::remove_file(&path);
+    }
 }

--- a/crates/metrics-store/src/promql/exec.rs
+++ b/crates/metrics-store/src/promql/exec.rs
@@ -15,9 +15,11 @@
 //! - 7 j < range ≤ 90 j → `TABLE_HOURLY`
 //! - > 90 j → `TABLE_DAILY`
 //!
-//! Pour `increase` sur tier compacté, on utilise `last_bucket.last -
-//! first_bucket.first` (correct pour les compteurs monotones — c'est
-//! le cas de `et112_energy_*` qui sont nos seuls usages réels).
+//! Pour `increase`/`rate`, on utilise `last - first` (sur points raw ou
+//! bornes `first/last` des buckets compactés). Un reset de compteur
+//! (`last < first`) est traité comme une remise à zéro → on retient `last`
+//! (cf. `counter_increase`). Correct pour nos compteurs monotones
+//! (`et112_energy_*`), qui ne reset qu'au remplacement matériel.
 //!
 //! ## Optimisations mémoire (cf. docs/memory-leak-investigation.md §12)
 //! L'Evaluator est scopé per-request et porte trois caches partagés sur
@@ -518,8 +520,12 @@ fn apply_range_fn_raw(name: &str, pts: &[(i64, f64)], range_ms: i64) -> Option<f
         };
     }
     Some(match name {
-        "increase" | "delta" => pts.last().unwrap().1 - pts.first().unwrap().1,
-        "rate" => (pts.last().unwrap().1 - pts.first().unwrap().1) / (range_ms as f64 / 1000.0),
+        "increase" => counter_increase(pts.first().unwrap().1, pts.last().unwrap().1),
+        "delta" => pts.last().unwrap().1 - pts.first().unwrap().1,
+        "rate" => {
+            counter_increase(pts.first().unwrap().1, pts.last().unwrap().1)
+                / (range_ms as f64 / 1000.0)
+        }
         "avg_over_time" => pts.iter().map(|p| p.1).sum::<f64>() / pts.len() as f64,
         "sum_over_time" => pts.iter().map(|p| p.1).sum::<f64>(),
         "min_over_time" => pts.iter().map(|p| p.1).fold(f64::INFINITY, f64::min),
@@ -528,6 +534,23 @@ fn apply_range_fn_raw(name: &str, pts: &[(i64, f64)], range_ms: i64) -> Option<f
         "last_over_time" => pts.last().unwrap().1,
         _ => return None,
     })
+}
+
+/// Augmentation d'un compteur entre `first` et `last`, avec gestion d'un
+/// reset (le compteur a été remis à zéro entre les deux bornes).
+///
+/// PromQL traite `increase`/`rate` comme des compteurs monotones : si
+/// `last < first`, on suppose une réinitialisation et on retient `last`
+/// (équivalent à un reset à 0 puis remontée jusqu'à `last`). Limitation
+/// connue : avec seulement les deux bornes, un reset *suivi* d'une remontée
+/// au-dessus de `first` n'est pas détectable — acceptable pour nos compteurs
+/// d'énergie (`et112_energy_*`), qui ne reset qu'au remplacement du compteur.
+fn counter_increase(first: f64, last: f64) -> f64 {
+    if last < first {
+        last
+    } else {
+        last - first
+    }
 }
 
 /// Variante de [`apply_range_fn_raw`] limitée aux fonctions qui n'ont besoin
@@ -540,8 +563,10 @@ fn apply_range_fn_endpoints(
 ) -> Option<f64> {
     let ((_, first_v), (_, last_v)) = fl?;
     Some(match name {
-        "increase" | "delta" => last_v - first_v,
-        "rate" => (last_v - first_v) / (range_ms as f64 / 1000.0),
+        "increase" => counter_increase(first_v, last_v),
+        // `delta` cible les jauges (peut décroître) → pas de gestion de reset.
+        "delta" => last_v - first_v,
+        "rate" => counter_increase(first_v, last_v) / (range_ms as f64 / 1000.0),
         "last_over_time" => last_v,
         _ => return None,
     })
@@ -564,9 +589,12 @@ fn apply_range_fn_buckets(
     }
     let total_sum: f64 = buckets.iter().map(|(_, b)| b.sum).sum();
     Some(match name {
-        "increase" | "delta" => buckets.last().unwrap().1.last - buckets.first().unwrap().1.first,
+        "increase" => {
+            counter_increase(buckets.first().unwrap().1.first, buckets.last().unwrap().1.last)
+        }
+        "delta" => buckets.last().unwrap().1.last - buckets.first().unwrap().1.first,
         "rate" => {
-            (buckets.last().unwrap().1.last - buckets.first().unwrap().1.first)
+            counter_increase(buckets.first().unwrap().1.first, buckets.last().unwrap().1.last)
                 / (range_ms as f64 / 1000.0)
         }
         "avg_over_time" => total_sum / total_cnt as f64,

--- a/crates/metrics-store/src/reader.rs
+++ b/crates/metrics-store/src/reader.rs
@@ -137,6 +137,11 @@ fn query_range_raw_inner(
     from_ms: i64,
     to_ms: i64,
 ) -> Result<Vec<(i64, f64)>> {
+    // Intervalle inversé → résultat vide (évite un panic redb sur bornes
+    // de range décroissantes).
+    if from_ms > to_ms {
+        return Ok(Vec::new());
+    }
     let t = rtx.open_table(TABLE_RAW)?;
     let k_lo = enc_skey(series_id, from_ms);
     let k_hi = enc_skey(series_id, to_ms);
@@ -155,6 +160,10 @@ fn last_point_in_range_inner(
     from_ms: i64,
     to_ms: i64,
 ) -> Result<Option<(i64, f64)>> {
+    // Garde anti-panic : bornes inversées → aucun point.
+    if from_ms > to_ms {
+        return Ok(None);
+    }
     let t = rtx.open_table(TABLE_RAW)?;
     let k_lo = enc_skey(series_id, from_ms);
     let k_hi = enc_skey(series_id, to_ms);
@@ -176,6 +185,10 @@ fn first_last_in_range_inner(
     from_ms: i64,
     to_ms: i64,
 ) -> Result<Option<((i64, f64), (i64, f64))>> {
+    // Garde anti-panic : bornes inversées → aucun point.
+    if from_ms > to_ms {
+        return Ok(None);
+    }
     let t = rtx.open_table(TABLE_RAW)?;
     let k_lo = enc_skey(series_id, from_ms);
     let k_hi = enc_skey(series_id, to_ms);
@@ -208,6 +221,9 @@ fn query_range_buckets_inner(
     to_ms: i64,
     tier: Tier,
 ) -> Result<Vec<(i64, AggBucket)>> {
+    if from_ms > to_ms {
+        return Ok(Vec::new());
+    }
     let table = match tier {
         Tier::Raw => anyhow::bail!("query_range_buckets: Tier::Raw non supporté"),
         Tier::Hourly => TABLE_HOURLY,

--- a/crates/metrics-store/src/writer.rs
+++ b/crates/metrics-store/src/writer.rs
@@ -29,6 +29,22 @@ use crate::tables::{
 
 const META_KEY_NEXT_SERIES_ID: &str = "next_series_id";
 
+/// Cache d'identité de série → `series_id`, keyé par fingerprint `u64`.
+/// La valeur conserve `(metric, labels, series_id)` pour la vérification
+/// anti-collision (cf. `commit_batch`).
+type SeriesCache = LruCache<u64, (String, LabelVec, u32)>;
+
+/// Fingerprint d'une série calculé sans allocation à partir de références.
+/// Sensible à l'ordre des labels (deux ordres ⇒ deux entrées de cache qui
+/// résolvent vers le même `series_id` via la clé canonique `series_by_key`).
+fn series_fingerprint(metric: &str, labels: &LabelVec) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    metric.hash(&mut h);
+    labels.hash(&mut h);
+    h.finish()
+}
+
 /// Taille max du cache LRU.
 ///
 /// 50k est volontairement large pour éviter un churn excessif tout en
@@ -159,7 +175,11 @@ pub(crate) fn spawn(
 }
 
 fn run(db: Arc<Database>, mut rx: mpsc::Receiver<WriterMsg>, cfg: WriterConfig) -> Result<()> {
-    let mut series_cache: LruCache<(String, LabelVec), u32> = LruCache::new(
+    // Cache keyé par fingerprint u64 calculé depuis des références (zéro
+    // allocation/clone sur cache-hit, le cas nominal). La valeur stocke
+    // l'identité `(metric, labels)` pour pouvoir détecter une collision de
+    // hash (astronomiquement rare) et retomber sur le lookup canonique.
+    let mut series_cache: SeriesCache = LruCache::new(
         NonZeroUsize::new(SERIES_CACHE_CAPACITY).unwrap(),
     );
 
@@ -225,7 +245,7 @@ fn load_next_id(db: &Database) -> Result<u32> {
 fn commit_batch(
     db: &Database,
     batch: &[Sample],
-    cache: &mut LruCache<(String, LabelVec), u32>,
+    cache: &mut SeriesCache,
     next_id: &mut u32,
 ) -> Result<()> {
     let wtx = db.begin_write()?;
@@ -240,15 +260,22 @@ fn commit_batch(
         let mut t_smeta = wtx.open_table(TABLE_SERIES_META)?;
 
         for s in batch {
-            // P1 : clé de cache bon marché — (metric, labels bruts), sans
-            // sérialisation JSON ni BTreeMap. Le `canonical_json` (coûteux)
-            // n'est calculé que sur cache-miss, pour la clé persistée. Deux
-            // ordres de labels différents produisent deux entrées de cache
-            // mais résolvent vers le **même** series_id via la clé canonique
-            // de `series_by_key` — aucun doublon de série possible.
-            let cache_key = (s.metric.clone(), s.labels.clone());
+            // P1 : fingerprint u64 calculé depuis des références — aucune
+            // allocation ni clone sur cache-hit (le cas nominal >99%). Le
+            // `canonical_json` (coûteux) et les clones ne se produisent que
+            // sur cache-miss. La vérification d'identité ci-dessous garantit
+            // qu'une collision de hash (extrêmement rare) ne renvoie jamais
+            // un mauvais `series_id` : on retombe alors sur le lookup
+            // canonique. Deux ordres de labels différents produisent deux
+            // entrées de cache mais résolvent vers le **même** series_id via
+            // la clé canonique de `series_by_key`.
+            let fp = series_fingerprint(&s.metric, &s.labels);
+            let cached_id = match cache.get(&fp) {
+                Some((m, l, id)) if m == &s.metric && l == &s.labels => Some(*id),
+                _ => None, // miss ou collision de hash
+            };
 
-            let series_id = if let Some(&id) = cache.get(&cache_key) {
+            let series_id = if let Some(id) = cached_id {
                 id
             } else {
                 let labels_json = canonical_json(&s.labels);
@@ -286,7 +313,9 @@ fn commit_batch(
                     id
                 };
 
-                cache.put(cache_key, id);
+                // Clone uniquement sur miss : stocke l'identité pour la
+                // vérification anti-collision des hits futurs.
+                cache.put(fp, (s.metric.clone(), s.labels.clone(), id));
 
                 id
             };


### PR DESCRIPTION
## Contexte

PR de suivi adressant les **3 remarques du bot `gemini-code-assist`** sur la PR #520 (audit `metrics-store`, déjà mergée dans `main` — commit `c2446ae`).

## Corrections

### 1. P1 — Clonage systématique sur cache-hit (`writer.rs`)
Le cache de séries était keyé par `(String, LabelVec)`, clonés à **chaque** sample même sur hit (cas nominal >99 %).
→ Cache désormais keyé par **fingerprint `u64`** calculé depuis des références (`series_fingerprint`) : **zéro allocation ni clone sur cache-hit**. Le `canonical_json` et les clones ne se produisent plus que sur cache-miss (création de série).
→ **Sécurité anti-collision** : la valeur stocke l'identité `(metric, labels, id)`. Sur hit, on vérifie l'identité ; en cas de collision de hash (astronomiquement rare), on retombe sur le lookup canonique `series_by_key` → **jamais de mauvais `series_id`**.

### 2. Correctitude `increase`/`rate` — reset de compteur (`exec.rs`)
`last - first` renvoyait une valeur **négative** si le compteur s'était réinitialisé (`last < first`).
→ Helper `counter_increase` : un reset (`last < first`) est traité comme une remise à zéro ⇒ on retient `last`. Appliqué de façon **cohérente sur les 3 chemins** (raw / endpoints / buckets compactés). `delta` (jauges, peut décroître) reste `last - first`. Limitation documentée (un reset puis remontée au-dessus de `first` reste indétectable avec 2 bornes — acceptable pour nos compteurs `et112_energy_*`).

### 3. Robustesse — panic sur intervalle inversé (`reader.rs`)
`from_ms > to_ms` provoquait un **panic** dans `redb::range` (bornes décroissantes).
→ Garde `from > to ⇒ vide/None` ajoutée sur les **4** fonctions de range (les 2 nouvelles signalées + les 2 préexistantes, par cohérence défensive).

## Validation (zéro régression)
- **40 tests** crate + **2** golden PromQL → tous OK
- +2 tests de régression : `increase_rate_handle_counter_reset`, `inverted_interval_does_not_panic`
- `daly-bms-server` (consommateur) compile — **aucune API publique modifiée** (changements internes uniquement)
- Clippy : aucune nouvelle alerte

https://claude.ai/code/session_011ppGg1oh2FVFxc8itq1Zs1

---
_Generated by [Claude Code](https://claude.ai/code/session_011ppGg1oh2FVFxc8itq1Zs1)_