### PR TITLE
feat(promql): P2 (deriv/predict_linear/quantile|stddev|stdvar_over_ti…

### DIFF
--- a/crates/metrics-store/src/lib.rs
+++ b/crates/metrics-store/src/lib.rs
@@ -591,6 +591,84 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn promql_p2_p3_functions() {
+        use crate::promql::{parse_and_validate, Evaluator};
+
+        let path = tmp_db_path("promql_p2p3");
+        let _ = std::fs::remove_file(&path);
+        {
+            let opts = Options {
+                writer: WriterConfig { batch_max: 64, flush_ms: 20, poll_idle_ms: 2 },
+                ..Options::default()
+            };
+            let store = MetricsStore::open(&path, opts).expect("open");
+            let writer = store.writer();
+
+            // soc : droite décroissante 100,90,…,10 sur 10 pts (pas 1 s) → pente -10/s.
+            // status : 0,0,1,1,2 → 2 changements. cnt : 0,5,10,2,8 → 1 reset.
+            for i in 0..10_i64 {
+                let ts = 100_000 + i * 1_000;
+                writer
+                    .write(Sample::new("soc", ts, 100.0 - 10.0 * i as f64))
+                    .await
+                    .unwrap();
+            }
+            for (i, v) in [0.0, 0.0, 1.0, 1.0, 2.0].iter().enumerate() {
+                writer
+                    .write(Sample::new("status", 100_000 + i as i64 * 1_000, *v))
+                    .await
+                    .unwrap();
+            }
+            for (i, v) in [0.0, 5.0, 10.0, 2.0, 8.0].iter().enumerate() {
+                writer
+                    .write(Sample::new("cnt", 100_000 + i as i64 * 1_000, *v))
+                    .await
+                    .unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(150)).await;
+
+            let reader = store.reader();
+            let ev = Evaluator::new(&reader);
+            let at = 109_000;
+            let scalar = |q: &str| {
+                let expr = parse_and_validate(q).unwrap();
+                let v = ev.eval_instant(&expr, at).unwrap();
+                assert_eq!(v.len(), 1, "{q}");
+                v[0].value
+            };
+
+            // deriv ≈ -10/s
+            assert!((scalar("deriv(soc[10s])") - (-10.0)).abs() < 1e-6);
+            // predict_linear : à t=109s soc=10, pente -10 → +5 s ⇒ 10-50 = -40
+            assert!((scalar("predict_linear(soc[10s], 5)") - (-40.0)).abs() < 1e-6);
+            // quantile_over_time 0.5 sur [10..100] → médiane 55
+            assert!((scalar("quantile_over_time(0.5, soc[10s])") - 55.0).abs() < 1e-9);
+            // stddev_over_time > 0
+            assert!(scalar("stddev_over_time(soc[10s])") > 0.0);
+            // changes(status) = 2
+            assert!((scalar("changes(status[10s])") - 2.0).abs() < 1e-9);
+            // resets(cnt) = 1
+            assert!((scalar("resets(cnt[10s])") - 1.0).abs() < 1e-9);
+
+            // absent : série existante → vecteur vide
+            let expr = parse_and_validate("absent(soc)").unwrap();
+            assert_eq!(ev.eval_instant(&expr, at).unwrap().len(), 0);
+            // absent : série inexistante → 1 sample à 1 avec labels du matcher
+            let expr = parse_and_validate(r#"absent(missing_metric{site="A"})"#).unwrap();
+            let v = ev.eval_instant(&expr, at).unwrap();
+            assert_eq!(v.len(), 1);
+            assert!((v[0].value - 1.0).abs() < 1e-9);
+            assert_eq!(v[0].labels.get("site").map(String::as_str), Some("A"));
+
+            // round(v, 0.1) honore to_nearest (105.0 reste 105.0 ; vérifie via soc=100)
+            let expr = parse_and_validate("round(soc, 0.1)").unwrap();
+            let v = ev.eval_instant(&expr, 100_000).unwrap();
+            assert!((v[0].value - 100.0).abs() < 1e-9);
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn promql_math_and_label_functions() {
         use crate::promql::{parse_and_validate, Evaluator};
 

--- a/crates/metrics-store/src/promql/exec.rs
+++ b/crates/metrics-store/src/promql/exec.rs
@@ -496,11 +496,19 @@ impl<'r> Evaluator<'r> {
                 label_join(inner, c)
             };
         }
-        // Fonctions à fenêtre : 1er arg = MatrixSelector.
-        if let Some(first) = c.args.first() {
-            if let Expr::MatrixSelector(MatrixSelector { vs, range }) = first.as_ref() {
-                return self.eval_range_call(name, vs, range, t);
-            }
+        // `absent(v)` : sémantique spéciale (1 sample si v est vide, sinon vide)
+        // — nécessite les matchers du sélecteur pour construire les labels.
+        if name == "absent" {
+            return self.eval_absent(c, t);
+        }
+        // Fonctions à fenêtre : le MatrixSelector peut être le 1er argument
+        // (`rate(m[5m])`, `predict_linear(m[1h], 3600)`) ou le 2e
+        // (`quantile_over_time(0.95, m[1d])`). On le localise n'importe où.
+        if let Some((vs, range)) = c.args.args.iter().find_map(|a| match a.as_ref() {
+            Expr::MatrixSelector(MatrixSelector { vs, range }) => Some((vs, range)),
+            _ => None,
+        }) {
+            return self.eval_range_call(name, vs, range, c, t);
         }
         // Fonctions instantanées : 1er arg = vecteur, args suivants = scalaires.
         let inner = match self.eval_at(c.args.args[0].as_ref(), t)? {
@@ -510,17 +518,60 @@ impl<'r> Evaluator<'r> {
         self.apply_instant_fn(name, inner, c, t)
     }
 
+    /// `absent(v)` : renvoie un vecteur vide si `v` a des éléments, sinon un
+    /// unique sample à `1` étiqueté avec les matchers d'égalité du sélecteur
+    /// (utile pour l'alerting « série absente »).
+    fn eval_absent(&self, c: &Call, t: i64) -> Result<Value, PromQlError> {
+        let non_empty = match self.eval_at(c.args.args[0].as_ref(), t)? {
+            Value::Vector(v) => !v.is_empty(),
+            Value::Scalar(_) => true,
+        };
+        if non_empty {
+            return Ok(Value::Vector(vec![]));
+        }
+        let mut labels = Labels::new();
+        if let Expr::VectorSelector(vs) = c.args.args[0].as_ref() {
+            for m in &vs.matchers.matchers {
+                if matches!(m.op, MatchOp::Equal) && m.name != "__name__" {
+                    labels.insert(m.name.clone(), m.value.clone());
+                }
+            }
+        }
+        Ok(Value::Vector(vec![InstantSample { labels: Arc::new(labels), value: 1.0 }]))
+    }
+
     fn eval_range_call(
         &self,
         name: &str,
         vs: &VectorSelector,
         range: &Duration,
+        c: &Call,
         t: i64,
     ) -> Result<Value, PromQlError> {
         let range_ms = range.as_millis() as i64;
         let win_start = t - range_ms;
         let tier = tier_for_range(range_ms);
         let matched = self.match_series(vs)?;
+        // Paramètre scalaire éventuel = 1er argument qui n'est pas le
+        // MatrixSelector (`predict_linear(m, T)` → T ; `quantile_over_time(φ, m)`
+        // → φ). Évalué une seule fois.
+        let param: Option<f64> = {
+            let mut p = None;
+            for a in &c.args.args {
+                if !matches!(a.as_ref(), Expr::MatrixSelector(_)) {
+                    match self.eval_at(a, t)? {
+                        Value::Scalar(v) => p = Some(v),
+                        Value::Vector(_) => {
+                            return Err(PromQlError::Execution(format!(
+                                "{name}: paramètre scalaire attendu"
+                            )))
+                        }
+                    }
+                    break;
+                }
+            }
+            p
+        };
         let rtx = self.txn()?;
         let mut out = Vec::with_capacity(matched.len());
         // P2 : `delta` (différence de jauge) et `last_over_time` n'ont besoin
@@ -552,14 +603,14 @@ impl<'r> Evaluator<'r> {
                         .reader
                         .query_range_raw_with_tx(rtx, *sid, win_start, t)
                         .map_err(|e| PromQlError::Execution(e.to_string()))?;
-                    apply_range_fn_raw(name, &pts, range_ms)
+                    apply_range_fn_raw(name, &pts, range_ms, t, param)
                 }
                 Tier::Hourly | Tier::Daily => {
                     let buckets = self
                         .reader
                         .query_range_buckets_with_tx(rtx, *sid, win_start, t, tier)
                         .map_err(|e| PromQlError::Execution(e.to_string()))?;
-                    apply_range_fn_buckets(name, &buckets, range_ms)
+                    apply_range_fn_buckets(name, &buckets, range_ms, t, param)
                 }
             };
             if let Some(v) = value_opt {
@@ -589,10 +640,15 @@ impl<'r> Evaluator<'r> {
                 .into_iter()
                 .map(|s| InstantSample { labels: s.labels, value: s.value.floor() })
                 .collect(),
-            "round" => inner
-                .into_iter()
-                .map(|s| InstantSample { labels: s.labels, value: s.value.round() })
-                .collect(),
+            "round" => {
+                // 2e argument optionnel `to_nearest` (défaut 1) — était
+                // auparavant ignoré (résultat faux silencieux).
+                let to_nearest = scalar_arg_opt(c, 1, t, self)?.unwrap_or(1.0);
+                inner
+                    .into_iter()
+                    .map(|s| InstantSample { labels: s.labels, value: round_to(s.value, to_nearest) })
+                    .collect()
+            }
             "clamp_min" => {
                 let k = scalar_arg(c, 1, t, self)?;
                 inner
@@ -637,7 +693,7 @@ impl<'r> Evaluator<'r> {
             "abs" => s.abs(),
             "ceil" => s.ceil(),
             "floor" => s.floor(),
-            "round" => s.round(),
+            "round" => round_to(s, scalar_arg_opt(c, 1, t, self)?.unwrap_or(1.0)),
             "clamp_min" => s.max(scalar_arg(c, 1, t, self)?),
             "clamp_max" => s.min(scalar_arg(c, 1, t, self)?),
             "clamp" => clamp_val(s, scalar_arg(c, 1, t, self)?, scalar_arg(c, 2, t, self)?),
@@ -720,23 +776,127 @@ fn scalar_arg(c: &Call, idx: usize, t: i64, ev: &Evaluator) -> Result<f64, PromQ
     }
 }
 
-fn apply_range_fn_raw(name: &str, pts: &[(i64, f64)], range_ms: i64) -> Option<f64> {
+/// Variante optionnelle de `scalar_arg` : `Ok(None)` si l'argument est absent.
+fn scalar_arg_opt(
+    c: &Call,
+    idx: usize,
+    t: i64,
+    ev: &Evaluator,
+) -> Result<Option<f64>, PromQlError> {
+    if c.args.args.get(idx).is_none() {
+        return Ok(None);
+    }
+    scalar_arg(c, idx, t, ev).map(Some)
+}
+
+/// Arrondi PromQL au plus proche multiple de `to_nearest` (`round(v, tn)`),
+/// demi-vers-le-haut comme Prometheus (`floor(v/tn + 0.5) * tn`).
+fn round_to(v: f64, to_nearest: f64) -> f64 {
+    let tn = if to_nearest == 0.0 { 1.0 } else { to_nearest };
+    (v / tn + 0.5).floor() * tn
+}
+
+/// Régression linéaire par moindres carrés sur `pts`, avec l'origine de l'axe x
+/// fixée à `intercept_time_ms` (en ms). Renvoie `(pente_par_seconde, ordonnée
+/// à intercept_time)`. Utilisé par `deriv` et `predict_linear`.
+fn linear_regression(pts: &[(i64, f64)], intercept_time_ms: i64) -> (f64, f64) {
+    let n = pts.len() as f64;
+    let (mut sum_x, mut sum_y, mut sum_xy, mut sum_x2) = (0.0, 0.0, 0.0, 0.0);
+    for (ts, v) in pts {
+        let x = (*ts - intercept_time_ms) as f64 / 1000.0;
+        sum_x += x;
+        sum_y += v;
+        sum_xy += x * v;
+        sum_x2 += x * x;
+    }
+    let cov_xy = sum_xy - sum_x * sum_y / n;
+    let var_x = sum_x2 - sum_x * sum_x / n;
+    let slope = cov_xy / var_x;
+    let intercept = sum_y / n - slope * sum_x / n;
+    (slope, intercept)
+}
+
+/// Variance de population (`Σ(x-µ)²/n`) sur une série de valeurs.
+fn variance_pop(values: &[f64]) -> f64 {
+    let n = values.len() as f64;
+    let mean = values.iter().sum::<f64>() / n;
+    values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n
+}
+
+/// φ-quantile avec interpolation linéaire (sémantique Prometheus). `φ<0` →
+/// `-Inf`, `φ>1` → `+Inf`. `values` doit être non vide.
+fn quantile_value(phi: f64, mut values: Vec<f64>) -> f64 {
+    if phi.is_nan() {
+        return f64::NAN;
+    }
+    if phi < 0.0 {
+        return f64::NEG_INFINITY;
+    }
+    if phi > 1.0 {
+        return f64::INFINITY;
+    }
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = values.len();
+    let rank = phi * (n - 1) as f64;
+    let lower = rank.floor() as usize;
+    let upper = rank.ceil() as usize;
+    let weight = rank - lower as f64;
+    values[lower] * (1.0 - weight) + values[upper] * weight
+}
+
+/// Nombre de changements de valeur entre points consécutifs (`changes`). Deux
+/// `NaN` consécutifs ne comptent pas comme un changement (sémantique Prometheus).
+fn changes_count(values: &[f64]) -> f64 {
+    values
+        .windows(2)
+        .filter(|w| w[0] != w[1] && !(w[0].is_nan() && w[1].is_nan()))
+        .count() as f64
+}
+
+/// Nombre de resets de compteur (`resets`) : transitions où la valeur décroît.
+fn resets_count(values: &[f64]) -> f64 {
+    values.windows(2).filter(|w| w[1] < w[0]).count() as f64
+}
+
+fn apply_range_fn_raw(
+    name: &str,
+    pts: &[(i64, f64)],
+    range_ms: i64,
+    eval_t: i64,
+    param: Option<f64>,
+) -> Option<f64> {
     if pts.is_empty() {
         return match name {
             "count_over_time" => Some(0.0),
+            "changes" | "resets" => Some(0.0),
             _ => None,
         };
     }
+    // Fonctions nécessitant ≥ 2 points (régression / dérivée).
+    if matches!(name, "deriv" | "predict_linear") && pts.len() < 2 {
+        return None;
+    }
+    let vals: Vec<f64> = pts.iter().map(|p| p.1).collect();
     Some(match name {
         "increase" => raw_counter_increase(pts),
         "delta" => pts.last().unwrap().1 - pts.first().unwrap().1,
         "rate" => raw_counter_increase(pts) / (range_ms as f64 / 1000.0),
-        "avg_over_time" => pts.iter().map(|p| p.1).sum::<f64>() / pts.len() as f64,
-        "sum_over_time" => pts.iter().map(|p| p.1).sum::<f64>(),
-        "min_over_time" => pts.iter().map(|p| p.1).fold(f64::INFINITY, f64::min),
-        "max_over_time" => pts.iter().map(|p| p.1).fold(f64::NEG_INFINITY, f64::max),
-        "count_over_time" => pts.len() as f64,
+        "deriv" => linear_regression(pts, pts[0].0).0,
+        "predict_linear" => {
+            let (slope, intercept) = linear_regression(pts, eval_t);
+            slope * param? + intercept
+        }
+        "changes" => changes_count(&vals),
+        "resets" => resets_count(&vals),
+        "avg_over_time" => vals.iter().sum::<f64>() / vals.len() as f64,
+        "sum_over_time" => vals.iter().sum::<f64>(),
+        "min_over_time" => vals.iter().copied().fold(f64::INFINITY, f64::min),
+        "max_over_time" => vals.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+        "count_over_time" => vals.len() as f64,
         "last_over_time" => pts.last().unwrap().1,
+        "stdvar_over_time" => variance_pop(&vals),
+        "stddev_over_time" => variance_pop(&vals).sqrt(),
+        "quantile_over_time" => quantile_value(param?, vals),
         _ => return None,
     })
 }
@@ -812,12 +972,57 @@ fn apply_range_fn_buckets(
     name: &str,
     buckets: &[(i64, AggBucket)],
     range_ms: i64,
+    eval_t: i64,
+    param: Option<f64>,
 ) -> Option<f64> {
     if buckets.is_empty() {
         return match name {
             "count_over_time" => Some(0.0),
+            "changes" | "resets" => Some(0.0),
             _ => None,
         };
+    }
+    // Fonctions statistiques / régression sur tier compacté : les points raw
+    // sont purgés. Approximation documentée — on opère sur les valeurs
+    // représentatives des buckets (`avg` pour régression/stats ; séquence
+    // `first,last` pour changes/resets). Précis sur tier raw, approché ici.
+    match name {
+        "deriv" | "predict_linear" => {
+            if buckets.len() < 2 {
+                return None;
+            }
+            let pts: Vec<(i64, f64)> = buckets.iter().map(|(ts, b)| (*ts, b.avg)).collect();
+            return Some(if name == "deriv" {
+                linear_regression(&pts, pts[0].0).0
+            } else {
+                let (slope, intercept) = linear_regression(&pts, eval_t);
+                slope * param? + intercept
+            });
+        }
+        "stdvar_over_time" | "stddev_over_time" | "quantile_over_time" => {
+            let vals: Vec<f64> = buckets.iter().map(|(_, b)| b.avg).collect();
+            return Some(match name {
+                "stdvar_over_time" => variance_pop(&vals),
+                "stddev_over_time" => variance_pop(&vals).sqrt(),
+                _ => quantile_value(param?, vals),
+            });
+        }
+        "changes" | "resets" => {
+            // Séquence first→last de chaque bucket (capture le net intra-bucket
+            // et les transitions inter-buckets ; les oscillations internes sont
+            // invisibles).
+            let mut seq = Vec::with_capacity(buckets.len() * 2);
+            for (_, b) in buckets {
+                seq.push(b.first);
+                seq.push(b.last);
+            }
+            return Some(if name == "changes" {
+                changes_count(&seq)
+            } else {
+                resets_count(&seq)
+            });
+        }
+        _ => {}
     }
     // `irate` sur tier compacté : mal défini (points raw purgés). Choix retenu
     // (cf. roadmap §3c) : approximer avec les `last` des deux derniers buckets,
@@ -1190,5 +1395,45 @@ mod tests {
         assert_eq!(unary_math("sgn", -0.0), 0.0);
         assert!(unary_math("sgn", f64::NAN).is_nan());
         assert_eq!(unary_math("sqrt", 9.0), 3.0);
+    }
+
+    #[test]
+    fn round_to_honors_to_nearest() {
+        assert!((round_to(1.27, 0.1) - 1.3).abs() < 1e-9);
+        assert!((round_to(1.24, 0.1) - 1.2).abs() < 1e-9);
+        assert_eq!(round_to(2.5, 1.0), 3.0); // demi-vers-le-haut
+        assert_eq!(round_to(7.0, 5.0), 5.0);
+        assert_eq!(round_to(8.0, 5.0), 10.0);
+        assert_eq!(round_to(42.0, 0.0), 42.0); // to_nearest=0 → défaut 1
+    }
+
+    #[test]
+    fn linear_regression_pente_et_ordonnee() {
+        // y = 10 + 2*(t en s) à partir de t=0, pas de 1 s.
+        let pts: Vec<(i64, f64)> = (0..5).map(|i| (i * 1000, 10.0 + 2.0 * i as f64)).collect();
+        let (slope, intercept) = linear_regression(&pts, 0);
+        assert!((slope - 2.0).abs() < 1e-9);
+        assert!((intercept - 10.0).abs() < 1e-9);
+        // deriv = pente quelle que soit l'origine.
+        let (slope2, _) = linear_regression(&pts, pts[0].0);
+        assert!((slope2 - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn quantile_value_interpolation() {
+        let v = vec![1.0, 2.0, 3.0, 4.0];
+        assert_eq!(quantile_value(0.0, v.clone()), 1.0);
+        assert_eq!(quantile_value(1.0, v.clone()), 4.0);
+        assert_eq!(quantile_value(0.5, v.clone()), 2.5);
+        assert!(quantile_value(-0.1, v.clone()) == f64::NEG_INFINITY);
+        assert!(quantile_value(1.1, v) == f64::INFINITY);
+    }
+
+    #[test]
+    fn variance_changes_resets() {
+        assert!((variance_pop(&[2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]) - 4.0).abs() < 1e-9);
+        assert_eq!(changes_count(&[1.0, 1.0, 2.0, 2.0, 3.0]), 2.0);
+        assert_eq!(changes_count(&[f64::NAN, f64::NAN]), 0.0); // 2 NaN consécutifs
+        assert_eq!(resets_count(&[0.0, 5.0, 10.0, 2.0, 8.0]), 1.0); // un seul reset (10→2)
     }
 }

--- a/crates/metrics-store/src/promql/validate.rs
+++ b/crates/metrics-store/src/promql/validate.rs
@@ -14,18 +14,25 @@ pub const SUPPORTED_RANGE_FUNCS: &[&str] = &[
     "rate",
     "irate",
     "delta",
+    "deriv",
+    "predict_linear",
+    "changes",
+    "resets",
     "avg_over_time",
     "sum_over_time",
     "min_over_time",
     "max_over_time",
     "count_over_time",
     "last_over_time",
+    "stddev_over_time",
+    "stdvar_over_time",
+    "quantile_over_time",
 ];
 
 /// Fonctions instantanées (`f(vec)` ou `f(vec, scalar…)`).
 pub const SUPPORTED_INSTANT_FUNCS: &[&str] = &[
     "abs", "clamp_min", "clamp_max", "clamp", "ceil", "floor", "round", "sqrt", "exp", "ln",
-    "log2", "log10", "sgn",
+    "log2", "log10", "sgn", "absent",
 ];
 
 /// Fonctions de manipulation de labels (`f(vec, "str", …)`) — arguments string
@@ -218,6 +225,21 @@ mod tests {
     }
 
     #[test]
+    fn accepts_p2_p3_functions() {
+        // P2
+        ok("deriv(bms_v[10m])");
+        ok("predict_linear(bms_soc[1h], 3600)");
+        ok("quantile_over_time(0.95, bms_v[1d])");
+        ok("stddev_over_time(bms_v[1h])");
+        ok("stdvar_over_time(bms_v[1h])");
+        // P3
+        ok("changes(bms_status[1h])");
+        ok("resets(bms_uptime[1d])");
+        ok(r#"absent(bms_v{bms_id="1"})"#);
+        ok("round(bms_v, 0.1)");
+    }
+
+    #[test]
     fn accepts_label_functions() {
         ok(r#"label_replace(bms_v, "pack", "$1", "bms_id", "(.*)")"#);
         ok(r#"label_join(bms_v, "combo", "-", "bms_id", "phase")"#);
@@ -241,7 +263,7 @@ mod tests {
     fn rejects_unsupported_function() {
         ko("histogram_quantile(0.95, foo)", "function: histogram_quantile");
         ko("vector(1)", "function: vector");
-        ko("deriv(foo[5m])", "function: deriv");
+        ko("idelta(foo[5m])", "function: idelta");
     }
 
     #[test]

--- a/docs/plan_migration_vm_redb.md
+++ b/docs/plan_migration_vm_redb.md
@@ -1217,10 +1217,18 @@ fausse. Toujours **pas** de set ops `unless`/`and`/`or`.
   conservés, support optionnel de `by (…)`.
 - **`irate(m[w])`** (Phase 3c) — taux instantané sur les 2 derniers points.
 - **Math instant** (Phase 4) : `sqrt exp ln log2 log10 sgn clamp(v,min,max)`
-  (en plus de `abs clamp_min clamp_max ceil floor round`).
+  (en plus de `abs clamp_min clamp_max ceil floor round`). `round(v,to_nearest)`
+  honore désormais le 2ᵉ argument (demi-vers-le-haut).
 - **Manipulation de labels** (Phase 4) : `label_replace(v,dst,repl,src,regex)`
   (regex ancrée, expansion `$1`/`${name}`) et `label_join(v,dst,sep,src…)`.
   Seules fonctions à accepter des arguments string.
+- **Prédiction / stats** (Phase 5, P2) : `deriv`, `predict_linear(v[w],T)`,
+  `quantile_over_time(φ,v[w])`, `stddev_over_time`, `stdvar_over_time`.
+- **Alerting / compteurs** (Phase 5, P3) : `absent(v)` (labels = matchers
+  d'égalité), `changes(v[w])`, `resets(v[w])`.
+- Sur tier compacté, `deriv`/`predict_linear`/`stddev`/`stdvar`/`quantile_over_time`
+  opèrent sur les `avg` des buckets et `changes`/`resets` sur la séquence
+  `first,last` (approximation documentée — exact sur tier raw, ≤ 7 j).
 
 **Subqueries** : une seule occurrence — `[24h:1m]` dans le panel 43
 (`grafana-ess_dashboard.json`, calcul du proxy de cyclage batterie) :

--- a/docs/promql-compat-roadmap.md
+++ b/docs/promql-compat-roadmap.md
@@ -366,8 +366,24 @@ dynamiques, échelles log, normalisation).
 | 3c | irate | ½ j | faible | basse | ✅ fait |
 | 4a | Math instant (sqrt/exp/ln/log/sgn/clamp) | ¼ j | faible | moyenne | ✅ fait |
 | 4b | label_replace / label_join | ½ j | faible | **haute** | ✅ fait |
+| 5 (P2) | deriv, predict_linear, quantile/stddev/stdvar_over_time | ½ j | moyen | moyenne | ✅ fait |
+| 5 (P3) | absent, changes, resets + fix `round(v,to_nearest)` | ½ j | faible | moyenne | ✅ fait |
 
-**Ordre recommandé** : 1 → 2 → (3a/3b/3c à la demande) → 4 (avant dashboards sophistiqués).
+**Ordre recommandé** : 1 → 2 → (3a/3b/3c à la demande) → 4 → 5 (avant dashboards sophistiqués).
+
+### Phase 5 — notes d'implémentation
+- `eval_call` localise le `MatrixSelector` **n'importe où** dans les args (gère
+  `quantile_over_time(φ, m[w])` dont la matrice est le 2ᵉ arg) ; le scalaire
+  éventuel (`φ`, durée `predict_linear`) est extrait comme « 1er arg non-matrice ».
+- `deriv`/`predict_linear` : régression linéaire moindres carrés
+  (`linear_regression`, origine x = `intercept_time`). `predict_linear` ancre
+  l'ordonnée à l'instant d'éval et renvoie `slope*T + intercept`.
+- `absent` : routé à part (a besoin des matchers du sélecteur) ; renvoie 1 sample
+  étiqueté des matchers `=` quand la série est absente.
+- Tier compacté : approximations documentées (cf. §6.5 du plan de migration).
+- **Restants (P4, à la demande)** : `histogram_quantile`, `holt_winters`,
+  trigo (`sin/cos/…`), `sort`/`sort_desc`, `scalar`/`vector`, fonctions date,
+  set ops `and/or/unless`, vector matching, `{__name__=~…}`.
 
 ### Définition de « terminé » par PR
 - [ ] `cargo test -p metrics-store` vert (unitaires + golden + coverage 16 dashboards).


### PR DESCRIPTION
…me) + P3 (absent/changes/resets) + fix round(to_nearest)

Phase 5 du roadmap promql-compat.

P2 — prédiction & stats :
- deriv, predict_linear : régression linéaire moindres carrés (linear_regression). predict_linear ancre l'ordonnée à l'instant d'éval → slope*T + intercept.
- quantile_over_time (interpolation linéaire, φ<0→-Inf, φ>1→+Inf), stddev_over_time, stdvar_over_time (variance de population).

P3 — alerting :
- absent(v) : routé à part, renvoie 1 sample étiqueté des matchers d'égalité quand la série est absente, sinon vecteur vide.
- changes, resets (2 NaN consécutifs ≠ changement).
- fix round(v, to_nearest) : le 2e argument était silencieusement ignoré (résultat faux) → arrondi demi-vers-le-haut au multiple.

eval_call localise le MatrixSelector n'importe où dans les args (quantile_over_time a la matrice en 2e position) et extrait le scalaire comme 1er arg non-matrice. Tier compacté : approximations documentées (régression/stats sur avg des buckets ; changes/resets sur séquence first,last).

69 unitaires + 3 golden verts ; clippy propre ; build serveur OK.