### PR TITLE
fix(deploy): extraction config robuste (awk) + auto-diagnostic profiling

### DIFF
--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -146,8 +146,7 @@ fi
 if [[ -f "$CONF" ]]; then
     # Port série vide → auto-détection qui échoue si le BMS tarde. Port fixe ici.
     step "Vérification port série…"
-    SERIAL_PORT=$(awk '/^\[serial\]/,/^\[/' "$CONF" \
-        | grep -E '^port' | sed -E 's/.*=\s*"([^"]*)".*/\1/' | head -1 || true)
+    SERIAL_PORT=$(awk -F'"' '/^\[serial\]/{s=1;next} /^\[/{s=0} s&&/^[[:space:]]*port[[:space:]]*=/{print $2;exit}' "$CONF" || true)
     if [[ -z "$SERIAL_PORT" ]]; then
         if $DRY_RUN; then warn "[dry-run] [serial].port vide → serait forcé à /dev/ttyUSB0"
         else
@@ -163,8 +162,7 @@ if [[ -f "$CONF" ]]; then
     # metrics-store = seule TSDB de lecture ; désactivée par accident = dashboards vides.
     step "Vérification config critique (metrics_store)…"
     grep -q '^\[metrics_store\]' "$CONF" || error "Section [metrics_store] absente de $CONF — éditer manuellement"
-    METRICS_ENABLED=$(awk '/^\[metrics_store\]/,/^\[/' "$CONF" \
-        | grep -E '^enabled' | sed -E 's/.*=\s*(true|false).*/\1/' | head -1 || true)
+    METRICS_ENABLED=$(awk '/^\[metrics_store\]/{s=1;next} /^\[/{s=0} s&&/^[[:space:]]*enabled[[:space:]]*=/{print $3;exit}' "$CONF" || true)
     if [[ "$METRICS_ENABLED" != "true" ]]; then
         if $DRY_RUN; then warn "[dry-run] [metrics_store].enabled='$METRICS_ENABLED' → serait forcé à true"
         else
@@ -180,7 +178,7 @@ if [[ -f "$CONF" ]]; then
     fi
 
     # db_path : parent doit exister et appartenir à l'utilisateur du service.
-    DB_PATH=$(grep -E '^db_path' "$CONF" | sed -E 's/.*=\s*"([^"]+)".*/\1/' | head -1 || true)
+    DB_PATH=$(awk -F'"' '/^[[:space:]]*db_path[[:space:]]*=/{print $2;exit}' "$CONF" || true)
     DB_PATH="${DB_PATH:-/mnt/nvme/daly-bms/metrics.redb}"
     DB_DIR=$(dirname "$DB_PATH")
     DALY_USER=$(systemctl show daly-bms --property=User --value 2>/dev/null || echo dalybms)

--- a/scripts/jemalloc-leak-profile.sh
+++ b/scripts/jemalloc-leak-profile.sh
@@ -128,10 +128,19 @@ for _ in $(seq 1 30); do
     if ls $HEAP_GLOB >/dev/null 2>&1; then first_ok=1; break; fi
 done
 if [ "$first_ok" -eq 0 ]; then
-    err "Aucun profil produit après activation → le profiling jemalloc n'est"
-    err "pas actif dans le binaire déployé. Redéploie la dernière version :"
-    err "  make sync && sudo bash scripts/deploy-pi5.sh"
-    err "Indice : journalctl -u $SVC -n 20 | grep -i prof"
+    err "Aucun profil produit après activation. Diagnostic automatique :"
+    err "── 1) logs de dump du service (prof.dump réussi ou échoué ?) ──"
+    journalctl -u "$SVC" --since "5 min ago" --no-pager 2>/dev/null \
+        | grep -i "prof\|jemalloc" | tail -15 >&2 || true
+    err "── 2) profils écrits quelque part (y compris /tmp privé) ? ──"
+    find /tmp /var/lib/daly-bms -name 'jeprof.*.heap' 2>/dev/null >&2 || true
+    err "── 3) le binaire a-t-il vraiment --enable-prof ? (opt.prof, doit être >0) ──"
+    grep -ac 'opt.prof' "$BIN" >&2 || true
+    err "──────────────────────────────────────────────────────────────"
+    err "Interprétation :"
+    err " • 'prof.dump a échoué' OU (3)=0  → build ARM sans --enable-prof effectif."
+    err " • 'heap profile écrit' + (2) trouve des fichiers → souci de chemin/visibilité."
+    err " • (1) vide → l'agent monitor ne tourne pas / DALY_JEMALLOC_PROF non vu."
     exit 1
 fi
 log "Profiling confirmé (1er profil capturé). Mesure pendant $DURATION…"


### PR DESCRIPTION
Suite au déploiement qui passe enfin : nettoyage des effets de bord.

- **deploy-pi5.sh** : les 3 extractions de config `… | head -1` (rendues non-fatales par `|| true` au commit précédent) renvoyaient vide quand le SIGPIPE frappait → fausses « réparations » (serial.port vide / metrics_store.enabled='') + restarts inutiles. Remplacées par un `awk` unique avec `exit` (impossible de SIGPIPE). Vérifié localement.
- **jemalloc-leak-profile.sh** : en cas d'absence de profil, affiche maintenant le diagnostic automatiquement (logs `prof.dump`, recherche des `.heap` partout, présence de `opt.prof` dans le binaire) → plus d'aller-retour pour savoir pourquoi.

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_