### PR TITLE
feat(deye): coupure relais à 51 Hz sur les deux DEYE + garde anti-reb…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,7 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 | energy-manager ne démarre pas | `journalctl -u energy-manager -n 50` — souvent TOML manquant ou `.env` absent |
 | `missing field energy_manager` | `sudo cp Config.toml /etc/daly-bms/config.toml` — section `[energy_manager]` absente |
 | energy-manager ne reçoit pas MQTT | Vérifier `portal_id` dans Config.toml et que Mosquitto est accessible sur `mqtt.host` |
+| Micro-coupures AC Out au passage 51,5 Hz (auto-coupure DEYE) | Le Shelly doit couper les DEYE **avant** leur auto-trip 51,5 Hz : `[energy_manager.deye] freq_high_hz=51.0` + `freq_hard_hz=51.3` (coupure immédiate), et `[energy_manager.victron] shelly_deye_channels=[0,1]` (un canal par DEYE — **les deux**). Garde anti-rebattement SmartShunt/Irradiance (`restore_*`) + re-sync relais (`relay_resync_secs`). Détail → docs/app-energy-manager.md §4.3. |
 | LG ThinQ ne répond pas | Vérifier `LG_BEARER_TOKEN` et `LG_API_KEY` dans `/etc/daly-bms/.env` |
 | Grafana dossier vide "No items" | Dashboards au mauvais format (export vs provisioning) — `__inputs`/`__requires` doivent être absents, datasource UID = `daly-metrics` |
 | Grafana ne démarre pas | `journalctl -u grafana-server -n 50` — souvent YAML provisioning invalide |

--- a/Config.toml
+++ b/Config.toml
@@ -557,7 +557,8 @@ mppt1_instance       = 273             # SmartSolar MPPT 1
 mppt2_instance       = 289             # SmartSolar MPPT 2
 pvinverter_instance  = 32              # ET112 Micro-Onduleurs
 shelly_deye_id       = "shellypro2pm-ec62608840a4"
-shelly_deye_channel  = 0
+shelly_deye_channel  = 0                # fallback mono-canal (hérité)
+shelly_deye_channels = [0, 1]           # un canal par DEYE — coupe/restaure les deux
 tasmota_waterheater_id = "tongou_3BC764"
 # SmartShunt device instance sur Venus OS — vérifier avec :
 #   ssh root@192.168.1.120 "dbus -y | grep battery"
@@ -591,11 +592,16 @@ pv_excess_threshold_w = 50.0          # W minimum pour déclencher l'excédent
 
 # --- Commande relais DEYE (via Shelly) ---
 [energy_manager.deye]
-freq_high_hz          = 52.0          # Hz — seuil de coupure
-freq_low_hz           = 50.3          # Hz — seuil de réactivation
-cut_delay_secs        = 15            # s — délai avant coupure
-reenable_delay_secs   = 45            # s — délai avant réactivation
-lockout_secs          = 120           # s — anti-oscillation après coupure
+freq_high_hz               = 51.0     # Hz — coupure débouncée (sous l'auto-trip DEYE 51.5)
+freq_hard_hz               = 51.3     # Hz — coupure immédiate (filet pré-trip)
+freq_low_hz                = 50.3     # Hz — seuil de réactivation
+cut_delay_secs             = 3        # s — débounce coupure (bat la rampe vers 51.5)
+reenable_delay_secs        = 45       # s — bas-soutenu avant réactivation
+lockout_secs               = 120      # s — anti-oscillation après coupure
+restore_soc_pct            = 95.0     # % — SOC ≥ → excédent structurel présumé → maintien coupé
+restore_irradiance_wm2     = 250.0    # W/m² — irradiance ≥ → soleil fort → maintien coupé
+corroboration_max_age_secs = 60       # s — fraîcheur SmartShunt (au-delà : fréquence seule, fail-open)
+relay_resync_secs          = 60       # s — ré-affirmation périodique de l'état des 2 canaux
 
 # --- Chauffe-eau LG ThinQ ---
 [energy_manager.water_heater]

--- a/crates/energy-manager/rules/deye_command.grl
+++ b/crates/energy-manager/rules/deye_command.grl
@@ -3,12 +3,15 @@
 //
 // Input facts (injected from Rust before evaluate):
 //   DY.state                  (string: "On"|"PendingCut"|"Off"|"PendingRestore"|"Lockout")
-//   DY.freq_high_exceeded     (bool, pre-computed: freq_hz >= freq_high_hz)
+//   DY.freq_high_exceeded     (bool, pre-computed: freq_hz >= freq_high_hz)  — debounced cut
+//   DY.freq_hard_exceeded     (bool, pre-computed: freq_hz >= freq_hard_hz)  — immediate cut
 //   DY.freq_low_reached       (bool, pre-computed: freq_hz <= freq_low_hz)
 //   DY.cut_delay_elapsed      (bool, pre-computed: time_in_state_secs >= cut_delay_secs)
 //   DY.reenable_delay_elapsed (bool, pre-computed: time_in_state_secs >= reenable_delay_secs)
 //   DY.lockout_expired        (bool, pre-computed: now >= lockout_until)
 //   DY.grid_connected         (bool)
+//   DY.restore_blocked        (bool, pre-computed: fresh structural PV excess — battery
+//                              full + strong irradiance + not discharging → hold DEYE off)
 //
 // Output facts (read from Rust after execute):
 //   DY.next_state             (string, absent if no transition)
@@ -20,12 +23,34 @@
 // The rule engine fires all matching rules; higher-salience fires first but
 // lower-salience can still overwrite the same fact without this guard.
 
+// ── Hard cut: immediate, pre-empts the DEYE 51.5 Hz self-trip (salience 150) ──
+// Fires above grid-reconnect priority guards (grid_connected==false) but below the
+// salience-200 reconnect rules, and is mutually exclusive with the debounced
+// DY_On_HighFreq path (which carries `freq_hard_exceeded == false`).
+
+rule "DY_On_HardFreq" salience 150 no-loop {
+    when
+        DY.state == "On" && DY.freq_hard_exceeded == true && DY.grid_connected == false
+    then
+        DY.next_state = "Lockout";
+        DY.relay_off = true;
+}
+
+rule "DY_PendingCut_HardFreq" salience 150 no-loop {
+    when
+        DY.state == "PendingCut" && DY.freq_hard_exceeded == true && DY.grid_connected == false
+    then
+        DY.next_state = "Lockout";
+        DY.relay_off = true;
+}
+
 // ── Normal state machine transitions (salience 100) ─────────────────────────
 
-// On → PendingCut when frequency exceeds threshold
+// On → PendingCut when frequency exceeds the soft threshold (but not the hard one,
+// which is handled immediately above). Guarded against the grid-reconnect override.
 rule "DY_On_HighFreq" salience 100 no-loop {
     when
-        DY.state == "On" && DY.freq_high_exceeded == true
+        DY.state == "On" && DY.freq_high_exceeded == true && DY.freq_hard_exceeded == false && DY.grid_connected == false
     then
         DY.next_state = "PendingCut";
 }
@@ -38,10 +63,11 @@ rule "DY_PendingCut_FreqDrop" salience 100 no-loop {
         DY.next_state = "On";
 }
 
-// PendingCut → Lockout after delay (only if frequency is still high)
+// PendingCut → Lockout after delay (only if frequency is still high).
+// Grid guard prevents this from overwriting a salience-200 reconnect into Lockout.
 rule "DY_PendingCut_Elapsed" salience 100 no-loop {
     when
-        DY.state == "PendingCut" && DY.cut_delay_elapsed == true && DY.freq_high_exceeded == true
+        DY.state == "PendingCut" && DY.cut_delay_elapsed == true && DY.freq_high_exceeded == true && DY.grid_connected == false
     then
         DY.next_state = "Lockout";
         DY.relay_off = true;
@@ -55,10 +81,12 @@ rule "DY_Lockout_Expired" salience 100 no-loop {
         DY.next_state = "Off";
 }
 
-// Off → PendingRestore when frequency drops to low threshold (guard: grid not connected)
+// Off → PendingRestore when frequency drops to low threshold, UNLESS a fresh
+// structural PV excess is still present (restore_blocked) — that would just
+// re-trigger a cut, thrashing the relay. Guard: grid not connected.
 rule "DY_Off_LowFreq" salience 100 no-loop {
     when
-        DY.state == "Off" && DY.freq_low_reached == true && DY.grid_connected == false
+        DY.state == "Off" && DY.freq_low_reached == true && DY.grid_connected == false && DY.restore_blocked == false
     then
         DY.next_state = "PendingRestore";
 }

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -131,9 +131,14 @@ pub struct VictronConfig {
     /// Shelly device ID for DEYE relay (e.g. "shellypro2pm-ec62608840a4")
     #[serde(default)]
     pub shelly_deye_id: String,
-    /// Shelly switch channel for DEYE (0-indexed)
+    /// Shelly switch channel for DEYE (0-indexed) — legacy single-channel fallback.
     #[serde(default)]
     pub shelly_deye_channel: u8,
+    /// Shelly switch channels for the DEYE relays (0-indexed, one per DEYE).
+    /// When non-empty this takes precedence over `shelly_deye_channel`.
+    /// Example: `[0, 1]` to drive both channels of a Shelly Pro 2PM.
+    #[serde(default)]
+    pub shelly_deye_channels: Vec<u8>,
     /// Tasmota device ID for water heater relay (e.g. "tongou_3BC764")
     #[serde(default)]
     pub tasmota_waterheater_id: String,
@@ -274,9 +279,14 @@ impl Default for ChargeCurrent {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct DeyeConfig {
-    /// Frequency threshold to cut DEYE (Hz)
+    /// Frequency threshold to cut DEYE after `cut_delay_secs` debounce (Hz).
+    /// Set below the DEYE's own 51.5 Hz self-trip so the Shelly relay pre-empts it.
     #[serde(default = "default_freq_high")]
     pub freq_high_hz: f64,
+    /// Hard frequency threshold for an immediate cut, bypassing the debounce (Hz).
+    /// Safety net if the frequency ramps quickly toward the 51.5 Hz self-trip.
+    #[serde(default = "default_freq_hard")]
+    pub freq_hard_hz: f64,
     /// Frequency threshold to re-enable DEYE (Hz)
     #[serde(default = "default_freq_low")]
     pub freq_low_hz: f64,
@@ -289,22 +299,47 @@ pub struct DeyeConfig {
     /// Anti-oscillation lockout after cut (seconds)
     #[serde(default = "default_lockout_secs")]
     pub lockout_secs: u64,
+    /// Battery SOC at/above which a structural PV excess is assumed, blocking
+    /// DEYE restore to avoid relay thrashing while the battery stays full (%).
+    #[serde(default = "default_restore_soc_pct")]
+    pub restore_soc_pct: f64,
+    /// Irradiance at/above which a structural PV excess is assumed (W/m²).
+    #[serde(default = "default_restore_irradiance_wm2")]
+    pub restore_irradiance_wm2: f64,
+    /// Max age of SmartShunt data for the restore-block guard to apply (seconds).
+    /// Beyond this the guard fails open → frequency-only hysteresis takes over.
+    #[serde(default = "default_corroboration_max_age_secs")]
+    pub corroboration_max_age_secs: u64,
+    /// Period at which the desired relay state is re-asserted on every channel,
+    /// so the physical relay reconverges after a missed command or Shelly reboot (seconds).
+    #[serde(default = "default_relay_resync_secs")]
+    pub relay_resync_secs: u64,
 }
 
-fn default_freq_high() -> f64 { 52.0 }
+fn default_freq_high() -> f64 { 51.0 }
+fn default_freq_hard() -> f64 { 51.3 }
 fn default_freq_low() -> f64 { 50.3 }
-fn default_cut_delay_secs() -> u64 { 15 }
+fn default_cut_delay_secs() -> u64 { 3 }
 fn default_reenable_delay_secs() -> u64 { 45 }
 fn default_lockout_secs() -> u64 { 120 }
+fn default_restore_soc_pct() -> f64 { 95.0 }
+fn default_restore_irradiance_wm2() -> f64 { 250.0 }
+fn default_corroboration_max_age_secs() -> u64 { 60 }
+fn default_relay_resync_secs() -> u64 { 60 }
 
 impl Default for DeyeConfig {
     fn default() -> Self {
         Self {
             freq_high_hz: default_freq_high(),
+            freq_hard_hz: default_freq_hard(),
             freq_low_hz: default_freq_low(),
             cut_delay_secs: default_cut_delay_secs(),
             reenable_delay_secs: default_reenable_delay_secs(),
             lockout_secs: default_lockout_secs(),
+            restore_soc_pct: default_restore_soc_pct(),
+            restore_irradiance_wm2: default_restore_irradiance_wm2(),
+            corroboration_max_age_secs: default_corroboration_max_age_secs(),
+            relay_resync_secs: default_relay_resync_secs(),
         }
     }
 }

--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -77,12 +77,19 @@ async fn run(
     let t_connected = format!("N/{pid}/vebus/{vb}/Ac/ActiveIn/Connected");
 
     let shelly_id = &vic.shelly_deye_id;
-    let channel   = vic.shelly_deye_channel;
+    // One channel per DEYE. Prefer the multi-channel list; fall back to the
+    // legacy single-channel field for backward compatibility.
+    let channels: Vec<u8> = if vic.shelly_deye_channels.is_empty() {
+        vec![vic.shelly_deye_channel]
+    } else {
+        vic.shelly_deye_channels.clone()
+    };
 
     if shelly_id.is_empty() {
         info!("DEYE control disabled — shelly_deye_id not configured");
         return;
     }
+    info!("DEYE control: shelly={shelly_id} channels={channels:?}");
 
     let src = loader.load("deye_command");
     let mut rule_engine = match rules::DeyeRuleEngine::with_source(&src) {
@@ -119,6 +126,10 @@ async fn run(
     let mut rx        = bus.subscribe_mqtt();
     let mut reload_rx = bus.subscribe_rule_reload();
     let mut ticker    = interval(Duration::from_secs(1));
+    // Periodic idempotent re-assert of the relay state on every channel, so the
+    // physical Shelly reconverges after a missed command or a reboot. The first
+    // tick fires immediately, asserting the restored state at startup.
+    let mut resync    = interval(Duration::from_secs(cfg.relay_resync_secs.max(1)));
 
     loop {
         tokio::select! {
@@ -137,12 +148,10 @@ async fn run(
                     if let Some(freq) = msg.victron_value::<f64>() {
                         last_freq = freq;
 
-                        let connected = {
-                            state.read().await.ac_ignore.map(|v| v == 0).unwrap_or(true)
-                        };
+                        let now = Utc::now();
+                        let (connected, restore_blocked) = read_gates(&state, &cfg, now).await;
                         if connected { continue; }
 
-                        let now = Utc::now();
                         let new_state = apply_decision(
                             rule_engine.evaluate(
                                 state_name(&deye_sm),
@@ -150,17 +159,19 @@ async fn run(
                                 time_in_state_secs(&deye_sm, now),
                                 false,
                                 cfg.freq_high_hz,
+                                cfg.freq_hard_hz,
                                 cfg.freq_low_hz,
                                 cfg.cut_delay_secs,
                                 cfg.reenable_delay_secs,
                                 lockout_expired(&deye_sm, now),
+                                restore_blocked,
                             ),
                             deye_sm,
                             now,
                             &cfg,
                             &bus,
                             shelly_id,
-                            channel,
+                            &channels,
                         ).await;
                         if new_state != deye_sm {
                             deye_sm = new_state;
@@ -180,9 +191,11 @@ async fn run(
                                     0,
                                     true,
                                     cfg.freq_high_hz,
+                                    cfg.freq_hard_hz,
                                     cfg.freq_low_hz,
                                     cfg.cut_delay_secs,
                                     cfg.reenable_delay_secs,
+                                    false,
                                     false,
                                 ),
                                 deye_sm,
@@ -190,7 +203,7 @@ async fn run(
                                 &cfg,
                                 &bus,
                                 shelly_id,
-                                channel,
+                                &channels,
                             ).await;
                             if new_state != deye_sm {
                                 deye_sm = new_state;
@@ -204,6 +217,7 @@ async fn run(
 
             _ = ticker.tick() => {
                 let now = Utc::now();
+                let (_connected, restore_blocked) = read_gates(&state, &cfg, now).await;
                 let new_state = apply_decision(
                     rule_engine.evaluate(
                         state_name(&deye_sm),
@@ -211,23 +225,31 @@ async fn run(
                         time_in_state_secs(&deye_sm, now),
                         false,
                         cfg.freq_high_hz,
+                        cfg.freq_hard_hz,
                         cfg.freq_low_hz,
                         cfg.cut_delay_secs,
                         cfg.reenable_delay_secs,
                         lockout_expired(&deye_sm, now),
+                        restore_blocked,
                     ),
                     deye_sm,
                     now,
                     &cfg,
                     &bus,
                     shelly_id,
-                    channel,
+                    &channels,
                 ).await;
                 if new_state != deye_sm {
                     deye_sm = new_state;
                     persist_deye_state(&bus, &deye_sm).await;
                     update_deye_state(&state, &deye_sm).await;
                 }
+            }
+
+            _ = resync.tick() => {
+                // Re-assert the current logical relay state on every channel (idempotent).
+                let desired_on = matches!(deye_sm, DeyeState::On | DeyeState::PendingCut(_));
+                send_shelly(&bus, shelly_id, &channels, desired_on).await;
             }
 
             Ok(name) = reload_rx.recv() => {
@@ -262,6 +284,7 @@ async fn update_deye_state(state: &Arc<RwLock<EnergyState>>, deye: &DeyeState) {
     s.deye_last_change = Some(Utc::now());
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn apply_decision(
     decision: anyhow::Result<rules::DeyeDecision>,
     current: DeyeState,
@@ -269,7 +292,7 @@ async fn apply_decision(
     cfg: &DeyeConfig,
     bus: &AppBus,
     shelly_id: &str,
-    channel: u8,
+    channels: &[u8],
 ) -> DeyeState {
     let d = match decision {
         Ok(d)  => d,
@@ -280,10 +303,10 @@ async fn apply_decision(
     };
 
     if d.relay_off {
-        send_shelly(bus, shelly_id, channel, false).await;
+        send_shelly(bus, shelly_id, channels, false).await;
     }
     if d.relay_on {
-        send_shelly(bus, shelly_id, channel, true).await;
+        send_shelly(bus, shelly_id, channels, true).await;
     }
 
     let Some(next_name) = d.next_state else {
@@ -319,14 +342,51 @@ async fn apply_decision(
     }
 }
 
-async fn send_shelly(bus: &AppBus, shelly_id: &str, channel: u8, on: bool) {
-    let topic   = publish::shelly_rpc(shelly_id);
-    let payload = json!({
-        "id":     1,
-        "src":    "energy-manager",
-        "method": "Switch.Set",
-        "params": { "id": channel, "on": on }
-    });
-    bus.publish(MqttOutgoing::transient(topic, &payload)).await;
-    info!("DEYE Shelly: switch {} = {}", channel, if on { "ON" } else { "OFF" });
+/// Sends a `Switch.Set` to every DEYE channel (idempotent on the Shelly side).
+/// Logged at DEBUG because it also runs on each periodic re-assert; real state
+/// transitions are logged at INFO by `apply_decision`.
+async fn send_shelly(bus: &AppBus, shelly_id: &str, channels: &[u8], on: bool) {
+    let topic = publish::shelly_rpc(shelly_id);
+    for &channel in channels {
+        let payload = json!({
+            "id":     1,
+            "src":    "energy-manager",
+            "method": "Switch.Set",
+            "params": { "id": channel, "on": on }
+        });
+        bus.publish(MqttOutgoing::transient(topic.clone(), &payload)).await;
+    }
+    tracing::debug!("DEYE Shelly: channels {channels:?} = {}", if on { "ON" } else { "OFF" });
+}
+
+/// Reads the gating signals from shared state in a single lock acquisition.
+/// Returns `(grid_connected, restore_blocked)`.
+async fn read_gates(state: &Arc<RwLock<EnergyState>>, cfg: &DeyeConfig, now: DateTime<Utc>) -> (bool, bool) {
+    let s = state.read().await;
+    let grid_connected = s.ac_ignore.map(|v| v == 0).unwrap_or(true);
+    (grid_connected, restore_blocked(&s, cfg, now))
+}
+
+/// Structural PV-excess guard. While the battery is full, irradiance is strong and
+/// the battery is not discharging, restoring the DEYE would immediately re-trigger a
+/// cut and thrash the relay — so hold them off.
+///
+/// Fails OPEN: if the SmartShunt data is stale or absent, returns `false` so the
+/// frequency hysteresis alone governs restore. The AC-out frequency (Victron) stays
+/// the authority for cutting; this only ever *delays a restore*.
+fn restore_blocked(s: &EnergyState, cfg: &DeyeConfig, now: DateTime<Utc>) -> bool {
+    let fresh = s
+        .shunt_last_seen_ts
+        .map(|ts| (now - ts).num_seconds() <= cfg.corroboration_max_age_secs as i64)
+        .unwrap_or(false);
+    if !fresh {
+        return false;
+    }
+    let Some(soc) = s.soc_pct else { return false };
+    let irradiance = s.irradiance_wm2.unwrap_or(0.0);
+    // Sign convention: + = charging, - = discharging. Allow 1 A of noise around zero.
+    let current = s.battery_current_a.unwrap_or(0.0);
+    soc >= cfg.restore_soc_pct
+        && irradiance >= cfg.restore_irradiance_wm2
+        && current >= -1.0
 }

--- a/crates/energy-manager/src/logic/deye_command/rules.rs
+++ b/crates/energy-manager/src/logic/deye_command/rules.rs
@@ -45,19 +45,23 @@ impl DeyeRuleEngine {
         time_in_state_secs: u64,
         grid_connected: bool,
         cfg_freq_high: f64,
+        cfg_freq_hard: f64,
         cfg_freq_low: f64,
         cfg_cut_delay: u64,
         cfg_reenable_delay: u64,
         lockout_expired: bool,
+        restore_blocked: bool,
     ) -> anyhow::Result<DeyeDecision> {
         let facts = Facts::new();
         facts.set("DY.state",                  Value::String(state_str.to_string()));
         facts.set("DY.freq_high_exceeded",     Value::Boolean(freq_hz >= cfg_freq_high));
+        facts.set("DY.freq_hard_exceeded",     Value::Boolean(freq_hz >= cfg_freq_hard));
         facts.set("DY.freq_low_reached",       Value::Boolean(freq_hz <= cfg_freq_low));
         facts.set("DY.cut_delay_elapsed",      Value::Boolean(time_in_state_secs >= cfg_cut_delay));
         facts.set("DY.reenable_delay_elapsed", Value::Boolean(time_in_state_secs >= cfg_reenable_delay));
         facts.set("DY.lockout_expired",        Value::Boolean(lockout_expired));
         facts.set("DY.grid_connected",         Value::Boolean(grid_connected));
+        facts.set("DY.restore_blocked",        Value::Boolean(restore_blocked));
 
         self.engine
             .execute(&facts)
@@ -86,9 +90,15 @@ mod tests {
 
     fn e() -> DeyeRuleEngine { DeyeRuleEngine::new().unwrap() }
 
-    // Shorthand: evaluate with default config thresholds (52 Hz / 50.3 Hz / 15s / 45s)
+    // Shorthand: evaluate with default config thresholds
+    // (high 51.0 Hz / hard 51.3 Hz / low 50.3 Hz / cut 3s / reenable 45s, restore unblocked).
     fn eval(engine: &mut DeyeRuleEngine, state: &str, freq: f64, time_s: u64, grid: bool, lockout_exp: bool) -> DeyeDecision {
-        engine.evaluate(state, freq, time_s, grid, 52.0, 50.3, 15, 45, lockout_exp).unwrap()
+        engine.evaluate(state, freq, time_s, grid, 51.0, 51.3, 50.3, 3, 45, lockout_exp, false).unwrap()
+    }
+
+    // Variant exposing the restore-block guard.
+    fn eval_rb(engine: &mut DeyeRuleEngine, state: &str, freq: f64, time_s: u64, grid: bool, lockout_exp: bool, restore_blocked: bool) -> DeyeDecision {
+        engine.evaluate(state, freq, time_s, grid, 51.0, 51.3, 50.3, 3, 45, lockout_exp, restore_blocked).unwrap()
     }
 
     #[test]
@@ -101,8 +111,26 @@ mod tests {
 
     #[test]
     fn on_high_freq_transitions_pending_cut() {
-        let d = eval(&mut e(), "On", 52.5, 0, false, false);
+        // 51.1 Hz: above the soft cut (51.0) but below the hard cut (51.3) → debounced PendingCut.
+        let d = eval(&mut e(), "On", 51.1, 0, false, false);
         assert_eq!(d.next_state.as_deref(), Some("PendingCut"));
+        assert!(!d.relay_off);
+    }
+
+    #[test]
+    fn on_hard_freq_cuts_immediately() {
+        // 51.4 Hz ≥ hard threshold → straight to Lockout + relay_off, no debounce wait.
+        let d = eval(&mut e(), "On", 51.4, 0, false, false);
+        assert_eq!(d.next_state.as_deref(), Some("Lockout"));
+        assert!(d.relay_off);
+    }
+
+    #[test]
+    fn pending_cut_hard_freq_cuts_immediately() {
+        // Hard threshold reached while waiting in PendingCut → cut now, even before cut_delay.
+        let d = eval(&mut e(), "PendingCut", 51.4, 1, false, false);
+        assert_eq!(d.next_state.as_deref(), Some("Lockout"));
+        assert!(d.relay_off);
     }
 
     #[test]
@@ -113,7 +141,8 @@ mod tests {
 
     #[test]
     fn pending_cut_delay_elapsed_high_freq_locks() {
-        let d = eval(&mut e(), "PendingCut", 52.5, 20, false, false);
+        // 51.1 Hz (soft, not hard) held past cut_delay → Lockout via the debounce path.
+        let d = eval(&mut e(), "PendingCut", 51.1, 5, false, false);
         assert_eq!(d.next_state.as_deref(), Some("Lockout"));
         assert!(d.relay_off);
     }
@@ -131,6 +160,14 @@ mod tests {
     }
 
     #[test]
+    fn off_low_freq_restore_blocked_stays_off() {
+        // Structural PV excess still present (battery full + sun) → hold DEYE off despite low freq.
+        let d = eval_rb(&mut e(), "Off", 50.1, 0, false, false, true);
+        assert!(d.next_state.is_none());
+        assert!(!d.relay_on);
+    }
+
+    #[test]
     fn pending_restore_elapsed_low_freq_restores() {
         let d = eval(&mut e(), "PendingRestore", 50.0, 50, false, false);
         assert_eq!(d.next_state.as_deref(), Some("On"));
@@ -145,6 +182,14 @@ mod tests {
     }
 
     #[test]
+    fn grid_reconnect_overrides_restore_block() {
+        // Even with a structural excess flagged, grid reconnect restores immediately.
+        let d = eval_rb(&mut e(), "Off", 50.0, 0, true, false, true);
+        assert_eq!(d.next_state.as_deref(), Some("On"));
+        assert!(d.relay_on);
+    }
+
+    #[test]
     fn grid_reconnect_from_lockout_restores_immediately() {
         let d = eval(&mut e(), "Lockout", 50.0, 0, true, false);
         assert_eq!(d.next_state.as_deref(), Some("On"));
@@ -153,8 +198,11 @@ mod tests {
 
     #[test]
     fn grid_reconnect_from_pending_cut_restores_immediately() {
-        let d = eval(&mut e(), "PendingCut", 52.5, 5, true, false);
+        // Hard freq + grid reconnect + cut_delay elapsed: grid override must win cleanly
+        // (no conflicting relay_off from the cut path).
+        let d = eval(&mut e(), "PendingCut", 51.4, 5, true, false);
         assert_eq!(d.next_state.as_deref(), Some("On"));
         assert!(d.relay_on);
+        assert!(!d.relay_off);
     }
 }

--- a/docs/app-energy-manager.md
+++ b/docs/app-energy-manager.md
@@ -322,61 +322,58 @@ ac_ignore == 1 ?
 
 ### 4.3 DEYE_COMMAND
 
-**Fichier** : `logic/deye_command.rs`
+**Fichier** : `logic/deye_command/` (`mod.rs` + `rules.rs`)
 
-**Rôle** : Machine d'états fréquence AC → couper/restaurer l'onduleur DEYE via relais Shelly.
+**Rôle** : Machine d'états fréquence AC → couper/restaurer les onduleurs DEYE via un Shelly Pro 2PM (**un canal par DEYE**). Le but est de **pré-empter l'auto-coupure des DEYE à 51,5 Hz** (qui provoque des micro-coupures sur AC Out) par une déconnexion relais propre et déterministe, dès 51,0 Hz.
 
 **Topics en entrée** :
 - `N/{pid}/vebus/{vb}/Ac/Out/L1/F` → fréquence AC (Hz)
 - `N/{pid}/vebus/{vb}/Ac/ActiveIn/Connected` → trigger reconnexion réseau (direct, **PAS via ac_ignore**)
+- État partagé (`EnergyState`) pour la corroboration : `soc_pct`, `battery_current_a`, `irradiance_wm2`, `shunt_last_seen_ts` (fraîcheur)
 
 > ⚠️ **Important** : `Ac/ActiveIn/Connected` déclenche **directement** le rule engine avec `grid_connected=true`. Ce n'est **PAS** une lecture de `ac_ignore` (qui vient de `IgnoreAcIn1`). Les deux topics sont distincts.
 
-**Règles GRL** (`deye_command.grl`) — 11 règles :
+**Conception en deux couches** :
+1. **Cœur fréquence** (autorité = mesure Victron, règle projet #13) — coupe/restaure sur seuils + hystérésis + timers.
+2. **Corroboration anti-rebattement** (SmartShunt + Irradiance, *fail-open*) — empêche une restauration prématurée tant qu'un excédent solaire **structurel** persiste (batterie pleine + soleil fort + non en décharge), pour éviter le cyclage du relais l'après-midi. Si les données SmartShunt sont périmées (> `corroboration_max_age_secs`), la garde s'efface → hystérésis fréquence seule.
 
-| État courant | Condition | → Nouvel état | Relay |
-|---|---|---|---|
-| On | freq ≥ 52 Hz | PendingCut | — |
-| PendingCut | 15 s écoulé + freq ≥ 52 Hz | Lockout | **OFF** |
-| Lockout | 120 s écoulé | Off | — |
-| Off | freq ≤ 50,3 Hz | PendingRestore | — |
-| PendingRestore | 45 s écoulé + freq ≤ 50,3 Hz | On | **ON** |
-| **Toute** | grid_connected==true (reconnect réseau) | On | **ON** (salience 200) |
+**Règles GRL** (`deye_command.grl`) :
+
+| État courant | Condition | → Nouvel état | Relay | Salience |
+|---|---|---|---|---|
+| On | freq ≥ `freq_hard_hz` (51,3) | Lockout | **OFF** (les 2 canaux) | 150 |
+| On | freq ≥ `freq_high_hz` (51,0), < hard | PendingCut | — | 100 |
+| PendingCut | freq ≥ `freq_hard_hz` | Lockout | **OFF** | 150 |
+| PendingCut | `cut_delay_secs` (3 s) écoulé + freq ≥ 51,0 | Lockout | **OFF** | 100 |
+| PendingCut | freq < 51,0 (annule) | On | — | 100 |
+| Lockout | `lockout_secs` (120 s) écoulé | Off | — | 100 |
+| Off | freq ≤ `freq_low_hz` (50,3) **et `restore_blocked==false`** | PendingRestore | — | 100 |
+| PendingRestore | `reenable_delay_secs` (45 s) écoulé + freq ≤ 50,3 | On | **ON** (les 2 canaux) | 100 |
+| **Toute** | `grid_connected==true` (reconnect réseau) | On | **ON** | 200 |
+
+`restore_blocked` (pré-calculé en Rust) = données SmartShunt fraîches **et** `soc ≥ restore_soc_pct` **et** `irradiance ≥ restore_irradiance_wm2` **et** `battery_current ≥ -1 A` (non en décharge).
 
 **Diagramme de la machine d'états** :
 ```
-         Grid reconnect (salience 200, override tout)
-         ├─ any state + grid==true → On + relay_on
-         │
-         ▼
-    ┌────────┐
-    │   On   │ ◄──────────── freq redescend < 52Hz (annule)
-    └──┬─────┘
-       │ freq ≥ 52Hz
-       ▼
-    ┌─────────────┐
-    │ PendingCut  │ ◄──────── freq redescend < 52Hz (annule)
-    │   (timer)   │
-    └──┬──────────┘
-       │ 15s + freq ≥ 52Hz
-       ▼
-    ┌─────────────┐   lockout_secs=120
-    │  Lockout    ├─────────────►  Off  ◄──┐
-    │   (120s)    │    (expire)           freq≤50.3Hz
-    └─────────────┘                        │
-                                      ┌─────────────┐
-                                      │PendingRestore│
-                                      │   (timer)    │
-                                      └──┬──────────┘
-                                         │ 45s + freq≤50.3Hz
-                                         ▼ relay_on
-                                        On
+         Grid reconnect (salience 200, override tout) → On + relay_on (2 canaux)
+                                   ▲
+    ┌────────┐  freq ≥ 51,0 (3 s)  │  ou  freq ≥ 51,3 (immédiat, salience 150)
+    │   On   ├─────────────────────┼──────────────────────────────┐
+    └────────┘ ◄── freq < 51,0     │                              ▼
+        ▲                          │                       ┌─────────────┐
+        │ restore autorisé         │                       │ PendingCut  │
+        │ (restore_blocked==false) │                       └──────┬──────┘
+   ┌────┴─────────┐  lockout 120 s   ┌─────────┐  3 s + freq haute │
+   │PendingRestore│◄─────────────────┤ Lockout │◄───── relay_off (2 canaux)
+   └──────────────┘                  └─────────┘
+        ▲ 45 s + freq ≤ 50,3            │ expire
+        └──────────────────── Off ◄─────┘
 ```
 
-**Commande Shelly MQTT transient** :
+**Commande Shelly MQTT transient** (envoyée sur **chaque** canal) :
 ```
 Topic   : {shelly_id}/rpc  (ex: shellypro2pm-ec62608840a4/rpc)
-Payload :
+Payload (pour chaque canal de shelly_deye_channels) :
 {
   "id": 1,
   "src": "energy-manager",
@@ -385,13 +382,16 @@ Payload :
 }
 ```
 
+**Re-synchronisation idempotente** : toutes les `relay_resync_secs` (60 s), l'état logique courant est ré-émis sur tous les canaux → le relais physique reconverge après un message MQTT manqué ou un reboot du Shelly. La première émission a lieu au démarrage (affirme l'état restauré). Log en `DEBUG` ; seules les transitions réelles sont en `INFO`.
+
 **Persistance de l'état DEYE** : L'état du relais (On/Off) est persisté en MQTT retained sur `santuario/persist/deye_state`. Au redémarrage, le service attend 3 secondes avant d'activer la logique DEYE pour laisser le broker MQTT livrer le message retained.
 
 États persistés :
 - `"On"` — DEYE actif (états `On` ou `PendingCut`)
 - `"Off"` — DEYE coupé (états `Off`, `Lockout`, `PendingRestore`)
 
-**Config** : `freq_high_hz=52.0`, `freq_low_hz=50.3`, `cut_delay_secs=15`, `reenable_delay_secs=45`, `lockout_secs=120`
+**Config** (`[energy_manager.deye]`) : `freq_high_hz=51.0`, `freq_hard_hz=51.3`, `freq_low_hz=50.3`, `cut_delay_secs=3`, `reenable_delay_secs=45`, `lockout_secs=120`, `restore_soc_pct=95.0`, `restore_irradiance_wm2=250.0`, `corroboration_max_age_secs=60`, `relay_resync_secs=60`.
+Canaux : `[energy_manager.victron] shelly_deye_channels = [0, 1]` (un canal par DEYE ; fallback mono-canal `shelly_deye_channel` si la liste est vide).
 
 ---
 


### PR DESCRIPTION
…attement

Audit : freq_high_hz=52.0 > auto-trip DEYE 51.5 Hz → le relais Shelly ne se déclenchait jamais ; et seul le canal 0 était piloté (un seul DEYE coupé). Ce sont donc toujours les DEYE qui s'auto-coupaient à 51.5 Hz, provoquant les micro-coupures sur AC Out.

- Seuil de coupure 52.0 → 51.0 Hz (débouncée 3 s) + seuil dur 51.3 Hz (coupure immédiate) pour pré-empter l'auto-coupure 51.5 Hz.
- Coupe/restaure les DEUX canaux Shelly (shelly_deye_channels=[0,1], fallback mono-canal shelly_deye_channel conservé).
- Garde anti-rebattement (restore_blocked) : maintient les DEYE coupés tant qu'un excédent structurel persiste (SOC>=95 % + irradiance>=250 W/m² + batterie non en décharge), fail-open si données SmartShunt périmées.
- Re-sync idempotent des canaux (relay_resync_secs) → reconvergence après message MQTT manqué / reboot Shelly.
- Corrige gardes grid_connected manquantes (DY_On_HighFreq, DY_PendingCut_Elapsed) pour ne pas écraser l'override reconnexion réseau.

La fréquence Victron reste l'autorité pour couper (règle projet #13) ; SmartShunt/Irradiance ne font que différer une restauration.

Tests : 38/38 OK, clippy -D warnings propre.

https://claude.ai/code/session_0168rhK1PX6KRpaPk9jfjFDh