### PR TITLE
docs(promql): MAJ couverture (exec/mod modules + audit-metriques) ; f…

### DIFF
--- a/crates/metrics-store/src/lib.rs
+++ b/crates/metrics-store/src/lib.rs
@@ -673,6 +673,11 @@ mod tests {
             // absent_over_time : fenêtre sans point (trop ancienne) → 1 sample
             let expr = parse_and_validate("absent_over_time(soc[10s])").unwrap();
             assert_eq!(ev.eval_instant(&expr, 10_000_000).unwrap().len(), 1);
+            // absent avec argument parenthésé : labels du sélecteur préservés.
+            let expr = parse_and_validate(r#"absent((missing_metric{site="C"}))"#).unwrap();
+            let v = ev.eval_instant(&expr, at).unwrap();
+            assert_eq!(v.len(), 1);
+            assert_eq!(v[0].labels.get("site").map(String::as_str), Some("C"));
 
             // round(v, 0.1) honore to_nearest (105.0 reste 105.0 ; vérifie via soc=100)
             let expr = parse_and_validate("round(soc, 0.1)").unwrap();

--- a/crates/metrics-store/src/promql/exec.rs
+++ b/crates/metrics-store/src/promql/exec.rs
@@ -1,14 +1,24 @@
-//! Évaluateur PromQL minimal — couvre le golden set §6.5.
+//! Évaluateur PromQL — couvre le golden set §6.5 + extensions roadmap
+//! promql-compat (cf. `docs/promql-compat-roadmap.md`).
 //!
 //! ## Couverture
 //! - `VectorSelector` (instant) avec matchers `= != =~ !~`
-//! - Arithmétique : `+ - * /` entre vecteurs et scalaires (alignement
-//!   par labels hors `__name__`)
-//! - Agrégations instant : `sum max min avg count`
-//! - Fonctions à fenêtre : `increase rate delta avg_over_time
-//!   sum_over_time min_over_time max_over_time count_over_time
-//!   last_over_time`
-//! - Fonctions instant : `abs clamp_min clamp_max ceil floor round`
+//! - Arithmétique : `+ - * /` (vec×scalar, vec×vec aligné hors `__name__`)
+//! - Comparaisons : `== != > < >= <=` (filtre, ou 0/1 avec `bool`) — Phase 3a
+//! - Agrégations instant : `sum max min avg count` avec `by`/`without`
+//!   (Phase 2) ; `topk`/`bottomk` (Phase 3b, labels d'origine conservés)
+//! - Fonctions à fenêtre : `increase rate irate delta deriv predict_linear
+//!   changes resets avg_over_time sum_over_time min_over_time max_over_time
+//!   count_over_time last_over_time stddev_over_time stdvar_over_time
+//!   quantile_over_time` (`irate` Phase 3c ; deriv/predict_linear/stats Phase 5)
+//! - Fonctions instant : `abs clamp clamp_min clamp_max ceil floor round
+//!   sqrt exp ln log2 log10 sgn` (Phase 4 ; `round(v, to_nearest)` honoré)
+//! - Labels : `label_replace label_join` (Phase 4)
+//! - Absence : `absent` (vecteur instant) / `absent_over_time` (range) — Phase 5
+//!
+//! ## Sémantique des labels
+//! Agrégations (sauf topk/bottomk) et comparaisons **droppent `__name__`** ;
+//! topk/bottomk et les fonctions de fenêtre **conservent** les labels.
 //!
 //! ## Sélection automatique de tier (§6.3)
 //! - matrix range ≤ 7 j → `TABLE_RAW`
@@ -526,7 +536,13 @@ impl<'r> Evaluator<'r> {
     /// Le parser garantit le type de l'argument : `absent` reçoit toujours un
     /// vecteur instantané, `absent_over_time` toujours un `MatrixSelector`.
     fn eval_absent(&self, c: &Call, t: i64) -> Result<Value, PromQlError> {
-        let arg = c.args.args[0].as_ref();
+        // Déroule les parenthèses éventuelles (`absent_over_time((m[5m]))`) pour
+        // que le filtrage du MatrixSelector et l'extraction des labels du
+        // sélecteur fonctionnent (revue Gemini PR #528).
+        let mut arg = c.args.args[0].as_ref();
+        while let Expr::Paren(ParenExpr { expr }) = arg {
+            arg = expr.as_ref();
+        }
         let present = match arg {
             // absent_over_time : présent si ≥ 1 série matchée a un point dans la
             // fenêtre.
@@ -845,10 +861,12 @@ fn linear_regression(pts: &[(i64, f64)], intercept_time_ms: i64) -> (f64, f64) {
     }
     let cov_xy = sum_xy - sum_x * sum_y / n;
     let var_x = sum_x2 - sum_x * sum_x / n;
-    // Garde anti division par zéro : si tous les points partagent le même x
-    // (timestamps identiques), var_x == 0 → pente nulle, ordonnée = moyenne de Y
-    // (sémantique Prometheus). En pratique improbable (ts uniques par série).
-    if var_x == 0.0 {
+    // Garde anti division par zéro : si tous les points partagent le même
+    // timestamp, la variance en x est nulle. On compare directement le premier
+    // et le dernier timestamp (pts trié par ts croissant) — exact et O(1),
+    // contrairement à `var_x == 0.0` qui est instable en flottant (revue Gemini
+    // PR #528). Pente nulle, ordonnée = moyenne de Y (sémantique Prometheus).
+    if pts[0].0 == pts[pts.len() - 1].0 {
         return (0.0, sum_y / n);
     }
     let slope = cov_xy / var_x;

--- a/crates/metrics-store/src/promql/mod.rs
+++ b/crates/metrics-store/src/promql/mod.rs
@@ -5,8 +5,11 @@
 //! Pipeline :
 //! 1. **parse** : délégué à [`promql_parser::parser::parse`].
 //! 2. **validate** ([`validate::validate`]) : rejette les constructions
-//!    non supportées (subqueries, comparaisons, set ops, fonctions hors
-//!    liste blanche). Liste blanche calibrée sur le golden set §6.5.
+//!    non supportées (subqueries, `offset`/`@`, set ops `and/or/unless`,
+//!    vector matching `on/ignoring/group_left/right`, fonctions hors liste
+//!    blanche). Liste blanche étendue au-delà du golden set §6.5 (cf.
+//!    `docs/promql-compat-roadmap.md` : comparaisons, `by/without`,
+//!    `topk/bottomk`, `irate`, math, labels, prédiction/stats, `absent`).
 //! 3. **execute** ([`exec::Evaluator`]) : évalue l'AST sur une plage
 //!    `(start, end, step)` en interrogeant le `Reader`. Sélection
 //!    automatique de la table (raw/hourly/daily) selon §6.3.

--- a/docs/audit-metriques-redb.md
+++ b/docs/audit-metriques-redb.md
@@ -27,11 +27,27 @@ Sélection automatique selon la plage Grafana :
 - `7 j – 90 j` → tier Hourly
 - `> 90 j` → tier Daily
 
-**Fonctions PromQL supportées :**
-`sum`, `max`, `min`, `avg`, `count`, `increase`, `rate`, `delta`,
-`avg_over_time`, `sum_over_time`, `min_over_time`, `max_over_time`,
-`count_over_time`, `last_over_time`, `abs`, `clamp_min`, `clamp_max`,
-`ceil`, `floor`, `round`
+**Fonctions PromQL supportées** (étendues via la roadmap promql-compat —
+cf. `docs/promql-compat-roadmap.md`) :
+
+- **Agrégation** : `sum max min avg count` (avec `by`/`without`),
+  `topk` `bottomk`
+- **Opérateurs** : `+ - * /` ; comparaisons `== != > < >= <=` (filtre ou
+  `bool`)
+- **Fenêtre** : `increase rate irate delta deriv predict_linear changes
+  resets avg_over_time sum_over_time min_over_time max_over_time
+  count_over_time last_over_time stddev_over_time stdvar_over_time
+  quantile_over_time`
+- **Instant / math** : `abs clamp clamp_min clamp_max ceil floor round
+  sqrt exp ln log2 log10 sgn`
+- **Labels** : `label_replace` `label_join`
+- **Absence** : `absent` (vecteur instant) / `absent_over_time` (range)
+
+**Non supporté** (rejeté en `bad_data`) : subqueries `[r:s]`, `offset`, `@`,
+set ops `and`/`or`/`unless`, vector matching `on`/`ignoring`/`group_left|right`,
+`%` `^`, `quantile`/`stddev`/`stdvar`/`group`/`count_values`,
+`histogram_quantile`, `holt_winters`, `idelta`, `sort`/`sort_desc`,
+`scalar`/`vector`, fonctions date/temps, trigonométrie, `{__name__=~"…"}`.
 
 ---
 

--- a/docs/plan_migration_vm_redb.md
+++ b/docs/plan_migration_vm_redb.md
@@ -1224,8 +1224,8 @@ fausse. Toujours **pas** de set ops `unless`/`and`/`or`.
   Seules fonctions à accepter des arguments string.
 - **Prédiction / stats** (Phase 5, P2) : `deriv`, `predict_linear(v[w],T)`,
   `quantile_over_time(φ,v[w])`, `stddev_over_time`, `stdvar_over_time`.
-- **Alerting / compteurs** (Phase 5, P3) : `absent(v)` (labels = matchers
-  d'égalité), `changes(v[w])`, `resets(v[w])`.
+- **Alerting / compteurs** (Phase 5, P3) : `absent(v)` / `absent_over_time(v[w])`
+  (labels = matchers d'égalité du sélecteur), `changes(v[w])`, `resets(v[w])`.
 - Sur tier compacté, `deriv`/`predict_linear`/`stddev`/`stdvar`/`quantile_over_time`
   opèrent sur les `avg` des buckets et `changes`/`resets` sur la séquence
   `first,last` (approximation documentée — exact sur tier raw, ≤ 7 j).

--- a/docs/promql-compat-roadmap.md
+++ b/docs/promql-compat-roadmap.md
@@ -367,7 +367,7 @@ dynamiques, échelles log, normalisation).
 | 4a | Math instant (sqrt/exp/ln/log/sgn/clamp) | ¼ j | faible | moyenne | ✅ fait |
 | 4b | label_replace / label_join | ½ j | faible | **haute** | ✅ fait |
 | 5 (P2) | deriv, predict_linear, quantile/stddev/stdvar_over_time | ½ j | moyen | moyenne | ✅ fait |
-| 5 (P3) | absent, changes, resets + fix `round(v,to_nearest)` | ½ j | faible | moyenne | ✅ fait |
+| 5 (P3) | absent, absent_over_time, changes, resets + fix `round(v,to_nearest)` | ½ j | faible | moyenne | ✅ fait |
 
 **Ordre recommandé** : 1 → 2 → (3a/3b/3c à la demande) → 4 → 5 (avant dashboards sophistiqués).
 
@@ -378,8 +378,13 @@ dynamiques, échelles log, normalisation).
 - `deriv`/`predict_linear` : régression linéaire moindres carrés
   (`linear_regression`, origine x = `intercept_time`). `predict_linear` ancre
   l'ordonnée à l'instant d'éval et renvoie `slope*T + intercept`.
-- `absent` : routé à part (a besoin des matchers du sélecteur) ; renvoie 1 sample
-  étiqueté des matchers `=` quand la série est absente.
+- `absent` / `absent_over_time` : routés à part (besoin des matchers du
+  sélecteur) ; renvoient 1 sample étiqueté des matchers `=` quand la série est
+  absente. `absent` reste instant-only (le parser rejette `absent(m[w])`) ;
+  `absent_over_time(m[w])` couvre l'absence sur fenêtre. L'argument est
+  dé-parenthésé (`Expr::Paren`) avant analyse.
+- `linear_regression` : garde anti division par zéro via comparaison des
+  timestamps de bornes (`pts[0] == pts[last]`, exact) plutôt que `var_x == 0.0`.
 - Tier compacté : approximations documentées (cf. §6.5 du plan de migration).
 - **Restants (P4, à la demande)** : `histogram_quantile`, `holt_winters`,
   trigo (`sin/cos/…`), `sort`/`sort_desc`, `scalar`/`vector`, fonctions date,


### PR DESCRIPTION
…ixes revue #528

Revue Gemini (suivi Phase 5) :
- linear_regression : garde anti-/0 via comparaison des timestamps de bornes (pts[0]==pts[last], exact) au lieu de var_x==0.0 (instable float).
- eval_absent : déroule les Expr::Paren de l'argument (absent((m[5m]))) pour fiabiliser le matching MatrixSelector et l'extraction des labels.

Docs synchronisées avec l'état réel de la couverture PromQL :
- exec.rs : doc de module ## Couverture réécrite (comparaisons, by/without, topk/bottomk, irate, math, labels, deriv/predict_linear/stats, absent*).
- mod.rs : liste blanche décrite à jour (comparaisons supportées).
- docs/audit-metriques-redb.md : liste "Fonctions PromQL supportées" complétée + section "Non supporté".
- docs/plan_migration_vm_redb.md + roadmap : absent_over_time, fixes notés.

70 unitaires + 3 golden verts ; clippy propre ; build serveur OK.