### PR TITLE
fix(mem): plancher d'écriture redb configurable (défaut 30s) — fuite ÷6

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -426,6 +426,12 @@ maintenance_interval_hours = 6
 raw_retention_days = 7
 hourly_retention_days = 365
 daily_retention_days = 1825   # 5 ans
+# Plancher global d'écriture redb (secondes) : une série est écrite au plus 1×
+# par cet intervalle. 30 = défaut (le débit de commits redb dominait la
+# croissance RSS — profiling 2026-06-14). RETOUR ARRIÈRE résolution fine :
+# mettre 5, puis `sudo cp Config.toml /etc/daly-bms/config.toml && sudo systemctl
+# restart daly-bms` (pas de recompilation). Cf. docs/diagnostic-depannage.md §18.
+raw_write_interval_secs = 30
 
 
 [alerts]

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -527,6 +527,13 @@ pub struct MetricsStoreConfig {
     /// requête à step minuscule peut allouer sans limite — OOM du Pi).
     #[serde(default = "default_metrics_query_max_points")]
     pub query_max_points: i64,
+    /// Plancher global d'écriture redb en secondes (défaut 30). Une série n'est
+    /// écrite au plus qu'une fois par cet intervalle (relevé au-dessus des
+    /// planchers par tier). Réduire le débit de commits redb a réduit la
+    /// croissance RSS (profiling 2026-06-14). Mettre 5 pour retrouver la
+    /// résolution fine d'avant (cf. docs/diagnostic-depannage.md §18).
+    #[serde(default = "default_metrics_write_interval_secs")]
+    pub raw_write_interval_secs: u64,
 }
 
 fn default_metrics_db_path() -> String { "/mnt/nvme/daly-bms/metrics.redb".into() }
@@ -538,6 +545,7 @@ fn default_metrics_hourly_days() -> u32 { 365 }
 fn default_metrics_daily_days() -> u32 { 5 * 365 }
 fn default_metrics_query_backend() -> String { "redb".into() }
 fn default_metrics_query_max_points() -> i64 { metrics_store::promql::DEFAULT_MAX_RANGE_POINTS }
+fn default_metrics_write_interval_secs() -> u64 { 30 }
 
 impl Default for MetricsStoreConfig {
     fn default() -> Self {
@@ -552,6 +560,7 @@ impl Default for MetricsStoreConfig {
             daily_retention_days: default_metrics_daily_days(),
             default_backend: default_metrics_query_backend(),
             query_max_points: default_metrics_query_max_points(),
+            raw_write_interval_secs: default_metrics_write_interval_secs(),
         }
     }
 }

--- a/crates/daly-bms-server/src/redb_writes.rs
+++ b/crates/daly-bms-server/src/redb_writes.rs
@@ -5,10 +5,21 @@
 //!
 //! ## Rate limiting
 //!
-//! Chaque métrique est rate-limitée à 1 écriture toutes les 5 secondes (par
-//! couple metric+labels) pour éviter de saturer le writer batché. Sur ~50
-//! métriques actives × 1 écriture / 5 s = 10 writes/sec = 36 000 writes/h.
-//! Le writer batche par 500 → ~72 commits redb/h. Empreinte I/O négligeable.
+//! Chaque métrique est rate-limitée par couple metric+labels. Les intervalles
+//! par tier (rapide / énergie / température) ci-dessous sont des PLANCHERS
+//! internes, mais l'intervalle effectif minimum est relevé par un PLANCHER
+//! GLOBAL configurable : `[metrics_store].raw_write_interval_secs` (défaut 30 s).
+//!
+//! Pourquoi 30 s par défaut (profiling heap 2026-06-14) : le chemin d'écriture
+//! redb (commit B-tree + cache de pages + bitmaps de pages libres) dominait la
+//! croissance RSS, et son coût mémoire est proportionnel au débit de commits.
+//! À ~1044 séries × 1/5 s ≈ 200 écritures/s c'était trop ; 30 s divise par 6
+//! sans perte d'usage (Grafana rafraîchit à 30 s–1 min ; les vues temps réel
+//! lisent les ring buffers en RAM, pas redb).
+//!
+//! RETOUR ARRIÈRE (résolution plus fine) : mettre `raw_write_interval_secs = 5`
+//! dans `/etc/daly-bms/config.toml` puis redémarrer — aucune recompilation
+//! (cf. docs/diagnostic-depannage.md §18).
 //!
 //! ## Politique non-bloquante
 //!
@@ -29,14 +40,14 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-/// Intervalle minimum entre 2 écritures d'une même série (metric+labels).
-/// Garde le rate global gérable (1 écriture / 5 s max par série).
+/// Plancher par tier (relevé par le plancher global configurable, cf. doc du
+/// module + `RateLimiter::floor`). Tier rapide (tension, courant, SOC…).
 const MIN_WRITE_INTERVAL: Duration = Duration::from_secs(5);
 
-/// Intervalle min pour les compteurs d'énergie (varient lentement).
+/// Tier énergie (compteurs cumulés, varient lentement).
 const ENERGY_WRITE_INTERVAL: Duration = Duration::from_secs(30);
 
-/// Intervalle min pour température (varient très lentement).
+/// Tier température (varie très lentement).
 const TEMP_WRITE_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Rate limiter clonable basé sur Arc<Mutex<HashMap>>.
@@ -47,11 +58,18 @@ const TEMP_WRITE_INTERVAL: Duration = Duration::from_secs(60);
 #[derive(Default, Clone)]
 pub struct RateLimiter {
     last_writes: std::sync::Arc<Mutex<HashMap<String, Instant>>>,
+    /// Plancher GLOBAL : l'intervalle effectif d'une écriture est
+    /// `max(interval_du_tier, floor)`. Configurable via
+    /// `[metrics_store].raw_write_interval_secs`. 0 = pas de plancher (les
+    /// tiers s'appliquent tels quels). Permet un retour arrière sans recompiler.
+    floor: Duration,
 }
 
 impl RateLimiter {
-    pub fn new() -> Self {
-        Self::default()
+    /// Construit avec un plancher global d'écriture (depuis la config).
+    /// `floor = 0` ⇒ pas de plancher (les intervalles par tier s'appliquent).
+    pub fn with_floor(floor: Duration) -> Self {
+        Self { floor, ..Self::default() }
     }
 
     /// Garde-fou anti-cardinalité. La map est keyée par `metric:labels` ; une
@@ -68,6 +86,8 @@ impl RateLimiter {
     /// qu'à la PREMIÈRE rencontre d'une série, plus jamais ensuite (review
     /// gemini phase D — zéro allocation sur le chemin chaud).
     pub fn allow(&self, key: &str, min_interval: Duration) -> bool {
+        // Plancher global : on n'écrit jamais plus souvent que `floor`.
+        let min_interval = min_interval.max(self.floor);
         let now = Instant::now();
         // unwrap_or_else pour rester safe si un panic a empoisonné le mutex.
         let mut map = self.last_writes.lock().unwrap_or_else(|p| p.into_inner());

--- a/crates/daly-bms-server/src/state.rs
+++ b/crates/daly-bms-server/src/state.rs
@@ -545,6 +545,8 @@ impl AppState {
         metrics_store: Option<Arc<metrics_store::MetricsStore>>,
     ) -> Self {
         let (ws_tx, _) = broadcast::channel(WS_BROADCAST_CAPACITY);
+        // Capturé avant que `config` ne soit déplacé dans l'Arc ci-dessous.
+        let config_write_interval_secs = config.metrics_store.raw_write_interval_secs;
         let addresses = config.bms_addresses();
         let ring_size = config.serial.ring_buffer_size;
         let mut buffers = BTreeMap::new();
@@ -598,7 +600,9 @@ impl AppState {
             alert_engine,
             alert_tx,
             metrics_store,
-            redb_rl: crate::redb_writes::RateLimiter::new(),
+            redb_rl: crate::redb_writes::RateLimiter::with_floor(
+                std::time::Duration::from_secs(config_write_interval_secs),
+            ),
             freshness: Arc::new(crate::freshness::FreshnessRegistry::new()),
         }
     }

--- a/docs/diagnostic-depannage.md
+++ b/docs/diagnostic-depannage.md
@@ -56,6 +56,7 @@
   - [§16 Phase C (commit 018e363) — axum 0.7 → 0.8](#16-phase-c-commit-018e363--axum-07--08)
   - [§17 Phase D (2026-06) — root cause du résiduel : trafic HTTP passif 1 Hz](#17-phase-d-2026-06--root-cause-du-residuel--trafic-http-passif-1-hz)
   - [§18 Phase E (2026-06-13) — la fuite est une VRAIE fuite heap](#18-phase-e-2026-06-13--la-fuite-est-une-vraie-fuite-heap-mesures-terrain)
+  - [§19 Phase F (2026-06-14) — fuite localisée : chemin d'écriture redb](#19-phase-f-2026-06-14--fuite-localisee--chemin-decriture-redb)
 - [Voir aussi](#voir-aussi)
 - [Sources consolidées](#sources-consolidees)
 
@@ -1535,6 +1536,56 @@ ralentit les commits/compactions. Recommandé : baisser
 conservent l'historique long terme. ⚠ redb ne rétrécit pas le fichier
 automatiquement (réutilise l'espace libéré) ; pour récupérer le disque,
 compaction redb ou recréation de la base.
+
+---
+
+### §19 Phase F (2026-06-14) — fuite localisée : chemin d'écriture redb
+
+#### §19.1 — Profiling heap symbolisé
+
+Le binaire release étant strippé (`strip="symbols"`), jeprof rendait
+`?? ??:0`. Solution : profil `release-symbols` (= `release` + symboles, **même
+`.text`** donc adresses identiques au binaire déployé) via `make build-arm-symbols`,
+puis agrégation par fonction du diff de deux profils heap (3 h d'écart) avec
+`scripts/analyze-jeprof-diff.py`.
+
+#### §19.2 — Verdict
+
+La croissance (~8 Mo/h de heap VIVANT, `jemalloc allocated`) est **dominée par
+le chemin d'écriture redb**, déclenché par `metrics_store::writer::commit_batch` :
+`redb …commit_inner`, `process_freed_pages`, `BtreeBitmap` / `U64GroupedBitmap`,
+`PagedCachedFile::read`, `LeafAccessor` / `RawLeafBuilder` / `LeafMutator`. Ce
+n'est PAS le clone tower/axum (tout en bas du classement) ni un `SplitSink`.
+redb maintient en mémoire des structures (cache de pages, bitmaps de pages
+libres, nœuds B-tree) dont le coût croît avec **le débit de commits** et la
+**taille de la base**. À ~1044 séries × 1 écriture/5 s ≈ 200 écritures/s, le
+débit était énorme pour un usage domestique.
+
+#### §19.3 — Correctif : plancher d'écriture configurable
+
+`[metrics_store].raw_write_interval_secs` (défaut **30 s**, était 5 s) : une
+série est écrite au plus 1× par cet intervalle (`RateLimiter::floor`). Divise
+le débit de commits redb par ~6 → fuite ~÷6. Sans perte d'usage : Grafana
+rafraîchit à 30 s–1 min, et les vues temps réel (dashboard SSR, WebSocket)
+lisent les ring buffers **en RAM**, pas redb. Le polling RS485 et les alertes
+sont inchangés.
+
+**RETOUR ARRIÈRE (résolution fine 5 s)** — aucune recompilation :
+
+```bash
+sudo sed -i 's/^raw_write_interval_secs = .*/raw_write_interval_secs = 5/' /etc/daly-bms/config.toml
+sudo systemctl restart daly-bms
+```
+
+Valeurs intermédiaires possibles : 15 (÷3), 10 (÷2). Le réglage est dans
+`Config.toml` (préservé par `deploy-pi5.sh`).
+
+#### §19.4 — Outils ajoutés (réutilisables)
+
+- `make build-arm-symbols` → binaire `release-symbols` (symbolisation hors-ligne).
+- `scripts/analyze-jeprof-diff.py <ancien.heap> <recent.heap> <bin-symbols>` →
+  classement par fonction des allocations qui ont crû.
+- `scripts/jemalloc-leak-profile.sh` → capture + restauration auto (§18).
 
 ---
 


### PR DESCRIPTION
## Verdict du profiling heap (phase F, docs §19)
La croissance RSS (~8 Mo/h de heap **vivant**, confirmé par `jemalloc allocated`) est **dominée par le chemin d'écriture redb** (`metrics_store::writer::commit_batch` → `redb commit_inner`, `process_freed_pages`, `BtreeBitmap`/`U64GroupedBitmap`, `PagedCachedFile::read`, `LeafAccessor`/`RawLeafBuilder`). Pas le clone tower/axum, pas un SplitSink. Coût proportionnel au **débit de commits** (~200 écritures/s à 1044 séries × 1/5 s).

## Correctif
`[metrics_store].raw_write_interval_secs` (défaut **30 s**, était 5 s) : plancher global d'écriture (`RateLimiter::with_floor`) → débit de commits redb ÷6 → fuite ÷6. **Sans perte d'usage** (Grafana rafraîchit à 30 s–1 min ; vues temps réel en RAM ; polling RS485 & alertes inchangés).

**Retour arrière** (résolution 5 s) sans recompilation : `raw_write_interval_secs = 5` dans `/etc/daly-bms/config.toml` + restart. Préservé par `deploy-pi5.sh`.

Outils de diagnostic conservés : `make build-arm-symbols`, `scripts/analyze-jeprof-diff.py`, `scripts/jemalloc-leak-profile.sh`.

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_