### PR TITLE
fix(deploy): deploy-pi5.sh déploie aussi mosquitto.conf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,10 @@ contrib/grafana/                        ← provisioning Grafana complet
   provisioning/datasources/daly-metrics.yaml        ← datasource PromQL → :8080
   provisioning/dashboards/daly-bms.yaml             ← provider → /var/lib/grafana/dashboards
 scripts/setup-grafana.sh                ← installation Grafana (première fois)
-scripts/deploy-pi5.sh                   ← déploiement complet (binaires + Grafana + validation)
+scripts/deploy-pi5.sh                   ← déploiement complet (binaires + mosquitto.conf + Grafana + validation)
+                                          ⚠ NE déploie PAS Config.toml si /etc/daly-bms/config.toml existe
+                                          (préserve la prod) → `sudo cp Config.toml /etc/daly-bms/config.toml` manuel.
+                                          ⚠ NE déploie PAS le NanoPi → `make install-venus-v7` séparément.
 ```
 
 **IMPORTANT** : Le service lit `/etc/daly-bms/config.toml`, PAS `~/Daly-BMS-Rust/Config.toml`.

--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -190,6 +190,35 @@ if [[ -f contrib/energy-manager.service ]] \
     info "Unit systemd energy-manager mis à jour"
 fi
 
+# ── 5.bis Mosquitto bridge config (si modifié dans le repo) ──────────────────
+# Le bridge MQTT Pi5→NanoPi est défini dans contrib/mosquitto/mosquitto.conf
+# (règles `out` santuario/*). Toute nouvelle famille de topic (ex: santuario/grid/#
+# pour les ET112 acload/grid) DOIT y figurer, sinon le NanoPi ne reçoit rien.
+# Déploiement sécurisé : backup → copie → verify-no-loop.sh → restart, avec
+# restauration automatique si la validation anti-boucle échoue (règle projet n°11).
+MOSQ_SRC=contrib/mosquitto/mosquitto.conf
+MOSQ_DST=/etc/mosquitto/mosquitto.conf
+if [[ -f "$MOSQ_SRC" ]] && ! sudo diff -q "$MOSQ_SRC" "$MOSQ_DST" >/dev/null 2>&1; then
+    step "Mise à jour mosquitto.conf (bridge topics)…"
+    MOSQ_BAK="${MOSQ_DST}.bak-$(date +%Y%m%d_%H%M%S)"
+    sudo cp "$MOSQ_DST" "$MOSQ_BAK" 2>/dev/null || true
+    sudo cp "$MOSQ_SRC" "$MOSQ_DST"
+    if [[ -x /usr/local/bin/verify-no-loop.sh ]]; then
+        if ! sudo /usr/local/bin/verify-no-loop.sh; then
+            warn "verify-no-loop a échoué — restauration de mosquitto.conf depuis $MOSQ_BAK"
+            [[ -f "$MOSQ_BAK" ]] && sudo cp "$MOSQ_BAK" "$MOSQ_DST"
+            error "Bridge mosquitto invalide (risque de boucle) — config restaurée, déploiement interrompu"
+        fi
+        info "Bridge validé (aucune boucle)"
+    else
+        warn "verify-no-loop.sh absent — bridge NON validé (vérifier manuellement les règles 'out')"
+    fi
+    sudo systemctl restart mosquitto-broker
+    info "mosquitto.conf déployé + mosquitto-broker redémarré"
+else
+    info "mosquitto.conf déjà à jour (ou absent du repo)"
+fi
+
 # ── 6. Déploiement daly-bms-server ───────────────────────────────────────────
 step "Déploiement daly-bms-server…"
 sudo systemctl stop daly-bms


### PR DESCRIPTION
## Problème
`scripts/deploy-pi5.sh` ne déployait jamais `contrib/mosquitto/mosquitto.conf`. Tout changement de topic bridge (ex. `santuario/grid/#` ajouté pour les ET112 acload/grid) nécessitait une étape manuelle facile à oublier — le NanoPi ne recevait alors pas les nouveaux topics.

## Correctif
- **Section 5.bis** dans `deploy-pi5.sh` : si `mosquitto.conf` diffère de la version déployée → backup horodaté → copie → `verify-no-loop.sh` → restart `mosquitto-broker`. Restauration automatique de la config si la validation anti-boucle échoue (règle projet n°11). N'agit que si le fichier a changé (idempotent).
- `CLAUDE.md` : description de `deploy-pi5.sh` mise à jour + caveats explicites (Config.toml préservé si présent → `sudo cp` manuel ; NanoPi déployé séparément via `make install-venus-v7`).

## Vérifié
`bash -n` OK. Le build reste en aarch64 (`make build-arm`, pas de `target-cpu=native` problématique). Aucune régression : la nouvelle section est gardée par un `diff` et ne s'exécute que si `mosquitto.conf` a réellement changé.

https://claude.ai/code/session_01Abjpdh1X8367w3hifZcvmV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abjpdh1X8367w3hifZcvmV)_