### PR TITLE
fix(grafana): dashboard ET112 vide — label address au format hex 0x07…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,7 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 | `scp: dest open Failure` | `ssh root@192.168.1.120 "svc -d /service/dbus-mqtt-venus"` puis redéployer |
 | Venus symlink disparu (màj firmware) | `ssh root@192.168.1.120 "ln -sf /data/etc/sv/dbus-mqtt-venus /service/dbus-mqtt-venus"` |
 | ET112 "en attente de données" | Mauvaise adresse Modbus → `sudo systemctl stop daly-bms && mbpoll -m rtu -a 1:15 -b 9600 -t 3:float -r 1 -c 1 /dev/ttyUSB0` |
+| Dashboard Grafana ET112 vide alors que les données existent | **Format du label `address`** : le backend écrit `address="0x07/0x08/0x09"` (hex, `redb_writes.rs::write_et112`). Les requêtes PromQL doivent utiliser `address="0x07"`, **jamais** `address="7"` (décimal → 0 série). Vérif : `curl -s 'localhost:8080/api/v1/query?query=et112_power_w' \| jq '.data.result[].metric'`. |
 | Widget météo "Température: -" | Limitation Venus OS — inévitable, non fixable |
 | `mbpoll` sans réponse | daly-bms monopolise le port — `sudo systemctl stop daly-bms` d'abord |
 | Dashboard affiche cumul brut | Vérifier `pvinv_baseline` retained MQTT (`santuario/persist/pvinv_baseline`) |

--- a/contrib/grafana/dashboards/02-et112.json
+++ b/contrib/grafana/dashboards/02-et112.json
@@ -42,7 +42,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_power_w{address=\"7\"}",
+          "expr": "et112_power_w{address=\"0x07\"}",
           "legendFormat": "Micro-onduleurs (addr 7)",
           "refId": "A"
         },
@@ -51,7 +51,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_power_w{address=\"8\"}",
+          "expr": "et112_power_w{address=\"0x08\"}",
           "legendFormat": "Maison / Conso (addr 8)",
           "refId": "B"
         },
@@ -60,7 +60,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_power_w{address=\"9\"}",
+          "expr": "et112_power_w{address=\"0x09\"}",
           "legendFormat": "Réseau / Grid (addr 9)",
           "refId": "C"
         }
@@ -109,7 +109,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_voltage_v{address=\"7\"}",
+          "expr": "et112_voltage_v{address=\"0x07\"}",
           "legendFormat": "Tension addr 7",
           "refId": "A"
         },
@@ -118,7 +118,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_voltage_v{address=\"8\"}",
+          "expr": "et112_voltage_v{address=\"0x08\"}",
           "legendFormat": "Tension addr 8",
           "refId": "B"
         },
@@ -127,7 +127,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_voltage_v{address=\"9\"}",
+          "expr": "et112_voltage_v{address=\"0x09\"}",
           "legendFormat": "Tension addr 9",
           "refId": "C"
         }
@@ -176,7 +176,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_current_a{address=\"7\"}",
+          "expr": "et112_current_a{address=\"0x07\"}",
           "legendFormat": "Courant addr 7",
           "refId": "A"
         },
@@ -185,7 +185,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_current_a{address=\"8\"}",
+          "expr": "et112_current_a{address=\"0x08\"}",
           "legendFormat": "Courant addr 8",
           "refId": "B"
         },
@@ -194,7 +194,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_current_a{address=\"9\"}",
+          "expr": "et112_current_a{address=\"0x09\"}",
           "legendFormat": "Courant addr 9",
           "refId": "C"
         }
@@ -256,7 +256,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_energy_import_wh{address=\"9\"}",
+          "expr": "et112_energy_import_wh{address=\"0x09\"}",
           "legendFormat": "Import Réseau",
           "refId": "A"
         },
@@ -265,7 +265,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_energy_import_wh{address=\"8\"}",
+          "expr": "et112_energy_import_wh{address=\"0x08\"}",
           "legendFormat": "Import Maison",
           "refId": "B"
         }
@@ -314,7 +314,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_energy_export_wh{address=\"9\"}",
+          "expr": "et112_energy_export_wh{address=\"0x09\"}",
           "legendFormat": "Export Réseau",
           "refId": "A"
         },
@@ -323,7 +323,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_energy_export_wh{address=\"7\"}",
+          "expr": "et112_energy_export_wh{address=\"0x07\"}",
           "legendFormat": "Export Micro-ond.",
           "refId": "B"
         }
@@ -385,7 +385,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_power_factor{address=\"8\"}",
+          "expr": "et112_power_factor{address=\"0x08\"}",
           "legendFormat": "PF Maison",
           "refId": "A"
         }
@@ -440,7 +440,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_power_factor{address=\"9\"}",
+          "expr": "et112_power_factor{address=\"0x09\"}",
           "legendFormat": "PF Réseau",
           "refId": "A"
         }
@@ -495,7 +495,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_frequency_hz{address=\"8\"}",
+          "expr": "et112_frequency_hz{address=\"0x08\"}",
           "legendFormat": "Fréq Maison",
           "refId": "A"
         }
@@ -544,7 +544,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_reactive_power_var{address=\"7\"}",
+          "expr": "et112_reactive_power_var{address=\"0x07\"}",
           "legendFormat": "VAR addr 7",
           "refId": "A"
         },
@@ -553,7 +553,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_reactive_power_var{address=\"8\"}",
+          "expr": "et112_reactive_power_var{address=\"0x08\"}",
           "legendFormat": "VAR addr 8",
           "refId": "B"
         },
@@ -562,7 +562,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "et112_reactive_power_var{address=\"9\"}",
+          "expr": "et112_reactive_power_var{address=\"0x09\"}",
           "legendFormat": "VAR addr 9",
           "refId": "C"
         }


### PR DESCRIPTION
…/0x08/0x09

Le backend (redb_writes.rs::write_et112) écrit le label address au format `format!("0x{:02x}", snap.address)` → "0x07", "0x08", "0x09". Le dashboard 02-et112.json interrogeait en décimal (address="7/8/9") → aucune série ne matchait → tous les panneaux vides pour les 3 ET112.

Aligne les 19 sélecteurs sur le format hex réellement stocké (cohérent avec api/history.rs et les tests). Golden coverage toujours vert. CLAUDE.md : entrée de dépannage ajoutée.