### PR TITLE
fix(promql): offset négatif sature à i64::MIN (revue Gemini)

### DIFF
--- a/crates/metrics-store/src/promql/exec.rs
+++ b/crates/metrics-store/src/promql/exec.rs
@@ -83,10 +83,11 @@ use super::error::PromQlError;
 fn offset_ms(off: &Option<Offset>) -> i64 {
     match off {
         Some(Offset::Pos(d)) => d.as_millis().try_into().unwrap_or(i64::MAX),
-        Some(Offset::Neg(d)) => {
-            let ms: i64 = d.as_millis().try_into().unwrap_or(i64::MAX);
-            ms.saturating_neg()
-        }
+        Some(Offset::Neg(d)) => d
+            .as_millis()
+            .try_into()
+            .map(|ms: i64| ms.saturating_neg())
+            .unwrap_or(i64::MIN),
         None => 0,
     }
 }


### PR DESCRIPTION
Dans `offset_ms()`, la branche `Offset::Neg` utilise désormais `try_into().map(saturating_neg).unwrap_or(i64::MIN)` : sur une durée dépassant i64::MAX, on sature correctement à `i64::MIN` (au lieu de `i64::MIN + 1`) tout en simplifiant le code. 72 tests + 3 golden verts.

https://claude.ai/code/session_01CuudXGLsE1XjJZBaHa75zf