### PR TITLE
feat(et112): 0x08 → acload, 0x09 → grid (conformité D-Bus Victron)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,8 +182,8 @@ Bus `/dev/ttyUSB0` :
 | 0x02 | BMS-320Ah | `battery.mqtt_2` | `bms/2/venus` | 152 |
 | 0x05 | PRALRAN irradiance | `meteo` | `irradiance/raw` | 40 |
 | 0x07 | ET112-Micro-Onduleurs (SN 119253X) | `pvinverter.mqtt_7` | `pvinverter/7/venus` | 32 |
-| 0x08 | ET112-Maison (SN 119215X) | `heatpump.mqtt_8` | `heatpump/8/venus` | 30 |
-| 0x09 | ET112-Réseau (SN 061077X) | `heatpump.mqtt_9` | `heatpump/9/venus` | 31 |
+| 0x08 | ET112-Maison (SN 119215X) | `acload.mqtt_8` | `grid/8/venus` | 30 |
+| 0x09 | ET112-Réseau (SN 061077X) | `grid.mqtt_9` | `grid/9/venus` | 31 |
 
 Services D-Bus actifs nominaux :
 
@@ -191,8 +191,8 @@ Services D-Bus actifs nominaux :
 com.victronenergy.battery.mqtt_1          BMS-360Ah (inst. 151)
 com.victronenergy.battery.mqtt_2          BMS-320Ah (inst. 152)
 com.victronenergy.pvinverter.mqtt_7       ET112-Micro-Onduleurs (inst. 32)
-com.victronenergy.heatpump.mqtt_8         ET112-Maison / Consommation (inst. 30)
-com.victronenergy.heatpump.mqtt_9         ET112-Réseau / Grid (inst. 31)
+com.victronenergy.acload.mqtt_8           ET112-Maison / Consommation AC (inst. 30)
+com.victronenergy.grid.mqtt_9             ET112-Réseau / Compteur réseau EDF (inst. 31)
 com.victronenergy.temperature.mqtt_1      Capteur ext. (type 4, inst. 20)
 com.victronenergy.switch.mqtt_1           ATS CHINT (inst. 60)
 com.victronenergy.switch.mqtt_2           Tongou Switch1 (inst. 61)

--- a/Config.toml
+++ b/Config.toml
@@ -168,9 +168,11 @@ device_instance  = 20      # DeviceInstance Venus OS / VRM
 # Préfixe des topics heatpump
 topic_prefix = "santuario/heatpump"
 
-# Les PAC/chauffe-eau sont déclarés via [[et112.devices]] (service_type="heatpump")
-# et configurés dans nanoPi/config-nanopi.toml côté dbus-mqtt-venus.
-# Aucun [[heatpumps]] ici — daly-bms-server ne lit pas cette section.
+# Le vrai chauffe-eau (LG ThinQ) est publié par energy-manager sur
+# santuario/heatpump/1/venus → com.victronenergy.heatpump.mqtt_1.
+# Les ET112 0x08/0x09 ne sont PAS des PAC : ils sont déclarés en acload/grid
+# (cf. [[et112.devices]] ci-dessous). Aucun [[heatpumps]] ici —
+# daly-bms-server ne lit pas cette section.
 
 # =============================================================================
 # Capteur météo / irradiance RS485 (com.victronenergy.meteo)
@@ -211,9 +213,13 @@ poll_interval_ms = 5000
 # Les champs port/baud sont supprimés — bus hérité du SharedBus global.
 #
 # Adresses RS485 (configurées physiquement sur les compteurs) :
-#   0x07 = Micro-onduleurs → D-Bus pvinverter (mqtt_3, instance 63)
-#   0x08 = PAC Chauffe-eau  → D-Bus pvinverter ou acload
-#   0x09 = PAC Climatisation → D-Bus pvinverter ou acload
+#   0x07 = Micro-onduleurs  → D-Bus pvinverter (mqtt_7, instance 32)
+#   0x08 = Maison (conso)    → D-Bus acload     (mqtt_8, instance 30) — charge AC mesurée
+#   0x09 = Réseau (EDF)      → D-Bus grid       (mqtt_9, instance 31) — compteur réseau import/export
+#
+# Sémantique Victron (wiki dbus) :
+#   com.victronenergy.grid   = point de connexion réseau (compté import/export, ESS, bilan système)
+#   com.victronenergy.acload = consommation AC locale, monitoring indépendant (NON compté dans le grid)
 
 [et112]
 # Intervalle de polling en millisecondes (2000 = toutes les 2 secondes)
@@ -233,16 +239,16 @@ position         = 1
 [[et112.devices]]               # SN: 119215X — branché ✅
 address          = "0x08"
 name             = "ET112-Maison"
-mqtt_index       = 8           # → santuario/heatpump/8/venus
-service_type     = "heatpump"
+mqtt_index       = 8           # → santuario/grid/8/venus → com.victronenergy.acload.mqtt_8
+service_type     = "acload"
 device_instance  = 30
 position         = 1
 
 [[et112.devices]]               # SN: 061077X — branché ✅
 address          = "0x09"
 name             = "ET112-Réseau"
-mqtt_index       = 9           # → santuario/heatpump/9/venus
-service_type     = "heatpump"
+mqtt_index       = 9           # → santuario/grid/9/venus → com.victronenergy.grid.mqtt_9
+service_type     = "grid"
 device_instance  = 31
 position         = 1
 

--- a/contrib/mosquitto/mosquitto.conf
+++ b/contrib/mosquitto/mosquitto.conf
@@ -77,8 +77,11 @@ topic santuario/bms/# out 1 "" ""
 # ET112 Micro-Onduleurs → pvinverter.mqtt_7
 topic santuario/pvinverter/# out 0 "" ""
 
-# ET112 Maison + Réseau → heatpump.mqtt_8/9
+# Chauffe-eau LG ThinQ (energy-manager) → heatpump.mqtt_1
 topic santuario/heatpump/# out 0 "" ""
+
+# ET112 Maison + Réseau → acload.mqtt_8 / grid.mqtt_9
+topic santuario/grid/# out 0 "" ""
 
 # ATS CHINT + Tongou → switch.mqtt_1/2/3/4/5/6
 topic santuario/switch/# out 0 "" ""

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -206,7 +206,8 @@ async fn publish_irradiance(
 /// Publie un snapshot ET112 sur le topic `santuario/{service_type}/{idx}/venus`.
 ///
 /// service_type = "pvinverter" → topic pvinverter/{idx}/venus  (PvinverterPayload)
-/// service_type = "acload"     → topic grid/{idx}/venus        (GridPayload)
+/// service_type = "grid"       → topic grid/{idx}/venus        (GridPayload → com.victronenergy.grid)
+/// service_type = "acload"     → topic grid/{idx}/venus        (GridPayload → com.victronenergy.acload)
 /// service_type = "heatpump"   → topic heatpump/{idx}/venus    (HeatpumpPayload)
 async fn publish_et112_snapshot(
     client: &AsyncClient,
@@ -222,9 +223,9 @@ async fn publish_et112_snapshot(
         .unwrap_or("santuario");
 
     let topic_prefix = match service_type {
-        "acload"   => "grid",
-        "heatpump" => "heatpump",
-        _          => "pvinverter",
+        "grid" | "acload" => "grid",   // → com.victronenergy.grid / acload (selon service_type côté NanoPi)
+        "heatpump"        => "heatpump",
+        _                 => "pvinverter",
     };
     let topic = format!("{}/{}/{}/venus", base, topic_prefix, mqtt_index);
 

--- a/nanoPi/config-nanopi.toml
+++ b/nanoPi/config-nanopi.toml
@@ -85,19 +85,24 @@ device_instance  = 20
 # Pompes à chaleur / chauffe-eau
 # Topics : santuario/heatpump/{mqtt_index}/venus
 # D-Bus  : com.victronenergy.heatpump.mqtt_{mqtt_index}
+#
+# Seul le vrai chauffe-eau (LG ThinQ, publié par energy-manager sur
+# santuario/heatpump/1/venus) est une PAC. Les ET112 0x08/0x09 sont des
+# compteurs d'énergie → déclarés en acload/grid (section [grid] plus bas).
 # -----------------------------------------------------------------------------
 [heatpump]
 topic_prefix = "santuario/heatpump"
 
-[[heatpumps]]
-mqtt_index      = 8             # ET112 addr=0x08 (SN: 119215X) — PAC Chauffe-eau branché ✅
-name            = "PAC Chauffe-eau"
-device_instance = 30
-
-[[heatpumps]]
-mqtt_index      = 9             # ET112 addr=0x09 (SN: 061077X) — PAC Climatisation branché ✅
-name            = "PAC Climatisation"
-device_instance = 31
+# Aucun [[heatpumps]] déclaré actuellement.
+# NB : un index n'est enregistré sur D-Bus que s'il possède une entrée
+# [[heatpumps]] correspondante (heatpump_manager::is_configured).
+# Pour exposer le chauffe-eau LG ThinQ (publié par energy-manager sur
+# santuario/heatpump/1/venus) en com.victronenergy.heatpump.mqtt_1,
+# décommenter :
+# [[heatpumps]]
+# mqtt_index      = 1
+# name            = "Chauffe-eau LG ThinQ"
+# device_instance = 30
 
 # -----------------------------------------------------------------------------
 # Capteur météo / irradiance (singleton — un seul capteur)
@@ -178,41 +183,38 @@ custom_name     = "Tongou 5"
 group           = "Tongou"
 
 # -----------------------------------------------------------------------------
-# Compteurs réseau / consommation AC
-# Topics : santuario/grid/{mqtt_index}/venus
-# D-Bus  : com.victronenergy.grid.mqtt_{mqtt_index}
-#          com.victronenergy.acload.mqtt_{mqtt_index} (si service_type="acload")
+# Compteurs réseau / consommation AC — ET112 0x08 et 0x09 (RS485 Pi5)
+# Topics : santuario/grid/{mqtt_index}/venus  (publiés par daly-bms-server)
+# D-Bus  : com.victronenergy.grid.mqtt_{mqtt_index}    (service_type="grid")
+#          com.victronenergy.acload.mqtt_{mqtt_index}  (service_type="acload")
 #
-# PLAN MIGRATION 3 ET112 (quand tous sur Pi5) :
-#   mqtt_index=3 → pvinverter (ci-dessous, section [pvinverter])
-#   mqtt_index=4 → acload PAC climatisation (AC Out 1)
-#   mqtt_index=5 → acload chauffe-eau (AC Out 1)
+# Sémantique Victron (wiki dbus) :
+#   grid   = point de connexion réseau (compté dans import/export, ESS, bilan).
+#            Un seul compteur "grid" par système.
+#   acload = consommation AC locale, monitoring indépendant (NON compté grid).
 #
-# Le daly-bms-server publie les ET112 acload sur santuario/grid/{n}/venus
-# avec un payload GridPayload (même format que grid, service_type="acload").
+# Mapping production :
+#   0x08 "ET112-Maison"  (mqtt_index=8) → acload  → com.victronenergy.acload.mqtt_8
+#   0x09 "ET112-Réseau"  (mqtt_index=9) → grid    → com.victronenergy.grid.mqtt_9
+#
+# Le payload est identique (GridPayload : Ac/L1/{Voltage,Current,Power,Energy}
+# + Ac/Power + Ac/Energy/Forward+Reverse). Seul service_type ci-dessous
+# décide du nom de service D-Bus (grid vs acload).
 # -----------------------------------------------------------------------------
 [grid]
 topic_prefix = "santuario/grid"
 
-# Décommenter quand un compteur réseau sera connecté :
-# [[grids]]
-# mqtt_index      = 1
-# name            = "Compteur réseau"
-# device_instance = 401
-# service_type    = "grid"     # "grid" ou "acload"
+[[grids]]
+mqtt_index      = 8             # ET112 addr=0x08 (SN: 119215X) — Maison / consommation AC
+name            = "ET112-Maison"
+device_instance = 30
+service_type    = "acload"     # → com.victronenergy.acload.mqtt_8
 
-# Décommenter lors de la migration des ET112 acload depuis le Victron vers Pi5 :
-# [[grids]]
-# mqtt_index      = 4
-# name            = "PAC Climatisation"
-# device_instance = 501
-# service_type    = "acload"   # AC Out 1 — consommation PAC climatisation
-#
-# [[grids]]
-# mqtt_index      = 5
-# name            = "Chauffe-eau"
-# device_instance = 502
-# service_type    = "acload"   # AC Out 1 — consommation chauffe-eau
+[[grids]]
+mqtt_index      = 9             # ET112 addr=0x09 (SN: 061077X) — Réseau / compteur EDF
+name            = "ET112-Réseau"
+device_instance = 31
+service_type    = "grid"       # → com.victronenergy.grid.mqtt_9
 
 # -----------------------------------------------------------------------------
 # Onduleurs PV / compteurs énergie ET112 (Carlo Gavazzi)


### PR DESCRIPTION
Les ET112 0x08 (Maison) et 0x09 (Réseau) étaient déclarés en service_type="heatpump" (masquerade incorrect). Mise en conformité avec la sémantique Victron (wiki dbus) :

  0x08 "ET112-Maison"  → com.victronenergy.acload.mqtt_8
       (consommation AC locale, monitoring indépendant, NON compté grid)
  0x09 "ET112-Réseau"  → com.victronenergy.grid.mqtt_9
       (compteur réseau EDF, import/export, ESS, bilan système — unique)

Changements :
- Config.toml : service_type heatpump → acload (0x08) / grid (0x09).
- bridges/mqtt.rs : ajout de la branche "grid" dans publish_et112_snapshot (sans elle, service_type="grid" tombait par défaut sur le topic pvinverter). grid + acload publient sur santuario/grid/{idx}/venus.
- nanoPi/config-nanopi.toml : retrait des [[heatpumps]] 8/9, ajout des [[grids]] 8 (acload) et 9 (grid), instances 30/31 réutilisées.
- contrib/mosquitto/mosquitto.conf : ajout règle egress santuario/grid/#.
- CLAUDE.md : inventaire RS485 & D-Bus mis à jour.

Non-régression : les métriques redb (et112_*{address="0x08/0x09"}) sont indexées par adresse, indépendantes du service_type → dashboards Grafana, PromQL, /api/v1/chart, /api/v1/history/energy et visualization.html inchangés. energy-manager ne consomme pas ces topics.

Déploiement runtime (manuel) : purger les retained heatpump/8|9/venus et redémarrer dbus-mqtt-venus pour supprimer les services heatpump.mqtt_8/9.