### PR TITLE
fix(promql): linear_regression slice vide renvoie NaN (revue #528)

### DIFF
--- a/crates/metrics-store/src/promql/exec.rs
+++ b/crates/metrics-store/src/promql/exec.rs
@@ -850,11 +850,13 @@ fn round_to(v: f64, to_nearest: f64) -> f64 {
 /// fixée à `intercept_time_ms` (en ms). Renvoie `(pente_par_seconde, ordonnée
 /// à intercept_time)`. Utilisé par `deriv` et `predict_linear`.
 fn linear_regression(pts: &[(i64, f64)], intercept_time_ms: i64) -> (f64, f64) {
-    // Garde défensive : slice vide → pas de régression possible. Les appelants
+    // Garde défensive : slice vide → régression indéfinie. Les appelants
     // actuels garantissent ≥ 2 points, mais on évite tout panic (`pts[0]`,
-    // `pts.len() - 1`) pour un futur appelant (revue Gemini PR #528).
+    // `pts.len() - 1`) pour un futur appelant. On renvoie `NaN` (état indéfini,
+    // convention Prometheus) plutôt que 0 qui masquerait l'erreur (revue Gemini
+    // PR #528).
     if pts.is_empty() {
-        return (0.0, 0.0);
+        return (f64::NAN, f64::NAN);
     }
     let n = pts.len() as f64;
     let (mut sum_x, mut sum_y, mut sum_xy, mut sum_x2) = (0.0, 0.0, 0.0, 0.0);
@@ -1491,6 +1493,9 @@ mod tests {
         let (slope, intercept) = linear_regression(&pts, 0);
         assert_eq!(slope, 0.0);
         assert!((intercept - 20.0).abs() < 1e-9);
+        // Slice vide → (NaN, NaN) (état indéfini, pas de panic).
+        let (s, i) = linear_regression(&[], 0);
+        assert!(s.is_nan() && i.is_nan());
     }
 
     #[test]


### PR DESCRIPTION
Renvoie (NaN, NaN) au lieu de (0.0, 0.0) pour une régression indéfinie (slice vide) : convention Prometheus, évite de masquer l'erreur par une pente/ordonnée nulle. Cas défensif (appelants garantissent >=2 points).