### PR TITLE
feat(diag): script de profiling fuite heap (capture + restauration auto)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@
 | Healthcheck backend | `curl -s http://localhost:8080/-/healthy` |
 | Valider Config.toml avant déploiement | `DALY_CONFIG=Config.toml daly-bms-server --check-config` et `ENERGY_CONFIG=Config.toml energy-manager --check-config` (dry-run : parse + bornes + typos — audit 2026-06 §12) |
 | Diag pic réseau (capture immédiate) | `sudo bash scripts/netdiag.sh` |
+| Profiler une fuite RSS (heap jemalloc, auto-restauré) | `sudo bash scripts/jemalloc-leak-profile.sh 2h` → rapport `/tmp/jeprof/leak-report-*.txt` (cf. docs/diagnostic-depannage.md §18) |
 | Diag pic réseau (veille auto-capture) | `sudo bash scripts/netdiag.sh --watch` → rapport `/tmp/netdiag-*.txt` |
 | Logs energy-manager | `journalctl -u energy-manager -f` |
 | Compiler energy-manager | `make build-energy-arm` |

--- a/docs/diagnostic-depannage.md
+++ b/docs/diagnostic-depannage.md
@@ -1494,33 +1494,37 @@ base.
 #### §18.3 — Localiser la fuite au call-stack : heap profiling jemalloc
 
 Le binaire est désormais compilé avec `--enable-prof` (feature `profiling`,
-coût nul tant qu'inactif). Procédure (sans rebuild, sans écart à
-`make sync && deploy-pi5.sh`) :
+coût nul tant qu'inactif). **Tout est automatisé par un script unique** qui
+active le profiling, mesure, produit le rapport, et REMET la configuration
+normale à la fin (y compris si interrompu — Ctrl-C, déconnexion, erreur) :
 
 ```bash
-# 1. Activer le profiling via un drop-in systemd + le flag de dump périodique
-sudo systemctl edit daly-bms
-#   [Service]
-#   Environment=DALY_JEMALLOC_PROF=1
-#   Environment=_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true
-sudo systemctl restart daly-bms
+# Mesure 2 h par défaut (durée configurable : 30m, 3h, …)
+sudo bash scripts/jemalloc-leak-profile.sh 2h
 
-# 2. Laisser tourner ≥ 2-3 h. Des profils tombent dans /tmp/jeprof.<ts>.heap
-#    (~1 toutes les 5 min, via l'agent monitor).
-ls -la /tmp/jeprof.*.heap
-
-# 3. Installer jeprof si besoin
-sudo apt-get install -y libjemalloc-dev    # fournit /usr/bin/jeprof
-
-# 4. DIFF entre un profil ancien et un récent = ce qui a CRÛ (la fuite)
-jeprof --show_bytes --text \
-  --base=/tmp/jeprof.<ANCIEN>.heap \
-  /usr/local/bin/daly-bms-server /tmp/jeprof.<RECENT>.heap | head -40
+# Mesure longue sans garder le terminal ouvert :
+sudo tmux new -s prof 'bash scripts/jemalloc-leak-profile.sh 3h'
 ```
 
+Le script (`scripts/jemalloc-leak-profile.sh`) :
+1. vérifie que le binaire a le profiling compilé (sinon : déployer d'abord) ;
+2. installe `jeprof` au besoin (`libjemalloc-dev`) ;
+3. active le profiling via un drop-in systemd + redémarre `daly-bms` ;
+4. mesure (le service dumpe `/tmp/jeprof.*.heap` toutes les ~5 min) ;
+5. écrit un rapport `/tmp/jeprof/leak-report-*.txt` : le **diff** entre le
+   premier et le dernier profil = exactement ce qui a CRÛ (la fuite), au
+   call-stack près ;
+6. **rétablit** la config normale (profiling OFF) automatiquement.
+
 Le haut du diff donne la pile d'allocation responsable (notre code vs
-tokio/hyper/rumqttc/redb). **Désactiver après diagnostic** :
-`sudo systemctl revert daly-bms && sudo systemctl restart daly-bms`.
+tokio/hyper/rumqttc/redb) → c'est elle qu'on corrige.
+
+> Procédure manuelle équivalente (si besoin de piloter finement) : drop-in
+> `Environment=DALY_JEMALLOC_PROF=1` +
+> `Environment=_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,…`,
+> `systemctl restart daly-bms`, attendre, puis
+> `jeprof --show_bytes --text --base=<ancien> /usr/local/bin/daly-bms-server <récent>`.
+> Désactivation : `sudo systemctl revert daly-bms && sudo systemctl restart daly-bms`.
 
 #### §18.4 — Base redb à 3,8 Go (problème disque distinct)
 

--- a/scripts/jemalloc-leak-profile.sh
+++ b/scripts/jemalloc-leak-profile.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# =============================================================================
+# jemalloc-leak-profile.sh — capture automatisée d'un profil de fuite heap
+# pour daly-bms-server (investigation RSS, docs/diagnostic-depannage.md §18).
+#
+# Le script :
+#   1. vérifie que le binaire est compilé avec le profiling jemalloc,
+#   2. ACTIVE le profiling (drop-in systemd) et redémarre le service,
+#   3. mesure pendant une durée donnée (le service dumpe /tmp/jeprof.*.heap
+#      toutes les ~5 min via l'agent monitor),
+#   4. produit un rapport jeprof : le DIFF entre le 1er et le dernier profil
+#      = exactement ce qui a CRÛ (la fuite), au call-stack près,
+#   5. RÉTABLIT la configuration normale (profiling OFF) — y compris si le
+#      script est interrompu (Ctrl-C, déconnexion SSH, erreur).
+#
+# Usage :
+#   sudo bash scripts/jemalloc-leak-profile.sh [durée]
+#   durée : suffixes coreutils — 30m, 2h, 90s… (défaut : 2h)
+#
+# Pour une mesure longue sans garder le terminal ouvert :
+#   sudo tmux new -s prof 'bash scripts/jemalloc-leak-profile.sh 3h'
+# =============================================================================
+set -euo pipefail
+
+DURATION="${1:-2h}"
+SVC=daly-bms
+BIN=/usr/local/bin/daly-bms-server
+DROPIN_DIR="/etc/systemd/system/${SVC}.service.d"
+DROPIN="${DROPIN_DIR}/zz-jemalloc-prof.conf"
+OUTDIR=/tmp/jeprof
+HEAP_GLOB="/tmp/jeprof.*.heap"
+
+log() { printf '\033[1;34m[prof]\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m[prof]\033[0m %s\n' "$*" >&2; }
+
+if [ "$(id -u)" -ne 0 ]; then
+    err "À lancer avec sudo (modification de l'unité systemd)."
+    exit 1
+fi
+
+# --- Restauration garantie (succès, Ctrl-C, déconnexion, erreur) ------------
+RESTORED=0
+restore() {
+    [ "$RESTORED" -eq 1 ] && return
+    RESTORED=1
+    log "Restauration : profiling OFF + redémarrage normal de $SVC…"
+    rm -f "$DROPIN"
+    systemctl daemon-reload
+    systemctl restart "$SVC" || true
+    if systemctl is-active --quiet "$SVC"; then
+        log "$SVC redémarré en configuration normale (profiling désactivé)."
+    else
+        err "$SVC n'est pas actif après restauration — vérifie : journalctl -u $SVC -n 40"
+    fi
+}
+trap restore EXIT INT TERM HUP
+
+# --- 1. binaire compilé avec profiling ? ------------------------------------
+if ! strings "$BIN" 2>/dev/null | grep -q "prof.dump"; then
+    err "Le binaire $BIN n'a PAS le profiling jemalloc compilé."
+    err "Déploie la dernière version d'abord :  make sync && sudo bash scripts/deploy-pi5.sh"
+    exit 1
+fi
+
+# --- 2. jeprof disponible ? -------------------------------------------------
+if ! command -v jeprof >/dev/null 2>&1; then
+    log "jeprof absent — installation de libjemalloc-dev…"
+    apt-get update -qq && apt-get install -y libjemalloc-dev \
+        || { err "Échec installation de jeprof. Installe-le manuellement puis relance."; exit 1; }
+fi
+
+# --- 3. table rase des anciens profils --------------------------------------
+mkdir -p "$OUTDIR"
+# shellcheck disable=SC2086
+rm -f $HEAP_GLOB 2>/dev/null || true
+
+# --- 4. activer le profiling ------------------------------------------------
+log "Activation du profiling jemalloc (drop-in $DROPIN)…"
+mkdir -p "$DROPIN_DIR"
+cat > "$DROPIN" <<'EOF'
+[Service]
+Environment=DALY_JEMALLOC_PROF=1
+Environment=_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true
+EOF
+systemctl daemon-reload
+systemctl restart "$SVC"
+sleep 5
+if ! systemctl is-active --quiet "$SVC"; then
+    err "$SVC n'a pas redémarré avec le profiling :"
+    journalctl -u "$SVC" -n 30 --no-pager >&2 || true
+    exit 1
+fi
+log "Profiling actif. Mesure pendant $DURATION."
+log "Le service écrit un profil dans $HEAP_GLOB toutes les ~5 min."
+
+# --- 5. attendre la fenêtre de mesure ---------------------------------------
+sleep "$DURATION"
+
+# --- 6. analyse : diff premier → dernier profil -----------------------------
+mapfile -t HEAPS < <(ls -1tr $HEAP_GLOB 2>/dev/null || true)
+if [ "${#HEAPS[@]}" -lt 2 ]; then
+    err "Seulement ${#HEAPS[@]} profil(s) capturé(s) — il en faut ≥ 2."
+    err "Relance avec une durée plus longue (≥ 15m)."
+    exit 1
+fi
+FIRST="${HEAPS[0]}"
+LAST="${HEAPS[-1]}"
+REPORT="$OUTDIR/leak-report-$(date +%Y%m%dT%H%M%S).txt"
+
+log "Analyse du diff : ${FIRST##*/}  →  ${LAST##*/}  (${#HEAPS[@]} profils)"
+{
+    echo "==================================================================="
+    echo " Rapport fuite heap — daly-bms-server"
+    echo " Date    : $(date)"
+    echo " Binaire : $BIN"
+    echo " Fenêtre : ${FIRST##*/} → ${LAST##*/} (${#HEAPS[@]} profils)"
+    echo "==================================================================="
+    echo
+    echo "### Allocations qui ont CRÛ pendant la fenêtre (= la fuite) ########"
+    echo "# (diff inuse_space, trié par octets décroissants)"
+    echo
+    jeprof --show_bytes --text --base="$FIRST" "$BIN" "$LAST" 2>/dev/null | head -40
+    echo
+    echo "### Top allocations vivantes au dernier profil (référence) #########"
+    echo
+    jeprof --show_bytes --text "$BIN" "$LAST" 2>/dev/null | head -25
+} | tee "$REPORT"
+
+# conserver les deux profils clés à côté du rapport
+cp -f "$FIRST" "$LAST" "$OUTDIR"/ 2>/dev/null || true
+log "Rapport écrit : $REPORT"
+log "Profils conservés dans $OUTDIR/ (à joindre si besoin d'analyse)."
+
+# restauration via trap EXIT


### PR DESCRIPTION
Automatise la capture d'un profil de fuite heap jemalloc en une commande, avec restauration garantie.

```bash
sudo bash scripts/jemalloc-leak-profile.sh 2h
```

Le script : vérifie le binaire (profiling compilé), installe `jeprof` au besoin, active le profiling via drop-in systemd + restart, mesure, produit `/tmp/jeprof/leak-report-*.txt` (diff 1er→dernier profil = call-stack de la fuite), puis **rétablit la config normale même en cas d'interruption** (trap EXIT/INT/TERM/HUP).

docs §18.3 + CLAUDE.md §0 mis à jour (procédure manuelle conservée en référence).

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_