### PR TITLE
feat(diag): heap profiling jemalloc pour localiser la fuite RSS (phase E)

### DIFF
--- a/crates/daly-bms-server/Cargo.toml
+++ b/crates/daly-bms-server/Cargo.toml
@@ -52,8 +52,16 @@ tokio-metrics = { workspace = true }
 # fragmentation glibc confirmée. Switch jemalloc résoud le problème
 # sans appel manuel à trim.
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-# Feature "stats" : compile jemalloc avec --enable-stats (requis par le ctl).
-tikv-jemallocator = { version = "0.6", features = ["stats"] }
+# Features jemalloc :
+#  - "stats"     : compile avec --enable-stats (requis par le ctl ; dashboard 21).
+#  - "profiling" : compile avec --enable-prof → permet le heap profiling
+#                  (jeprof) pour localiser une fuite applicative au call-stack
+#                  près. COÛT NUL tant que prof n'est pas activé au runtime
+#                  (défaut prof:false). On l'active à la demande via un drop-in
+#                  systemd `_RJEM_MALLOC_CONF=prof:true,…` (cf.
+#                  docs/diagnostic-depannage.md §18) — sans rebuild ni écart
+#                  à la procédure `make sync && deploy-pi5.sh`.
+tikv-jemallocator = { version = "0.6", features = ["stats", "profiling"] }
 # Introspection jemalloc (stats.allocated/active/resident/mapped/retained)
 # exportée toutes les 30 s dans metrics-store par l'agent monitor →
 # dashboard Grafana « 21 - Mémoire daly-bms ». Permet de distinguer une

--- a/crates/daly-bms-server/src/monitor.rs
+++ b/crates/daly-bms-server/src/monitor.rs
@@ -62,8 +62,46 @@ pub async fn run_monitor_agent(state: AppState) {
         // distinguer fuite applicative (allocated croît) et rétention
         // allocateur (resident/RSS croissent, allocated plat).
         write_process_memory_metrics(&state).await;
+
+        // Heap profiling jemalloc à la demande (investigation fuite §18) :
+        // si `DALY_JEMALLOC_PROF=1` ET jemalloc compilé+activé avec prof, dump
+        // un profil toutes les ~5 min dans /tmp/jeprof.<ts>.heap. Diff de deux
+        // dumps via `jeprof` = call-stack exact de ce qui croît. No-op (et
+        // silencieux) en exploitation normale.
+        maybe_dump_jemalloc_profile();
     }
 }
+
+/// Dump périodique d'un profil heap jemalloc, gardé par `DALY_JEMALLOC_PROF`.
+/// Nécessite un binaire compilé avec la feature `profiling` (--enable-prof)
+/// ET `prof:true,prof_active:true` dans `_RJEM_MALLOC_CONF`. Dump 1 tick sur
+/// 10 (~5 min à 30 s/tick).
+#[cfg(not(target_env = "msvc"))]
+fn maybe_dump_jemalloc_profile() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static TICK: AtomicU64 = AtomicU64::new(0);
+
+    if std::env::var_os("DALY_JEMALLOC_PROF").is_none() {
+        return;
+    }
+    let n = TICK.fetch_add(1, Ordering::Relaxed);
+    if !n.is_multiple_of(10) {
+        return;
+    }
+    let ts = Utc::now().format("%Y%m%dT%H%M%S");
+    let path = format!("/tmp/jeprof.{ts}.heap");
+    let Ok(cpath) = std::ffi::CString::new(path.clone()) else { return };
+    // mallctl("prof.dump", NULL, NULL, &filename, sizeof(ptr)).
+    // Échoue proprement (ENOENT) si le binaire n'a pas prof compilé/activé.
+    let res = unsafe { tikv_jemalloc_ctl::raw::write(b"prof.dump\0", cpath.as_ptr()) };
+    match res {
+        Ok(()) => info!(profile = %path, "jemalloc heap profile écrit"),
+        Err(e) => warn!(error = %e, "jemalloc prof.dump a échoué (prof non activé ?)"),
+    }
+}
+
+#[cfg(target_env = "msvc")]
+fn maybe_dump_jemalloc_profile() {}
 
 // =============================================================================
 // Auto-télémétrie mémoire du process (RSS + jemalloc)

--- a/docs/diagnostic-depannage.md
+++ b/docs/diagnostic-depannage.md
@@ -55,6 +55,7 @@
   - [§15 Status final — investigation close](#15-status-final--investigation-close)
   - [§16 Phase C (commit 018e363) — axum 0.7 → 0.8](#16-phase-c-commit-018e363--axum-07--08)
   - [§17 Phase D (2026-06) — root cause du résiduel : trafic HTTP passif 1 Hz](#17-phase-d-2026-06--root-cause-du-residuel--trafic-http-passif-1-hz)
+  - [§18 Phase E (2026-06-13) — la fuite est une VRAIE fuite heap](#18-phase-e-2026-06-13--la-fuite-est-une-vraie-fuite-heap-mesures-terrain)
 - [Voir aussi](#voir-aussi)
 - [Sources consolidées](#sources-consolidees)
 
@@ -1451,6 +1452,85 @@ soit ~3,6 % de l'ancien débit.
 
 Correctifs livrés sur branche `claude/quirky-galileo-qvn74g`. Validation
 terrain (étapes ci-dessus) à faire après déploiement Pi5.
+
+---
+
+### §18 Phase E (2026-06-13) — la fuite est une VRAIE fuite heap (mesures terrain)
+
+#### §18.1 — Mesures décisives
+
+Binaire phase D confirmé en place (`strings … | grep dashboard/history = 0`,
+métrique `process_jemalloc_allocated_bytes` présente). RSS 37 → ~100 Mo en
+~12 h (≈ 3,7 MB/h). `smaps_rollup` + stats jemalloc :
+
+| Métrique | Valeur | Lecture |
+|----------|--------|---------|
+| `Rss` | 100 704 kB | — |
+| `Anonymous` / `Private_Dirty` | 90 016 kB | **tout est en heap anonyme** |
+| `Pss_File` | 9 046 kB | mmap/redb négligeable, **pas** la cause |
+| jemalloc `allocated` | 70,5 Mo | **mémoire VIVANTE réellement détenue** |
+| séries redb | 1 036 | pas d'explosion de cardinalité |
+| fichier redb | 3,8 Go | problème disque séparé (voir §18.4) |
+
+Conclusion sans ambiguïté : `allocated` (70 Mo) ≈ `Anonymous` (90 Mo) ⇒ ce
+n'est **ni** de la rétention allocateur (sinon `allocated` ≪ `resident`),
+**ni** du mmap redb (`Pss_File` minuscule), **ni** de la cardinalité (1 036
+séries). C'est une **vraie fuite applicative/dépendance** : du code retient
+des allocations vivantes, libérées seulement au restart. Le baseline bas
+après restart (37 Mo) avec la même base 3,8 Go montre que la croissance est
+une **accumulation runtime par opération**, pas un coût lié à la taille de la
+base.
+
+#### §18.2 — Candidats structurels éliminés par audit code
+
+- Aucune collection applicative non bornée (tous les `insert`/`push` sont
+  keyés par identifiants stables ou des `Vec` locaux transitoires).
+- Pas de transaction redb en lecture longue-durée (les `OnceCell<ReadTransaction>`
+  de l'`Evaluator` sont par-requête ; aucun reader ne pin la MVCC).
+- Corrigés au passage (réels mais marginaux) : fuite de tâches Shelly à
+  chaque reconnexion, `RateLimiter` non borné (noms de process transitoires),
+  `narenas:2` (rétention pire — retiré). Cf. commit phase E.
+
+#### §18.3 — Localiser la fuite au call-stack : heap profiling jemalloc
+
+Le binaire est désormais compilé avec `--enable-prof` (feature `profiling`,
+coût nul tant qu'inactif). Procédure (sans rebuild, sans écart à
+`make sync && deploy-pi5.sh`) :
+
+```bash
+# 1. Activer le profiling via un drop-in systemd + le flag de dump périodique
+sudo systemctl edit daly-bms
+#   [Service]
+#   Environment=DALY_JEMALLOC_PROF=1
+#   Environment=_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true
+sudo systemctl restart daly-bms
+
+# 2. Laisser tourner ≥ 2-3 h. Des profils tombent dans /tmp/jeprof.<ts>.heap
+#    (~1 toutes les 5 min, via l'agent monitor).
+ls -la /tmp/jeprof.*.heap
+
+# 3. Installer jeprof si besoin
+sudo apt-get install -y libjemalloc-dev    # fournit /usr/bin/jeprof
+
+# 4. DIFF entre un profil ancien et un récent = ce qui a CRÛ (la fuite)
+jeprof --show_bytes --text \
+  --base=/tmp/jeprof.<ANCIEN>.heap \
+  /usr/local/bin/daly-bms-server /tmp/jeprof.<RECENT>.heap | head -40
+```
+
+Le haut du diff donne la pile d'allocation responsable (notre code vs
+tokio/hyper/rumqttc/redb). **Désactiver après diagnostic** :
+`sudo systemctl revert daly-bms && sudo systemctl restart daly-bms`.
+
+#### §18.4 — Base redb à 3,8 Go (problème disque distinct)
+
+`raw_retention_days = 30` à ~100 écritures/s remplit la table raw sur des Go.
+Ce n'est pas la fuite RSS (mmap non résident) mais c'est volumineux et
+ralentit les commits/compactions. Recommandé : baisser
+`raw_retention_days` (ex. 7) dans `Config.toml` — les tiers hourly/daily
+conservent l'historique long terme. ⚠ redb ne rétrécit pas le fichier
+automatiquement (réutilise l'espace libéré) ; pour récupérer le disque,
+compaction redb ou recréation de la base.
 
 ---
 


### PR DESCRIPTION
## Verdict (mesures terrain 13/06)
RSS 37→100 Mo en 12 h. `smaps_rollup` + stats jemalloc :
- `Anonymous`/`Private_Dirty` = 90 Mo, `Pss_File` = 9 Mo → **heap anonyme**, pas mmap.
- jemalloc `allocated` = 70 Mo → **mémoire vivante réellement détenue** ⇒ vraie fuite, pas de la rétention.
- 1036 séries redb → pas de cardinalité. Base redb = 3,8 Go (problème disque distinct).

Conclusion : **vraie fuite heap applicative/dépendance**. Audit code : aucune collection non bornée, aucun reader redb long-vécu.

## Cette PR
- Compile jemalloc avec `--enable-prof` (feature `profiling`, **coût nul** tant qu'inactif) → débloque le heap profiling `jeprof`, impossible jusqu'ici (§9.2 échouait car jemalloc n'avait pas `--enable-prof`).
- Agent monitor : dump périodique `/tmp/jeprof.<ts>.heap` gardé par `DALY_JEMALLOC_PROF=1` (no-op en prod).
- `docs §18` : verdict + procédure `jeprof` (diff de 2 profils = call-stack exact de la fuite), sans écart à `make sync && deploy-pi5.sh`.

Inclut aussi les 3 correctifs marginaux déjà mergés (Shelly tasks, RateLimiter, narenas) — déjà sur main via #594.

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_