### PR TITLE
fix(ops): restart fiable avec grosse base redb (TimeoutStart/Stop) + script profiling robuste

### DIFF
--- a/contrib/daly-bms.service
+++ b/contrib/daly-bms.service
@@ -86,9 +86,19 @@ RuntimeMaxSec=86400
 MemoryHigh=256M
 MemoryMax=512M
 
-# Arrêt : SIGTERM → arrêt gracieux (drain HTTP 10 s + flush metrics-store,
-# audit 2026-06 §5). 20 s laissent la marge avant SIGKILL.
-TimeoutStopSec=20
+# Arrêt : SIGTERM → arrêt gracieux (drain HTTP + flush metrics-store, audit
+# 2026-06 §5). 60 s : laisse le flush + commit final redb se terminer sur une
+# grosse base (3-4 Go) AVANT le SIGKILL. Sans cette marge, un SIGKILL en plein
+# commit laisse la base à rouvrir en RÉCUPÉRATION au démarrage suivant
+# (lent → dépasse TimeoutStartSec → boucle de restart en échec).
+TimeoutStopSec=60
+
+# Démarrage : READY=1 (Type=notify) n'est envoyé qu'APRÈS l'ouverture de
+# metrics-store (redb). Sur une grosse base — surtout après un arrêt non
+# gracieux nécessitant une récupération — l'ouverture peut prendre > 90 s
+# (défaut systemd). 300 s évitent que systemd tue un démarrage légitime mais
+# lent (ce qui aggraverait la corruption et créerait une boucle d'échec).
+TimeoutStartSec=300
 
 # Accès au port série RS485 (/dev/ttyUSB* ou /dev/ttyACM*)
 SupplementaryGroups=dialout

--- a/scripts/jemalloc-leak-profile.sh
+++ b/scripts/jemalloc-leak-profile.sh
@@ -89,12 +89,24 @@ cat > "$DROPIN" <<'EOF'
 [Service]
 Environment=DALY_JEMALLOC_PROF=1
 Environment=_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true
+# Marge de démarrage : l'ouverture de la base redb (grosse / récupération)
+# peut être lente, et READY n'est envoyé qu'après. Évite un kill systemd.
+TimeoutStartSec=300
 EOF
 systemctl daemon-reload
 systemctl restart "$SVC"
-sleep 5
-if ! systemctl is-active --quiet "$SVC"; then
-    err "$SVC n'a pas redémarré avec le profiling :"
+# Attendre que le service soit ACTIF (l'ouverture redb peut être lente — on
+# poll jusqu'à 300 s au lieu d'un sleep fixe).
+log "Attente du démarrage de $SVC (≤ 300 s)…"
+up=0
+for _ in $(seq 1 60); do
+    sleep 5
+    if systemctl is-active --quiet "$SVC"; then up=1; break; fi
+    # échec définitif (failed) → inutile d'attendre la fin du timeout
+    if systemctl is-failed --quiet "$SVC"; then break; fi
+done
+if [ "$up" -eq 0 ]; then
+    err "$SVC n'a pas démarré avec le profiling :"
     journalctl -u "$SVC" -n 30 --no-pager >&2 || true
     exit 1
 fi


### PR DESCRIPTION
Le `restart` de daly-bms échouait en boucle : base redb 3,8 Go + `TimeoutStopSec=20` → SIGKILL pendant le flush → réouverture en récupération → `READY` (envoyé après l'ouverture de metrics-store, main.rs:798) dépasse le `TimeoutStartSec` par défaut (90 s) → systemd re-tue → boucle.

- **contrib/daly-bms.service** : `TimeoutStopSec` 20→60 (flush + commit final propres → pas de récupération au boot) et `TimeoutStartSec=300` (tolère une ouverture redb lente). Protège aussi le restart quotidien `RuntimeMaxSec`.
- **scripts/jemalloc-leak-profile.sh** : drop-in avec `TimeoutStartSec=300` ; poll de l'état actif jusqu'à 300 s au lieu d'un `sleep 5` fixe.

`deploy-pi5.sh` applique l'unité (daemon-reload) **avant** le restart qu'il déclenche → le déploiement de ce fix est sûr.

À suivre (problème distinct) : réduire `raw_retention_days` pour rétrécir la base.

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_