### PR TITLE
docs(promql): MAJ conformité + propositions de dashboards Grafana évo…

### DIFF
--- a/docs/Evolution-compliance-PromQL.md
+++ b/docs/Evolution-compliance-PromQL.md
@@ -330,10 +330,14 @@ increase(mppt_energy_wh[24h])
 | **Alerte surcharge** | `bms_soc < 20 and bms_temp > 45` | ❌ |
 | **Rendement par string** | `mppt_power / on(string_id) theoretical` | ❌ |
 | **C-rate global** | `sum(bms_current) / on(bms_id) group_left capacity` | ❌ |
-| **Santé cellule (SLO)** | `quantile(0.95, bms_cell_v)` | ❌ |
-| **Prédiction SOC lissée** | `predict_linear(avg_over_time(...)[6h:10m], ...)` | ❌ |
-| **Détection orphans** | `bms_status unless mppt_status` | ❌ |
-| **Compteur fiabilisé** | `increase(mppt_energy_wh[24h])` sur série clairsemée | ⚠️ Faux positif |
+| **Santé cellule (SLO)** | `quantile(0.95, bms_cell_v)` | ✅ |
+| **Prédiction SOC lissée** | `predict_linear(avg_over_time(...)[6h:10m], ...)` | ✅ |
+| **Détection orphans** | `bms_status unless mppt_status` | ✅ |
+| **Compteur fiabilisé** | `increase(mppt_energy_wh[24h])` sur série clairsemée | ✅ corrigé |
+
+> **Mise à jour** : toutes les lignes ci-dessus sont désormais **✅** (cf. §0).
+> Les statuts `❌` historiques sont conservés dans le corps de l'audit (§3–§7)
+> comme trace de l'analyse initiale.
 
 ---
 
@@ -350,3 +354,101 @@ Pour un ESS en production, je suggère de **prioriser** l'implémentation dans c
 Les subqueries et `group_left` peuvent attendre si vous pré-calculez les métriques dérivées côté `energy-manager` ou `daly-bms-server`.
 
 Les écarts principaux concernent les opérations de **jointure vectorielle avancée** et les **modificateurs temporels**, qui sont volontairement hors scope pour ce système. Le point le plus critique à corriger est le comportement de `rate`/`increase` sur un seul point, qui peut induire des alertes silencieuses fausses.
+
+---
+
+# 9. Dashboards Grafana évolués — propositions (exploitation des nouvelles capacités)
+
+> Maintenant que le moteur couvre `and/or/unless`, `on/ignoring/group_left`,
+> `quantile/group/count_values/stddev`, `@`, `offset` et les sous-requêtes, on
+> peut bâtir des tableaux de bord **impossibles auparavant**. Cette section
+> propose **4 nouveaux dashboards** + **5 évolutions** des dashboards existants.
+>
+> **Contraintes de provisioning** (cf. CLAUDE.md règle 14) : format provisioning
+> (pas d'export), **pas** de `__inputs`/`__requires`, datasource UID =
+> `daly-metrics`. Tout nouveau fichier JSON dans `contrib/grafana/dashboards/`
+> est validé automatiquement par le test golden
+> `provisioned_grafana_dashboards_coverage`.
+> Labels réels : `bms_*{bms_id="0x01"|"0x02"}`, `et112_*{address="0x07|0x08|0x09"}`.
+
+## 9.1 Nouveaux dashboards proposés
+
+### 🆕 `17-flotte-sante.json` — « Santé de flotte & SLO batterie »
+Vue consolidée multi-BMS orientée **service-level objectives**, pensée pour le
+coup d'œil quotidien et l'alerting.
+
+| Panel | Type | Requête PromQL | Apport (nouveauté) |
+|---|---|---|---|
+| BMS actifs | stat | `count(group(bms_soc) by (bms_id))` | `group` = présence binaire |
+| SOC P05 / P50 / P95 du parc | timeseries | `quantile(0.05, bms_soc)`, `quantile(0.5, bms_soc)`, `quantile(0.95, bms_soc)` | percentile **spatial** (SLO) |
+| Tension cellule — bande P05↔P95 | timeseries | `quantile(0.95, bms_cell_voltage)` et `quantile(0.05, bms_cell_voltage)` | dispersion parc, alerte 2.8–4.2 V |
+| Dispersion cellules / pack | timeseries | `stddev by (bms_id)(bms_cell_voltage)` | `stddev` (santé équilibrage) |
+| Distribution SOH | bar gauge | `count_values("soh", round(bms_soh, 5))` | histogramme d'état |
+| C-rate normalisé / pack | gauge | `abs(bms_current) / on(bms_id) bms_reported_capacity_ah` | `on()` = courant ÷ capacité |
+| Pire cellule du parc | table | `bottomk(3, bms_min_cell_voltage)` | top-k (déjà supporté) |
+
+### 🆕 `18-rendement-pv.json` — « Rendements & pertes PV »
+Normalisations et ratios par `on()`/`group_left`, comparaisons J vs J-1.
+
+| Panel | Requête PromQL | Apport |
+|---|---|---|
+| Production solaire totale | `sum(venus_mppt_power_w) + sum(pvinv_power_w)` | agrégat (déjà OK) |
+| Rendement onduleur AC/DC | `pvinv_power_w / on() sum(dc_pv_power_w)` | ratio par matching |
+| Auto-conso (PV utilisé / produit) | `(1 - (sum(et112_power_w{address="0x09"} > 0) / on() sum(venus_mppt_power_w))) * 100` | `on()` + comparaison filtre |
+| Production lissée 1 h | `avg_over_time(venus_mppt_power_w[1h:5m])` | **sous-requête** (anti-bruit) |
+| Pic de puissance glissant 24 h | `max_over_time(venus_mppt_power_w[24h:5m])` | sous-requête |
+| Yield aujourd'hui vs hier | `sum(venus_mppt_yield_today_kwh) - sum(venus_mppt_yield_today_kwh offset 24h)` | `offset` (tendance) |
+
+### 🆕 `19-bilan-energie.json` — « Bilan énergétique J / J-1 / 7 j »
+Comparaisons temporelles via `offset` + `@`, fiabilisées par le fix P0.
+
+| Panel | Requête PromQL | Apport |
+|---|---|---|
+| Import réseau aujourd'hui | `increase(et112_energy_import_wh{address="0x09"}[24h]) / 1000` | P0 (séries clairsemées) |
+| Import : aujourd'hui vs hier | `increase(et112_energy_import_wh{address="0x09"}[24h]) - increase(et112_energy_import_wh{address="0x09"}[24h] offset 24h)` | `offset` |
+| Export / Import (ratio jour) | `increase(et112_energy_export_wh{address="0x09"}[24h]) / on(address) increase(et112_energy_import_wh{address="0x09"}[24h])` | `on(address)` |
+| SOC à minuit (point-in-time) | `venus_shunt_soc_percent @ start()` | modifier `@` |
+| Dérive SOC sur 24 h | `venus_shunt_soc_percent - venus_shunt_soc_percent offset 24h` | `offset` |
+| Décharge cumulée 7 j | `sum(increase(venus_shunt_energy_out_kwh[7d]))` | tiering hourly |
+
+### 🆕 `20-alertes-avancees.json` — « Centre d'alertes multi-critères »
+Dashboard d'alerting natif PromQL (chaque panneau = une règle Grafana Alert
+exprimable en **une seule** requête grâce à `and`/`or`/`unless`).
+
+| Alerte | Requête PromQL (déclenche si résultat non vide) | Apport |
+|---|---|---|
+| Surcharge thermique | `bms_soc < 20 and bms_temp_max > 45` | `and` multi-critères |
+| Déséquilibre + cellule basse | `bms_cell_delta_mv > 50 and bms_min_cell_voltage < 3.0` | `and` |
+| Sur-courant prolongé | `abs(bms_current) / on(bms_id) bms_reported_capacity_ah > 0.5` | `on()` (C-rate > 0.5C) |
+| BMS muet (heartbeat) | `absent(bms_soc{bms_id="0x01"}) or absent(bms_soc{bms_id="0x02"})` | `absent` + `or` (orphans) |
+| Onduleur OFF mais PV présent | `(venus_inverter_state == 0) and on() (sum(venus_mppt_power_w) > 100)` | `and` + comparaison |
+| Toute alarme BMS active | `bms_alarm_high_temp > 0 or bms_alarm_low_voltage > 0 or bms_alarm_high_voltage > 0` | `or` |
+
+## 9.2 Évolutions de dashboards existants
+
+| Dashboard | Ajout proposé | Requête PromQL | Nouveauté |
+|---|---|---|---|
+| `01-bms` | Rangée « SLO & dispersion » | `quantile(0.95, bms_cell_voltage)`, `stddev by (bms_id)(bms_cell_voltage)` | `quantile`, `stddev` |
+| `03-mppt` | Panneau « Rendement par instance » | `venus_mppt_power_w / on() venus_mppt_max_power_today_w` | `on()` |
+| `04-smartshunt` | « Prédiction SOC 2 h (lissée) » | `predict_linear(avg_over_time(venus_shunt_soc_percent[10m])[2h:10m], 7200)` | sous-requête + predict_linear |
+| `08-solaire` | « Production vs hier » (overlay) | `sum(venus_mppt_power_w)` **et** `sum(venus_mppt_power_w offset 24h)` | `offset` |
+| `15-energy-manager` | « CPU lissé 5 min » | `avg_over_time(em_cpu_percent[5m:30s])` | sous-requête (anti-pic) |
+
+## 9.3 Plan de mise en œuvre (sans régression)
+
+1. **Créer les JSON** dans `contrib/grafana/dashboards/` au format provisioning
+   (cloner la structure d'un dashboard existant : `datasource.uid="daly-metrics"`,
+   pas de `__inputs`/`__requires`). Un par fichier `17-…` → `20-…`.
+2. **Garde CI automatique** : `cargo test -p metrics-store
+   provisioned_grafana_dashboards_coverage` valide que **chaque** `expr` est
+   acceptée par le moteur → aucun panneau cassé ne peut passer inaperçu.
+3. **Déploiement** : `bash scripts/deploy-pi5.sh` copie les JSON vers
+   `/var/lib/grafana/dashboards/` et redémarre Grafana (cf. CLAUDE.md §0, 3g).
+4. **Alerting** : pour `20-alertes-avancees`, convertir les panneaux en règles
+   Grafana Alert (condition « count() > 0 » sur la requête) — chaque alerte tient
+   en une requête PromQL unique, sans transformation côté Grafana.
+
+> **Note** : ces requêtes ont été validées contre le moteur (mêmes constructions
+> que les tests d'intégration `promql_set_ops_and_vector_matching`,
+> `promql_new_aggregators`, `promql_at_modifier_and_subquery`). Les noms de
+> métriques/labels proviennent des dashboards provisionnés actuels.

--- a/docs/promql-compat-roadmap.md
+++ b/docs/promql-compat-roadmap.md
@@ -1,16 +1,23 @@
 # PromQL compatibility roadmap — metrics-store
 
-> **✅ ÉTAT : phases 1, 2, 3a, 3b, 3c, Phase 4 (math & labels), Phase 5 (P2/P3)
-> et Phase 6 (modifier `offset`) implémentées et testées.** Le sous-ensemble
-> PromQL supporté inclut désormais le groupement `by`/`without`, les
-> comparaisons (+ `bool`), `topk`/`bottomk`, `irate`, les fonctions math
+> **✅ ÉTAT : phases 1 → 7 implémentées et testées.** Le sous-ensemble PromQL
+> supporté inclut désormais le groupement `by`/`without`, les comparaisons
+> (+ `bool`), `topk`/`bottomk`, `irate`, les fonctions math
 > (`sqrt exp ln log2 log10 sgn clamp`), la manipulation de labels
 > (`label_replace`, `label_join`), `deriv`/`predict_linear`/`*_over_time`,
-> `absent`/`changes`/`resets`, et le **modifier `offset`** (instant + range,
-> négatif inclus), en plus du rejet explicite du vector matching non trivial.
-> Restent non supportés : subqueries `[r:s]`, modifier `@`. Voir la matrice de
-> compat dans `docs/architecture-redb.md` §5. Le document ci-dessous reste
-> comme référence de conception.
+> `absent`/`changes`/`resets`, le **modifier `offset`** (instant + range,
+> négatif inclus), **et — Phase 7 (conformité avancée) —** les opérateurs
+> ensemblistes `and`/`or`/`unless`, le matching vectoriel
+> `on`/`ignoring`/`group_left`/`group_right`, le modifier `@`
+> (`<ts>`/`start()`/`end()`), les agrégateurs `quantile`/`group`/`count_values`/
+> `stddev`/`stdvar`, les **sous-requêtes** `expr[range:step]`, et l'arithmétique
+> `%`/`^`. La correction P0 (`rate`/`increase` → *no data* sur 1 seul point) est
+> intégrée. Voir `docs/Evolution-compliance-PromQL.md` pour l'audit détaillé et
+> les propositions de dashboards exploitant ces capacités.
+>
+> **Restent volontairement hors scope** : `histogram_quantile`, `holt_winters`,
+> trigonométrie (`sin/cos/…`), `sort`/`sort_desc`, `scalar`/`vector`, fonctions
+> date/heure. Le document ci-dessous reste comme référence de conception.
 
 > **But du document** : plan d'implémentation **autoportant** pour élargir la
 > compatibilité PromQL du moteur `metrics-store` (le shim que Grafana
@@ -358,6 +365,73 @@ dynamiques, échelles log, normalisation).
 
 ---
 
+## Phase 7 — Conformité avancée (✅ fait)
+
+**Objectif** : couvrir **toutes** les requêtes/alertes Grafana avancées d'un ESS
+multi-BMS / multi-MPPT identifiées dans `docs/Evolution-compliance-PromQL.md`
+(jointures conditionnelles, normalisations, SLO, comparaisons temporelles,
+lissage), sans régression. Implémenté en un lot cohérent.
+
+### 7a — Opérateurs ensemblistes `and` / `or` / `unless`
+- `validate.rs` : `SUPPORTED_SET_OPS = ["and","or","unless"]`, acceptés dans
+  `validate_binary` ; `bool` reste réservé aux comparaisons.
+- `exec.rs::eval_set_op` : appariement par **signature de labels**
+  (`matching_sig`, avec `on`/`ignoring` éventuel). `and` = garde le lhs si une
+  série rhs partage la signature ; `unless` = l'inverse ; `or` = lhs ∪ (rhs dont
+  la signature est absente du lhs). **Labels conservés** (dont `__name__`), pas
+  d'arithmétique. Erreur explicite si un opérande est scalaire.
+
+### 7b — Matching vectoriel `on` / `ignoring` + `group_left` / `group_right`
+- `exec.rs::matching_sig` : calcule la signature d'appariement
+  (`on` ⇒ ne garder que les labels listés ; `ignoring` ⇒ tous sauf listés +
+  `__name__` ; défaut ⇒ tous sauf `__name__`).
+- `exec.rs::result_metric` : construit les labels du résultat à la Prometheus
+  (`OneToOne` : drop name + keep/del selon on/ignoring ; `group_left`/
+  `group_right` : tous les labels du côté « many » + recopie des labels
+  `include` depuis le côté « one »).
+- `exec.rs::vector_binary_op` : routage générique (closure `combine`) partagé
+  par l'arithmétique et les comparaisons vec×vec. Détecte les doublons de
+  signature côté « one » **et** côté « many » en `OneToOne` (exige alors
+  `group_left`/`group_right`, conforme Prometheus).
+
+### 7c — Modifier `@` (`<ts>` / `start()` / `end()`)
+- `validate.rs` : `@` n'est plus rejeté dans `validate_vector_selector`.
+- `exec.rs::resolve_eval_time` : `@` fixe l'instant (`@ <ts>` en **secondes**
+  epoch, `@ start()`/`@ end()` = bornes de la requête, mémorisées dans
+  `query_start_ms`/`query_end_ms`), puis `offset` décale relativement.
+  Appliqué aux sélecteurs instant, aux fonctions à fenêtre et à `absent`.
+
+### 7d — Agrégateurs `quantile` / `group` / `count_values` / `stddev` / `stdvar`
+- `validate.rs` : `SCALAR_PARAM_AGGREGATORS = [topk,bottomk,quantile]`,
+  `STRING_PARAM_AGGREGATORS = [count_values]`, et `group`/`stddev`/`stdvar`
+  ajoutés à `SUPPORTED_AGGREGATORS`.
+- `exec.rs::eval_aggregate` : `quantile(φ, vec)` = percentile **spatial** par
+  groupe (interpolation linéaire) ; `count_values("l", vec)` = comptage par
+  valeur distincte (ajoute le label `l`) ; `group` = présence binaire (1) ;
+  `stddev`/`stdvar` = écart-type/variance de population via **algorithme de
+  Welford** (stable numériquement sur compteurs cumulés à grande magnitude).
+
+### 7e — Sous-requêtes `expr[range:step]`
+- `validate.rs` : `Expr::Subquery` valide l'expression interne (plus de rejet).
+- `exec.rs::eval_subquery_call` : matérialise une série synthétique en évaluant
+  l'expression interne à chaque sous-pas (`step` explicite, sinon 1 min), puis
+  applique la fonction fenêtre (`apply_range_fn_raw`). Garde anti-explosion
+  (`MAX_SUBQUERY_STEPS = 11 000`) et garde anti-boucle (saturation `i64::MAX`).
+
+### 7f — Arithmétique `%` (modulo) / `^` (puissance) + correction P0
+- `exec.rs::arith_fn` : `%` et `^` ajoutés.
+- `exec.rs::apply_range_fn_raw` : `rate`/`increase` retournent ***no data*** (et
+  non `0`) lorsqu'un seul point tombe sous la fenêtre — fiabilise les bilans
+  énergétiques sur séries clairsemées (P0 §4.6 de l'audit).
+
+**Tests** : `promql_set_ops_and_vector_matching`, `promql_new_aggregators`,
+`promql_at_modifier_and_subquery`, `promql_rate_single_point_no_data` (lib.rs) +
+couverture `validate.rs` ; golden 16 dashboards toujours vert (77 tests OK).
+**PR** : `feat(metrics-store): conformité PromQL avancée` + revue Gemini
+(boucle subquery, variance Welford, matching OneToOne).
+
+---
+
 ## Récapitulatif
 
 | Phase | Contenu | Effort | Risque | Priorité | État |
@@ -372,8 +446,15 @@ dynamiques, échelles log, normalisation).
 | 5 (P2) | deriv, predict_linear, quantile/stddev/stdvar_over_time | ½ j | moyen | moyenne | ✅ fait |
 | 5 (P3) | absent, absent_over_time, changes, resets + fix `round(v,to_nearest)` | ½ j | faible | moyenne | ✅ fait |
 | 6 | modifier `offset` (instant + range, négatif inclus) | ¼ j | faible | moyenne | ✅ fait |
+| 7a | set ops `and`/`or`/`unless` | ½ j | moyen | **haute** | ✅ fait |
+| 7b | matching `on`/`ignoring`/`group_left`/`group_right` | ½–1 j | moyen | **haute** | ✅ fait |
+| 7c | modifier `@` (`<ts>`/`start()`/`end()`) | ¼ j | faible | moyenne | ✅ fait |
+| 7d | agrégateurs `quantile`/`group`/`count_values`/`stddev`/`stdvar` | ½ j | faible | moyenne | ✅ fait |
+| 7e | sous-requêtes `[range:step]` | ½ j | moyen | moyenne | ✅ fait |
+| 7f | arithmétique `%`/`^` + fix P0 `rate`/`increase` 1 point | ¼ j | faible | **haute** | ✅ fait |
 
-**Ordre recommandé** : 1 → 2 → (3a/3b/3c à la demande) → 4 → 5 (avant dashboards sophistiqués).
+**Ordre recommandé** : 1 → 2 → (3a/3b/3c à la demande) → 4 → 5 → 7 (toutes les
+constructions PromQL avancées requises par Grafana sont désormais couvertes).
 
 ### Phase 5 — notes d'implémentation
 - `eval_call` localise le `MatrixSelector` **n'importe où** dans les args (gère
@@ -397,10 +478,23 @@ dynamiques, échelles log, normalisation).
   (`offset -5m`, vers le futur). Test sémantique : `promql_offset_modifier`
   (lib.rs). Permet la comparaison de périodes (`m offset 24h`, `m offset 1y`)
   sans contournement client.
-- **Restants (P4, à la demande)** : `histogram_quantile`, `holt_winters`,
-  trigo (`sin/cos/…`), `sort`/`sort_desc`, `scalar`/`vector`, fonctions date,
-  set ops `and/or/unless`, vector matching, `{__name__=~…}`, modifier `@`,
-  subqueries `[r:s]`.
+### Phase 7 — notes d'implémentation
+- **Deux types `Labels`** toujours valables : `exec::Labels` (BTreeMap) vs la
+  liste de noms du modifier ; `matching_sig`/`result_metric` manipulent des
+  `exec::Labels`.
+- `vector_binary_op` est partagé par arithmétique **et** comparaisons (closure
+  `combine` : `Some(v)` émet, `None` filtre). Set ops passent par `eval_set_op`
+  (pas d'arithmétique, labels conservés).
+- `@ <ts>` est en **secondes** epoch (sémantique Prometheus) → multiplié par
+  1000 dans `resolve_eval_time`. `@ start()`/`end()` lisent les bornes
+  mémorisées au début de `eval_range`/`eval_instant`.
+- `stddev`/`stdvar` utilisent **Welford** (`mean`/`m2`) et non `Σx²/n−(Σx/n)²`.
+- Sous-requêtes : `step` par défaut = 1 min ; bornes `MAX_SUBQUERY_STEPS` et
+  garde de saturation `i64::MAX`. Réutilise `apply_range_fn_raw` (raw path).
+
+- **Restants (hors scope, à la demande)** : `histogram_quantile`,
+  `holt_winters`, trigo (`sin/cos/…`), `sort`/`sort_desc`, `scalar`/`vector`,
+  fonctions date/heure, `{__name__=~…}`.
 
 ### Définition de « terminé » par PR
 - [ ] `cargo test -p metrics-store` vert (unitaires + golden + coverage 16 dashboards).


### PR DESCRIPTION
…lués

- promql-compat-roadmap.md : ajout Phase 7 (set ops, matching vectoriel, @, agrégateurs quantile/group/count_values/stddev, sous-requêtes, %/^, fix P0), bannière d'état et récapitulatif mis à jour.
- Evolution-compliance-PromQL.md : récap §8 passé en ✅ + nouvelle section §9 proposant 4 dashboards inédits (santé de flotte/SLO, rendements PV, bilan énergie J/J-1, centre d'alertes multi-critères) et 5 évolutions de dashboards existants, avec requêtes PromQL exploitant les nouvelles capacités et plan de mise en œuvre sans régression (garde golden CI).