### PR TITLE
revert(mem): restaurer rétention 30j + résolution 5s (la fuite n'en dépend pas)

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -420,18 +420,19 @@ cache_mb = 16
 queue_depth = 10000
 # Intervalle de la passe de compaction tiered (heures, 0 = désactivé).
 maintenance_interval_hours = 6
-# Données brutes (pleine résolution) conservées 7 j ; au-delà, agrégation
-# horaire/journalière (historique préservé à résolution réduite). 30 j de raw
-# faisaient grossir la base à plusieurs Go → démarrages lents (cf. scripts/compact-redb.sh).
-raw_retention_days = 7
+# Données brutes (pleine résolution). 30 j = valeur RESTAURÉE à la demande
+# (2026-06-14). ⚠ La base regrossit alors à ~3-4 Go en 30 j → démarrages plus
+# lents (tolérés par TimeoutStartSec=300 ; compaction possible via
+# scripts/compact-redb.sh). La rétention n'a AUCUN effet sur la fuite RSS.
+raw_retention_days = 30
 hourly_retention_days = 365
 daily_retention_days = 1825   # 5 ans
-# Plancher global d'écriture redb (secondes) : une série est écrite au plus 1×
-# par cet intervalle. 30 = défaut (le débit de commits redb dominait la
-# croissance RSS — profiling 2026-06-14). RETOUR ARRIÈRE résolution fine :
-# mettre 5, puis `sudo cp Config.toml /etc/daly-bms/config.toml && sudo systemctl
-# restart daly-bms` (pas de recompilation). Cf. docs/diagnostic-depannage.md §18.
-raw_write_interval_secs = 30
+# Plancher global d'écriture redb (secondes). 5 = résolution fine RESTAURÉE
+# (2026-06-14). NB : passer à 30 divisait le débit de commits redb par 6 mais
+# NE corrigeait PAS la fuite RSS (cf. docs/diagnostic-depannage.md §20). 5 s est
+# la résolution la plus fine (plancher des tiers internes). Configurable sans
+# recompiler.
+raw_write_interval_secs = 5
 
 
 [alerts]

--- a/crates/daly-bms-server/src/config.rs
+++ b/crates/daly-bms-server/src/config.rs
@@ -527,11 +527,11 @@ pub struct MetricsStoreConfig {
     /// requête à step minuscule peut allouer sans limite — OOM du Pi).
     #[serde(default = "default_metrics_query_max_points")]
     pub query_max_points: i64,
-    /// Plancher global d'écriture redb en secondes (défaut 30). Une série n'est
-    /// écrite au plus qu'une fois par cet intervalle (relevé au-dessus des
-    /// planchers par tier). Réduire le débit de commits redb a réduit la
-    /// croissance RSS (profiling 2026-06-14). Mettre 5 pour retrouver la
-    /// résolution fine d'avant (cf. docs/diagnostic-depannage.md §18).
+    /// Plancher global d'écriture redb en secondes (défaut 5 = résolution fine).
+    /// Une série est écrite au plus 1× par cet intervalle (relevé au-dessus des
+    /// planchers par tier). Le porter à 30 divise le débit de commits redb par
+    /// 6 MAIS ne corrige PAS la fuite RSS (cf. docs/diagnostic-depannage.md
+    /// §20) — restauré à 5 le 2026-06-14.
     #[serde(default = "default_metrics_write_interval_secs")]
     pub raw_write_interval_secs: u64,
 }
@@ -545,7 +545,7 @@ fn default_metrics_hourly_days() -> u32 { 365 }
 fn default_metrics_daily_days() -> u32 { 5 * 365 }
 fn default_metrics_query_backend() -> String { "redb".into() }
 fn default_metrics_query_max_points() -> i64 { metrics_store::promql::DEFAULT_MAX_RANGE_POINTS }
-fn default_metrics_write_interval_secs() -> u64 { 30 }
+fn default_metrics_write_interval_secs() -> u64 { 5 }
 
 impl Default for MetricsStoreConfig {
     fn default() -> Self {

--- a/docs/diagnostic-depannage.md
+++ b/docs/diagnostic-depannage.md
@@ -57,6 +57,7 @@
   - [§17 Phase D (2026-06) — root cause du résiduel : trafic HTTP passif 1 Hz](#17-phase-d-2026-06--root-cause-du-residuel--trafic-http-passif-1-hz)
   - [§18 Phase E (2026-06-13) — la fuite est une VRAIE fuite heap](#18-phase-e-2026-06-13--la-fuite-est-une-vraie-fuite-heap-mesures-terrain)
   - [§19 Phase F (2026-06-14) — fuite localisée : chemin d'écriture redb](#19-phase-f-2026-06-14--fuite-localisee--chemin-decriture-redb)
+  - [§20 Phase G (2026-06-14) — bilan : ce qui N'A PAS corrigé la fuite](#20-phase-g-2026-06-14--bilan--ce-qui-na-pas-corrige-la-fuite)
 - [Voir aussi](#voir-aussi)
 - [Sources consolidées](#sources-consolidees)
 
@@ -1541,6 +1542,10 @@ compaction redb ou recréation de la base.
 
 ### §19 Phase F (2026-06-14) — fuite localisée : chemin d'écriture redb
 
+> ⚠️ **INFIRMÉ par §20** : réduire le débit d'écriture redb n'a PAS corrigé
+> la fuite (et §9.1 montre qu'elle persiste avec metrics-store désactivé).
+> redb n'est que l'allocateur le plus actif, pas la cause. Voir §20.
+
 #### §19.1 — Profiling heap symbolisé
 
 Le binaire release étant strippé (`strip="symbols"`), jeprof rendait
@@ -1586,6 +1591,60 @@ Valeurs intermédiaires possibles : 15 (÷3), 10 (÷2). Le réglage est dans
 - `scripts/analyze-jeprof-diff.py <ancien.heap> <recent.heap> <bin-symbols>` →
   classement par fonction des allocations qui ont crû.
 - `scripts/jemalloc-leak-profile.sh` → capture + restauration auto (§18).
+
+---
+
+### §20 Phase G (2026-06-14) — bilan : ce qui N'A PAS corrigé la fuite
+
+Mesures terrain après TOUS les changements ci-dessous : la pente `jemalloc
+allocated` (heap vivant) reste **~7–9 Mo/h**, identique à avant. La fuite de
+fond n'est PAS résolue.
+
+#### §20.1 — Tentatives infructueuses (à NE PAS refaire)
+
+| Changement | Effet sur la fuite | Verdict |
+|------------|--------------------|---------|
+| `narenas:2` retiré du `_RJEM_MALLOC_CONF` | nul | n'était pas la cause |
+| `RateLimiter` borné (anti-cardinalité process) | nul | bug réel mais marginal |
+| Fuite de tâches Shelly (abort sur reconnexion) | nul | bug réel mais marginal |
+| **Intervalle d'écriture redb 5 s → 30 s** (÷6 commits) | **nul** | **la fuite n'est PAS le volume d'écriture** |
+| Rétention raw 30 j → 7 j + compaction | nul *sur la fuite* | ✅ a corrigé le **disque/démarrage lent** (problème distinct) |
+
+#### §20.2 — Preuve que ce n'est PAS redb / les écritures
+
+Le profiling heap (§19) pointait le chemin d'écriture redb, MAIS :
+1. réduire le débit d'écriture ×6 (30 s) n'a rien changé à la pente ;
+2. surtout, l'investigation **§9.1 avait déjà mesuré** que la fuite persiste
+   à ~7,8 Mo/h **avec `metrics_store.enabled=false`** (redb totalement à
+   l'arrêt).
+
+⇒ redb est seulement l'**allocateur le plus actif** (il masque la vraie fuite
+dans les profils), pas la cause. La fuite est dans une **couche partagée**
+active même sans redb : runtime tokio, hyper/axum (HTTP), ou rumqttc (MQTT).
+
+#### §20.3 — Réglages restaurés (2026-06-14)
+
+À la demande, retour aux valeurs d'origine (elles n'influencent pas la fuite) :
+`raw_retention_days = 30`, `raw_write_interval_secs = 5`. ⚠ La rétention 30 j
+fait regrossir la base (~3-4 Go) → démarrages plus lents (tolérés par
+`TimeoutStartSec=300`).
+
+#### §20.4 — Prochaine étape : profiler metrics-store DÉSACTIVÉ
+
+Pour exposer la vraie fuite sans le bruit redb :
+1. `sudo systemctl edit daly-bms` → `[Service]` `Environment=DALY_JEMALLOC_PROF=1`
+   + `Environment=_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,background_thread:true`
+   + un drop-in qui force `metrics_store.enabled=false` n'existe pas (c'est dans
+   Config.toml) → mettre `enabled = false` dans `/etc/daly-bms/config.toml`
+   (sauvegarder d'abord), `PrivateTmp=false`, restart.
+2. Laisser tourner 1–2 h (la fuite ~8 Mo/h se voit vite).
+3. `make build-arm-symbols` puis
+   `python3 scripts/analyze-jeprof-diff.py <ancien>.heap <recent>.heap <bin-symbols>`.
+4. Cette fois redb est absent → la couche fautive (tokio/hyper/rumqttc)
+   ressortira nettement. Restaurer ensuite `enabled = true`.
+
+En attendant, le **restart quotidien** (`RuntimeMaxSec=86400`) contient la
+fuite (~8 Mo/h × 24 ≈ 190 Mo, très en dessous de `MemoryMax=512M` sur Pi5 8 Go).
 
 ---
 


### PR DESCRIPTION
Les courbes terrain montrent que la fuite RSS persiste (~7–9 Mo/h) malgré le plancher d'écriture 30 s. Donc le volume d'écriture n'est pas la cause — et §9.1 avait déjà prouvé que la fuite persiste avec `metrics_store` désactivé (ce n'est pas redb). À la demande, retour aux valeurs d'origine.

- **Config.toml** : `raw_retention_days` 7→30, `raw_write_interval_secs` 30→5.
- **config.rs** : défaut du champ 30→5.
- **docs §20** : bilan des tentatives infructueuses (narenas, RateLimiter, Shelly, write-interval, retention), preuve « pas redb », prochaine étape = profiler **metrics-store OFF**. Note d'infirmation sur §19.

⚠ Rétention 30 j fait regrossir la base (~3-4 Go) → démarrages plus lents (tolérés par `TimeoutStartSec=300` ; compaction via `scripts/compact-redb.sh`). La rétention n'a aucun effet sur la fuite.

https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WAT6aSrmgT2PuJwUb16a)_