### PR TITLE
feat(build): profil release-symbols pour symboliser les profils jeprof

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,17 @@ debug = true                     # Garde les symboles pour perf
 strip = "none"                   # Ne pas strip pour le profiling
 panic = "unwind"                 # Permet backtrace pour debug
 
+# Profile de SYMBOLISATION des profils jemalloc/jeprof.
+# IDENTIQUE à `release` (mêmes lto=fat, panic=abort, codegen-units, opt) — donc
+# le code (.text) est byte-à-byte le même que le binaire déployé — mais on
+# garde la table de symboles + les line-tables DWARF. Permet de résoudre les
+# adresses des .heap déjà capturés (issus du binaire release strippé) SANS
+# re-profiler : `jeprof <binaire-release-symbols> <heap>`.
+[profile.release-symbols]
+inherits = "release"
+strip = "none"
+debug = 1                        # line-tables (suffit pour addr2line/jeprof)
+
 # Profile "size" si espace disque critique (optionnel)
 [profile.release-size]
 inherits = "release"

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,17 @@ build-arm: check-arm-deps
 	@echo "✓ Binaire ARM optimisé Pi5 : $(ARM_RELEASE_DIR)/$(BINARY)"
 	@ls -lh $(ARM_RELEASE_DIR)/$(BINARY) 2>/dev/null || true
 
+# Build ARM64 SYMBOLISÉ pour jeprof — mêmes flags que build-arm (donc même
+# .text que le binaire déployé) + symboles conservés. NE PAS déployer : sert
+# uniquement à résoudre les adresses des profils heap jemalloc déjà capturés :
+#   jeprof --text --base=<ancien>.heap \
+#     target/aarch64-unknown-linux-gnu/release-symbols/daly-bms-server <recent>.heap
+build-arm-symbols: check-arm-deps
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(CROSS_LINKER_GNU) \
+	RUSTFLAGS="$(ARM_RUSTFLAGS)" \
+	$(CARGO) build --profile release-symbols --target $(TARGET_ARM) --bin $(BINARY)
+	@echo "✓ Binaire ARM symbolisé (NE PAS déployer) : target/$(TARGET_ARM)/release-symbols/$(BINARY)"
+
 # Build ARM64 avec symboles pour profiling (perf/flamegraph)
 build-arm-debug: check-arm-deps
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(CROSS_LINKER_GNU) \


### PR DESCRIPTION
Le binaire release est strippé (`strip="symbols"`) → jeprof affiche `?? ??:0` (rapport de fuite sans noms de fonctions).

Nouveau profil `release-symbols` : hérite de `release` (mêmes `lto=fat`, `panic=abort`, `codegen-units=1`, `opt-level=3` → **.text identique au binaire déployé**) mais garde la table de symboles + line-tables (`debug=1`). Permet de **résoudre les adresses des `.heap` déjà capturés** sans re-profiler 3 h.

Cible Makefile `build-arm-symbols` (mêmes RUSTFLAGS que `build-arm`, donc même codegen).

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_