### PR TITLE
fix(mem): 3 causes réelles de croissance RSS (Shelly tasks, RateLimiter, narenas)

### DIFF
--- a/contrib/daly-bms.service
+++ b/contrib/daly-bms.service
@@ -33,22 +33,20 @@ Environment=MALLOC_ARENA_MAX=2
 
 # Tuning jemalloc (tikv-jemallocator utilise le préfixe `_RJEM_` pour
 # éviter les conflits avec d'autres jemalloc embarqués).
-# Observation prod 18 mai 2026 : un dashboard 30 jours fait grimper
-# VmPeak à 367 Mo (eval_range sur ~270 séries × 43k itérations) et
-# jemalloc retient ~55 Mo après libération avec les defaults (delay 10s
-# avant retour des pages au kernel). Configuration agressive :
-#   narenas:2             — limite à 2 arenas (défaut = 4×N_CPU = 16 sur Pi5)
-#                           ATTENTION : MALLOC_ARENA_MAX ci-dessus est
-#                           glibc-only, jemalloc l'ignore. Ce narenas est
-#                           le VRAI équivalent. Voir mesures 2026-05-19 :
-#                           +11 MB persistants après nav /dashboard/history,
-#                           imputables à la rétention multi-arena.
-#   dirty_decay_ms:1000   — pages dirty rendues après 1 s (vs 10 s)
+# Objectif : rendre les pages au kernel rapidement pour que le RSS
+# redescende après chaque pic, sans high-water mark.
+#   dirty_decay_ms:1000   — pages dirty rendues après 1 s (vs 10 s par défaut)
 #   muzzy_decay_ms:0      — pages muzzy rendues IMMÉDIATEMENT
 #   background_thread:true — un thread dédié fait le purging en arrière-plan
-# Effet : RSS retombe au baseline ~30-40 Mo après chaque burst, plus
-# de high-water mark.
-Environment=_RJEM_MALLOC_CONF=narenas:2,dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true
+#
+# ⚠ narenas:2 RETIRÉ (2026-06). L'investigation §9.1 a mesuré que limiter
+# à 2 arenas EMPIRE la rétention sous concurrence (le runtime tokio + le
+# thread writer redb + le background_thread jemalloc se disputent 2 arenas →
+# fragmentation accrue, ~7-8 MB/h « pire »). On laisse jemalloc choisir le
+# nombre d'arenas (défaut = 4×N_CPU). Le diagnostic fuite-vs-rétention se
+# fait désormais via le dashboard Grafana « 21 - Mémoire daly-bms »
+# (process_jemalloc_allocated_bytes vs process_jemalloc_resident_bytes).
+Environment=_RJEM_MALLOC_CONF=dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true
 
 ExecStart=/usr/local/bin/daly-bms-server
 

--- a/crates/daly-bms-server/src/redb_writes.rs
+++ b/crates/daly-bms-server/src/redb_writes.rs
@@ -54,6 +54,14 @@ impl RateLimiter {
         Self::default()
     }
 
+    /// Garde-fou anti-cardinalité. La map est keyée par `metric:labels` ; une
+    /// source à cardinalité non bornée (ex: noms de process transitoires
+    /// `kworker/…`, `ps`, jobs cron) la ferait croître sans limite en heap
+    /// anonyme. Au-delà de ce seuil on purge tout le suivi (conséquence
+    /// bénigne : une rafale d'écritures autorisées le temps que le rate-limit
+    /// se re-remplisse). Nos séries légitimes se comptent en centaines.
+    const MAX_KEYS: usize = 16_384;
+
     /// Retourne `true` si l'écriture est autorisée (et marque le timestamp).
     ///
     /// `get_mut` + mise à jour en place : la `String` de la clé n'est allouée
@@ -73,6 +81,9 @@ impl RateLimiter {
             *last = now;
             true
         } else {
+            if map.len() >= Self::MAX_KEYS {
+                map.clear();
+            }
             map.insert(key.to_string(), now);
             true
         }

--- a/crates/daly-bms-server/src/shelly/mqtt.rs
+++ b/crates/daly-bms-server/src/shelly/mqtt.rs
@@ -53,6 +53,13 @@ where
         cache.insert(dev.id, ShellyCache::default());
     }
 
+    // Tâche de polling périodique spawnée à chaque (re)connexion. On conserve
+    // son handle pour ABORTER la précédente avant d'en spawner une nouvelle :
+    // sans cela, chaque reconnexion MQTT laissait une tâche zombie qui tickait
+    // toutes les 30 s pour toujours sur un client mort (fuite de tâches +
+    // mémoire à chaque flap du broker — investigation RSS).
+    let mut poll_handle: Option<tokio::task::JoinHandle<()>> = None;
+
     loop {
         let mut opts = MqttOptions::new(
             format!("{}-{}", RPC_SRC, uuid::Uuid::new_v4()),
@@ -90,9 +97,14 @@ where
 
         // Tâche de polling périodique (30 s) via RPC Switch.GetStatus.
         // Permet d'obtenir l'état initial et de rafraîchir même sans changement d'état.
+        // Aborte la tâche de la connexion précédente avant d'en spawner une
+        // nouvelle (sinon fuite de tâches à chaque reconnexion).
+        if let Some(h) = poll_handle.take() {
+            h.abort();
+        }
         let poll_client  = client.clone();
         let poll_devices = devices.clone();
-        tokio::spawn(async move {
+        poll_handle = Some(tokio::spawn(async move {
             let mut ticker = tokio::time::interval(Duration::from_secs(30));
             loop {
                 ticker.tick().await;
@@ -114,7 +126,7 @@ where
                     }
                 }
             }
-        });
+        }));
 
         loop {
             match eventloop.poll().await {


### PR DESCRIPTION
Audit approfondi suite à RSS 37→102 Mo en 12 h (~5,4 MB/h). Trois causes réelles de croissance corrigées :

1. **Fuite de tâches Shelly** — la tâche de polling 30 s était spawnée *dans* la boucle de reconnexion ; chaque reconnexion MQTT laissait une tâche zombie. Désormais abortée avant respawn.
2. **RateLimiter non borné** — keyé par `metric:labels`, il reçoit des noms de process transitoires (`kworker/…`, `ps`) via `pi5_process_*` → croissance heap anonyme. Garde-fou `MAX_KEYS=16384`.
3. **`narenas:2` retiré** du `_RJEM_MALLOC_CONF` — l'investigation §9.1 avait mesuré que 2 arenas EMPIRE la rétention sous concurrence.

⚠ Ces correctifs sont réels mais ne remplacent pas le diagnostic runtime (dashboard Grafana 21 : `process_jemalloc_allocated_bytes` vs `resident`). Validation terrain requise.

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_