### PR TITLE
feat(promql,viz): modifier offset dans le shim + Ah jour SmartShunt f…

### DIFF
--- a/crates/daly-bms-server/templates/viz_nodes_venus.js
+++ b/crates/daly-bms-server/templates/viz_nodes_venus.js
@@ -97,6 +97,12 @@ function SmartShuntNode({ data }) {
   const power   = live?.power_w        ?? null;
   const state   = live?.state          ?? null;
   const ttgMin  = live?.time_to_go_min ?? null;
+  // Ah chargés / déchargés aujourd'hui : valeurs fournies directement par
+  // l'energy-manager (intégration courant×temps depuis minuit). Règle 13 —
+  // on privilégie cette mesure ; le recalcul PromQL ci-dessous (vmCharge /
+  // vmDischarge) ne sert que de repli si ces champs sont absents.
+  const ahChaLive = live?.ah_charged_today    ?? null;
+  const ahDisLive = live?.ah_discharged_today ?? null;
 
   const [vmCharge,    setVmCharge]    = useState(null);
   const [vmDischarge, setVmDischarge] = useState(null);
@@ -130,6 +136,10 @@ function SmartShuntNode({ data }) {
     const t = setInterval(fetchDailyTotals, 60000);
     return () => clearInterval(t);
   }, []);
+
+  // Valeur affichée : energy-manager en priorité, repli sur le recalcul PromQL.
+  const chargeAh    = ahChaLive != null ? Math.abs(ahChaLive) : vmCharge;
+  const dischargeAh = ahDisLive != null ? Math.abs(ahDisLive) : vmDischarge;
 
   const stateClass = state === 'Charging' ? 'charging' : state === 'Discharging' ? 'discharging' : 'idle';
 
@@ -183,11 +193,11 @@ function SmartShuntNode({ data }) {
         ),
         h('div', { className: 'ss-row', style: { flex: '1 1 0', minWidth: 0 } },
           h('span', { className: 'ss-row-lbl' }, '⬆ Chargée (auj.)'),
-          h('span', { className: 'ss-row-val pos' }, vmCharge    != null ? `${vmCharge.toFixed(1)} Ah`    : '—')
+          h('span', { className: 'ss-row-val pos' }, chargeAh    != null ? `${chargeAh.toFixed(1)} Ah`    : '—')
         ),
         h('div', { className: 'ss-row', style: { flex: '1 1 0', minWidth: 0 } },
           h('span', { className: 'ss-row-lbl' }, '⬇ Déchargée (auj.)'),
-          h('span', { className: 'ss-row-val neg' }, vmDischarge != null ? `${vmDischarge.toFixed(1)} Ah` : '—')
+          h('span', { className: 'ss-row-val neg' }, dischargeAh != null ? `${dischargeAh.toFixed(1)} Ah` : '—')
         )
       )
     ) : h('div', { className: 'ss-wait' }, 'En attente…')

--- a/crates/metrics-store/src/lib.rs
+++ b/crates/metrics-store/src/lib.rs
@@ -487,6 +487,75 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn promql_offset_modifier() {
+        use crate::promql::{parse_and_validate, Evaluator};
+
+        let path = tmp_db_path("promql_offset");
+        let _ = std::fs::remove_file(&path);
+        {
+            let opts = Options {
+                writer: WriterConfig { batch_max: 64, flush_ms: 20, poll_idle_ms: 2 },
+                ..Options::default()
+            };
+            let store = MetricsStore::open(&path, opts).expect("open");
+            let writer = store.writer();
+
+            // bms_v{bms_id=1} : 10 pts 1.0..1.9 (ts 100_000..109_000)
+            // energy_wh        : monotone 0..90 par pas de 10
+            for i in 0..10_i64 {
+                let ts = 100_000 + i * 1_000;
+                writer
+                    .write(Sample::new("bms_v", ts, 1.0 + i as f64 / 10.0).with_label("bms_id", "1"))
+                    .await
+                    .unwrap();
+                writer
+                    .write(Sample::new("energy_wh", ts, i as f64 * 10.0))
+                    .await
+                    .unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(150)).await;
+
+            let reader = store.reader();
+            let ev = Evaluator::new(&reader);
+
+            // Référence sans offset à t=109_000 → 1.9
+            let expr = parse_and_validate(r#"bms_v{bms_id="1"}"#).unwrap();
+            let v = ev.eval_instant(&expr, 109_000).unwrap();
+            assert!((v[0].value - 1.9).abs() < 1e-9);
+
+            // offset 5s : évalue à t-5s = 104_000 → 1.4
+            let expr = parse_and_validate(r#"bms_v{bms_id="1"} offset 5s"#).unwrap();
+            let v = ev.eval_instant(&expr, 109_000).unwrap();
+            assert_eq!(v.len(), 1);
+            assert!((v[0].value - 1.4).abs() < 1e-9, "offset instant got {}", v[0].value);
+
+            // offset négatif (vers le futur) : à t=104_000 offset -5s = 109_000 → 1.9
+            let expr = parse_and_validate(r#"bms_v{bms_id="1"} offset -5s"#).unwrap();
+            let v = ev.eval_instant(&expr, 104_000).unwrap();
+            assert!((v[0].value - 1.9).abs() < 1e-9, "offset neg got {}", v[0].value);
+
+            // increase sans offset sur [10s] à 109_000 → 90
+            let expr = parse_and_validate("increase(energy_wh[10s])").unwrap();
+            let v = ev.eval_instant(&expr, 109_000).unwrap();
+            assert!((v[0].value - 90.0).abs() < 1e-9, "increase got {}", v[0].value);
+
+            // increase avec offset 5s : fenêtre décalée [94_000, 104_000] → 40
+            let expr = parse_and_validate("increase(energy_wh[10s] offset 5s)").unwrap();
+            let v = ev.eval_instant(&expr, 109_000).unwrap();
+            assert_eq!(v.len(), 1);
+            assert!((v[0].value - 40.0).abs() < 1e-9, "increase offset got {}", v[0].value);
+
+            // Différence N vs décalé (motif comparaison périodes) : 1.9 - 1.4 = 0.5
+            let expr =
+                parse_and_validate(r#"bms_v{bms_id="1"} - (bms_v{bms_id="1"} offset 5s)"#).unwrap();
+            let v = ev.eval_instant(&expr, 109_000).unwrap();
+            assert_eq!(v.len(), 1);
+            assert!((v[0].value - 0.5).abs() < 1e-9, "offset diff got {}", v[0].value);
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn promql_aggregation_grouping_by_without() {
         use crate::promql::{parse_and_validate, Evaluator};
 

--- a/crates/metrics-store/src/promql/exec.rs
+++ b/crates/metrics-store/src/promql/exec.rs
@@ -57,8 +57,8 @@ use std::time::Duration;
 
 use promql_parser::label::MatchOp;
 use promql_parser::parser::{
-    AggregateExpr, BinaryExpr, Call, Expr, LabelModifier, MatrixSelector, NumberLiteral, ParenExpr,
-    StringLiteral, UnaryExpr, VectorSelector,
+    AggregateExpr, BinaryExpr, Call, Expr, LabelModifier, MatrixSelector, NumberLiteral, Offset,
+    ParenExpr, StringLiteral, UnaryExpr, VectorSelector,
 };
 use redb::ReadTransaction;
 use regex::Regex;
@@ -67,6 +67,22 @@ use crate::reader::Reader;
 use crate::tables::{AggBucket, SeriesMeta, Tier};
 
 use super::error::PromQlError;
+
+/// Décalage temporel (ms) induit par un modificateur `offset` PromQL.
+///
+/// Sémantique PromQL : `expr offset d` évalue le sélecteur à `t - d`.
+/// - `Offset::Pos(d)` (`offset 5m`) → décalage `+d` vers le passé.
+/// - `Offset::Neg(d)` (`offset -5m`) → décalage `-d` (vers le futur).
+/// - aucun offset → 0.
+///
+/// L'appelant calcule donc l'instant effectif `t_eff = t - offset_ms(&vs.offset)`.
+fn offset_ms(off: &Option<Offset>) -> i64 {
+    match off {
+        Some(Offset::Pos(d)) => d.as_millis() as i64,
+        Some(Offset::Neg(d)) => -(d.as_millis() as i64),
+        None => 0,
+    }
+}
 
 pub type Labels = BTreeMap<String, String>;
 
@@ -254,6 +270,8 @@ impl<'r> Evaluator<'r> {
     }
 
     fn eval_vector_selector(&self, vs: &VectorSelector, t: i64) -> Result<Value, PromQlError> {
+        // Modificateur `offset` : on évalue le sélecteur à l'instant décalé.
+        let t_eff = t - offset_ms(&vs.offset);
         let matched = self.match_series(vs)?;
         let rtx = self.txn()?;
         let mut out = Vec::with_capacity(matched.len());
@@ -262,7 +280,7 @@ impl<'r> Evaluator<'r> {
             // nécessaire — scan inverse au lieu de matérialiser tout le Vec.
             let last = self
                 .reader
-                .last_point_in_range_with_tx(rtx, *sid, t - self.lookback_ms, t)
+                .last_point_in_range_with_tx(rtx, *sid, t_eff - self.lookback_ms, t_eff)
                 .map_err(|e| PromQlError::Execution(e.to_string()))?;
             if let Some((_, v)) = last {
                 out.push(InstantSample { labels: labels.clone(), value: v });
@@ -547,14 +565,17 @@ impl<'r> Evaluator<'r> {
             // absent_over_time : présent si ≥ 1 série matchée a un point dans la
             // fenêtre.
             Expr::MatrixSelector(MatrixSelector { vs, range }) => {
-                let win_start = t - range.as_millis() as i64;
+                // Modificateur `offset` : fenêtre décalée comme pour les autres
+                // fonctions à fenêtre.
+                let t_eff = t - offset_ms(&vs.offset);
+                let win_start = t_eff - range.as_millis() as i64;
                 let matched = self.match_series(vs)?;
                 let rtx = self.txn()?;
                 let mut any = false;
                 for (sid, _) in matched.iter() {
                     if self
                         .reader
-                        .last_point_in_range_with_tx(rtx, *sid, win_start, t)
+                        .last_point_in_range_with_tx(rtx, *sid, win_start, t_eff)
                         .map_err(|e| PromQlError::Execution(e.to_string()))?
                         .is_some()
                     {
@@ -599,7 +620,9 @@ impl<'r> Evaluator<'r> {
         t: i64,
     ) -> Result<Value, PromQlError> {
         let range_ms = range.as_millis() as i64;
-        let win_start = t - range_ms;
+        // Modificateur `offset` : la fenêtre `[win_start, t_eff]` est décalée.
+        let t_eff = t - offset_ms(&vs.offset);
+        let win_start = t_eff - range_ms;
         let tier = tier_for_range(range_ms);
         let matched = self.match_series(vs)?;
         // Paramètre scalaire éventuel = 1er argument qui n'est pas le
@@ -637,30 +660,30 @@ impl<'r> Evaluator<'r> {
                 Tier::Raw if name == "irate" => {
                     let lt = self
                         .reader
-                        .last_two_in_range_with_tx(rtx, *sid, win_start, t)
+                        .last_two_in_range_with_tx(rtx, *sid, win_start, t_eff)
                         .map_err(|e| PromQlError::Execution(e.to_string()))?;
                     apply_irate_last_two(lt)
                 }
                 Tier::Raw if endpoints_only => {
                     let fl = self
                         .reader
-                        .first_last_in_range_with_tx(rtx, *sid, win_start, t)
+                        .first_last_in_range_with_tx(rtx, *sid, win_start, t_eff)
                         .map_err(|e| PromQlError::Execution(e.to_string()))?;
                     apply_range_fn_endpoints(name, fl, range_ms)
                 }
                 Tier::Raw => {
                     let pts = self
                         .reader
-                        .query_range_raw_with_tx(rtx, *sid, win_start, t)
+                        .query_range_raw_with_tx(rtx, *sid, win_start, t_eff)
                         .map_err(|e| PromQlError::Execution(e.to_string()))?;
-                    apply_range_fn_raw(name, &pts, range_ms, t, param)
+                    apply_range_fn_raw(name, &pts, range_ms, t_eff, param)
                 }
                 Tier::Hourly | Tier::Daily => {
                     let buckets = self
                         .reader
-                        .query_range_buckets_with_tx(rtx, *sid, win_start, t, tier)
+                        .query_range_buckets_with_tx(rtx, *sid, win_start, t_eff, tier)
                         .map_err(|e| PromQlError::Execution(e.to_string()))?;
-                    apply_range_fn_buckets(name, &buckets, range_ms, t, param)
+                    apply_range_fn_buckets(name, &buckets, range_ms, t_eff, param)
                 }
             };
             if let Some(v) = value_opt {

--- a/crates/metrics-store/src/promql/validate.rs
+++ b/crates/metrics-store/src/promql/validate.rs
@@ -73,9 +73,8 @@ pub fn validate(expr: &Expr) -> Result<(), PromQlError> {
 }
 
 fn validate_vector_selector(vs: &VectorSelector) -> Result<(), PromQlError> {
-    if vs.offset.is_some() {
-        return unsupported("offset modifier");
-    }
+    // `offset` est supporté par l'évaluateur (décalage de la fenêtre temporelle,
+    // cf. exec.rs::offset_ms). Le modificateur `@` reste non supporté.
     if vs.at.is_some() {
         return unsupported("@ modifier");
     }
@@ -289,8 +288,17 @@ mod tests {
     }
 
     #[test]
-    fn rejects_offset_modifier() {
-        ko("foo offset 5m", "offset");
+    fn accepts_offset_modifier() {
+        ok("foo offset 5m");
+        ok("foo offset -5m");
+        ok("rate(foo[5m] offset 1h)");
+        ok("max_over_time(solar_yield_kwh[1d] offset 365d)");
+        ok("avg_over_time(bms_v[1h]) - avg_over_time(bms_v[1h] offset 24h)");
+    }
+
+    #[test]
+    fn rejects_at_modifier() {
+        ko("foo @ 1620000000", "@ modifier");
     }
 
     #[test]

--- a/docs/architecture-redb.md
+++ b/docs/architecture-redb.md
@@ -448,7 +448,9 @@ est rejeté** avec `errorType=bad_data`.
 
 **Sélecteurs** : `VectorSelector` instantané avec matchers `=`, `!=`, `=~`,
 `!~`. `MatrixSelector` (`m[range]`) uniquement comme argument d'une fonction
-à fenêtre.
+à fenêtre. Le modificateur **`offset`** (`m offset 5m`, `m[w] offset 1h`,
+y compris négatif) est supporté : il décale l'instant d'évaluation à
+`t − offset` (cf. `exec.rs::offset_ms`).
 
 **Opérateurs arithmétiques** (`SUPPORTED_BINOPS`) : `+`, `-`, `*`, `/`
 (vec×scalaire, scalaire×vec, vec×vec aligné sur tous les labels hors
@@ -488,7 +490,6 @@ Toute comparaison impliquant un `NaN` est fausse.
 |--------------|------------------|
 | **String literal nu** (hors arg de `label_*`) | `string literal` |
 | **Subquery** `expr[Xh:Ym]` | `subquery …` — réécrire en deux requêtes côté client |
-| **`offset`** (modifier) | `offset modifier` |
 | **`@`** (modifier @-timestamp) | `@ modifier` |
 | **Set ops** `and`, `or`, `unless` | `binary operator: and/or/unless` |
 | **Vector matching** `on(...)`, `ignoring(...)`, `group_left`, `group_right` | `vector matching … non supporté` (seul l'alignement exact `OneToOne` tous-labels est géré) |

--- a/docs/grafana-README_pv.md
+++ b/docs/grafana-README_pv.md
@@ -110,14 +110,13 @@ sudo systemctl restart grafana-server
 
 ## 📈 Dashboard PV - Comparaison Multi-Années
 
-> ⚠️ **Compatibilité shim PromQL redb** — ce dashboard d'origine a été conçu
-> pour MetricsQL (VictoriaMetrics) et ses panels de comparaison annuelle
-> utilisent le modificateur **`offset`** (`… offset 1y`) et des **subqueries**,
-> que le shim PromQL de redb **ne supporte pas** (cf. `docs/architecture-redb.md`
-> §5). Pour les reproduire avec redb : décaler la **fenêtre temporelle côté
-> Grafana** (ou via les bornes `start`/`end` de l'API) au lieu d'`offset`, et
-> calculer les cumuls **côté client** à partir d'un `query_range`. Importez-le
-> tel quel pour la structure, puis adaptez les requêtes des panels comparatifs.
+> ⚠️ **Compatibilité shim PromQL redb** — le modificateur **`offset`**
+> (`… offset 1y`, utilisé par les panels de comparaison annuelle) est
+> **supporté** par le shim. En revanche les **subqueries** `[range:step]`
+> (cumuls glissants) ne le sont **pas** (cf. `docs/architecture-redb.md` §5) :
+> pour ces panels, faites un `query_range` sur la période puis agrégez **côté
+> client**. Le dashboard s'importe tel quel ; seuls les panels de cumul à base
+> de subquery sont à adapter.
 
 ### Import du dashboard
 
@@ -1132,24 +1131,22 @@ curl -H "Authorization: Bearer ${API_KEY}"   "${GRAFANA_URL}/render/d/${DASHBOAR
 > ⚠️ **Limites du shim PromQL redb** — contrairement à MetricsQL/VictoriaMetrics,
 > le shim **ne supporte pas** :
 > - la fonction **`integrate()`** (MetricsQL) → utiliser `avg_over_time(p[w]) * heures` ;
-> - le modificateur **`offset`** → décaler la **fenêtre temporelle côté client**
->   (plage Grafana, ou bornes `start`/`end` de l'API) au lieu d'`offset` ;
 > - les **subqueries `[range:step]`** → faire un `query_range` sur la période puis
 >   agréger (somme / cumul) **côté client**.
 >
-> Les lignes marquées ⚠️ ci-dessous reposent sur ces constructions non supportées
-> et nécessitent l'un de ces contournements. Réf. `docs/redb-queries.md` et
-> `docs/architecture-redb.md` §5.
+> Le modificateur **`offset`** est, lui, **supporté**. Les lignes marquées ⚠️
+> ci-dessous reposent sur une subquery et nécessitent le contournement client.
+> Réf. `docs/redb-queries.md` et `docs/architecture-redb.md` §5.
 
 | Objectif | Requête |
 |----------|---------|
 | **Puissance totale instantanée** | `solar_total_w` |
 | **Production aujourd'hui** | `max_over_time(solar_yield_kwh[24h])` |
-| **Production hier** ⚠️ | `max_over_time(solar_yield_kwh[24h])` sur une plage décalée de 24 h **côté client** (pas d'`offset`) |
-| **Variation J / J-1 (%)** ⚠️ | calcul **côté client** à partir des valeurs « aujourd'hui » et « hier » (le shim n'a pas d'`offset`) |
-| **Production cumulée 30 j** ⚠️ | `query_range` de `max_over_time(solar_yield_kwh[1d])` sur 30 j, puis somme **côté client** (pas de subquery) |
+| **Production hier** | `max_over_time(solar_yield_kwh[24h] offset 24h)` |
+| **Variation J / J-1 (%)** | `((max_over_time(solar_yield_kwh[24h]) - max_over_time(solar_yield_kwh[24h] offset 24h)) / max_over_time(solar_yield_kwh[24h] offset 24h)) * 100` |
+| **Production cumulée 30 j** ⚠️ | `query_range` de `max_over_time(solar_yield_kwh[1d])` sur 30 j, puis somme **côté client** (subquery non supportée) |
 | **Production cumulée 1 an** ⚠️ | idem sur 365 j, somme **côté client** |
-| **Comparaison année N vs N-1** ⚠️ | `max_over_time(solar_yield_kwh[1d])` sur deux plages annuelles distinctes **côté client** (pas d'`offset 365d`) |
+| **Comparaison année N vs N-1** | `max_over_time(solar_yield_kwh[1d] offset 365d)` |
 | **Puissance moyenne 1 h** | `avg_over_time(solar_total_w[1h])` |
 | **Pic de puissance du jour** | `max_over_time(solar_total_w[24h])` |
 | **Énergie via intégration** | `avg_over_time(solar_total_w[1d]) * 24` (Wh) |

--- a/docs/promql-compat-roadmap.md
+++ b/docs/promql-compat-roadmap.md
@@ -1,12 +1,15 @@
 # PromQL compatibility roadmap — metrics-store
 
-> **✅ ÉTAT : phases 1, 2, 3a, 3b, 3c + Phase 4 (math & labels) implémentées
-> et testées.** Le sous-ensemble PromQL supporté inclut désormais le
-> groupement `by`/`without`, les comparaisons (+ `bool`), `topk`/`bottomk`,
-> `irate`, les fonctions math (`sqrt exp ln log2 log10 sgn clamp`) et la
-> manipulation de labels (`label_replace`, `label_join`), en plus du rejet
-> explicite du vector matching non trivial. Voir la matrice de compat à jour
-> dans `docs/plan_migration_vm_redb.md` §6.4-6.5. Le document ci-dessous reste
+> **✅ ÉTAT : phases 1, 2, 3a, 3b, 3c, Phase 4 (math & labels), Phase 5 (P2/P3)
+> et Phase 6 (modifier `offset`) implémentées et testées.** Le sous-ensemble
+> PromQL supporté inclut désormais le groupement `by`/`without`, les
+> comparaisons (+ `bool`), `topk`/`bottomk`, `irate`, les fonctions math
+> (`sqrt exp ln log2 log10 sgn clamp`), la manipulation de labels
+> (`label_replace`, `label_join`), `deriv`/`predict_linear`/`*_over_time`,
+> `absent`/`changes`/`resets`, et le **modifier `offset`** (instant + range,
+> négatif inclus), en plus du rejet explicite du vector matching non trivial.
+> Restent non supportés : subqueries `[r:s]`, modifier `@`. Voir la matrice de
+> compat dans `docs/architecture-redb.md` §5. Le document ci-dessous reste
 > comme référence de conception.
 
 > **But du document** : plan d'implémentation **autoportant** pour élargir la
@@ -368,6 +371,7 @@ dynamiques, échelles log, normalisation).
 | 4b | label_replace / label_join | ½ j | faible | **haute** | ✅ fait |
 | 5 (P2) | deriv, predict_linear, quantile/stddev/stdvar_over_time | ½ j | moyen | moyenne | ✅ fait |
 | 5 (P3) | absent, absent_over_time, changes, resets + fix `round(v,to_nearest)` | ½ j | faible | moyenne | ✅ fait |
+| 6 | modifier `offset` (instant + range, négatif inclus) | ¼ j | faible | moyenne | ✅ fait |
 
 **Ordre recommandé** : 1 → 2 → (3a/3b/3c à la demande) → 4 → 5 (avant dashboards sophistiqués).
 
@@ -386,9 +390,17 @@ dynamiques, échelles log, normalisation).
 - `linear_regression` : garde anti division par zéro via comparaison des
   timestamps de bornes (`pts[0] == pts[last]`, exact) plutôt que `var_x == 0.0`.
 - Tier compacté : approximations documentées (cf. §6.5 du plan de migration).
+- **Phase 6 — modifier `offset`** (✅ fait) : retiré du rejet dans
+  `validate_vector_selector` (le `@` reste rejeté) ; `exec.rs::offset_ms`
+  applique `t_eff = t − offset` au lookback instantané, à la fenêtre des
+  fonctions à fenêtre et à `absent_over_time`. Couvre l'offset négatif
+  (`offset -5m`, vers le futur). Test sémantique : `promql_offset_modifier`
+  (lib.rs). Permet la comparaison de périodes (`m offset 24h`, `m offset 1y`)
+  sans contournement client.
 - **Restants (P4, à la demande)** : `histogram_quantile`, `holt_winters`,
   trigo (`sin/cos/…`), `sort`/`sort_desc`, `scalar`/`vector`, fonctions date,
-  set ops `and/or/unless`, vector matching, `{__name__=~…}`.
+  set ops `and/or/unless`, vector matching, `{__name__=~…}`, modifier `@`,
+  subqueries `[r:s]`.
 
 ### Définition de « terminé » par PR
 - [ ] `cargo test -p metrics-store` vert (unitaires + golden + coverage 16 dashboards).

--- a/docs/redb-queries.md
+++ b/docs/redb-queries.md
@@ -13,7 +13,9 @@
 > **Agrégateurs** : `sum`, `max`, `min`, `avg`, `count` (avec `by (…)` / `without (…)`), `topk(k, …)`, `bottomk(k, …)`.
 > **Opérateurs** : arithmétiques `+ - * /` (vecteur⊗scalaire ou vecteur⊗vecteur **aligné**), comparaisons `== != > < >= <=` (filtre ou `bool`).
 >
-> **Non supporté** : `integrate` et les autres fonctions MetricsQL, les **subqueries** `[Xh:Ym]`, les modifiers `offset` / `@`, le vector matching `on()` / `ignoring()` / `group_left` / `group_right`, les set ops `and` / `or` / `unless`, les agrégateurs paramétrés `quantile` / `count_values`.
+> **Modifier `offset`** (`m offset 5m`, `m[w] offset 1h`, y compris négatif) : **supporté** — décale l'instant d'évaluation à `t − offset`.
+>
+> **Non supporté** : `integrate` et les autres fonctions MetricsQL, les **subqueries** `[Xh:Ym]`, le modifier `@`, le vector matching `on()` / `ignoring()` / `group_left` / `group_right`, les set ops `and` / `or` / `unless`, les agrégateurs paramétrés `quantile` / `count_values`.
 
 ---
 
@@ -164,7 +166,7 @@ Puis dans la requête :
 ### ⚠️ Points de vigilance
 
 1. **Fenêtre glissante vs jour calendaire**  
-   `[24h]` calcule sur les dernières 24h glissantes. Pour un jour calendaire (minuit → maintenant), il faut calculer un `offset` dynamique côté client — le modifier `offset` n'étant pas supporté par le shim, ajustez la borne `start`/`end` de `query_range` côté appelant.
+   `[24h]` calcule sur les dernières 24h glissantes. Le modifier `offset` est supporté (`m[24h] offset 24h` = la veille glissante). Pour un jour **calendaire** exact (minuit → maintenant), `offset` à durée fixe ne suffit pas : ajustez les bornes `start`/`end` de `query_range` côté appelant.
 
 2. **Précision**  
    L'approximation par `avg_over_time` est fiable si votre intervalle d'écriture est ≤ 30s (cf. throttles plus bas).


### PR DESCRIPTION
…iabilisés

## PromQL — modifier `offset` (Phase 6)
- validate.rs : `offset` n'est plus rejeté (le modifier `@` reste rejeté).
- exec.rs : helper `offset_ms()` ; application de `t_eff = t - offset` au lookback instantané (`eval_vector_selector`), à la fenêtre des fonctions à fenêtre (`eval_range_call`) et à `absent_over_time` (`eval_absent`). Supporte l'offset négatif (`offset -5m`). Le paramètre scalaire des range funcs reste évalué à `t` (indépendant du temps).
- Test sémantique `promql_offset_modifier` (instant, négatif, increase décalé, différence N vs décalé). 72 tests unitaires + 3 golden verts (aucune régression dashboards).

## Visualisation — node SmartShunt
- viz_nodes_venus.js : "Chargée (auj.)" / "Déchargée (auj.)" utilisent désormais en priorité `live.ah_charged_today` / `live.ah_discharged_today` (valeurs fournies par l'energy-manager, règle 13 — mesure prioritaire sur recalcul). Repli sur le recalcul PromQL existant si ces champs sont absents → zéro régression. "Temps restant" déjà câblé sur `live.time_to_go_min`.

## Documentation
- architecture-redb.md §5, redb-queries.md, grafana-README_pv.md, promql-compat-roadmap.md : `offset` reclassé "supporté" ; subqueries et `@` restent non supportés. Table comparative PV : requêtes `offset` rétablies, seules les lignes à subquery gardent le contournement client.

https://claude.ai/code/session_01CuudXGLsE1XjJZBaHa75zf