### PR TITLE
fix(deye): passer l'état réseau réel au ticker (anti-coupure intempes…

### DIFF
--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -217,13 +217,16 @@ async fn run(
 
             _ = ticker.tick() => {
                 let now = Utc::now();
-                let (_connected, restore_blocked) = read_gates(&state, &cfg, now).await;
+                let (grid_connected, restore_blocked) = read_gates(&state, &cfg, now).await;
+                // Pass the real grid state: when grid-connected the GRL suppresses the
+                // cut rules (no spurious disconnect on a grid-frequency transient) and the
+                // salience-200 reconnect rules self-heal the relay back to On.
                 let new_state = apply_decision(
                     rule_engine.evaluate(
                         state_name(&deye_sm),
                         last_freq,
                         time_in_state_secs(&deye_sm, now),
-                        false,
+                        grid_connected,
                         cfg.freq_high_hz,
                         cfg.freq_hard_hz,
                         cfg.freq_low_hz,

--- a/crates/energy-manager/src/logic/deye_command/rules.rs
+++ b/crates/energy-manager/src/logic/deye_command/rules.rs
@@ -175,6 +175,16 @@ mod tests {
     }
 
     #[test]
+    fn on_hard_freq_grid_connected_no_cut() {
+        // Grid-connected: a high/hard frequency transient must NOT cut the DEYE
+        // (the ticker passes the real grid state, suppressing the cut rules).
+        let d = eval(&mut e(), "On", 51.4, 30, true, false);
+        assert!(d.next_state.is_none());
+        assert!(!d.relay_off);
+        assert!(!d.relay_on);
+    }
+
+    #[test]
     fn grid_reconnect_from_off_restores_immediately() {
         let d = eval(&mut e(), "Off", 50.0, 0, true, false);
         assert_eq!(d.next_state.as_deref(), Some("On"));


### PR DESCRIPTION
…tive + self-heal)

Le ticker périodique évaluait avec grid_connected=false codé en dur. Comme last_freq est rafraîchi avant le `continue` de la branche fréquence, un transitoire réseau >= freq_hard_hz pouvait déclencher la coupure dure immédiate alors que le réseau est connecté.

Passer le vrai grid_connected (déjà lu via read_gates) :
- supprime les règles de coupure quand le réseau est connecté → plus de déconnexion DEYE sur un transitoire de fréquence réseau ;
- active les règles de reconnexion (salience 200) → auto-réparation du relais vers On si le service redémarre réseau-connecté avec un état restauré à Off (en contournant restore_blocked, correct car l'excédent part au réseau).

Hors-réseau : grid_connected=false → comportement inchangé. Test de non-régression ajouté (on_hard_freq_grid_connected_no_cut). 15/15 OK.

https://claude.ai/code/session_0168rhK1PX6KRpaPk9jfjFDh