### PR TITLE
feat(bms): intégration BMS-620Ah (0x03) — config, visualisation, moni…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,7 @@ Bus `/dev/ttyUSB0` :
 |------|----------|-----------|------------|----------|
 | 0x01 | BMS-360Ah | `battery.mqtt_1` | `bms/1/venus` | 151 |
 | 0x02 | BMS-320Ah | `battery.mqtt_2` | `bms/2/venus` | 152 |
+| 0x03 | BMS-620Ah | `battery.mqtt_3` | `bms/3/venus` | 153 |
 | 0x05 | PRALRAN irradiance | `meteo` | `irradiance/raw` | 40 |
 | 0x07 | ET112-Micro-Onduleurs (SN 119253X) | `pvinverter.mqtt_7` | `pvinverter/7/venus` | 32 |
 | 0x08 | ET112-Maison (SN 119215X) | `acload.mqtt_8` | `grid/8/venus` | 30 |
@@ -194,6 +195,7 @@ Services D-Bus actifs nominaux :
 ```
 com.victronenergy.battery.mqtt_1          BMS-360Ah (inst. 151)
 com.victronenergy.battery.mqtt_2          BMS-320Ah (inst. 152)
+com.victronenergy.battery.mqtt_3          BMS-620Ah (inst. 153)
 com.victronenergy.pvinverter.mqtt_7       ET112-Micro-Onduleurs (inst. 32)
 com.victronenergy.acload.mqtt_8           ET112-Maison / Consommation AC (inst. 30)
 com.victronenergy.grid.mqtt_9             ET112-Réseau / Compteur réseau EDF (inst. 31)

--- a/Config.toml
+++ b/Config.toml
@@ -46,7 +46,7 @@ auto_discover_end   = 16
 
 # Liste explicite des BMS (recommandé en production)
 # Format : "0x01,0x02,0x03" ou tableau TOML ["0x01", "0x02"]
-addresses = ["0x01", "0x02"]
+addresses = ["0x01", "0x02", "0x03"]
 
 
 [api]
@@ -497,14 +497,14 @@ max_discharge_a = 120.0
 mqtt_index      = 2
 device_instance = 152
 
-# [[bms]]                          # ← décommenter quand branché
-# address         = "0x03"
-# name            = "BMS-628Ah"
-# capacity_ah     = 628.0
-# max_charge_a    = 200.0
-# max_discharge_a = 120.0
-# mqtt_index      = 3
-# device_instance = 153
+[[bms]]
+address         = "0x03"
+name            = "BMS-620Ah"
+capacity_ah     = 620.0
+max_charge_a    = 200.0
+max_discharge_a = 120.0
+mqtt_index      = 3
+device_instance = 153
 
 # [[bms]]                          # ← décommenter quand branché
 # address         = "0x04"

--- a/contrib/grafana/dashboards/01-bms.json
+++ b/contrib/grafana/dashboards/01-bms.json
@@ -1046,6 +1046,242 @@
         },
         "overrides": []
       }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 24,
+      "panels": [],
+      "title": "🔋 BMS-620Ah (0x03)",
+      "type": "row"
+    },
+    {
+      "id": 25,
+      "type": "gauge",
+      "title": "SOC — BMS-620Ah",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 71
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "bms_soc{bms_id=\"0x03\"}",
+          "legendFormat": "SOC BMS-620Ah",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "red"
+              },
+              {
+                "value": 20,
+                "color": "orange"
+              },
+              {
+                "value": 50,
+                "color": "green"
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 26,
+      "type": "stat",
+      "title": "SOH BMS-620Ah",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 71
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "bms_soh{bms_id=\"0x03\"}",
+          "legendFormat": "SOH BMS-620Ah",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 27,
+      "type": "stat",
+      "title": "Capacité restante 620Ah",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 71
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "bms_capacity_remaining_ah{bms_id=\"0x03\"}",
+          "legendFormat": "Cap restante 620Ah",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amph",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 28,
+      "type": "timeseries",
+      "title": "Tensions des cellules — BMS-620Ah",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 79
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "bms_cell_voltage{bms_id=\"0x03\"}",
+          "legendFormat": "Cellule {{cell}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mvolt",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "drawStyle": "line",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
     }
   ],
   "refresh": "30s",

--- a/contrib/grafana/dashboards/20-alertes-avancees.json
+++ b/contrib/grafana/dashboards/20-alertes-avancees.json
@@ -300,7 +300,7 @@
             "type": "prometheus",
             "uid": "daly-metrics"
           },
-          "expr": "absent(bms_soc{bms_id=\"0x01\"}) or absent(bms_soc{bms_id=\"0x02\"})",
+          "expr": "absent(bms_soc{bms_id=\"0x01\"}) or absent(bms_soc{bms_id=\"0x02\"}) or absent(bms_soc{bms_id=\"0x03\"})",
           "legendFormat": "BMS absent",
           "refId": "A"
         }

--- a/crates/daly-bms-server/src/api/console.rs
+++ b/crates/daly-bms-server/src/api/console.rs
@@ -3,7 +3,7 @@
 //! GET /ws/console
 //!
 //! Optional query parameters (comma-separated lists):
-//!   devices = bms1,bms2,et112,smartshunt,ats,energy_manager,venus,system
+//!   devices = bms1,bms2,bms3,et112,smartshunt,ats,energy_manager,venus,system
 //!   kinds   = mqtt_in,mqtt_out,rs485,state,error,system
 
 use crate::console::{EventDevice, EventKind};
@@ -92,6 +92,7 @@ fn device_to_str(d: &EventDevice) -> &'static str {
     match d {
         EventDevice::Bms1        => "bms1",
         EventDevice::Bms2        => "bms2",
+        EventDevice::Bms3        => "bms3",
         EventDevice::Et112       => "et112",
         EventDevice::Ats         => "ats",
         EventDevice::Irradiance  => "irradiance",

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -118,7 +118,11 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
                 .cloned()
                 .unwrap_or_else(|| snap.address.to_string());
             let topic = format!("{}/bms/{}/venus", cfg.topic_prefix.trim_end_matches('/').rsplit_once('/').map(|(p,_)| p).unwrap_or("santuario"), topic_id);
-            let device = if snap.address == 1 { EventDevice::Bms1 } else { EventDevice::Bms2 };
+            let device = match snap.address {
+                1 => EventDevice::Bms1,
+                3 => EventDevice::Bms3,
+                _ => EventDevice::Bms2,
+            };
             if state.console_bus.receiver_count() > 0 {
                 state.console_bus.emit(ConsoleEvent::mqtt_out(device, &topic, json!({
                     "Soc": snap.soc,

--- a/crates/daly-bms-server/src/console.rs
+++ b/crates/daly-bms-server/src/console.rs
@@ -33,6 +33,7 @@ pub enum EventKind {
 pub enum EventDevice {
     Bms1,
     Bms2,
+    Bms3,
     Et112,
     Ats,
     Irradiance,   // PRALRAN capteur irradiance RS485

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -650,7 +650,11 @@ impl AppState {
         // Console diagnostic event — seulement si quelqu'un écoute (évite de retenir
         // un Arc<ConsoleEvent> volumineux dans le ring buffer du broadcast).
         if self.console_bus.receiver_count() > 0 {
-            let device = if snap.address == 1 { EventDevice::Bms1 } else { EventDevice::Bms2 };
+            let device = match snap.address {
+                1 => EventDevice::Bms1,
+                3 => EventDevice::Bms3,
+                _ => EventDevice::Bms2,
+            };
             self.console_bus.emit(ConsoleEvent::rs485(device, &format!("BMS-{} snapshot", snap.address), json!({
                 "address": snap.address,
                 "soc": snap.soc,

--- a/crates/daly-bms-server/templates/console.html
+++ b/crates/daly-bms-server/templates/console.html
@@ -220,6 +220,7 @@
 /* Device dot colours */
 .dev-bms1         { background: #58a6ff; }
 .dev-bms2         { background: #56d364; }
+.dev-bms3         { background: #79c0ff; }
 .dev-et112        { background: #d29922; }
 .dev-ats          { background: #f0883e; }
 .dev-irradiance   { background: #ffdf5d; }
@@ -354,6 +355,7 @@
         <div class="con-filter-title">RS485</div>
         <label class="con-check"><input type="checkbox" class="dev-filter" value="bms1"       checked onchange="applyFilters()"><span class="con-dot dev-bms1"></span> BMS-1</label>
         <label class="con-check"><input type="checkbox" class="dev-filter" value="bms2"       checked onchange="applyFilters()"><span class="con-dot dev-bms2"></span> BMS-2</label>
+        <label class="con-check"><input type="checkbox" class="dev-filter" value="bms3"       checked onchange="applyFilters()"><span class="con-dot dev-bms3"></span> BMS-3</label>
         <label class="con-check"><input type="checkbox" class="dev-filter" value="et112"      checked onchange="applyFilters()"><span class="con-dot dev-et112"></span> ET112</label>
         <label class="con-check"><input type="checkbox" class="dev-filter" value="ats"        checked onchange="applyFilters()"><span class="con-dot dev-ats"></span> ATS CHINT</label>
         <label class="con-check"><input type="checkbox" class="dev-filter" value="irradiance" checked onchange="applyFilters()"><span class="con-dot dev-irradiance"></span> PRALRAN</label>
@@ -711,7 +713,7 @@ function kindLabel(k) {
 }
 function deviceLabel(d) {
   return {
-    bms1:'BMS-1', bms2:'BMS-2', et112:'ET112', ats:'ATS',
+    bms1:'BMS-1', bms2:'BMS-2', bms3:'BMS-3', et112:'ET112', ats:'ATS',
     irradiance:'PRALRAN', smartshunt:'SmartShunt',
     tasmota:'Tasmota', shelly:'Shelly',
     water_heater:'ChauffEau', solar:'Solaire',

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -53,7 +53,7 @@ const edgeTypes = { doubleLine: AnimatedFlowEdge, customBezier: CustomBezierEdge
 const NODES0 = [
   { id: 'spiral-race',   type: 'spiralRace',  position: { x: -350, y: -30  }, data: { prodKwh: 0, soc: 0, irrWm2: 0 } },
   { id: 'production',  type: 'summary',     position: { x: -30,  y: -30  }, data: { label: 'Production',  icon: '☀️',  value: '—', sub: 'Micro-onduleurs',   dotClass: '' } },
-  { id: 'batteries',   type: 'summary',     position: { x: 170,  y: -30  }, data: { label: 'Batteries',   icon: '🔋', value: '—', sub: '360 Ah + 320 Ah',  dotClass: '' } },
+  { id: 'batteries',   type: 'summary',     position: { x: 170,  y: -30  }, data: { label: 'Batteries',   icon: '🔋', value: '—', sub: '360 Ah + 320 Ah + 620 Ah',  dotClass: '' } },
   { id: 'meteo',       type: 'summary',     position: { x: 370,  y: -30  }, data: { label: 'Météo',       icon: '🌤️',  value: '—', sub: 'Irradiance solaire', dotClass: '' } },
   { id: 'temp-ext',    type: 'temperature', position: { x: 570, y: -30 }, data: { label: 'Température', icon: '🌡️', live: null } },
   { id: 'chauffe-eau',   type: 'waterheater', position: { x: 780,  y: 550 }, data: { label: 'Chauffe-eau',   icon: '🚿', live: null, heatpump: null, isClimatisation: false } },
@@ -95,7 +95,7 @@ const HIST_ET112_8 = { metric: 'et112_power_w',                    address: '0x0
 const HIST_ET112_9 = { metric: 'et112_power_w',                    address: '0x09', label: 'Climatisation — W (6h)' };
 const HIST_BMS_1   = { metric: 'bms_current',   bms_id: '0x01',                    label: 'BMS-360Ah — I (6h)' };
 const HIST_BMS_2   = { metric: 'bms_current',   bms_id: '0x02',                    label: 'BMS-320Ah — I (6h)' };
-const HIST_BMS_3   = { metric: 'bms_current',   bms_id: '0x03',                    label: 'BMS-3 — I (6h)' };
+const HIST_BMS_3   = { metric: 'bms_current',   bms_id: '0x03',                    label: 'BMS-620Ah — I (6h)' };
 const HIST_MPPT    = { metric: 'solar_total_w',                                     label: 'Solaire total — W (6h)' };
 const HIST_INV_DC  = { metric: 'venus_inverter_power_w',                            label: 'Onduleur — P DC (6h)' };
 const HIST_INV_AC  = { metric: 'venus_inverter_ac_output_power_w',                  label: 'Onduleur — P AC sortie (6h)' };
@@ -167,7 +167,7 @@ const atsExecRef = useRef(null);
   }, []);
 
   const applyData = useCallback(function(d) {
-    const bms1 = d.bms1, bms2 = d.bms2;
+    const bms1 = d.bms1, bms2 = d.bms2, bms3 = d.bms3;
     const et7  = d.et7,  et8  = d.et8, et9 = d.et9;
     const irr  = d.irr;
     const mpptList        = d.mpptList        ?? [];
@@ -182,7 +182,7 @@ const atsExecRef = useRef(null);
     const hp1 = heatpumps.find(h => h.mqtt_index === 1) ?? null;
     const hp9 = heatpumps.find(h => h.mqtt_index === 9) ?? null;
 
-    const validBms = [bms1, bms2].filter(Boolean);
+    const validBms = [bms1, bms2, bms3].filter(Boolean);
     const avgSoc   = validBms.length
       ? (validBms.reduce((s, b) => s + (b.Soc ?? 0), 0) / validBms.length).toFixed(0)
       : null;
@@ -197,7 +197,7 @@ const atsExecRef = useRef(null);
     const prodSub      = et7 ? `${((et7.energy_export_wh ?? 0) / 1000).toFixed(1)} kWh ET112` : mpptList.length > 0 ? `${mpptYieldSumG.toFixed(2)} kWh MPPT` : 'Micro-onduleurs';
     const prodDot      = (et7?.connected || mpptList.length > 0) ? (totalProdPwr > 50 ? 'live' : '') : '';
     const batVal       = displaySoc != null ? `SOC ${displaySoc.toFixed(0)}%` : '—';
-    const batSub       = totalPwr ? `${totalPwr > 0 ? '+' : ''}${(totalPwr / 1000).toFixed(2)} kW` : '360 Ah + 320 Ah';
+    const batSub       = totalPwr ? `${totalPwr > 0 ? '+' : ''}${(totalPwr / 1000).toFixed(2)} kW` : '360 Ah + 320 Ah + 620 Ah';
     const batDot       = displaySoc == null ? '' : displaySoc > 50 ? 'live' : displaySoc > 20 ? 'warn' : 'alarm';
     const irrVal       = irr?.irradiance_wm2 != null ? `${irr.irradiance_wm2.toFixed(0)} W/m²` : '—';
     const irrSub       = irr?.total_yield_kwh != null ? `☀ ${irr.total_yield_kwh.toFixed(1)} kWh` : 'Irradiance solaire';
@@ -226,6 +226,9 @@ const atsExecRef = useRef(null);
           }
           case 'e-hubBMS-b2': {
             const pw = bms2?.Dc?.Power ?? 0; fv = Math.abs(pw); rev = pw > 0; break;
+          }
+          case 'e-hubBMS-b3': {
+            const pw = bms3?.Dc?.Power ?? 0; fv = Math.abs(pw); rev = pw > 0; break;
           }
         }
         return {
@@ -308,6 +311,7 @@ const atsExecRef = useRef(null);
           return { ...n, data: { ...n.data, value: irrVal, sub: irrSub, dotClass: irrDot } };
         case 'bms1': return { ...n, data: { ...n.data, live: bms1 ?? null } };
         case 'bms2': return { ...n, data: { ...n.data, live: bms2 ?? null } };
+        case 'bms3': return { ...n, data: { ...n.data, live: bms3 ?? null } };
         case 'micro-ond':   return { ...n, data: { ...n.data, live: et7  ?? null } };
         case 'et112-reseau': return { ...n, data: { ...n.data, live: et9 ?? null } };
         case 'et112-maison': return { ...n, data: { ...n.data, live: et8 ?? null } };
@@ -365,9 +369,10 @@ const atsExecRef = useRef(null);
   useEffect(function() {
     const safe = p => p.catch(() => null);
     async function fetchAll() {
-      const [bms1, bms2, et7, et8, et9, irr, venusResp, tempResp, atsResp] = await Promise.all([
+      const [bms1, bms2, bms3, et7, et8, et9, irr, venusResp, tempResp, atsResp] = await Promise.all([
         safe(fetch('/api/v1/bms/1/status').then(r => r.ok ? r.json() : null)),
         safe(fetch('/api/v1/bms/2/status').then(r => r.ok ? r.json() : null)),
+        safe(fetch('/api/v1/bms/3/status').then(r => r.ok ? r.json() : null)),
         safe(fetch('/api/v1/et112/7/status').then(r => r.ok ? r.json() : null)),
         safe(fetch('/api/v1/et112/8/status').then(r => r.ok ? r.json() : null)),
         safe(fetch('/api/v1/et112/9/status').then(r => r.ok ? r.json() : null)),
@@ -413,7 +418,7 @@ const atsExecRef = useRef(null);
       const temp = temps.length > 0 ? temps[0] : null;
       const ats = atsResp?.values ?? null;
 
-      applyData({ bms1, bms2, et7, et8, et9, irr, mpptList, mpptTotalPowerW, mpptTotalDcA, shunt, inverter, temp, ats, tasmotaDevices, heatpumps });
+      applyData({ bms1, bms2, bms3, et7, et8, et9, irr, mpptList, mpptTotalPowerW, mpptTotalDcA, shunt, inverter, temp, ats, tasmotaDevices, heatpumps });
     }
     fetchAll();
     const timer = setInterval(fetchAll, 2000);

--- a/nanoPi/config-nanopi.toml
+++ b/nanoPi/config-nanopi.toml
@@ -56,6 +56,15 @@ capacity_ah     = 320.0
 max_charge_a    = 200.0
 max_discharge_a = 120.0
 
+[[bms]]
+address         = "0x03"
+name            = "BMS-620Ah"
+mqtt_index      = 3
+device_instance = 153
+capacity_ah     = 620.0
+max_charge_a    = 200.0
+max_discharge_a = 120.0
+
 # -----------------------------------------------------------------------------
 # Capteurs de température
 # Topics : santuario/heat/{mqtt_index}/venus


### PR DESCRIPTION
…toring, Grafana

Ajout du 3ᵉ BMS Daly (RS485 0x03, mqtt_index 3, device_instance 153, capacité 620 Ah) selon docs/AJOUT-BMS.md.

Config (config-only Pi5 + NanoPi) :
- Config.toml : "0x03" dans [serial].addresses + bloc [[bms]] BMS-620Ah
- nanoPi/config-nanopi.toml : bloc [[bms]] identique (mqtt_index 3, inst. 153)

Interface web (templates compilés → recompilation requise) :
- visualization.html : câblage complet bms3 (fetch /api/v1/bms/3/status, applyData, nœud bms3, edge e-hubBMS-b3, moyenne SOC, sous-titre batteries)
- console.html : filtre + couleur + label BMS-3
- console : variante EventDevice::Bms3 (console.rs, api/console.rs) et classification par adresse (state.rs, bridges/mqtt.rs : addr 3 → Bms3)

Grafana :
- 01-bms.json : section dédiée BMS-620Ah (SOC, SOH, capacité, tensions cellules)
- 20-alertes-avancees.json : alerte "BMS absent" étendue à bms_id="0x03"

Pages auto-config (aucune modif) : /dashboard, détail BMS, RS485-health, 16-bms-detail ($bms_id), 17-flotte-santé (agrégats) — détectent 0x03 seuls.

CLAUDE.md : inventaire RS485 + services D-Bus mis à jour.