### PR TITLE
fix(deye): éviter le battement relais — reconnexion seulement si vrai…

### DIFF
--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -182,10 +182,18 @@ async fn run(
 
                 } else if *t == t_connected {
                     if let Some(v) = msg.victron_value::<i64>() {
-                        // Track the physical grid connection so read_gates detects a real
-                        // outage (Connected==0) even when IgnoreAcIn1 stays 0.
-                        state.write().await.ac_connected = Some(v);
-                        if v == 1 {
+                        // Track the physical grid connection (so read_gates can detect a real
+                        // outage) and only force an immediate reconnect when this makes us
+                        // *truly* grid-connected — not merely physically reconnected while the
+                        // ESS still deliberately ignores AC-in (ac_ignore==1) and keeps
+                        // frequency-shifting. Otherwise the ticker would re-cut 1 s later and
+                        // thrash the relay. Consistent with read_gates / is_grid_connected.
+                        let truly_connected = {
+                            let mut s = state.write().await;
+                            s.ac_connected = Some(v);
+                            is_grid_connected(s.ac_ignore, s.ac_connected)
+                        };
+                        if truly_connected {
                             let now = Utc::now();
                             let new_state = apply_decision(
                                 rule_engine.evaluate(


### PR DESCRIPTION
…ment grid-tied

Le handler t_connected forçait la reconnexion DEYE sur v==1 (état physique) seul, alors que read_gates et le ticker utilisent désormais le prédicat combiné is_grid_connected(ac_ignore, ac_connected). Incohérence : si ac_ignore==1 (îlotage délibéré, ESS sur batterie, le Victron décale toujours la fréquence) et que le réseau physique se reconnecte (v==1), le handler remettait les DEYE ON, puis au tic suivant is_grid_connected(Some(1),Some(1)) == false → recoupe les DEYE si la fréquence est haute → battement du relais (ON puis OFF 1 s après) → usure/casse matérielle.

Le handler vérifie maintenant is_grid_connected(ac_ignore, ac_connected) avant de forcer la reconnexion → cohérent avec les deux autres chemins. La transition ignore→grid (ac_ignore 1→0) reste prise en charge par le ticker (salience 200) sous 1 s. Cas couvert par le test islanded_on_deliberate_ignore.

43/43 tests OK, clippy -D warnings propre.

https://claude.ai/code/session_0168rhK1PX6KRpaPk9jfjFDh