### PR TITLE
fix(diag): profils heap invisibles (PrivateTmp) — drop-in PrivateTmp=false

### DIFF
--- a/scripts/jemalloc-leak-profile.sh
+++ b/scripts/jemalloc-leak-profile.sh
@@ -92,6 +92,11 @@ Environment=_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,dirty
 # Marge de démarrage : l'ouverture de la base redb (grosse / récupération)
 # peut être lente, et READY n'est envoyé qu'après. Évite un kill systemd.
 TimeoutStartSec=300
+# CRUCIAL : sans cela, l'unité a PrivateTmp=true → le service écrit ses
+# profils dans un /tmp PRIVÉ (namespace), invisible depuis le vrai /tmp où ce
+# script les cherche. On désactive l'isolation /tmp le temps de la mesure ;
+# la restauration (retrait du drop-in) rétablit PrivateTmp=true.
+PrivateTmp=false
 EOF
 systemctl daemon-reload
 systemctl restart "$SVC"


### PR DESCRIPTION
`jemalloc-leak-profile.sh` concluait « aucun profil produit » alors que le profiling fonctionne : l'unité a `PrivateTmp=true`, donc le service écrit ses `/tmp/jeprof.*.heap` dans un **/tmp privé** (namespace systemd), invisible depuis le vrai `/tmp` où le script les cherche.

Fix : le drop-in du script ajoute `PrivateTmp=false` le temps de la mesure ; la restauration (retrait du drop-in) rétablit `PrivateTmp=true`. Aucun rebuild du binaire (le profiling est déjà déployé et actif). Seul `PrivateTmp` bloquait — aucune autre directive de sandbox (pas de ProtectSystem/ReadOnlyPaths).

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_