### PR TITLE
fix(et112): script — REPO_DIR depuis le script + build/ssh sous $SUDO…

### DIFF
--- a/scripts/migrate-et112-grid-acload.sh
+++ b/scripts/migrate-et112-grid-acload.sh
@@ -6,8 +6,14 @@
 #   0x08 "ET112-Maison"  : heatpump.mqtt_8  →  acload.mqtt_8
 #   0x09 "ET112-Réseau"  : heatpump.mqtt_9  →  grid.mqtt_9
 #
-# À exécuter SUR LE PI5, depuis ~/Daly-BMS-Rust, APRÈS `make sync`
+# À exécuter SUR LE PI5 avec sudo, depuis le dépôt, APRÈS `make sync`
 # (la branche claude/confident-feynman-riH89 doit être mergée/récupérée).
+#
+# Important — exécution sous sudo :
+#   Les opérations privilégiées (/etc, /usr/local/bin, systemctl) tournent en
+#   root. Les opérations « utilisateur » (make build-arm, ssh/scp NanoPi) sont
+#   relancées sous $SUDO_USER pour récupérer rustup ET les clés SSH du user
+#   (sinon : « rustup not found » ou « Permission denied » SSH).
 #
 # Caractéristiques :
 #   - Sauvegarde horodatée de chaque fichier avant écrasement (rollback facile).
@@ -25,9 +31,14 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Paramètres
+# Chemin du dépôt : dérivé de l'emplacement du script (robuste sous sudo).
 # ---------------------------------------------------------------------------
-REPO_DIR="${REPO_DIR:-$HOME/Daly-BMS-Rust}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(dirname "$SCRIPT_DIR")}"
+
+# Utilisateur non-root pour build + SSH (clés dans ~user/.ssh, rustup user).
+RUN_USER="${SUDO_USER:-$(id -un)}"
+
 NANOPI="${NANOPI:-root@192.168.1.120}"
 NANOPI_SVC="/service/dbus-mqtt-venus"
 NANOPI_CFG="/data/daly-bms/config.toml"
@@ -55,13 +66,14 @@ ok()   { echo -e "${c_grn}✓ $*${c_off}"; }
 warn() { echo -e "${c_yel}⚠ $*${c_off}"; }
 die()  { echo -e "${c_red}✗ $*${c_off}" >&2; exit 1; }
 
-run() {
-  if [[ $DRY_RUN -eq 1 ]]; then
-    echo "  [dry-run] $*"
-  else
-    eval "$@"
-  fi
-}
+# Préfixe pour relancer une commande sous l'utilisateur non-root (si on est root).
+USER_PREFIX=""
+if [[ $EUID -eq 0 && "$RUN_USER" != "root" ]]; then
+  USER_PREFIX="sudo -u $RUN_USER -H"
+fi
+
+run()       { if [[ $DRY_RUN -eq 1 ]]; then echo "  [dry-run] $*"; else eval "$@"; fi; }   # root
+run_user()  { run "$USER_PREFIX $*"; }                                                     # $RUN_USER
 
 confirm() {
   [[ $ASSUME_YES -eq 1 || $DRY_RUN -eq 1 ]] && return 0
@@ -69,7 +81,7 @@ confirm() {
   [[ "$ans" == "o" || "$ans" == "O" ]] || die "Abandon utilisateur."
 }
 
-backup() {  # backup <fichier> — copie horodatée si le fichier existe
+backup() {  # backup <fichier> — copie horodatée si le fichier existe (root)
   local f="$1"
   [[ -f "$f" ]] || { warn "pas de fichier à sauvegarder : $f"; return 0; }
   run "mkdir -p '$BACKUP_DIR'"
@@ -81,7 +93,8 @@ backup() {  # backup <fichier> — copie horodatée si le fichier existe
 # Phase 0 — Pré-vol
 # ---------------------------------------------------------------------------
 step "Phase 0 — Vérifications préalables"
-cd "$REPO_DIR" || die "REPO_DIR introuvable : $REPO_DIR"
+cd "$REPO_DIR" || die "Dépôt introuvable : $REPO_DIR"
+ok "Dépôt : $REPO_DIR   (build+ssh sous : $RUN_USER)"
 
 command -v mosquitto_pub >/dev/null || die "mosquitto_pub manquant (apt install mosquitto-clients)"
 [[ -f Config.toml ]]                || die "Config.toml absent"
@@ -89,23 +102,26 @@ command -v mosquitto_pub >/dev/null || die "mosquitto_pub manquant (apt install 
 
 # Le code doit contenir la mise en conformité (garde-fou anti-vieux checkout)
 grep -q 'service_type     = "acload"' Config.toml \
-  || die "Config.toml ne contient pas service_type=acload — fais `make sync` d'abord."
+  || die "Config.toml ne contient pas service_type=acload — fais 'make sync' d'abord."
 grep -q 'service_type     = "grid"'   Config.toml \
-  || die "Config.toml ne contient pas service_type=grid — fais `make sync` d'abord."
+  || die "Config.toml ne contient pas service_type=grid — fais 'make sync' d'abord."
 grep -q '"grid" | "acload" => "grid"' crates/daly-bms-server/src/bridges/mqtt.rs \
-  || die "mqtt.rs ne contient pas la branche grid/acload — fais `make sync` d'abord."
+  || die "mqtt.rs ne contient pas la branche grid/acload — fais 'make sync' d'abord."
 
-ssh -o ConnectTimeout=5 "$NANOPI" true 2>/dev/null \
-  && ok "SSH NanoPi OK" || die "SSH NanoPi ($NANOPI) injoignable"
+if run_user "ssh -o ConnectTimeout=5 -o BatchMode=yes '$NANOPI' true" 2>/dev/null; then
+  ok "SSH NanoPi OK (clé de $RUN_USER)"
+else
+  die "SSH NanoPi ($NANOPI) injoignable sous l'utilisateur $RUN_USER (vérifie ~$RUN_USER/.ssh)"
+fi
 ok "Pré-vol OK"
 [[ $DRY_RUN -eq 1 ]] && warn "MODE DRY-RUN : aucune modification ne sera appliquée."
 confirm
 
 # ---------------------------------------------------------------------------
-# Phase 1 — Compilation Pi5 (aarch64)
+# Phase 1 — Compilation Pi5 (aarch64) — sous $RUN_USER (rustup)
 # ---------------------------------------------------------------------------
 step "Phase 1 — Compilation daly-bms-server (aarch64)"
-run "make build-arm"
+run_user "make build-arm"
 [[ $DRY_RUN -eq 1 || -f $BIN_SRC ]] || die "Binaire non produit : $BIN_SRC"
 ok "Binaire compilé"
 
@@ -122,7 +138,7 @@ run "cp contrib/mosquitto/mosquitto.conf /etc/mosquitto/mosquitto.conf"
 # Garde-fou anti-boucle bridge (règle projet n°11)
 if [[ -x /usr/local/bin/verify-no-loop.sh ]]; then
   step "Validation anti-boucle bridge MQTT"
-  run "/usr/local/bin/verify-no-loop.sh" || die "verify-no-loop a échoué — mosquitto.conf NON appliqué en prod, rollback."
+  run "/usr/local/bin/verify-no-loop.sh" || die "verify-no-loop a échoué — rollback mosquitto.conf depuis $BACKUP_DIR avant restart."
   ok "Aucune boucle détectée"
 else
   warn "verify-no-loop.sh absent — vérifie manuellement les règles 'out' santuario/grid/#"
@@ -132,7 +148,7 @@ run "systemctl restart mosquitto-broker"
 ok "mosquitto-broker redémarré"
 
 # ---------------------------------------------------------------------------
-# Phase 3 — Déploiement binaire + redémarrage daly-bms
+# Phase 3 — Déploiement binaire + redémarrage daly-bms (root)
 # ---------------------------------------------------------------------------
 step "Phase 3 — Déploiement binaire daly-bms-server"
 backup "$BIN_DST"   # rollback binaire
@@ -146,19 +162,19 @@ ok "daly-bms redémarré (publie désormais santuario/grid/8|9/venus)"
 # ---------------------------------------------------------------------------
 step "Phase 4 — Purge des messages retained obsolètes (heatpump 8/9)"
 for idx in 8 9; do
-  run "mosquitto_pub -h '$MQTT_HOST' -t 'santuario/heatpump/$idx/venus' -r -n"
-  run "ssh '$NANOPI' \"mosquitto_pub -h localhost -t 'santuario/heatpump/$idx/venus' -r -n\""
+  run_user "mosquitto_pub -h '$MQTT_HOST' -t 'santuario/heatpump/$idx/venus' -r -n"
+  run_user "ssh '$NANOPI' \"mosquitto_pub -h localhost -t 'santuario/heatpump/$idx/venus' -r -n\""
 done
 ok "Retained heatpump/8 et heatpump/9 purgés (Pi5 + NanoPi)"
 
 # ---------------------------------------------------------------------------
 # Phase 5 — Déploiement config NanoPi + redémarrage dbus-mqtt-venus
-# (AUCUNE recompilation NanoPi : seule la config change)
+# (AUCUNE recompilation NanoPi : seule la config change) — ssh/scp sous $RUN_USER
 # ---------------------------------------------------------------------------
 step "Phase 5 — Déploiement config NanoPi + restart dbus-mqtt-venus"
-run "ssh '$NANOPI' \"cp '$NANOPI_CFG' '${NANOPI_CFG}.bak-$(date +%Y%m%d-%H%M%S)'\" || true"
-run "scp nanoPi/config-nanopi.toml '$NANOPI:$NANOPI_CFG'"
-run "ssh '$NANOPI' 'svc -t $NANOPI_SVC'"
+run_user "ssh '$NANOPI' \"cp '$NANOPI_CFG' '${NANOPI_CFG}.bak-$(date +%Y%m%d-%H%M%S)'\" || true"
+run_user "scp nanoPi/config-nanopi.toml '$NANOPI:$NANOPI_CFG'"
+run_user "ssh '$NANOPI' 'svc -t $NANOPI_SVC'"
 ok "dbus-mqtt-venus redémarré (supprime heatpump.mqtt_8/9, crée acload.mqtt_8 + grid.mqtt_9)"
 
 # ---------------------------------------------------------------------------
@@ -172,7 +188,7 @@ else
   echo "--- Topics MQTT grid (doit montrer 8 et 9) ---"
   timeout 6 mosquitto_sub -h "$MQTT_HOST" -t 'santuario/grid/+/venus' -v -W 5 || true
   echo "--- Services D-Bus Victron (NanoPi) ---"
-  ssh "$NANOPI" "dbus -y | grep -E 'acload|grid|heatpump'" || true
+  ${USER_PREFIX} ssh "$NANOPI" "dbus -y | grep -E 'acload|grid|heatpump'" || true
   echo "--- Healthcheck daly-bms ---"
   curl -s http://localhost:8080/-/healthy || true
   echo
@@ -190,10 +206,10 @@ Attendu côté NanoPi :
 
 Sauvegardes : $BACKUP_DIR
 Rollback Pi5 :
-  cp $BACKUP_DIR/config.toml /etc/daly-bms/config.toml
-  cp $BACKUP_DIR/mosquitto.conf /etc/mosquitto/mosquitto.conf
-  cp $BACKUP_DIR/daly-bms-server /usr/local/bin/daly-bms-server
-  systemctl restart mosquitto-broker daly-bms
+  sudo cp $BACKUP_DIR/config.toml /etc/daly-bms/config.toml
+  sudo cp $BACKUP_DIR/mosquitto.conf /etc/mosquitto/mosquitto.conf
+  sudo cp $BACKUP_DIR/daly-bms-server /usr/local/bin/daly-bms-server
+  sudo systemctl restart mosquitto-broker daly-bms
 Rollback NanoPi :
   ssh $NANOPI 'cp ${NANOPI_CFG}.bak-* $NANOPI_CFG && svc -t $NANOPI_SVC'
 RESUME


### PR DESCRIPTION
…_USER

Sous sudo, $HOME=/root cassait REPO_DIR et les opérations user :
- REPO_DIR dérivé de l'emplacement du script (robuste sous sudo)
- make build-arm + ssh/scp NanoPi relancés sous $SUDO_USER (rustup + clés SSH)
- pré-vol SSH testé sous l'utilisateur cible