### PR TITLE
fix(deye): détecter l'îlotage par panne réseau réelle, pas seulement …

### DIFF
--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -182,6 +182,9 @@ async fn run(
 
                 } else if *t == t_connected {
                     if let Some(v) = msg.victron_value::<i64>() {
+                        // Track the physical grid connection so read_gates detects a real
+                        // outage (Connected==0) even when IgnoreAcIn1 stays 0.
+                        state.write().await.ac_connected = Some(v);
                         if v == 1 {
                             let now = Utc::now();
                             let new_state = apply_decision(
@@ -366,8 +369,20 @@ async fn send_shelly(bus: &AppBus, shelly_id: &str, channels: &[u8], on: bool) {
 /// Returns `(grid_connected, restore_blocked)`.
 async fn read_gates(state: &Arc<RwLock<EnergyState>>, cfg: &DeyeConfig, now: DateTime<Utc>) -> (bool, bool) {
     let s = state.read().await;
-    let grid_connected = s.ac_ignore.map(|v| v == 0).unwrap_or(true);
-    (grid_connected, restore_blocked(&s, cfg, now))
+    (is_grid_connected(s.ac_ignore, s.ac_connected), restore_blocked(&s, cfg, now))
+}
+
+/// Whether the Victron is grid-tied (NOT islanded). The DEYE cut logic must stay active
+/// whenever the Victron forms the AC-Out grid and can frequency-shift the DEYE — which
+/// happens both on a deliberate ignore (`IgnoreAcIn1 == 1`) AND on a real grid outage
+/// (`ActiveIn/Connected == 0`, where `IgnoreAcIn1` may remain 0).
+///
+/// The grid is considered connected only when *neither* signal indicates islanding.
+/// Unknown signals keep the conservative "assume connected" default — identical to the
+/// previous `ac_ignore`-only behaviour, so this degrades gracefully if `ac_connected`
+/// has not been observed yet.
+fn is_grid_connected(ac_ignore: Option<i64>, ac_connected: Option<i64>) -> bool {
+    ac_ignore != Some(1) && ac_connected != Some(0)
 }
 
 /// Structural PV-excess guard. While the battery is full, irradiance is strong and
@@ -392,4 +407,34 @@ fn restore_blocked(s: &EnergyState, cfg: &DeyeConfig, now: DateTime<Utc>) -> boo
     soc >= cfg.restore_soc_pct
         && irradiance >= cfg.restore_irradiance_wm2
         && current >= -1.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_grid_connected;
+
+    #[test]
+    fn grid_tied_when_connected_and_not_ignored() {
+        assert!(is_grid_connected(Some(0), Some(1)));
+    }
+
+    #[test]
+    fn islanded_on_deliberate_ignore() {
+        // ESS running off-battery while physically still connected → frequency shifting active.
+        assert!(!is_grid_connected(Some(1), Some(1)));
+    }
+
+    #[test]
+    fn islanded_on_real_outage_even_if_ignore_stays_zero() {
+        // Real grid loss: ActiveIn/Connected drops to 0 while IgnoreAcIn1 may remain 0.
+        assert!(!is_grid_connected(Some(0), Some(0)));
+    }
+
+    #[test]
+    fn unknown_signals_assume_connected() {
+        // Graceful degradation: no data → previous ac_ignore-only "assume connected" default.
+        assert!(is_grid_connected(None, None));
+        assert!(is_grid_connected(Some(0), None));
+        assert!(!is_grid_connected(Some(1), None));
+    }
 }

--- a/docs/app-energy-manager.md
+++ b/docs/app-energy-manager.md
@@ -328,10 +328,13 @@ ac_ignore == 1 ?
 
 **Topics en entrée** :
 - `N/{pid}/vebus/{vb}/Ac/Out/L1/F` → fréquence AC (Hz)
-- `N/{pid}/vebus/{vb}/Ac/ActiveIn/Connected` → trigger reconnexion réseau (direct, **PAS via ac_ignore**)
+- `N/{pid}/vebus/{vb}/Ac/ActiveIn/Connected` → reconnexion réseau (`v==1`) **et** état physique de connexion stocké dans `ac_connected`
+- `Ac/State/IgnoreAcIn1` → `ac_ignore` (peuplé par les modules inverter/charge_current)
 - État partagé (`EnergyState`) pour la corroboration : `soc_pct`, `battery_current_a`, `irradiance_wm2`, `shunt_last_seen_ts` (fraîcheur)
 
-> ⚠️ **Important** : `Ac/ActiveIn/Connected` déclenche **directement** le rule engine avec `grid_connected=true`. Ce n'est **PAS** une lecture de `ac_ignore` (qui vient de `IgnoreAcIn1`). Les deux topics sont distincts.
+> ⚠️ **Important** : `Ac/ActiveIn/Connected` déclenche **directement** le rule engine avec `grid_connected=true` (`v==1`). Ce n'est **PAS** une lecture de `ac_ignore` (qui vient de `IgnoreAcIn1`). Les deux topics sont distincts.
+
+**Détection d'îlotage** (`is_grid_connected`) : le réseau est considéré connecté **uniquement** si `ac_ignore != 1` **et** `ac_connected != 0`. Cela couvre l'îlotage délibéré (`IgnoreAcIn1==1`, ESS sur batterie) **et** la panne réseau réelle (`ActiveIn/Connected==0`, où `IgnoreAcIn1` peut rester à 0) → la coupure de sécurité DEYE reste active dans les deux cas. Signaux inconnus → défaut « connecté » (dégradation gracieuse vers l'ancien comportement `ac_ignore` seul).
 
 **Conception en deux couches** :
 1. **Cœur fréquence** (autorité = mesure Victron, règle projet #13) — coupe/restaure sur seuils + hystérésis + timers.


### PR DESCRIPTION
…IgnoreAcIn1

read_gates déduisait grid_connected du seul ac_ignore (IgnoreAcIn1). Or IgnoreAcIn1 traduit un ignore *délibéré* : lors d'une panne réseau réelle il peut rester à 0 alors que le Victron îlote et décale la fréquence. Les règles de coupure (gardées par grid_connected==false) auraient été supprimées → les DEYE non coupés → fréquence montante → auto-trip 51.5 Hz et micro-coupures pendant une vraie coupure secteur.

- Nouveau helper is_grid_connected(ac_ignore, ac_connected) : réseau connecté uniquement si ac_ignore != 1 ET ac_connected != 0. Couvre l'ignore délibéré ET la panne réseau physique. Signaux inconnus → défaut « connecté » (dégradation gracieuse, identique à l'ancien comportement ac_ignore seul).
- Peuplement de ac_connected depuis le handler Ac/ActiveIn/Connected (jusqu'ici déclaré mais jamais écrit).
- Tests unitaires du helper (panne réelle, ignore délibéré, signaux inconnus).

Corrige aussi le chemin pré-existant de la branche fréquence (qui utilisait déjà ac_ignore seul via read_gates).

43/43 tests OK, clippy -D warnings propre.

https://claude.ai/code/session_0168rhK1PX6KRpaPk9jfjFDh