### PR TITLE
feat(metrics): compaction redb hors-ligne (réduit le fichier, garde l'historique)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 | Déployer binaire Pi5 | `sudo systemctl stop daly-bms && sudo cp target/aarch64-unknown-linux-gnu/release/daly-bms-server /usr/local/bin/ && sudo systemctl start daly-bms` |
 | Broker MQTT (status/logs) | `systemctl status mosquitto-broker` / `journalctl -u mosquitto-broker -f` |
 | Taille base redb | `du -sh /mnt/nvme/daly-bms/metrics.redb` |
+| Compacter la base redb (réduit le fichier, garde l'historique ; service arrêté pdt l'op) | `sudo bash scripts/compact-redb.sh 7` (abaisse raw_retention_days à 7 + tiering + compaction physique) |
 | Nettoyer disque (build) | `rm -rf target/armv7-unknown-linux-gnueabihf target/debug target/release && rm -rf ~/.cargo/registry/cache ~/.cargo/registry/src && sudo apt-get clean` (≈ -2,6 G ; garde `target/aarch64`). Reset total : `cargo clean` |
 | Nb séries en base | `curl -s http://localhost:8080/api/v1/redb/series \| jq '.data \| length'` |
 | Healthcheck backend | `curl -s http://localhost:8080/-/healthy` |

--- a/Config.toml
+++ b/Config.toml
@@ -420,7 +420,10 @@ cache_mb = 16
 queue_depth = 10000
 # Intervalle de la passe de compaction tiered (heures, 0 = désactivé).
 maintenance_interval_hours = 6
-raw_retention_days = 30
+# Données brutes (pleine résolution) conservées 7 j ; au-delà, agrégation
+# horaire/journalière (historique préservé à résolution réduite). 30 j de raw
+# faisaient grossir la base à plusieurs Go → démarrages lents (cf. scripts/compact-redb.sh).
+raw_retention_days = 7
 hourly_retention_days = 365
 daily_retention_days = 1825   # 5 ans
 

--- a/crates/daly-bms-server/src/main.rs
+++ b/crates/daly-bms-server/src/main.rs
@@ -129,6 +129,9 @@ struct ServerArgs {
     /// `--check-config` : valide la config (parse + bornes) puis sort —
     /// dry-run pour CI/déploiement (audit 2026-06 §12).
     check_config: bool,
+    /// `--compact-db` : compacte la base redb hors-ligne (tiering + compaction
+    /// physique) puis sort. À lancer service ARRÊTÉ (redb mono-process).
+    compact_db: bool,
 }
 
 impl ServerArgs {
@@ -145,8 +148,9 @@ impl ServerArgs {
             .unwrap_or_default();
 
         let check_config = args.iter().any(|a| a == "--check-config");
+        let compact_db   = args.iter().any(|a| a == "--compact-db");
 
-        Self { port, bms_addrs, check_config }
+        Self { port, bms_addrs, check_config, compact_db }
     }
 
     fn parse_addresses(s: &str) -> Vec<u8> {
@@ -250,6 +254,34 @@ async fn main() -> anyhow::Result<()> {
             return Ok(());
         }
         anyhow::bail!("--check-config : aucun fichier de config trouvé");
+    }
+
+    // `--compact-db` : compaction hors-ligne de la base redb puis sortie.
+    // À lancer service ARRÊTÉ (redb mono-process) — sinon "Database already open".
+    if args.compact_db {
+        let db_path = std::path::PathBuf::from(&config.metrics_store.db_path);
+        let policy = metrics_store::TierPolicy {
+            raw_retention_days:    config.metrics_store.raw_retention_days,
+            hourly_retention_days: config.metrics_store.hourly_retention_days,
+            daily_retention_days:  config.metrics_store.daily_retention_days,
+        };
+        println!(
+            "Compaction de {} (raw_retention_days={})…",
+            db_path.display(), policy.raw_retention_days
+        );
+        let r = metrics_store::compact_database(&db_path, &policy)?;
+        let mb = |b: u64| b as f64 / 1_048_576.0;
+        println!(
+            "Tiering : {} buckets écrits, {} points purgés.",
+            r.tiering.buckets_written, r.tiering.points_purged
+        );
+        println!(
+            "Fichier : {:.0} Mo → {:.0} Mo (récupéré {:.0} Mo, compaction physique : {}).",
+            mb(r.bytes_before), mb(r.bytes_after),
+            mb(r.bytes_before.saturating_sub(r.bytes_after)),
+            if r.physically_compacted { "oui" } else { "non" }
+        );
+        return Ok(());
     }
 
     // ── Flags d'auto-détection ────────────────────────────────────────────────

--- a/crates/metrics-store/src/lib.rs
+++ b/crates/metrics-store/src/lib.rs
@@ -252,6 +252,60 @@ impl MetricsStore {
     }
 }
 
+/// Rapport d'une compaction hors-ligne ([`compact_database`]).
+#[derive(Debug, Clone, Copy)]
+pub struct CompactionReport {
+    pub bytes_before: u64,
+    pub bytes_after: u64,
+    /// Stats de la passe de tiering (buckets écrits + points purgés).
+    pub tiering: tiering::CompactionStats,
+    /// `true` si la compaction physique redb a effectivement réécrit le fichier.
+    pub physically_compacted: bool,
+}
+
+/// Compaction COMPLÈTE d'une base redb **hors-ligne** (le service ne doit PAS
+/// tourner — redb est mono-process). Deux phases :
+///
+/// 1. **Tiering** ([`MetricsStore::compact_now`]) : purge `raw → hourly → daily`
+///    selon `policy`. Les données brutes plus vieilles que `raw_retention_days`
+///    deviennent des agrégats horaires (l'historique long terme est CONSERVÉ,
+///    à résolution réduite). Cela libère des pages *logiquement*.
+/// 2. **Compaction physique** (`redb::Database::compact`, en boucle jusqu'à
+///    `false`) : réécrit le fichier sans les pages libres → le fichier
+///    rétrécit réellement sur le disque.
+///
+/// Sans la phase 1, la phase 2 ne récupère que l'espace déjà libre ; c'est la
+/// phase 1 qui réduit le volume de données brutes.
+pub fn compact_database(db_path: &Path, policy: &TierPolicy) -> Result<CompactionReport> {
+    let bytes_before = std::fs::metadata(db_path).map(|m| m.len()).unwrap_or(0);
+
+    // Phase 1 — tiering. Bloc fermé : le writer est joint et l'`Arc<Database>`
+    // libéré à la sortie du bloc, donc le fichier est entièrement relâché
+    // avant la phase 2 (sinon `compact` échouerait, base déjà ouverte).
+    let tiering = {
+        let store = MetricsStore::open(db_path, Options::default())?;
+        let stats = store.compact_now(policy)?;
+        store.shutdown();
+        stats
+    };
+
+    // Phase 2 — compaction physique (accès exclusif). `compact()` renvoie
+    // `true` tant qu'une passe supplémentaire est possible ; on itère (borné).
+    let mut db = Builder::new().create(db_path)?;
+    let mut physically_compacted = false;
+    for _ in 0..16 {
+        match db.compact() {
+            Ok(true) => physically_compacted = true,
+            Ok(false) => break,
+            Err(e) => return Err(anyhow::anyhow!("redb compact: {e}")),
+        }
+    }
+    drop(db);
+
+    let bytes_after = std::fs::metadata(db_path).map(|m| m.len()).unwrap_or(0);
+    Ok(CompactionReport { bytes_before, bytes_after, tiering, physically_compacted })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/scripts/compact-redb.sh
+++ b/scripts/compact-redb.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# =============================================================================
+# compact-redb.sh — compaction hors-ligne de la base metrics-store (redb).
+#
+# Réduit la taille de /mnt/nvme/daly-bms/metrics.redb SANS perdre l'historique :
+#   1. abaisse raw_retention_days dans la config (les données brutes anciennes
+#      seront agrégées en horaires/journaliers — historique conservé) ;
+#   2. arrête daly-bms (redb est mono-process) ;
+#   3. lance `daly-bms-server --compact-db` (tiering + compaction physique) ;
+#   4. redémarre daly-bms — y compris si le script est interrompu (trap).
+#
+# Usage : sudo bash scripts/compact-redb.sh [raw_retention_days]   (défaut : 7)
+#
+# ⚠ Pendant la compaction (quelques minutes sur une grosse base), daly-bms est
+#   ARRÊTÉ : pas de collecte BMS/MQTT durant cette fenêtre.
+# =============================================================================
+set -euo pipefail
+
+RAW_DAYS="${1:-7}"
+SVC=daly-bms
+BIN=/usr/local/bin/daly-bms-server
+CONF=/etc/daly-bms/config.toml
+DALY_USER=$(systemctl show "$SVC" --property=User --value 2>/dev/null || echo dalybms)
+DALY_USER="${DALY_USER:-dalybms}"
+
+log() { printf '\033[1;34m[compact]\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m[compact]\033[0m %s\n' "$*" >&2; }
+
+[ "$(id -u)" -eq 0 ] || { err "À lancer avec sudo."; exit 1; }
+[ -f "$CONF" ] || { err "Config introuvable : $CONF"; exit 1; }
+
+# Le binaire doit supporter --compact-db (grep -c, jamais grep -q sous pipefail).
+if [ "$(strings "$BIN" 2>/dev/null | grep -c 'compact-db' || true)" -eq 0 ]; then
+    err "Le binaire déployé ne supporte pas --compact-db."
+    err "Déploie d'abord : make sync && sudo bash scripts/deploy-pi5.sh"
+    exit 1
+fi
+
+# Redémarrage garanti du service quoi qu'il arrive.
+STOPPED=0
+restart_svc() {
+    [ "$STOPPED" -eq 1 ] || return 0
+    log "Redémarrage de $SVC…"
+    systemctl start "$SVC" || true
+    for _ in $(seq 1 60); do
+        systemctl is-active --quiet "$SVC" && { log "$SVC actif."; return 0; }
+        systemctl is-failed --quiet "$SVC" && break
+        sleep 5
+    done
+    err "$SVC n'est pas actif — vérifie : journalctl -u $SVC -n 40"
+}
+trap restart_svc EXIT INT TERM HUP
+
+# 1. Abaisser raw_retention_days (persistant), avec backup.
+CURRENT=$(awk '/^\[metrics_store\]/{s=1;next} /^\[/{s=0} s&&/^[[:space:]]*raw_retention_days[[:space:]]*=/{print $3;exit}' "$CONF" || true)
+if [ "${CURRENT:-}" != "$RAW_DAYS" ]; then
+    BACKUP="$CONF.before-compact-$(date +%Y%m%d_%H%M%S)"
+    cp "$CONF" "$BACKUP"
+    sed -i "s/^\([[:space:]]*raw_retention_days[[:space:]]*=[[:space:]]*\).*/\1$RAW_DAYS/" "$CONF"
+    log "raw_retention_days : ${CURRENT:-?} → $RAW_DAYS (backup → $BACKUP)"
+else
+    log "raw_retention_days déjà à $RAW_DAYS"
+fi
+
+# 2. Arrêt du service (libère la base pour un accès exclusif).
+log "Arrêt de $SVC (redb mono-process)…"
+systemctl stop "$SVC"
+STOPPED=1
+sleep 3
+
+# 3. Compaction (peut durer plusieurs minutes).
+log "Compaction en cours (tiering + compaction physique)… patiente."
+if sudo -u "$DALY_USER" env DALY_CONFIG="$CONF" "$BIN" --compact-db; then
+    log "Compaction terminée."
+else
+    err "Compaction en échec — le service va être redémarré tel quel."
+fi
+
+# 4. Redémarrage via le trap EXIT.


### PR DESCRIPTION
Réduit la base redb de 3,8 Go (cause des démarrages lents) **en conservant l'historique**.

- `metrics-store::compact_database()` : phase 1 tiering (raw > rétention → agrégats horaires/journaliers, historique préservé à résolution réduite) puis phase 2 compaction physique redb (`Database::compact` en boucle) → le fichier rétrécit réellement.
- `daly-bms-server --compact-db` : compaction hors-ligne puis sortie (lit `db_path` + rétention depuis la config). Service arrêté requis (redb mono-process).
- `scripts/compact-redb.sh [jours=7]` : abaisse `raw_retention_days` (backup), arrête daly-bms, compacte, redémarre (restart garanti par trap EXIT/INT/TERM/HUP).
- `Config.toml` : `raw_retention_days` 30 → 7.

Usage Pi5 : `make sync && sudo bash scripts/deploy-pi5.sh` (déploie le binaire avec `--compact-db`), puis `sudo bash scripts/compact-redb.sh 7`.

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_