### PR TITLE
fix(promql): arithmétique saturante dans la borne de points + doc aut…

### DIFF
--- a/crates/daly-bms-server/src/api/bms.rs
+++ b/crates/daly-bms-server/src/api/bms.rs
@@ -609,6 +609,14 @@ pub async fn ws_all(
 /// Pong automatiquement). Sans cela, un client mort en silence (Wi-Fi coupé,
 /// onglet figé) retenait sa tâche + son récepteur broadcast pendant des
 /// minutes/heures, jusqu'au remplissage des buffers TCP.
+///
+/// NB : les Pings ENTRANTS (client → serveur) n'ont pas besoin d'être gérés
+/// ici — tungstenite y répond automatiquement au niveau protocole
+/// (`set_additional(Frame::pong(...))` à la lecture), y compris après
+/// `socket.split()` (le BiLock donne à `poll_next` l'accès `&mut` complet).
+/// Doc axum `Message::Ping` : « will be automatically responded to by the
+/// server ». Répondre manuellement produirait des doubles Pongs. On compte
+/// simplement ces trames comme preuve de vie (`last_rx`).
 const WS_PING_INTERVAL_SECS: u64 = 30;
 const WS_IDLE_TIMEOUT_SECS:  u64 = 90;
 

--- a/crates/metrics-store/src/lib.rs
+++ b/crates/metrics-store/src/lib.rs
@@ -552,6 +552,13 @@ mod tests {
             // 0 = garde désactivée.
             ev_small.max_range_points = 0;
             assert!(ev_small.eval_range(&expr, 100_000, 109_000, 3_000).is_ok());
+            // Bornes extrêmes : la soustraction saturante doit déclencher la
+            // limite au lieu de wrapper en négatif (et la contourner).
+            ev_small.max_range_points = 3;
+            let err = ev_small
+                .eval_range(&expr, i64::MIN + 1, i64::MAX - 1, 1)
+                .unwrap_err();
+            assert!(err.message().contains("maximum resolution"));
         }
         let _ = std::fs::remove_file(&path);
     }

--- a/crates/metrics-store/src/promql/exec.rs
+++ b/crates/metrics-store/src/promql/exec.rs
@@ -225,7 +225,12 @@ impl<'r> Evaluator<'r> {
             return Err(PromQlError::Execution("end < start".into()));
         }
         // Garde-fou mémoire (audit 2026-06 §3) — sémantique Prometheus.
-        let steps = (end_ms - start_ms) / step_ms + 1;
+        // NB : `step_ms > 0` et `end_ms ≥ start_ms` sont garantis par les
+        // gardes ci-dessus ; l'arithmétique saturante neutralise l'overflow
+        // i64 sur des bornes extrêmes (le wrap silencieux en release rendrait
+        // `steps` négatif et contournerait la limite ; le `+ 1` peut lui-même
+        // déborder après saturation de la soustraction).
+        let steps = (end_ms.saturating_sub(start_ms) / step_ms).saturating_add(1);
         if self.max_range_points > 0 && steps > self.max_range_points {
             return Err(PromQlError::Execution(format!(
                 "exceeded maximum resolution of {} points beyond which time series data \


### PR DESCRIPTION
…o-Pong WS (suite revue PR #576)

Revue Gemini PR #576, deux remarques contre-vérifiées :

1. « Division par zéro si step_ms == 0 » — faux positif : la garde préexistante `step_ms <= 0` (exec.rs, 5 lignes au-dessus) rend la division inatteignable, en plus de la validation côté API (api/promql.rs). En revanche la contre-vérification a révélé un vrai angle mort : sur des bornes extrêmes, `end_ms - start_ms` peut déborder i64 (wrap silencieux en release → steps négatif → limite contournée). Corrigé par saturating_sub + saturating_add (le +1 débordait aussi après saturation) + test aux bornes i64.

2. « Répondre Pong manuellement après split() » — non : tungstenite met le Pong en file au niveau protocole dès la LECTURE du Ping (protocol/mod.rs, set_additional(Frame::pong)), y compris socket divisé (poll_next a l'accès &mut complet via le BiLock). Doc axum Message::Ping : « will be automatically responded to by the server ». Une réponse manuelle produirait des doubles Pongs. Commentaire ajouté sur les constantes keepalive pour éviter que la remarque revienne.

https://claude.ai/code/session_01FfWYbCnXhWubmBLMYFFpto