### PR TITLE
feat(deye): observabilité de la règle DEYE — API rules-status + carte…

### DIFF
--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -165,21 +165,26 @@
       <div>
         <div style="font-family:monospace;font-size:0.7rem;font-weight:700;color:#38bdf8;margin-bottom:0.4rem;display:flex;justify-content:space-between;">
           <span>🔌 Gestion Relais DEYE</span>
-          <span id="deye-state-badge" style="font-size:0.68rem;padding:1px 6px;border-radius:4px;background:#1e293b;color:#475569;">—</span>
+          <span id="deye-state-badge" style="font-size:0.68rem;padding:1px 6px;border-radius:4px;background:#1e293b;color:#475569;" title="État machine : On / PendingCut / Lockout / Off / PendingRestore">—</span>
         </div>
         <div style="display:flex;gap:0.4rem;margin-bottom:0.4rem;">
           <div style="background:#1e293b;border-radius:5px;padding:0.35rem 0.5rem;flex:1;display:flex;align-items:center;gap:0.5rem;">
             <span id="deye-dot" style="width:8px;height:8px;border-radius:50%;flex-shrink:0;background:#475569;"></span>
             <div>
-              <div style="font-size:0.6rem;color:#64748b;">Relais</div>
+              <div style="font-size:0.6rem;color:#64748b;">Relais (2 canaux)</div>
               <div id="deye-on-val" style="font-family:monospace;font-size:0.8rem;font-weight:700;color:#94a3b8;">—</div>
             </div>
           </div>
           <div style="background:#1e293b;border-radius:5px;padding:0.35rem 0.5rem;flex:1;">
-            <div style="font-size:0.6rem;color:#64748b;">Dernier changement</div>
+            <div style="font-size:0.6rem;color:#64748b;">Fréquence AC</div>
+            <div id="deye-freq-val" style="font-family:monospace;font-size:0.8rem;font-weight:700;color:#94a3b8;">—</div>
+          </div>
+          <div style="background:#1e293b;border-radius:5px;padding:0.35rem 0.5rem;flex:1;">
+            <div style="font-size:0.6rem;color:#64748b;">Dernier chgt</div>
             <div id="deye-change-ts" style="font-family:monospace;font-size:0.7rem;color:#64748b;">—</div>
           </div>
         </div>
+        <div style="font-family:monospace;font-size:0.6rem;color:#475569;margin-bottom:0.35rem;">Coupe ≥ 51,0 Hz (dur ≥ 51,3) · restaure ≤ 50,3 Hz · 2 DEYE</div>
         <div id="deye-rule-grid" style="display:flex;flex-direction:column;gap:0.35rem;"></div>
       </div>
 
@@ -595,14 +600,22 @@ async function fetchRulesStatus() {
   // Card c) Relais DEYE
   // ══════════════════════════════════════════════════════════════════════════
   try {
-    const deye = emR?.deye ?? null;
-    const deyeOn = deye?.on ?? null;
+    const deye      = emR?.deye ?? null;
+    const deyeOn    = deye?.on ?? null;
+    const deyeState = deye?.state ?? null;            // On/PendingCut/Lockout/Off/PendingRestore
+    const deyeFreq  = deye?.freq_hz ?? null;
+    const deyeBlock = deye?.restore_blocked ?? false;
+    const deyeAcCon = deye?.ac_connected ?? null;     // 1=connecté, 0=panne réseau
+    // Combined islanding predicate from the energy-manager; fall back to ac_ignore.
+    const gridConn  = deye?.grid_connected ?? (acIgnore != null ? !acIgnore : null);
 
+    // Badge → état machine
     const badge = document.getElementById('deye-state-badge');
     if (badge) {
-      badge.textContent   = deyeOn === true ? 'ON' : deyeOn === false ? 'OFF' : '—';
-      badge.style.background = deyeOn ? '#14532d' : '#1c1917';
-      badge.style.color      = deyeOn ? '#4ade80' : '#78716c';
+      badge.textContent = deyeState ?? (deyeOn === true ? 'ON' : deyeOn === false ? 'OFF' : '—');
+      const cut = deyeState === 'Lockout' || deyeState === 'Off' || deyeState === 'PendingRestore';
+      badge.style.background = deyeState == null ? '#1e293b' : cut ? '#1c1917' : '#14532d';
+      badge.style.color      = deyeState == null ? '#475569' : cut ? '#f87171' : '#4ade80';
     }
     const dot = document.getElementById('deye-dot');
     if (dot) {
@@ -611,8 +624,16 @@ async function fetchRulesStatus() {
     }
     const onEl = document.getElementById('deye-on-val');
     if (onEl) {
-      onEl.textContent = deyeOn === true ? 'Actif' : deyeOn === false ? 'Inactif' : '—';
-      onEl.style.color = deyeOn ? '#22c55e' : '#94a3b8';
+      onEl.textContent = deyeOn === true ? 'Actif' : deyeOn === false ? 'Coupé' : '—';
+      onEl.style.color = deyeOn ? '#22c55e' : '#f87171';
+    }
+    const freqEl = document.getElementById('deye-freq-val');
+    if (freqEl) {
+      freqEl.textContent = deyeFreq != null ? deyeFreq.toFixed(2) + ' Hz' : '—';
+      freqEl.style.color = deyeFreq == null ? '#94a3b8'
+        : deyeFreq >= 51.3 ? '#ef4444'
+        : deyeFreq >= 51.0 ? '#eab308'
+        : '#22c55e';
     }
     const chEl = document.getElementById('deye-change-ts');
     if (chEl) chEl.textContent = fmtTs(deye?.last_change);
@@ -620,10 +641,20 @@ async function fetchRulesStatus() {
     // Conditions for DEYE
     const dGrid = document.getElementById('deye-rule-grid');
     if (dGrid) {
-      dGrid.innerHTML = [
-        ruleRow('Grid déconnecté',   gridOffOk, acIgnore != null ? (acIgnore ? 'ACTIF' : 'Normal') : '—', null),
-        ruleRow('Relais DEYE actif', !!deyeOn,  deyeOn != null ? (deyeOn ? 'ON' : 'OFF') : '—', null),
-      ].join('');
+      const rows = [
+        ruleRow('Réseau connecté', gridConn === true,
+                gridConn == null ? '—' : (gridConn ? 'Connecté' : 'Îloté'),
+                deyeAcCon === 0 ? 'panne réseau' : null),
+        ruleRow('Fréquence < seuil coupure', deyeFreq != null ? deyeFreq < 51.0 : true,
+                deyeFreq != null ? deyeFreq.toFixed(2) + ' Hz' : '—', 'coupe ≥ 51,0/51,3'),
+      ];
+      if (deyeOn === false) {
+        rows.push(ruleRow('Restauration autorisée', !deyeBlock,
+                  deyeBlock ? 'BLOQUÉE' : 'libre',
+                  deyeBlock ? 'batterie pleine + soleil' : null));
+      }
+      rows.push(ruleRow('Relais DEYE (2 canaux)', !!deyeOn, deyeOn != null ? (deyeOn ? 'ON' : 'OFF') : '—', null));
+      dGrid.innerHTML = rows.join('');
     }
   } catch(e) { console.warn('fetchRulesStatus/deye:', e); }
 }

--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -150,8 +150,18 @@ struct ChargeCurrent {
 
 #[derive(Serialize)]
 struct DeyeCard {
-    on:            bool,
-    last_change:   Option<DateTime<Utc>>,
+    on:              bool,
+    /// State-machine state: On / PendingCut / Lockout / Off / PendingRestore
+    state:           Option<String>,
+    last_change:     Option<DateTime<Utc>>,
+    /// Restore held off by the structural-excess guard (battery full + sun + not discharging)
+    restore_blocked: bool,
+    /// Combined islanding predicate (ac_ignore != 1 && ac_connected != 0)
+    grid_connected:  bool,
+    /// AC-out frequency driving the cut/restore thresholds (Hz)
+    freq_hz:         Option<f64>,
+    /// Physical grid connection (ActiveIn/Connected): 1=connected, 0=outage
+    ac_connected:    Option<i64>,
 }
 
 #[derive(Serialize)]
@@ -185,8 +195,13 @@ async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
             last_ts:      s.last_charge_ts,
         },
         deye: DeyeCard {
-            on:          s.deye_on,
-            last_change: s.deye_last_change,
+            on:              s.deye_on,
+            state:           s.deye_state.clone(),
+            last_change:     s.deye_last_change,
+            restore_blocked: s.deye_restore_blocked,
+            grid_connected:  crate::logic::deye_command::is_grid_connected(s.ac_ignore, s.ac_connected),
+            freq_hz:         s.ac_frequency_hz,
+            ac_connected:    s.ac_connected,
         },
         soc_pct:        s.soc_pct,
         irradiance_wm2: s.irradiance_wm2,

--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -229,6 +229,12 @@ async fn run(
             _ = ticker.tick() => {
                 let now = Utc::now();
                 let (grid_connected, restore_blocked) = read_gates(&state, &cfg, now).await;
+                // Refresh observability fields (1 Hz) for /api/rules-status.
+                {
+                    let mut s = state.write().await;
+                    s.deye_state           = Some(state_name(&deye_sm).to_string());
+                    s.deye_restore_blocked = restore_blocked;
+                }
                 // Pass the real grid state: when grid-connected the GRL suppresses the
                 // cut rules (no spurious disconnect on a grid-frequency transient) and the
                 // salience-200 reconnect rules self-heal the relay back to On.
@@ -294,8 +300,10 @@ async fn persist_deye_state(bus: &AppBus, state: &DeyeState) {
 /// Updates EnergyState with DEYE relay info for the REST /api/rules-status endpoint.
 async fn update_deye_state(state: &Arc<RwLock<EnergyState>>, deye: &DeyeState) {
     let mut s = state.write().await;
-    s.deye_on          = matches!(deye, DeyeState::On | DeyeState::PendingCut(_));
-    s.deye_last_change = Some(Utc::now());
+    s.deye_on            = matches!(deye, DeyeState::On | DeyeState::PendingCut(_));
+    s.deye_state         = Some(state_name(deye).to_string());
+    s.deye_lockout_until = match deye { DeyeState::Lockout(until) => Some(*until), _ => None };
+    s.deye_last_change   = Some(Utc::now());
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -389,7 +397,7 @@ async fn read_gates(state: &Arc<RwLock<EnergyState>>, cfg: &DeyeConfig, now: Dat
 /// Unknown signals keep the conservative "assume connected" default — identical to the
 /// previous `ac_ignore`-only behaviour, so this degrades gracefully if `ac_connected`
 /// has not been observed yet.
-fn is_grid_connected(ac_ignore: Option<i64>, ac_connected: Option<i64>) -> bool {
+pub(crate) fn is_grid_connected(ac_ignore: Option<i64>, ac_connected: Option<i64>) -> bool {
     ac_ignore != Some(1) && ac_connected != Some(0)
 }
 

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -164,6 +164,10 @@ pub struct EnergyState {
     pub deye_lockout_until: Option<DateTime<Utc>>,
     /// Persisted DEYE state from retained MQTT (set by persist watcher at startup)
     pub deye_persisted_state: Option<String>,
+    /// Current state-machine state name (On/PendingCut/Lockout/Off/PendingRestore) — observability.
+    pub deye_state: Option<String>,
+    /// Whether DEYE restore is currently held off by the structural-excess guard — observability.
+    pub deye_restore_blocked: bool,
 
     // --- Irradiance ---
     pub irradiance_wm2: Option<f64>,

--- a/docs/app-daly-bms-server.md
+++ b/docs/app-daly-bms-server.md
@@ -596,7 +596,7 @@ wscat -c ws://localhost:8080/ws/bms/1/stream
 | `/dashboard/tasmota` | `tasmota.html` | Liste des appareils Tasmota |
 | `/dashboard/tasmota/:id` | `tasmota_detail.html` | Détail Tasmota (état relais, mesures énergie) |
 | `/dashboard/ats` | `ats.html` | État ATS CHINT (source active, tensions, commandes) |
-| `/dashboard/monitor` | `monitor.html` | Santé RS485 (CRC errors, timeouts, taux succès par appareil) |
+| `/dashboard/monitor` | `monitor.html` | Règles système (courant Victron, chauffe-eau LG, relais DEYE : état machine, fréquence, gardes îlotage/restore — via `:8081/api/rules-status`) + santé RS485 (CRC, timeouts, taux succès par appareil) |
 | `/dashboard/console` | `console.html` | Console logs WebSocket temps réel |
 | `/dashboard/visualization` | `visualization.html` | Diagramme flux d'énergie (ReactFlow / schéma SVG) |
 | `/dashboard/history` | `history.html` | Historique long terme (requête redb, sélecteur de période) |

--- a/docs/app-energy-manager.md
+++ b/docs/app-energy-manager.md
@@ -919,13 +919,27 @@ websocat ws://192.168.1.141:8081/live
   },
   "deye": {
     "on": true,
-    "last_change": null
+    "state": "On",
+    "last_change": null,
+    "restore_blocked": false,
+    "grid_connected": true,
+    "freq_hz": 50.01,
+    "ac_connected": 1
   },
   "soc_pct": null,
   "irradiance_wm2": null,
   "ac_ignore": null
 }
 ```
+
+Champs `deye` :
+- `state` — état machine : `On` / `PendingCut` / `Lockout` / `Off` / `PendingRestore`.
+- `restore_blocked` — restauration différée par la garde d'excédent structurel (batterie pleine + soleil + non en décharge).
+- `grid_connected` — prédicat d'îlotage combiné (`ac_ignore != 1` **et** `ac_connected != 0`).
+- `freq_hz` — fréquence AC-Out pilotant les seuils.
+- `ac_connected` — connexion physique réseau (`1`=connecté, `0`=panne).
+
+Ces champs alimentent la carte **« Règles système → Gestion Relais DEYE »** de `/dashboard/monitor`.
 
 ---
 
@@ -976,15 +990,21 @@ mppt2_instance       = 289             # MPPT 2
 pvinverter_instance  = 32
 smartshunt           = 274             # Instance SmartShunt (batterie)
 shelly_deye_id       = "shellypro2pm-ec62608840a4"
-shelly_deye_channel  = 0               # Canal du relais Shelly
+shelly_deye_channel  = 0               # Fallback mono-canal (hérité)
+shelly_deye_channels = [0, 1]          # Un canal par DEYE — coupe/restaure les deux
 tasmota_waterheater_id = "tongou_3BC764"
 
 [energy_manager.deye]
-freq_high_hz         = 52.0   # Seuil de coupure DEYE
-freq_low_hz          = 50.3   # Seuil de réactivation
-cut_delay_secs       = 15     # Délai avant coupure (PendingCut → Lockout)
-reenable_delay_secs  = 45     # Délai avant réactivation (PendingRestore → On)
-lockout_secs         = 120    # Durée du verrou anti-oscillation (Lockout → Off)
+freq_high_hz               = 51.0   # Seuil de coupure débouncée (sous l'auto-trip DEYE 51.5)
+freq_hard_hz               = 51.3   # Seuil de coupure immédiate (filet pré-trip)
+freq_low_hz                = 50.3   # Seuil de réactivation
+cut_delay_secs             = 3      # Délai avant coupure (PendingCut → Lockout)
+reenable_delay_secs        = 45     # Délai avant réactivation (PendingRestore → On)
+lockout_secs               = 120    # Durée du verrou anti-oscillation (Lockout → Off)
+restore_soc_pct            = 95.0   # SOC ≥ → excédent structurel → maintien coupé
+restore_irradiance_wm2     = 250.0  # Irradiance ≥ → soleil fort → maintien coupé
+corroboration_max_age_secs = 60     # Fraîcheur SmartShunt (au-delà : fréquence seule, fail-open)
+relay_resync_secs          = 60     # Ré-affirmation périodique de l'état des 2 canaux
 
 [energy_manager.water_heater]
 solar_min_w            = 2000.0   # Production min pour HEAT_PUMP (non utilisé par la règle GRL)


### PR DESCRIPTION
… /dashboard/monitor + doc

La carte « Règles système → Gestion Relais DEYE » de /dashboard/monitor ne montrait que ON/OFF. Elle reflète désormais la nouvelle logique.

Pipeline d'observabilité :
- EnergyState : nouveaux champs deye_state (état machine) et deye_restore_blocked, rafraîchis à 1 Hz par la tâche DEYE (+ deye_lockout_until renseigné en Lockout).
- /api/rules-status (energy-manager :8081) : DeyeCard enrichie de state, restore_blocked, grid_connected (prédicat îlotage combiné partagé via is_grid_connected pub(crate)), freq_hz, ac_connected.
- monitor.html : badge = état machine (On/PendingCut/Lockout/Off/PendingRestore), fréquence AC colorée (vert <51,0 / ambre ≥51,0 / rouge ≥51,3), légende des seuils, et conditions live : réseau connecté (panne réseau si ac_connected=0), fréquence vs seuil, restauration bloquée (excédent structurel), relais 2 canaux.

Doc :
- app-energy-manager.md §10.2 (payload deye) + §12.1 (config deye : 51.0/51.3/3s
  + canaux [0,1] + gardes restore_* + relay_resync).
- app-daly-bms-server.md : description /dashboard/monitor.

43/43 tests OK, clippy -D warnings propre, daly-bms-server compile (template Askama).

https://claude.ai/code/session_0168rhK1PX6KRpaPk9jfjFDh