### PR TITLE
fix(et112): script lancé SANS sudo + rollback config auto si verify-n…

### DIFF
--- a/scripts/migrate-et112-grid-acload.sh
+++ b/scripts/migrate-et112-grid-acload.sh
@@ -6,14 +6,16 @@
 #   0x08 "ET112-Maison"  : heatpump.mqtt_8  →  acload.mqtt_8
 #   0x09 "ET112-Réseau"  : heatpump.mqtt_9  →  grid.mqtt_9
 #
-# À exécuter SUR LE PI5 avec sudo, depuis le dépôt, APRÈS `make sync`
-# (la branche claude/confident-feynman-riH89 doit être mergée/récupérée).
+# ┌───────────────────────────────────────────────────────────────────────┐
+# │  LANCER SANS SUDO :   bash scripts/migrate-et112-grid-acload.sh        │
+# │  (le script appelle `sudo` lui-même pour /etc, /usr/local/bin, systemctl)│
+# └───────────────────────────────────────────────────────────────────────┘
 #
-# Important — exécution sous sudo :
-#   Les opérations privilégiées (/etc, /usr/local/bin, systemctl) tournent en
-#   root. Les opérations « utilisateur » (make build-arm, ssh/scp NanoPi) sont
-#   relancées sous $SUDO_USER pour récupérer rustup ET les clés SSH du user
-#   (sinon : « rustup not found » ou « Permission denied » SSH).
+# Pourquoi pas `sudo bash ...` ? Sous sudo, $HOME=/root et surtout
+# SSH_AUTH_SOCK est supprimé → l'agent SSH (clé NanoPi) n'est plus accessible
+# et ssh/scp échouent. En lançant le script en tant que pi5compute, ssh/scp,
+# rustup (make build-arm) et l'agent fonctionnent nativement ; seules les
+# commandes privilégiées passent par sudo (qui demandera le mot de passe 1×).
 #
 # Caractéristiques :
 #   - Sauvegarde horodatée de chaque fichier avant écrasement (rollback facile).
@@ -24,20 +26,17 @@
 #   - --yes     : pas de confirmation interactive.
 #
 # Usage :
-#   sudo bash scripts/migrate-et112-grid-acload.sh            # interactif
-#   sudo bash scripts/migrate-et112-grid-acload.sh --dry-run  # simulation
-#   sudo bash scripts/migrate-et112-grid-acload.sh --yes      # non interactif
+#   bash scripts/migrate-et112-grid-acload.sh            # interactif
+#   bash scripts/migrate-et112-grid-acload.sh --dry-run  # simulation
+#   bash scripts/migrate-et112-grid-acload.sh --yes      # non interactif
 # =============================================================================
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Chemin du dépôt : dérivé de l'emplacement du script (robuste sous sudo).
+# Chemin du dépôt : dérivé de l'emplacement du script (robuste).
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="${REPO_DIR:-$(dirname "$SCRIPT_DIR")}"
-
-# Utilisateur non-root pour build + SSH (clés dans ~user/.ssh, rustup user).
-RUN_USER="${SUDO_USER:-$(id -un)}"
 
 NANOPI="${NANOPI:-root@192.168.1.120}"
 NANOPI_SVC="/service/dbus-mqtt-venus"
@@ -66,14 +65,17 @@ ok()   { echo -e "${c_grn}✓ $*${c_off}"; }
 warn() { echo -e "${c_yel}⚠ $*${c_off}"; }
 die()  { echo -e "${c_red}✗ $*${c_off}" >&2; exit 1; }
 
-# Préfixe pour relancer une commande sous l'utilisateur non-root (si on est root).
-USER_PREFIX=""
-if [[ $EUID -eq 0 && "$RUN_USER" != "root" ]]; then
-  USER_PREFIX="sudo -u $RUN_USER -H"
+# sudo seulement si on n'est pas déjà root
+if [[ $EUID -eq 0 ]]; then
+  SUDO=""
+  warn "Lancé en root : ssh/scp utiliseront les clés de root (et non de l'agent user)."
+  warn "En cas d'échec SSH, relance SANS sudo : bash $0"
+else
+  SUDO="sudo"
 fi
 
-run()       { if [[ $DRY_RUN -eq 1 ]]; then echo "  [dry-run] $*"; else eval "$@"; fi; }   # root
-run_user()  { run "$USER_PREFIX $*"; }                                                     # $RUN_USER
+run()  { if [[ $DRY_RUN -eq 1 ]]; then echo "  [dry-run] $*"; else eval "$@"; fi; }
+priv() { run "$SUDO $*"; }   # commande privilégiée (sudo si nécessaire)
 
 confirm() {
   [[ $ASSUME_YES -eq 1 || $DRY_RUN -eq 1 ]] && return 0
@@ -81,11 +83,11 @@ confirm() {
   [[ "$ans" == "o" || "$ans" == "O" ]] || die "Abandon utilisateur."
 }
 
-backup() {  # backup <fichier> — copie horodatée si le fichier existe (root)
+backup() {  # backup <fichier> — copie horodatée si le fichier existe
   local f="$1"
   [[ -f "$f" ]] || { warn "pas de fichier à sauvegarder : $f"; return 0; }
-  run "mkdir -p '$BACKUP_DIR'"
-  run "cp -a '$f' '$BACKUP_DIR/$(basename "$f")'"
+  priv "mkdir -p '$BACKUP_DIR'"
+  priv "cp -a '$f' '$BACKUP_DIR/$(basename "$f")'"
   ok "backup → $BACKUP_DIR/$(basename "$f")"
 }
 
@@ -94,7 +96,7 @@ backup() {  # backup <fichier> — copie horodatée si le fichier existe (root)
 # ---------------------------------------------------------------------------
 step "Phase 0 — Vérifications préalables"
 cd "$REPO_DIR" || die "Dépôt introuvable : $REPO_DIR"
-ok "Dépôt : $REPO_DIR   (build+ssh sous : $RUN_USER)"
+ok "Dépôt : $REPO_DIR   (utilisateur : $(id -un))"
 
 command -v mosquitto_pub >/dev/null || die "mosquitto_pub manquant (apt install mosquitto-clients)"
 [[ -f Config.toml ]]                || die "Config.toml absent"
@@ -108,20 +110,29 @@ grep -q 'service_type     = "grid"'   Config.toml \
 grep -q '"grid" | "acload" => "grid"' crates/daly-bms-server/src/bridges/mqtt.rs \
   || die "mqtt.rs ne contient pas la branche grid/acload — fais 'make sync' d'abord."
 
-if run_user "ssh -o ConnectTimeout=5 -o BatchMode=yes '$NANOPI' true" 2>/dev/null; then
-  ok "SSH NanoPi OK (clé de $RUN_USER)"
+# Test SSH NanoPi (comportement identique au ssh manuel : agent/passphrase OK)
+if ssh -o ConnectTimeout=8 "$NANOPI" true 2>/dev/null; then
+  ok "SSH NanoPi OK"
 else
-  die "SSH NanoPi ($NANOPI) injoignable sous l'utilisateur $RUN_USER (vérifie ~$RUN_USER/.ssh)"
+  die "SSH NanoPi ($NANOPI) injoignable. Teste : ssh $NANOPI true
+       (si tu utilises un agent : exécute ce script SANS sudo)"
 fi
+
+# Pré-autorisation sudo (prompt 1× en amont, évite une coupure en cours de route)
+if [[ -n "$SUDO" && $DRY_RUN -eq 0 ]]; then
+  echo "  (sudo requis pour /etc, /usr/local/bin, systemctl)"
+  $SUDO -v
+fi
+
 ok "Pré-vol OK"
 [[ $DRY_RUN -eq 1 ]] && warn "MODE DRY-RUN : aucune modification ne sera appliquée."
 confirm
 
 # ---------------------------------------------------------------------------
-# Phase 1 — Compilation Pi5 (aarch64) — sous $RUN_USER (rustup)
+# Phase 1 — Compilation Pi5 (aarch64) — natif (rustup user)
 # ---------------------------------------------------------------------------
 step "Phase 1 — Compilation daly-bms-server (aarch64)"
-run_user "make build-arm"
+run "make build-arm"
 [[ $DRY_RUN -eq 1 || -f $BIN_SRC ]] || die "Binaire non produit : $BIN_SRC"
 ok "Binaire compilé"
 
@@ -132,29 +143,39 @@ step "Phase 2 — Déploiement Config.toml + mosquitto.conf (Pi5)"
 backup /etc/daly-bms/config.toml
 backup /etc/mosquitto/mosquitto.conf
 
-run "cp Config.toml /etc/daly-bms/config.toml"
-run "cp contrib/mosquitto/mosquitto.conf /etc/mosquitto/mosquitto.conf"
+priv "cp Config.toml /etc/daly-bms/config.toml"
+priv "cp contrib/mosquitto/mosquitto.conf /etc/mosquitto/mosquitto.conf"
 
 # Garde-fou anti-boucle bridge (règle projet n°11)
+# Restauration automatique des configs depuis le backup si la validation échoue,
+# AVANT tout redémarrage du broker → aucune config invalide ne reste en place.
+restore_configs() {
+  warn "Restauration des configurations d'origine depuis $BACKUP_DIR…"
+  [[ -f "$BACKUP_DIR/mosquitto.conf" ]] && priv "cp -a '$BACKUP_DIR/mosquitto.conf' /etc/mosquitto/mosquitto.conf"
+  [[ -f "$BACKUP_DIR/config.toml" ]]    && priv "cp -a '$BACKUP_DIR/config.toml' /etc/daly-bms/config.toml"
+}
 if [[ -x /usr/local/bin/verify-no-loop.sh ]]; then
   step "Validation anti-boucle bridge MQTT"
-  run "/usr/local/bin/verify-no-loop.sh" || die "verify-no-loop a échoué — rollback mosquitto.conf depuis $BACKUP_DIR avant restart."
+  if ! priv "/usr/local/bin/verify-no-loop.sh"; then
+    restore_configs
+    die "verify-no-loop a échoué — configurations restaurées, migration annulée (broker NON redémarré)."
+  fi
   ok "Aucune boucle détectée"
 else
   warn "verify-no-loop.sh absent — vérifie manuellement les règles 'out' santuario/grid/#"
 fi
 
-run "systemctl restart mosquitto-broker"
+priv "systemctl restart mosquitto-broker"
 ok "mosquitto-broker redémarré"
 
 # ---------------------------------------------------------------------------
-# Phase 3 — Déploiement binaire + redémarrage daly-bms (root)
+# Phase 3 — Déploiement binaire + redémarrage daly-bms
 # ---------------------------------------------------------------------------
 step "Phase 3 — Déploiement binaire daly-bms-server"
 backup "$BIN_DST"   # rollback binaire
-run "systemctl stop daly-bms"
-run "cp '$BIN_SRC' '$BIN_DST'"
-run "systemctl start daly-bms"
+priv "systemctl stop daly-bms"
+priv "cp '$BIN_SRC' '$BIN_DST'"
+priv "systemctl start daly-bms"
 ok "daly-bms redémarré (publie désormais santuario/grid/8|9/venus)"
 
 # ---------------------------------------------------------------------------
@@ -162,19 +183,19 @@ ok "daly-bms redémarré (publie désormais santuario/grid/8|9/venus)"
 # ---------------------------------------------------------------------------
 step "Phase 4 — Purge des messages retained obsolètes (heatpump 8/9)"
 for idx in 8 9; do
-  run_user "mosquitto_pub -h '$MQTT_HOST' -t 'santuario/heatpump/$idx/venus' -r -n"
-  run_user "ssh '$NANOPI' \"mosquitto_pub -h localhost -t 'santuario/heatpump/$idx/venus' -r -n\""
+  run "mosquitto_pub -h '$MQTT_HOST' -t 'santuario/heatpump/$idx/venus' -r -n"
+  run "ssh '$NANOPI' \"mosquitto_pub -h localhost -t 'santuario/heatpump/$idx/venus' -r -n\""
 done
 ok "Retained heatpump/8 et heatpump/9 purgés (Pi5 + NanoPi)"
 
 # ---------------------------------------------------------------------------
 # Phase 5 — Déploiement config NanoPi + redémarrage dbus-mqtt-venus
-# (AUCUNE recompilation NanoPi : seule la config change) — ssh/scp sous $RUN_USER
+# (AUCUNE recompilation NanoPi : seule la config change)
 # ---------------------------------------------------------------------------
 step "Phase 5 — Déploiement config NanoPi + restart dbus-mqtt-venus"
-run_user "ssh '$NANOPI' \"cp '$NANOPI_CFG' '${NANOPI_CFG}.bak-$(date +%Y%m%d-%H%M%S)'\" || true"
-run_user "scp nanoPi/config-nanopi.toml '$NANOPI:$NANOPI_CFG'"
-run_user "ssh '$NANOPI' 'svc -t $NANOPI_SVC'"
+run "ssh '$NANOPI' \"cp '$NANOPI_CFG' '${NANOPI_CFG}.bak-$(date +%Y%m%d-%H%M%S)'\" || true"
+run "scp nanoPi/config-nanopi.toml '$NANOPI:$NANOPI_CFG'"
+run "ssh '$NANOPI' 'svc -t $NANOPI_SVC'"
 ok "dbus-mqtt-venus redémarré (supprime heatpump.mqtt_8/9, crée acload.mqtt_8 + grid.mqtt_9)"
 
 # ---------------------------------------------------------------------------
@@ -188,7 +209,7 @@ else
   echo "--- Topics MQTT grid (doit montrer 8 et 9) ---"
   timeout 6 mosquitto_sub -h "$MQTT_HOST" -t 'santuario/grid/+/venus' -v -W 5 || true
   echo "--- Services D-Bus Victron (NanoPi) ---"
-  ${USER_PREFIX} ssh "$NANOPI" "dbus -y | grep -E 'acload|grid|heatpump'" || true
+  ssh "$NANOPI" "dbus -y | grep -E 'acload|grid|heatpump'" || true
   echo "--- Healthcheck daly-bms ---"
   curl -s http://localhost:8080/-/healthy || true
   echo


### PR DESCRIPTION
…o-loop échoue

Problème : sous sudo, SSH_AUTH_SOCK est supprimé → l'agent SSH (clé NanoPi) devient inaccessible et ssh/scp échouent (NanoPi pourtant joignable).

Solution : le script se lance désormais en tant qu'utilisateur (pas sudo) et appelle sudo lui-même pour les seules opérations privilégiées (/etc, /usr/local/bin, systemctl). ssh/scp/make build-arm tournent nativement (agent + rustup OK) ; target/ n'est plus pollué par root.

Ajout (suggestion review) : si verify-no-loop.sh échoue, restauration automatique de mosquitto.conf + config.toml depuis le backup AVANT tout redémarrage du broker, puis abandon propre.