### PR TITLE
feat(promql): math functions + label_replace/label_join (Phase 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ dependencies = [
  "parking_lot",
  "promql-parser",
  "redb",
+ "regex",
  "serde",
  "serde_json",
  "smallvec",

--- a/crates/metrics-store/Cargo.toml
+++ b/crates/metrics-store/Cargo.toml
@@ -20,6 +20,7 @@ parking_lot = "0.12"
 promql-parser = "0.9.0"
 clap        = { workspace = true }
 lru = "0.18"
+regex       = "1"
 
 [dev-dependencies]
 criterion   = { version = "0.5", features = ["html_reports"] }

--- a/crates/metrics-store/src/lib.rs
+++ b/crates/metrics-store/src/lib.rs
@@ -591,6 +591,75 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn promql_math_and_label_functions() {
+        use crate::promql::{parse_and_validate, Evaluator};
+
+        let path = tmp_db_path("promql_mathlabel");
+        let _ = std::fs::remove_file(&path);
+        {
+            let opts = Options {
+                writer: WriterConfig { batch_max: 64, flush_ms: 20, poll_idle_ms: 2 },
+                ..Options::default()
+            };
+            let store = MetricsStore::open(&path, opts).expect("open");
+            let writer = store.writer();
+
+            // bms_v{bms_id="1",phase="a"} = 4.0
+            let ts = 100_000;
+            writer
+                .write(
+                    Sample::new("bms_v", ts, 4.0)
+                        .with_label("bms_id", "1")
+                        .with_label("phase", "a"),
+                )
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(150)).await;
+
+            let reader = store.reader();
+            let ev = Evaluator::new(&reader);
+            let at = 100_000;
+            let eval = |q: &str| {
+                let expr = parse_and_validate(q).unwrap();
+                ev.eval_instant(&expr, at).unwrap()
+            };
+
+            // sqrt(4) = 2
+            let v = eval("sqrt(bms_v)");
+            assert_eq!(v.len(), 1);
+            assert!((v[0].value - 2.0).abs() < 1e-9);
+
+            // clamp(4, 0, 2) = 2
+            let v = eval("clamp(bms_v, 0, 2)");
+            assert!((v[0].value - 2.0).abs() < 1e-9);
+            // clamp avec min > max → NaN
+            let v = eval("clamp(bms_v, 5, 1)");
+            assert!(v[0].value.is_nan());
+
+            // sgn(4) = 1
+            let v = eval("sgn(bms_v)");
+            assert!((v[0].value - 1.0).abs() < 1e-9);
+
+            // label_replace : crée pack="P1" depuis bms_id, valeur inchangée.
+            let v = eval(r#"label_replace(bms_v, "pack", "P$1", "bms_id", "(.*)")"#);
+            assert_eq!(v.len(), 1);
+            assert_eq!(v[0].labels.get("pack").map(String::as_str), Some("P1"));
+            assert!((v[0].value - 4.0).abs() < 1e-9);
+            // labels d'origine préservés.
+            assert_eq!(v[0].labels.get("bms_id").map(String::as_str), Some("1"));
+
+            // label_replace sans match → série inchangée (pas de label ajouté).
+            let v = eval(r#"label_replace(bms_v, "pack", "X", "bms_id", "zzz")"#);
+            assert!(!v[0].labels.contains_key("pack"));
+
+            // label_join : combo = "1-a"
+            let v = eval(r#"label_join(bms_v, "combo", "-", "bms_id", "phase")"#);
+            assert_eq!(v[0].labels.get("combo").map(String::as_str), Some("1-a"));
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn promql_irate() {
         use crate::promql::{parse_and_validate, Evaluator};
 

--- a/crates/metrics-store/src/promql/exec.rs
+++ b/crates/metrics-store/src/promql/exec.rs
@@ -48,9 +48,10 @@ use std::time::Duration;
 use promql_parser::label::MatchOp;
 use promql_parser::parser::{
     AggregateExpr, BinaryExpr, Call, Expr, LabelModifier, MatrixSelector, NumberLiteral, ParenExpr,
-    UnaryExpr, VectorSelector,
+    StringLiteral, UnaryExpr, VectorSelector,
 };
 use redb::ReadTransaction;
+use regex::Regex;
 
 use crate::reader::Reader;
 use crate::tables::{AggBucket, SeriesMeta, Tier};
@@ -478,6 +479,23 @@ impl<'r> Evaluator<'r> {
 
     fn eval_call(&self, c: &Call, t: i64) -> Result<Value, PromQlError> {
         let name = c.func.name;
+        // Fonctions de labels (`label_replace`/`label_join`) : arguments string
+        // → routage dédié (ne passent pas par l'évaluation scalaire des args).
+        if name == "label_replace" || name == "label_join" {
+            let inner = match self.eval_at(c.args.args[0].as_ref(), t)? {
+                Value::Vector(v) => v,
+                Value::Scalar(_) => {
+                    return Err(PromQlError::Execution(format!(
+                        "{name}: le premier argument doit être un vecteur instantané"
+                    )))
+                }
+            };
+            return if name == "label_replace" {
+                label_replace(inner, c)
+            } else {
+                label_join(inner, c)
+            };
+        }
         // Fonctions à fenêtre : 1er arg = MatrixSelector.
         if let Some(first) = c.args.first() {
             if let Expr::MatrixSelector(MatrixSelector { vs, range }) = first.as_ref() {
@@ -589,6 +607,18 @@ impl<'r> Evaluator<'r> {
                     .map(|s| InstantSample { labels: s.labels, value: s.value.min(k) })
                     .collect()
             }
+            "clamp" => {
+                let min = scalar_arg(c, 1, t, self)?;
+                let max = scalar_arg(c, 2, t, self)?;
+                inner
+                    .into_iter()
+                    .map(|s| InstantSample { labels: s.labels, value: clamp_val(s.value, min, max) })
+                    .collect()
+            }
+            "sqrt" | "exp" | "ln" | "log2" | "log10" | "sgn" => inner
+                .into_iter()
+                .map(|s| InstantSample { labels: s.labels, value: unary_math(name, s.value) })
+                .collect(),
             other => {
                 return Err(PromQlError::Unsupported(format!("instant fn {other}")))
             }
@@ -610,6 +640,8 @@ impl<'r> Evaluator<'r> {
             "round" => s.round(),
             "clamp_min" => s.max(scalar_arg(c, 1, t, self)?),
             "clamp_max" => s.min(scalar_arg(c, 1, t, self)?),
+            "clamp" => clamp_val(s, scalar_arg(c, 1, t, self)?, scalar_arg(c, 2, t, self)?),
+            "sqrt" | "exp" | "ln" | "log2" | "log10" | "sgn" => unary_math(name, s),
             other => return Err(PromQlError::Unsupported(format!("instant fn {other}"))),
         })
     }
@@ -853,6 +885,113 @@ fn align_and_op(
     out
 }
 
+/// Fonctions mathématiques unaires (`sqrt exp ln log2 log10 sgn`). `NaN` se
+/// propage naturellement (sauf `sgn` qui le renvoie explicitement).
+fn unary_math(name: &str, v: f64) -> f64 {
+    match name {
+        "sqrt" => v.sqrt(),
+        "exp" => v.exp(),
+        "ln" => v.ln(),
+        "log2" => v.log2(),
+        "log10" => v.log10(),
+        // `sgn` : 1 si >0, -1 si <0, 0 si ==0, NaN si NaN (sémantique Prometheus,
+        // différente de `f64::signum` qui renvoie ±1 pour 0).
+        "sgn" => {
+            if v.is_nan() {
+                f64::NAN
+            } else if v > 0.0 {
+                1.0
+            } else if v < 0.0 {
+                -1.0
+            } else {
+                0.0
+            }
+        }
+        _ => f64::NAN,
+    }
+}
+
+/// `clamp(v, min, max)` : borne `v` dans `[min, max]`. Renvoie `NaN` si
+/// `min > max` (sémantique Prometheus).
+fn clamp_val(v: f64, min: f64, max: f64) -> f64 {
+    if min > max {
+        f64::NAN
+    } else {
+        v.max(min).min(max)
+    }
+}
+
+/// Extrait l'argument string littéral d'indice `idx` d'un appel de fonction.
+/// La validation (`validate_call`) garantit déjà que ces arguments sont des
+/// `StringLiteral` pour `label_replace`/`label_join`.
+fn string_arg(c: &Call, idx: usize) -> Result<String, PromQlError> {
+    match c.args.args.get(idx).map(|a| a.as_ref()) {
+        Some(Expr::StringLiteral(StringLiteral { val })) => Ok(val.clone()),
+        _ => Err(PromQlError::Execution(format!(
+            "argument string #{idx} attendu"
+        ))),
+    }
+}
+
+/// `label_replace(v, dst, replacement, src, regex)` : si `regex` (ancrée sur la
+/// chaîne entière) matche la valeur du label `src`, le label `dst` reçoit
+/// `replacement` (avec expansion des groupes `$1`/`${name}`). Si la valeur
+/// résultante est vide, `dst` est retiré. Sinon le sample est inchangé.
+fn label_replace(inner: Vec<InstantSample>, c: &Call) -> Result<Value, PromQlError> {
+    let dst = string_arg(c, 1)?;
+    let repl = string_arg(c, 2)?;
+    let src = string_arg(c, 3)?;
+    let regex_src = string_arg(c, 4)?;
+    // Prometheus ancre le regex sur toute la valeur du label (full match).
+    let re = Regex::new(&format!("^(?:{regex_src})$"))
+        .map_err(|e| PromQlError::Execution(format!("label_replace: regex invalide: {e}")))?;
+    let mut out = Vec::with_capacity(inner.len());
+    for s in inner {
+        let src_val = s.labels.get(&src).map(String::as_str).unwrap_or("");
+        if let Some(caps) = re.captures(src_val) {
+            let mut expanded = String::new();
+            caps.expand(&repl, &mut expanded);
+            let mut labels = (*s.labels).clone();
+            if expanded.is_empty() {
+                labels.remove(&dst);
+            } else {
+                labels.insert(dst.clone(), expanded);
+            }
+            out.push(InstantSample { labels: Arc::new(labels), value: s.value });
+        } else {
+            out.push(s);
+        }
+    }
+    Ok(Value::Vector(out))
+}
+
+/// `label_join(v, dst, separator, src_1, …, src_n)` : concatène les valeurs des
+/// labels sources avec `separator` dans le label `dst`. Valeur vide → `dst`
+/// retiré.
+fn label_join(inner: Vec<InstantSample>, c: &Call) -> Result<Value, PromQlError> {
+    let dst = string_arg(c, 1)?;
+    let sep = string_arg(c, 2)?;
+    let srcs: Vec<String> = (3..c.args.args.len())
+        .map(|i| string_arg(c, i))
+        .collect::<Result<_, _>>()?;
+    let mut out = Vec::with_capacity(inner.len());
+    for s in inner {
+        let joined = srcs
+            .iter()
+            .map(|l| s.labels.get(l).map(String::as_str).unwrap_or(""))
+            .collect::<Vec<_>>()
+            .join(&sep);
+        let mut labels = (*s.labels).clone();
+        if joined.is_empty() {
+            labels.remove(&dst);
+        } else {
+            labels.insert(dst.clone(), joined);
+        }
+        out.push(InstantSample { labels: Arc::new(labels), value: s.value });
+    }
+    Ok(Value::Vector(out))
+}
+
 /// Renvoie la fonction de comparaison associée à un opérateur, ou `None` si
 /// l'opérateur n'est pas une comparaison.
 fn cmp_fn(op: &str) -> Option<fn(f64, f64) -> bool> {
@@ -900,14 +1039,19 @@ fn align_and_compare(
     return_bool: bool,
 ) -> Vec<InstantSample> {
     // `drop_name` réutilise l'Arc quand `__name__` est absent, et n'alloue
-    // qu'un Arc refcount=1 sinon (try_unwrap récupère alors le BTreeMap sans
-    // re-cloner). Côté lhs on conserve l'Arc pour le réinjecter en sortie.
+    // qu'un Arc refcount=1 sinon. On déstructure `s` puis on droppe `labels`
+    // avant `try_unwrap` : sans cela l'Arc original resterait vivant
+    // (refcount ≥ 2) et `try_unwrap` échouerait toujours, re-clonant le
+    // BTreeMap (revue Gemini PR #528). Côté lhs on conserve l'Arc pour le
+    // réinjecter en sortie.
     let rhs_idx: BTreeMap<Labels, f64> = rhs
         .into_iter()
         .map(|s| {
-            let l = drop_name(&s.labels);
+            let InstantSample { labels, value } = s;
+            let l = drop_name(&labels);
+            drop(labels);
             let l = Arc::try_unwrap(l).unwrap_or_else(|arc| (*arc).clone());
-            (l, s.value)
+            (l, value)
         })
         .collect();
     let mut out = Vec::with_capacity(lhs.len().min(rhs_idx.len()));

--- a/crates/metrics-store/src/promql/validate.rs
+++ b/crates/metrics-store/src/promql/validate.rs
@@ -22,9 +22,15 @@ pub const SUPPORTED_RANGE_FUNCS: &[&str] = &[
     "last_over_time",
 ];
 
-/// Fonctions instantanées (`f(vec)` ou `f(vec, scalar)`).
-pub const SUPPORTED_INSTANT_FUNCS: &[&str] =
-    &["abs", "clamp_min", "clamp_max", "ceil", "floor", "round"];
+/// Fonctions instantanées (`f(vec)` ou `f(vec, scalar…)`).
+pub const SUPPORTED_INSTANT_FUNCS: &[&str] = &[
+    "abs", "clamp_min", "clamp_max", "clamp", "ceil", "floor", "round", "sqrt", "exp", "ln",
+    "log2", "log10", "sgn",
+];
+
+/// Fonctions de manipulation de labels (`f(vec, "str", …)`) — arguments string
+/// autorisés uniquement pour ces fonctions.
+pub const SUPPORTED_LABEL_FUNCS: &[&str] = &["label_replace", "label_join"];
 
 /// Opérateurs d'agrégation instant supportés (sans paramètre).
 pub const SUPPORTED_AGGREGATORS: &[&str] = &["sum", "max", "min", "avg", "count"];
@@ -122,8 +128,27 @@ fn validate_call(c: &Call) -> Result<(), PromQlError> {
     let name = c.func.name;
     let is_range = SUPPORTED_RANGE_FUNCS.contains(&name);
     let is_instant = SUPPORTED_INSTANT_FUNCS.contains(&name);
-    if !is_range && !is_instant {
+    let is_label = SUPPORTED_LABEL_FUNCS.contains(&name);
+    if !is_range && !is_instant && !is_label {
         return unsupported(&format!("function: {name}"));
+    }
+    if is_label {
+        // `label_replace`/`label_join` : 1er arg = vecteur instantané (validé),
+        // arguments suivants = string literals (autorisés uniquement ici).
+        let first = c
+            .args
+            .args
+            .first()
+            .ok_or_else(|| PromQlError::Unsupported(format!("{name}: argument manquant")))?;
+        validate(first)?;
+        for arg in &c.args.args[1..] {
+            if !matches!(arg.as_ref(), Expr::StringLiteral(_)) {
+                return unsupported(&format!(
+                    "{name}: les arguments après le vecteur doivent être des chaînes"
+                ));
+            }
+        }
+        return Ok(());
     }
     for arg in &c.args.args {
         validate(arg)?;
@@ -182,6 +207,29 @@ mod tests {
     }
 
     #[test]
+    fn accepts_math_functions() {
+        ok("sqrt(bms_v)");
+        ok("exp(bms_v)");
+        ok("ln(bms_v)");
+        ok("log2(bms_v)");
+        ok("log10(bms_v)");
+        ok("sgn(bms_v)");
+        ok("clamp(bms_v, 0, 100)");
+    }
+
+    #[test]
+    fn accepts_label_functions() {
+        ok(r#"label_replace(bms_v, "pack", "$1", "bms_id", "(.*)")"#);
+        ok(r#"label_join(bms_v, "combo", "-", "bms_id", "phase")"#);
+    }
+
+    #[test]
+    fn rejects_bare_string_literal() {
+        // Une chaîne nue (hors argument de fonction de labels) reste rejetée.
+        ko(r#""foo""#, "string literal");
+    }
+
+    #[test]
     fn rejects_subquery() {
         ko(
             r#"avg_over_time(clamp_min(venus_shunt_current_a,0)[24h:1m])"#,
@@ -192,7 +240,8 @@ mod tests {
     #[test]
     fn rejects_unsupported_function() {
         ko("histogram_quantile(0.95, foo)", "function: histogram_quantile");
-        ko("label_replace(foo, \"a\", \"b\", \"c\", \"d\")", "function: label_replace");
+        ko("vector(1)", "function: vector");
+        ko("deriv(foo[5m])", "function: deriv");
     }
 
     #[test]

--- a/docs/plan_migration_vm_redb.md
+++ b/docs/plan_migration_vm_redb.md
@@ -1216,6 +1216,11 @@ fausse. Toujours **pas** de set ops `unless`/`and`/`or`.
 - **`topk(k, vec)` / `bottomk(k, vec)`** (Phase 3b) — labels d'origine
   conservés, support optionnel de `by (…)`.
 - **`irate(m[w])`** (Phase 3c) — taux instantané sur les 2 derniers points.
+- **Math instant** (Phase 4) : `sqrt exp ln log2 log10 sgn clamp(v,min,max)`
+  (en plus de `abs clamp_min clamp_max ceil floor round`).
+- **Manipulation de labels** (Phase 4) : `label_replace(v,dst,repl,src,regex)`
+  (regex ancrée, expansion `$1`/`${name}`) et `label_join(v,dst,sep,src…)`.
+  Seules fonctions à accepter des arguments string.
 
 **Subqueries** : une seule occurrence — `[24h:1m]` dans le panel 43
 (`grafana-ess_dashboard.json`, calcul du proxy de cyclage batterie) :

--- a/docs/promql-compat-roadmap.md
+++ b/docs/promql-compat-roadmap.md
@@ -1,11 +1,13 @@
 # PromQL compatibility roadmap — metrics-store
 
-> **✅ ÉTAT : toutes les phases (1, 2, 3a, 3b, 3c) sont implémentées et
-> testées.** Le sous-ensemble PromQL supporté inclut désormais le groupement
-> `by`/`without`, les comparaisons (+ `bool`), `topk`/`bottomk` et `irate`,
-> en plus du rejet explicite du vector matching non trivial. Voir la matrice
-> de compat mise à jour dans `docs/plan_migration_vm_redb.md` §6.4-6.5. Le
-> document ci-dessous reste comme référence de conception.
+> **✅ ÉTAT : phases 1, 2, 3a, 3b, 3c + Phase 4 (math & labels) implémentées
+> et testées.** Le sous-ensemble PromQL supporté inclut désormais le
+> groupement `by`/`without`, les comparaisons (+ `bool`), `topk`/`bottomk`,
+> `irate`, les fonctions math (`sqrt exp ln log2 log10 sgn clamp`) et la
+> manipulation de labels (`label_replace`, `label_join`), en plus du rejet
+> explicite du vector matching non trivial. Voir la matrice de compat à jour
+> dans `docs/plan_migration_vm_redb.md` §6.4-6.5. Le document ci-dessous reste
+> comme référence de conception.
 
 > **But du document** : plan d'implémentation **autoportant** pour élargir la
 > compatibilité PromQL du moteur `metrics-store` (le shim que Grafana
@@ -324,6 +326,35 @@ point → pas de valeur.
 
 ---
 
+## Phase 4 — Fonctions math & manipulation de labels
+
+**Objectif** : préparer les dashboards plus sophistiqués à venir (légendes
+dynamiques, échelles log, normalisation).
+
+### 4a — Math instant
+- `validate.rs` : ajouter `sqrt exp ln log2 log10 sgn clamp` à
+  `SUPPORTED_INSTANT_FUNCS`.
+- `exec.rs` : helper `unary_math` (propagation NaN naturelle ; `sgn` renvoie
+  -1/0/1/NaN à la Prometheus) + `clamp_val` (NaN si `min > max`). Branché dans
+  `apply_instant_fn` (vecteur) et `apply_instant_scalar` (scalaire).
+
+### 4b — Labels
+- `validate.rs` : `SUPPORTED_LABEL_FUNCS = [label_replace, label_join]` ;
+  `validate_call` valide le 1er arg (vecteur) et **autorise les `StringLiteral`**
+  pour les arguments suivants (seul endroit où une string est acceptée). NB :
+  `promql-parser` type-check déjà la signature → un mauvais type donne une
+  `ParseError`.
+- `exec.rs` : routage dédié dans `eval_call` (les args string ne sont pas
+  évaluables). `label_replace` utilise la crate `regex` (ancrage `^(?:…)$`,
+  expansion `$1`/`${name}` via `Captures::expand`) ; valeur vide ⇒ label retiré.
+  `label_join` concatène les labels source avec le séparateur.
+- Dépendance : `regex = "1"` (déjà présente transitivement via promql-parser).
+
+**Tests** : `sqrt/clamp/sgn`, `label_replace` (match, non-match, label retiré),
+`label_join`. **PR** : `feat(promql): math functions + label_replace/label_join`.
+
+---
+
 ## Récapitulatif
 
 | Phase | Contenu | Effort | Risque | Priorité | État |
@@ -333,8 +364,10 @@ point → pas de valeur.
 | 3a | Comparaisons + bool | ½–1 j | moyen | moyenne | ✅ fait |
 | 3b | topk/bottomk | ½ j | faible | moyenne | ✅ fait |
 | 3c | irate | ½ j | faible | basse | ✅ fait |
+| 4a | Math instant (sqrt/exp/ln/log/sgn/clamp) | ¼ j | faible | moyenne | ✅ fait |
+| 4b | label_replace / label_join | ½ j | faible | **haute** | ✅ fait |
 
-**Ordre recommandé** : 1 → 2 → (3a/3b/3c à la demande).
+**Ordre recommandé** : 1 → 2 → (3a/3b/3c à la demande) → 4 (avant dashboards sophistiqués).
 
 ### Définition de « terminé » par PR
 - [ ] `cargo test -p metrics-store` vert (unitaires + golden + coverage 16 dashboards).


### PR DESCRIPTION
Prépare les dashboards plus sophistiqués à venir (légendes dynamiques, échelles log) et intègre la revue Gemini PR #528.

Phase 4a — math instant : sqrt exp ln log2 log10 sgn clamp(v,min,max)
  ajoutés à SUPPORTED_INSTANT_FUNCS, helpers unary_math (NaN propagé ;
  sgn -1/0/1/NaN) et clamp_val (NaN si min>max), branchés sur les chemins
  vecteur et scalaire.

Phase 4b — labels : label_replace (regex ancrée ^(?:…)$ + expansion
  $1/${name}, valeur vide ⇒ label retiré) et label_join. Seules fonctions
  acceptant des arguments string ; validate_call valide le vecteur et
  autorise les StringLiteral suivants. Dépendance regex = 1 (déjà
  transitive via promql-parser).

Revue PR #528 : align_and_compare déstructure le sample et droppe l'Arc
  labels avant Arc::try_unwrap, sinon le refcount restait ≥ 2 et le
  try_unwrap échouait systématiquement (re-clonage du BTreeMap).

61 tests unitaires + 3 golden verts ; matrice de compat docs à jour.