### PR TITLE
refactor(console): classification BMS explicite (addr 2 → Bms2)

### DIFF
--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -120,6 +120,7 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
             let topic = format!("{}/bms/{}/venus", cfg.topic_prefix.trim_end_matches('/').rsplit_once('/').map(|(p,_)| p).unwrap_or("santuario"), topic_id);
             let device = match snap.address {
                 1 => EventDevice::Bms1,
+                2 => EventDevice::Bms2,
                 3 => EventDevice::Bms3,
                 _ => EventDevice::Bms2,
             };

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -652,6 +652,7 @@ impl AppState {
         if self.console_bus.receiver_count() > 0 {
             let device = match snap.address {
                 1 => EventDevice::Bms1,
+                2 => EventDevice::Bms2,
                 3 => EventDevice::Bms3,
                 _ => EventDevice::Bms2,
             };


### PR DESCRIPTION
Suite review : match explicite de l'adresse 2 vers EventDevice::Bms2 plutôt que via la branche par défaut, pour la clarté et la robustesse lors d'un futur ajout de BMS.