### PR TITLE
fix(dashboards): panel 43 — supprime la subquery PromQL non supportée

### DIFF
--- a/crates/daly-bms-server/src/redb_writes.rs
+++ b/crates/daly-bms-server/src/redb_writes.rs
@@ -470,6 +470,13 @@ pub fn write_venus_smartshunt(writer: &Writer, rl: &RateLimiter, shunt: &VenusSm
         push(writer, rl, MIN_WRITE_INTERVAL,
              Sample::new("venus_shunt_current_a", ts, v as f64),
              "venus_shunt_current_a");
+        // Valeur absolue dérivée |I| — alimente le panel "Taux de Cyclage 24h".
+        // L'ancienne subquery `abs(avg(clamp_min(I,0))) + abs(avg(clamp_max(I,0)))`
+        // se simplifie exactement en `avg(|I|)` (cf. plan §6.5, décision (a)),
+        // donc le panel utilise désormais `avg_over_time(venus_shunt_current_abs[24h])`.
+        push(writer, rl, MIN_WRITE_INTERVAL,
+             Sample::new("venus_shunt_current_abs", ts, (v as f64).abs()),
+             "venus_shunt_current_abs");
     }
     if let Some(v) = shunt.power_w {
         push(writer, rl, MIN_WRITE_INTERVAL,

--- a/crates/metrics-store/tests/golden_promql.rs
+++ b/crates/metrics-store/tests/golden_promql.rs
@@ -36,7 +36,10 @@ fn extract_exprs(json_src: &str) -> Vec<(u64, String)> {
 /// supportée par le shim (cf. plan §6.5). Toute autre expression doit
 /// passer la validation.
 const KNOWN_UNSUPPORTED_PANELS: &[u64] = &[
-    43, // subquery `[24h:1m]` — décision (a) du plan : à réécrire côté JS
+    // (vide) — le panel 43 (ex-subquery `[24h:1m]`) a été réécrit en
+    // `avg_over_time(venus_shunt_current_abs[24h]) * 24/680*100` (décision (a)
+    // du plan §6.5), via la métrique dérivée |I|. Plus aucune expression non
+    // supportée dans les dashboards embarqués.
 ];
 
 #[test]

--- a/docs/grafana-ess_dashboard.json
+++ b/docs/grafana-ess_dashboard.json
@@ -2135,7 +2135,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(abs(avg_over_time(clamp_min(venus_shunt_current_a,0)[24h:1m])) + abs(avg_over_time(clamp_max(venus_shunt_current_a,0)[24h:1m]))) * 24 / 680 * 100",
+          "expr": "avg_over_time(venus_shunt_current_abs[24h]) * 24 / 680 * 100",
           "refId": "A"
         }
       ],

--- a/docs/plan_migration_vm_redb.md
+++ b/docs/plan_migration_vm_redb.md
@@ -1220,6 +1220,14 @@ ECharts, soit (b) ajouter un cas spécial `[Xh:Ym]` qui pré-bucketize en
 mémoire avant la fonction `*_over_time`. La complexité de (b) (~1 j) est
 disproportionnée pour un panel. **Retenir (a).**
 
+> **✅ Implémenté (2026-05)** : le numérateur se simplifie exactement —
+> `abs(avg(clamp_min(I,0))) + abs(avg(clamp_max(I,0)))` = `avg(clamp_min(I,0) −
+> clamp_max(I,0))` = `avg(|I|)`. On émet donc la métrique dérivée
+> `venus_shunt_current_abs = |I|` (cf. `write_venus_smartshunt`) et le panel 43
+> devient `avg_over_time(venus_shunt_current_abs[24h]) * 24 / 680 * 100` —
+> supporté nativement, sans subquery, exact (et plus précis que le
+> sous-échantillonnage 1 min puisqu'on agrège tous les points bruts).
+
 **Offset, label_replace, label_join, vector(), scalar()** : aucune
 occurrence — rejetés sans implémentation.
 


### PR DESCRIPTION
## Problème

Le panel **« Taux de Cyclage 24h »** (`docs/grafana-ess_dashboard.json`, id=43) utilisait une **subquery PromQL `[24h:1m]`**, rejetée par le moteur PromQL de `metrics-store` (décision (a) du plan §6.5 : pas de support des subqueries). Résultat : **`panel query failed` en boucle** dans les logs `daly-bms` à chaque refresh du dashboard interne.

```
panel=43 expr=(abs(avg_over_time(clamp_min(venus_shunt_current_a,0)[24h:1m])) + abs(avg_over_time(clamp_max(venus_shunt_current_a,0)[24h:1m]))) * 24 / 680 * 100
error=PromQL: unsupported: subquery [Xh:Ym]
```

## Correctif (décision (a) du plan, via simplification exacte)

Le numérateur se simplifie **mathématiquement sans approximation** :
```
abs(avg(clamp_min(I,0))) + abs(avg(clamp_max(I,0)))  ≡  avg(|I|)
```
car `clamp_min(I,0) − clamp_max(I,0) = max(I,0) − min(I,0) = |I|` (linéarité de la moyenne).

- **`redb_writes.rs`** : émet la métrique dérivée `venus_shunt_current_abs = |I|` (même rate-limit que `venus_shunt_current_a`).
- **Panel 43** : expr réécrite en `avg_over_time(venus_shunt_current_abs[24h]) * 24 / 680 * 100` — supportée nativement, efficace (un seul scan, pas de subquery), **exacte** (et plus précise que le sous-échantillonnage 1 min : agrège tous les points bruts).
- **`golden_promql.rs`** : panel 43 retiré de `KNOWN_UNSUPPORTED_PANELS` → toutes les expressions des dashboards embarqués passent désormais la validation.
- **plan §6.5** : note d'implémentation.

Le moteur **continue de rejeter les subqueries** (test `validate::rejects_subquery` inchangé) ; on a seulement supprimé l'unique usage du système.

## Validation
- `metrics-store` : **46 tests + 2 golden** OK
- `daly-bms-server` compile (exit 0)
- Aucune migration de base, aucun changement de config

## Déploiement
Le panel est embarqué dans le binaire (`include_str!`) et le nouveau write est dans `daly-bms-server` → **recompilation nécessaire** : `make sync && bash scripts/deploy-pi5.sh`.

⚠️ La métrique `|I|` n'existant qu'à partir du déploiement, le panel affichera une moyenne **partielle pendant les premières 24 h**, puis exacte.

https://claude.ai/code/session_011ppGg1oh2FVFxc8itq1Zs1

---
_Generated by [Claude Code](https://claude.ai/code/session_011ppGg1oh2FVFxc8itq1Zs1)_