### PR TITLE
docs(redb): corrections review Gemini PR #538 (PromQL non supporté)

### DIFF
--- a/docs/grafana-README_pv.md
+++ b/docs/grafana-README_pv.md
@@ -110,6 +110,15 @@ sudo systemctl restart grafana-server
 
 ## 📈 Dashboard PV - Comparaison Multi-Années
 
+> ⚠️ **Compatibilité shim PromQL redb** — ce dashboard d'origine a été conçu
+> pour MetricsQL (VictoriaMetrics) et ses panels de comparaison annuelle
+> utilisent le modificateur **`offset`** (`… offset 1y`) et des **subqueries**,
+> que le shim PromQL de redb **ne supporte pas** (cf. `docs/architecture-redb.md`
+> §5). Pour les reproduire avec redb : décaler la **fenêtre temporelle côté
+> Grafana** (ou via les bornes `start`/`end` de l'API) au lieu d'`offset`, et
+> calculer les cumuls **côté client** à partir d'un `query_range`. Importez-le
+> tel quel pour la structure, puis adaptez les requêtes des panels comparatifs.
+
 ### Import du dashboard
 
 1. **Dashboards → Import → Upload JSON file**
@@ -1110,28 +1119,40 @@ curl -H "Authorization: Bearer ${API_KEY}"   "${GRAFANA_URL}/render/d/${DASHBOAR
 
 ## 🔧 Requêtes PromQL Utiles
 
-> ⚠️ **Métriques réelles écrites par le projet** (voir `crates/daly-bms-server/src/vm_client.rs`):
+> ⚠️ **Métriques réelles écrites par le projet** (voir `crates/daly-bms-server/src/redb_writes.rs`):
 > - `solar_total_w` — gauge, puissance PV totale instantanée (W)
 > - `dc_pv_power_w` — gauge, somme MPPT côté DC (W)
 > - `pvinv_power_w` — gauge, micro-onduleurs ET112 côté AC (W)
 > - `solar_yield_kwh` — compteur journalier remis à 0 chaque jour (kWh)
 >
-> `increase()` ne s'applique **PAS** aux gauges. Pour l'énergie, utilisez
-> `solar_yield_kwh` (compteur journalier) ou les fonctions PromQL (shim redb)
-> `integrate()` / `sum_over_time()` sur la puissance.
+> `increase()` ne s'applique **PAS** aux gauges. Pour l'énergie, utilisez le
+> compteur `solar_yield_kwh` (cumul journalier) ou l'approximation
+> `avg_over_time(<puissance>[durée]) * heures` (Wh).
+
+> ⚠️ **Limites du shim PromQL redb** — contrairement à MetricsQL/VictoriaMetrics,
+> le shim **ne supporte pas** :
+> - la fonction **`integrate()`** (MetricsQL) → utiliser `avg_over_time(p[w]) * heures` ;
+> - le modificateur **`offset`** → décaler la **fenêtre temporelle côté client**
+>   (plage Grafana, ou bornes `start`/`end` de l'API) au lieu d'`offset` ;
+> - les **subqueries `[range:step]`** → faire un `query_range` sur la période puis
+>   agréger (somme / cumul) **côté client**.
+>
+> Les lignes marquées ⚠️ ci-dessous reposent sur ces constructions non supportées
+> et nécessitent l'un de ces contournements. Réf. `docs/redb-queries.md` et
+> `docs/architecture-redb.md` §5.
 
 | Objectif | Requête |
 |----------|---------|
 | **Puissance totale instantanée** | `solar_total_w` |
 | **Production aujourd'hui** | `max_over_time(solar_yield_kwh[24h])` |
-| **Production hier** | `max_over_time(solar_yield_kwh[24h] offset 24h)` |
-| **Variation J / J-1 (%)** | `((max_over_time(solar_yield_kwh[24h]) - max_over_time(solar_yield_kwh[24h] offset 24h)) / max_over_time(solar_yield_kwh[24h] offset 24h)) * 100` |
-| **Production cumulée 30 j** | `sum_over_time(max_over_time(solar_yield_kwh[1d])[30d:1d])` |
-| **Production cumulée 1 an** | `sum_over_time(max_over_time(solar_yield_kwh[1d])[365d:1d])` |
-| **Comparaison année N vs N-1** | `max_over_time(solar_yield_kwh[1d] offset 365d)` |
+| **Production hier** ⚠️ | `max_over_time(solar_yield_kwh[24h])` sur une plage décalée de 24 h **côté client** (pas d'`offset`) |
+| **Variation J / J-1 (%)** ⚠️ | calcul **côté client** à partir des valeurs « aujourd'hui » et « hier » (le shim n'a pas d'`offset`) |
+| **Production cumulée 30 j** ⚠️ | `query_range` de `max_over_time(solar_yield_kwh[1d])` sur 30 j, puis somme **côté client** (pas de subquery) |
+| **Production cumulée 1 an** ⚠️ | idem sur 365 j, somme **côté client** |
+| **Comparaison année N vs N-1** ⚠️ | `max_over_time(solar_yield_kwh[1d])` sur deux plages annuelles distinctes **côté client** (pas d'`offset 365d`) |
 | **Puissance moyenne 1 h** | `avg_over_time(solar_total_w[1h])` |
 | **Pic de puissance du jour** | `max_over_time(solar_total_w[24h])` |
-| **Énergie via intégration** | `integrate(solar_total_w[1d]) / 3600` (Wh) |
+| **Énergie via intégration** | `avg_over_time(solar_total_w[1d]) * 24` (Wh) |
 
 ---
 

--- a/docs/redb-queries.md
+++ b/docs/redb-queries.md
@@ -631,8 +631,9 @@ venus_shunt_soc_percent
 venus_shunt_power_w
 
 
-# Vérification : liste de toutes les métriques présentes (noms __name__)
-# curl http://192.168.1.141:8080/api/v1/labels | jq '.data | length'
+# Vérification : nombre de métriques présentes (valeurs distinctes de __name__)
+# curl http://192.168.1.141:8080/api/v1/label/__name__/values | jq '.data | length'
+# (NB : /api/v1/labels renvoie les NOMS de labels — bms_id, address… — pas les métriques)
 # ou via le dashboard custom /dashboard/history (sélecteur de série)
 
 # Dernier point de chaque métrique (vérification fraîcheur)


### PR DESCRIPTION
Suite à la review de `gemini-code-assist` sur la PR #538 (déjà mergée), correction des passages de documentation présentant des constructions PromQL **non supportées par le shim redb**.

## Remarques Gemini traitées

| # | Fichier | Remarque | Correction |
|---|---------|----------|------------|
| 1 | `grafana-README_pv.md` | `integrate()` proposé comme fonction du shim | Retiré de la note énergie ; gardé `solar_yield_kwh` + `avg_over_time × durée` |
| 2 | `grafana-README_pv.md` | `offset 365d` non supporté | Ligne annotée ⚠️ + contournement côté client |
| 3 | `grafana-README_pv.md` | `integrate(solar_total_w[1d]) / 3600` | → `avg_over_time(solar_total_w[1d]) * 24` (Wh) — suggestion exacte de Gemini |
| 4 | `redb-queries.md` | `/api/v1/labels` compte les *labels*, pas les métriques | → `/api/v1/label/__name__/values` (vérifié dans le code : `list_metrics` → `run_list_labels` renvoie les noms de labels) |
| 5 | `architecture-redb.md` | commentaire mal rattaché, suggestion incohérente | **Aucune correction** : §9 distingue déjà correctement labels vs `__name__/values` |

## Au-delà du strict périmètre Gemini (cohérence)

Le même problème touchait des lignes adjacentes et le dashboard JSON. Pour rester honnête sur les capacités du shim :

- Encadré ⚠️ général dans `grafana-README_pv.md` : `offset`, subqueries `[r:s]` et `integrate()` non supportés, avec le contournement côté client (plage Grafana / bornes `start`/`end` de l'API) ; chaque ligne concernée de la table comparative est annotée ⚠️.
- Avertissement sous « Comparaison Multi-Années » : le dashboard JSON importable repose sur `offset`/subqueries à adapter pour redb.
- Référence de fichier obsolète repérée au passage : `vm_client.rs` → `redb_writes.rs`.

## Périmètre

- Changements **documentation uniquement** — aucun code modifié, pas de recompilation nécessaire.
- 1 commit (`422e142`) posé sur `main` à jour : la PR ne montre que ces correctifs.

https://claude.ai/code/session_01CuudXGLsE1XjJZBaHa75zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuudXGLsE1XjJZBaHa75zf)_