### PR TITLE
refactor(server): retours review — try_reserve avant clone + saturati…

### DIFF
--- a/crates/daly-bms-server/src/redb_writes.rs
+++ b/crates/daly-bms-server/src/redb_writes.rs
@@ -64,7 +64,10 @@ impl RateLimiter {
         // unwrap_or_else pour rester safe si un panic a empoisonné le mutex.
         let mut map = self.last_writes.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(last) = map.get_mut(key) {
-            if now.duration_since(*last) < min_interval {
+            // saturating : Instant est monotone donc now >= *last en pratique,
+            // mais on reste explicite (et duration_since ne sature que depuis
+            // Rust 1.60 — autant ne laisser aucune ambiguïté).
+            if now.saturating_duration_since(*last) < min_interval {
                 return false;
             }
             *last = now;

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -662,19 +662,22 @@ impl AppState {
                 .push(snap.clone());
         }
         // AlertEngine : canal mpsc dédié (et non le broadcast ws_tx, cf. doc du
-        // champ `alert_tx`). `try_send` : si la boucle d'alertes prend du
-        // retard (ex: notification Telegram lente, jusqu'à 10 s), on jette le
-        // snapshot plutôt que de bloquer le chemin de poll RS485. Sans risque
-        // de désynchronisation durable : les règles sont à NIVEAU (chaque
-        // évaluation re-dérive l'état depuis le snapshot courant), un drop ne
-        // fait que décaler trigger/clear au prochain snapshot (~1 s). On le
-        // loggue quand même pour ne pas perdre l'information (review gemini).
+        // champ `alert_tx`). `try_reserve` avant clone : si la boucle d'alertes
+        // prend du retard (ex: notification Telegram lente, jusqu'à 10 s), on
+        // jette le snapshot SANS l'avoir cloné (review gemini) plutôt que de
+        // bloquer le chemin de poll RS485. Sans risque de désynchronisation
+        // durable : les règles sont à NIVEAU (chaque évaluation re-dérive
+        // l'état depuis le snapshot courant), un drop ne fait que décaler
+        // trigger/clear au prochain snapshot (~1 s).
         if let Some(tx) = &self.alert_tx {
-            if tx.try_send(snap.clone()).is_err() {
-                tracing::warn!(
-                    bms = format_args!("{:#04x}", snap.address),
-                    "AlertEngine saturé — snapshot non évalué (réévalué au prochain poll)"
-                );
+            match tx.try_reserve() {
+                Ok(permit) => permit.send(snap.clone()),
+                Err(_) => {
+                    tracing::warn!(
+                        bms = format_args!("{:#04x}", snap.address),
+                        "AlertEngine saturé — snapshot non évalué (réévalué au prochain poll)"
+                    );
+                }
             }
         }
         // Broadcast WebSocket : skip si aucun client connecté (évite d'allouer


### PR DESCRIPTION
…ng_duration_since

- state.on_snapshot : `try_reserve()` puis `permit.send(snap.clone())` — plus aucun clone de BmsSnapshot quand le canal AlertEngine est saturé (le clone partait à la poubelle sur le chemin d'erreur).
- RateLimiter::allow : `saturating_duration_since` (explicite ; Instant est monotone et duration_since sature depuis Rust 1.60, mais autant lever toute ambiguïté).

Suggestion « bms_id paresseux via OnceCell » volontairement NON appliquée : 1 seule String de 6 octets par snapshot (~3/s au total), contre ~80 allocations/snapshot déjà éliminées — le pattern OnceCell + duplication du format hex dans 170 clés dégraderait nettement la lisibilité pour un gain non mesurable.

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a