### PR TITLE
feat(energy-manager): passage chauffe-eau LG en VACATION si 60°C tenu…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -635,6 +635,8 @@ vacation_target_c     = 45.0          # °C cible en VACATION
 temp_set_delay_secs   = 15            # s — délai avant réglage temp
 keepalive_secs        = 25            # s — keepalive Venus OS watchdog
 irradiance_min_wm2    = 300         # W/m² — irradiance min pour activer HEAT_PUMP
+temp_max_c            = 60.0          # °C — seuil « cuve à température cible » : si la temp. actuelle reste ≥…
+temp_max_hold_secs    = 600           # s — …pendant ≥ 10 min → on force VACATION (inutile de chauffer plus)
 vm_url                = "http://127.0.0.1:8080"  # daly-bms-server → metrics-store redb (POST /api/v1/import/prometheus)
 
 # --- Production solaire ---

--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -509,19 +509,41 @@ async function fetchRulesStatus() {
     const readTs = document.getElementById('wh-read-ts');
     if (readTs) readTs.textContent = fmtTs(wh?.last_read_ts);
 
+    // ── Cuve à température cible : ≥ temp_max_c tenue ≥ temp_max_hold_secs → VACATION
+    const tMaxC      = wh?.temp_max_c ?? 60;
+    const tHoldSecs  = wh?.temp_max_hold_secs ?? 600;
+    const tMaxSince  = wh?.temp_max_since ?? null;
+    const tMaxReached = wh?.temp_max_reached ?? false;
+    const tHoldMin   = Math.round(tHoldSecs / 60);
+    // OK (favorable au HEAT_PUMP) = cible PAS encore atteinte
+    const tempOk     = !tMaxReached;
+    let tempVal = '—', tempDetail = null;
+    if (wh?.current_temp_c != null) {
+      tempVal = wh.current_temp_c.toFixed(1) + ' °C';
+      if (tMaxSince) {
+        const heldS = Math.max(0, Math.floor((Date.now() - new Date(tMaxSince)) / 1000));
+        const heldStr = heldS < 60 ? `${heldS}s` : `${Math.floor(heldS/60)}min`;
+        tempDetail = tMaxReached ? `≥ ${tMaxC}°C depuis ${heldStr} → cible atteinte`
+                                 : `≥ ${tMaxC}°C depuis ${heldStr} (seuil ${tHoldMin}min)`;
+      }
+    }
+
     const grid = document.getElementById('rule-grid');
     if (grid) {
       grid.innerHTML = [
         ruleRow('SOC ≥ 90 % (SmartShunt)',           socOk,    emSoc  != null ? `${emSoc.toFixed(1)} %`   : '—', null),
         ruleRow('Irradiance ≥ 300 W/m²',           irrOk,    irr    != null ? `${irr.toFixed(0)} W/m²` : '—', null),
         ruleRow('Grid déconnecté (AC IN Ignored)', gridOffOk, acIgnore != null ? (acIgnore ? 'ACTIF' : 'Normal') : '—', null),
+        ruleRow(`Temp < ${tMaxC} °C tenue < ${tHoldMin} min`, tempOk, tempVal, tempDetail),
       ].join('');
     }
 
-    const allOk = socOk && irrOk && gridOffOk;
+    const allOk = socOk && irrOk && gridOffOk && !tMaxReached;
     const dec = document.getElementById('rules-decision');
     if (dec) {
-      dec.textContent = allOk ? 'Cible calculée : HEAT_PUMP' : 'Cible calculée : VACATION';
+      let reason = '';
+      if (tMaxReached) reason = ' (cuve à température cible)';
+      dec.textContent = allOk ? 'Cible calculée : HEAT_PUMP' : 'Cible calculée : VACATION' + reason;
       dec.style.color = allOk ? '#4ade80' : '#94a3b8';
     }
   } catch(e) { console.warn('fetchRulesStatus/wh:', e); }

--- a/crates/energy-manager/rules/water_heater.grl
+++ b/crates/energy-manager/rules/water_heater.grl
@@ -7,11 +7,13 @@
 //   WH.grid_connected  (bool, true = ac_ignore == 0, grid ON → Vacation)
 //   WH.soc_low         (bool, pre-computed: soc_pct < soc_min_pct from WaterHeaterConfig)
 //   WH.irradiance_low  (bool, true when irradiance < irradiance_min_wm2 from WaterHeaterConfig)
+//   WH.temp_max_reached (bool, true when current_temp_c >= temp_max_c held for temp_max_hold_secs)
 //
 // Output facts (read from Rust after execute):
 //   WH.target_mode     (string: "HEAT_PUMP" | "VACATION")
 //
-// HEAT_PUMP requires ALL: soc_low=false, irradiance_low=false, grid_connected=false
+// HEAT_PUMP requires ALL: soc_low=false, irradiance_low=false, grid_connected=false,
+// temp_max_reached=false
 
 // ── Condition rules (salience 100) ──────────────────────────────────────────
 
@@ -32,6 +34,15 @@ rule "WH_Cond_SOC_Low" salience 100 {
 rule "WH_Cond_Irradiance_Low" salience 100 {
     when
         WH.irradiance_low == true
+    then
+        WH.want_vacation = true;
+}
+
+// Cuve à température cible (≥ temp_max_c, p.ex. 60°C) tenue ≥ temp_max_hold_secs
+// (p.ex. 10 min) → inutile de maintenir la pompe à chaleur, on passe en VACATION.
+rule "WH_Cond_TempMax" salience 100 {
+    when
+        WH.temp_max_reached == true
     then
         WH.want_vacation = true;
 }

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -395,6 +395,14 @@ pub struct WaterHeaterConfig {
     /// Minimum battery SOC to allow HEAT_PUMP mode (%)
     #[serde(default = "default_soc_min_pct")]
     pub soc_min_pct: f64,
+    /// Température à partir de laquelle la cuve est considérée « cible atteinte » (°C).
+    /// Si la température actuelle reste ≥ ce seuil pendant `temp_max_hold_secs`,
+    /// la règle force le passage en VACATION (inutile de maintenir la pompe à chaleur).
+    #[serde(default = "default_temp_max_c")]
+    pub temp_max_c: f64,
+    /// Durée de maintien à `temp_max_c` avant de forcer VACATION (secondes). Défaut : 600 (10 min).
+    #[serde(default = "default_temp_max_hold_secs")]
+    pub temp_max_hold_secs: u64,
     /// URL d'écriture des métriques chauffe-eau (daly-bms-server → redb,
     /// endpoint POST /api/v1/import/prometheus). Défaut : http://127.0.0.1:8080
     #[serde(default = "default_wh_vm_url")]
@@ -410,6 +418,8 @@ fn default_temp_set_delay_secs() -> u64 { 15 }
 fn default_keepalive_secs() -> u64 { 25 }
 fn default_irradiance_min_wm2() -> f64 { 300.0 }
 fn default_soc_min_pct() -> f64 { 90.0 }
+fn default_temp_max_c() -> f64 { 60.0 }
+fn default_temp_max_hold_secs() -> u64 { 600 }
 fn default_wh_vm_url() -> String { "http://127.0.0.1:8080".into() }
 
 impl Default for WaterHeaterConfig {
@@ -424,6 +434,8 @@ impl Default for WaterHeaterConfig {
             keepalive_secs: default_keepalive_secs(),
             irradiance_min_wm2: default_irradiance_min_wm2(),
             soc_min_pct: default_soc_min_pct(),
+            temp_max_c: default_temp_max_c(),
+            temp_max_hold_secs: default_temp_max_hold_secs(),
             vm_url: default_wh_vm_url(),
         }
     }

--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -25,6 +25,7 @@ use tokio::sync::{broadcast, RwLock};
 use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
 
+use crate::config::WaterHeaterConfig;
 use crate::http_clients::lg_thinq::LgThinqClient;
 use crate::rules_loader::RulesLoader;
 use crate::types::{EnergyState, LiveEvent, WaterHeaterMode};
@@ -37,6 +38,7 @@ struct ServerState {
     lg:          Option<Arc<LgThinqClient>>,
     loader:      Arc<RulesLoader>,
     rule_reload: broadcast::Sender<String>,
+    wh_cfg:      WaterHeaterConfig,
 }
 
 pub async fn serve(
@@ -46,8 +48,9 @@ pub async fn serve(
     lg: Option<Arc<LgThinqClient>>,
     loader: Arc<RulesLoader>,
     rule_reload: broadcast::Sender<String>,
+    wh_cfg: WaterHeaterConfig,
 ) {
-    let srv = ServerState { tx: live_tx, state, lg, loader, rule_reload };
+    let srv = ServerState { tx: live_tx, state, lg, loader, rule_reload, wh_cfg };
 
     let cors = CorsLayer::new()
         .allow_origin(Any)
@@ -139,6 +142,15 @@ struct WaterHeaterCard {
     last_change_ts: Option<DateTime<Utc>>,
     send_count:     u32,
     lg_enabled:     bool,
+    /// Seuil de température « cible atteinte » (°C) — règle 60°C par défaut.
+    temp_max_c:     f64,
+    /// Durée de maintien à `temp_max_c` avant de forcer VACATION (secondes).
+    temp_max_hold_secs: u64,
+    /// Depuis quand la cuve tient `temp_max_c` (None si en-dessous).
+    temp_max_since: Option<DateTime<Utc>>,
+    /// Vrai quand la cuve tient `temp_max_c` depuis ≥ `temp_max_hold_secs`
+    /// → la règle force VACATION.
+    temp_max_reached: bool,
 }
 
 #[derive(Serialize)]
@@ -184,6 +196,14 @@ struct RulesStatus {
 
 async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
     let s = srv.state.read().await;
+    // « Température cible atteinte » : la cuve tient temp_max_c depuis ≥ hold_secs.
+    // Recalculé ici à partir de l'horodatage tenu par le control_task, pour que
+    // la carte monitoring reste cohérente avec la décision du moteur de règles.
+    let temp_max_reached = s.water_heater_temp_max_since
+        .map(|since| {
+            (Utc::now() - since).num_seconds().max(0) as u64 >= srv.wh_cfg.temp_max_hold_secs
+        })
+        .unwrap_or(false);
     let status = RulesStatus {
         water_heater: WaterHeaterCard {
             mode:           s.water_heater_mode.to_lg_str().to_string(),
@@ -193,6 +213,10 @@ async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
             last_change_ts: s.water_heater_last_change,
             send_count:     s.water_heater_send_count,
             lg_enabled:     srv.lg.is_some(),
+            temp_max_c:     srv.wh_cfg.temp_max_c,
+            temp_max_hold_secs: srv.wh_cfg.temp_max_hold_secs,
+            temp_max_since: s.water_heater_temp_max_since,
+            temp_max_reached,
         },
         charge_current: ChargeCurrent {
             current_a:    s.last_charge_current_a,

--- a/crates/energy-manager/src/logic/water_heater/mod.rs
+++ b/crates/energy-manager/src/logic/water_heater/mod.rs
@@ -50,6 +50,32 @@ async fn publish_to_venus(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
     bus.emit_live(LiveEvent::new("water_heater_venus", &payload));
 }
 
+/// Met à jour le suivi « température cible atteinte » dans l'état partagé et
+/// renvoie `true` si la température de la cuve est restée ≥ `temp_max_c`
+/// pendant au moins `hold_secs`.
+///
+/// La température est lue régulièrement (poller LG ThinQ + ce control_task) et
+/// stockée dans `water_heater_temp_c` ; on date le premier instant où le seuil
+/// est franchi (`water_heater_temp_max_since`) puis on mesure la durée écoulée.
+/// Dès qu'elle redescend, le suivi est réarmé.
+fn update_temp_max_tracking(
+    s: &mut EnergyState,
+    now: DateTime<Utc>,
+    temp_max_c: f64,
+    hold_secs: u64,
+) -> bool {
+    match s.water_heater_temp_c {
+        Some(t) if t >= temp_max_c => {
+            let since = *s.water_heater_temp_max_since.get_or_insert(now);
+            (now - since).num_seconds().max(0) as u64 >= hold_secs
+        }
+        _ => {
+            s.water_heater_temp_max_since = None;
+            false
+        }
+    }
+}
+
 async fn write_wh_metrics(vm_url: &str, mode: WaterHeaterMode, temp: Option<f64>, target: Option<f64>) {
     let ts_ms = Utc::now().timestamp_millis();
     let mut lines = Vec::new();
@@ -128,6 +154,21 @@ async fn control_task(
             }
         };
 
+        // Suivi « cuve à température cible » : si la température (lue à l'instant
+        // ci-dessus, sinon valeur en cache rafraîchie par le poller LG) reste
+        // ≥ temp_max_c pendant temp_max_hold_secs → on forcera VACATION.
+        let temp_max_reached = {
+            let mut s = state.write().await;
+            update_temp_max_tracking(&mut s, now, cfg.temp_max_c, cfg.temp_max_hold_secs)
+        };
+        if temp_max_reached {
+            let since = state.read().await.water_heater_temp_max_since;
+            info!(
+                "Water heater: température ≥ {:.1}°C tenue ≥ {}s (depuis {:?}) → cible atteinte, VACATION forcé",
+                cfg.temp_max_c, cfg.temp_max_hold_secs, since
+            );
+        }
+
         // Read energy conditions — skip evaluation if MQTT data not yet available
         let (ac_ignore_opt, soc_opt, irradiance) = {
             let s = state.read().await;
@@ -171,10 +212,10 @@ async fn control_task(
             ac_ignore, grid_connected, soc, cfg.soc_min_pct, soc_low, irradiance_low
         );
 
-        let target_mode_str = match rule_engine.evaluate(grid_connected, soc_low, irradiance_low) {
+        let target_mode_str = match rule_engine.evaluate(grid_connected, soc_low, irradiance_low, temp_max_reached) {
             Ok(m) => {
-                info!("Water heater: rule engine → target_mode={m} (grid_connected={}, soc={:.1}%, irradiance_low={})",
-                    grid_connected, soc, irradiance_low);
+                info!("Water heater: rule engine → target_mode={m} (grid_connected={}, soc={:.1}%, irradiance_low={}, temp_max_reached={})",
+                    grid_connected, soc, irradiance_low, temp_max_reached);
                 m
             }
             Err(e) => {

--- a/crates/energy-manager/src/logic/water_heater/rules.rs
+++ b/crates/energy-manager/src/logic/water_heater/rules.rs
@@ -26,18 +26,22 @@ impl WaterHeaterRuleEngine {
     /// Returns "HEAT_PUMP" or "VACATION".
     ///
     /// `soc_low` is pre-computed by the caller: `soc_pct < cfg.soc_min_pct`.
+    /// `temp_max_reached` is pre-computed: current temp held `>= temp_max_c`
+    /// for at least `temp_max_hold_secs` (cuve à température cible).
     pub fn evaluate(
         &mut self,
         grid_connected: bool,
         soc_low: bool,
         irradiance_low: bool,
+        temp_max_reached: bool,
     ) -> anyhow::Result<String> {
         let facts = Facts::new();
-        facts.set("WH.want_vacation",  Value::Boolean(false));
-        facts.set("WH.grid_connected", Value::Boolean(grid_connected));
-        facts.set("WH.soc_low",        Value::Boolean(soc_low));
-        facts.set("WH.irradiance_low", Value::Boolean(irradiance_low));
-        facts.set("WH.target_mode",    Value::String("VACATION".to_string()));
+        facts.set("WH.want_vacation",   Value::Boolean(false));
+        facts.set("WH.grid_connected",  Value::Boolean(grid_connected));
+        facts.set("WH.soc_low",         Value::Boolean(soc_low));
+        facts.set("WH.irradiance_low",  Value::Boolean(irradiance_low));
+        facts.set("WH.temp_max_reached", Value::Boolean(temp_max_reached));
+        facts.set("WH.target_mode",     Value::String("VACATION".to_string()));
 
         self.engine
             .execute(&facts)
@@ -59,32 +63,37 @@ mod tests {
 
     fn e() -> WaterHeaterRuleEngine { WaterHeaterRuleEngine::new().unwrap() }
 
-    fn eval(grid: bool, soc_low: bool, irr_low: bool) -> String {
-        e().evaluate(grid, soc_low, irr_low).unwrap()
+    fn eval(grid: bool, soc_low: bool, irr_low: bool, temp_max: bool) -> String {
+        e().evaluate(grid, soc_low, irr_low, temp_max).unwrap()
     }
 
     #[test]
     fn all_ok_gives_heat_pump() {
-        assert_eq!(eval(false, false, false), "HEAT_PUMP");
+        assert_eq!(eval(false, false, false, false), "HEAT_PUMP");
     }
 
     #[test]
     fn grid_connected_forces_vacation() {
-        assert_eq!(eval(true, false, false), "VACATION");
+        assert_eq!(eval(true, false, false, false), "VACATION");
     }
 
     #[test]
     fn soc_low_forces_vacation() {
-        assert_eq!(eval(false, true, false), "VACATION");
+        assert_eq!(eval(false, true, false, false), "VACATION");
     }
 
     #[test]
     fn irradiance_low_forces_vacation() {
-        assert_eq!(eval(false, false, true), "VACATION");
+        assert_eq!(eval(false, false, true, false), "VACATION");
+    }
+
+    #[test]
+    fn temp_max_reached_forces_vacation() {
+        assert_eq!(eval(false, false, false, true), "VACATION");
     }
 
     #[test]
     fn all_bad_forces_vacation() {
-        assert_eq!(eval(true, true, true), "VACATION");
+        assert_eq!(eval(true, true, true, true), "VACATION");
     }
 }

--- a/crates/energy-manager/src/main.rs
+++ b/crates/energy-manager/src/main.rs
@@ -109,8 +109,9 @@ async fn main() -> anyhow::Result<()> {
     let srv_lg       = lg_arc.clone();
     let srv_loader   = loader.clone();
     let srv_reload   = bus.rule_reload.clone();
+    let srv_wh_cfg   = cfg.water_heater.clone();
     supervise::spawn_critical(async move {
-        live_ws::server::serve(&bind, live_tx, srv_state, srv_lg, srv_loader, srv_reload).await;
+        live_ws::server::serve(&bind, live_tx, srv_state, srv_lg, srv_loader, srv_reload, srv_wh_cfg).await;
     });
 
     // --- Module monitoring Pi5 (métriques système + tokio).

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -157,6 +157,10 @@ pub struct EnergyState {
     pub water_heater_last_change: Option<DateTime<Utc>>,
     pub water_heater_last_read: Option<DateTime<Utc>>,
     pub water_heater_send_count: u32,
+    /// Horodatage depuis lequel la température de la cuve atteint/dépasse le
+    /// seuil `temp_max_c`. None tant qu'elle est en-dessous. Sert à forcer le
+    /// passage en VACATION après `temp_max_hold_secs` (cible 60°C atteinte).
+    pub water_heater_temp_max_since: Option<DateTime<Utc>>,
 
     // --- DEYE relay (Shelly) ---
     pub deye_on: bool,

--- a/docs/app-energy-manager.md
+++ b/docs/app-energy-manager.md
@@ -142,7 +142,7 @@ Cloner `AppBus` est gratuit (tous les champs sont `Arc`-backed).
 | Batterie | `soc_pct`, `battery_voltage_v`, `battery_current_a`, `battery_power_w`, `battery_state`, `time_to_go_sec` |
 | AC/Grid | `ac_ignore` (0=réseau, 1=hors-réseau), `ac_frequency_hz` |
 | VEBus | `dc_voltage_v`, `dc_current_a`, `dc_power_w`, `ac_out_voltage_v`, `ac_out_current_a`, `ac_out_power_w` |
-| Chauffe-eau | `water_heater_mode`, `water_heater_temp_c`, `water_heater_target_c`, `water_heater_last_read`, `water_heater_last_change`, `water_heater_send_count` |
+| Chauffe-eau | `water_heater_mode`, `water_heater_temp_c`, `water_heater_target_c`, `water_heater_last_read`, `water_heater_last_change`, `water_heater_send_count`, `water_heater_temp_max_since` |
 | DEYE | `deye_on`, `deye_last_change`, `deye_lockout_until` |
 | Compteurs | `total_yield_today_kwh`, `pvinv_baseline_kwh`, `yield_yesterday_kwh`, `ah_charged_today`, `ah_discharged_today`, `shunt_charged_today_kwh`, `shunt_discharged_today_kwh` |
 
@@ -436,21 +436,31 @@ Conditions (salience 100) :
   si grid_connected==true  → want_vacation=true
   si soc_pct < 90          → want_vacation=true
   si irradiance_low==true  → want_vacation=true
+  si temp_max_reached==true → want_vacation=true   (cuve à température cible)
 
 Décision (salience 200) :
   si want_vacation==true   → target_mode="VACATION"
   sinon                    → target_mode="HEAT_PUMP"
 ```
 
-**Logique condensée** : `HEAT_PUMP` requiert **les 3 conditions simultanément** :
+**Logique condensée** : `HEAT_PUMP` requiert **les 4 conditions simultanément** :
 ```
-HEAT_PUMP exige les 3 SIMULTANÉMENT :
+HEAT_PUMP exige les 4 SIMULTANÉMENT :
 ✓ grid_connected == false (ac_ignore=1)
 ✓ soc_pct ≥ 90
 ✓ irradiance_wm2 ≥ 300 W/m²
+✓ temp_max_reached == false (cuve PAS encore à température cible)
 
 Sinon → VACATION
 ```
+
+**Condition « cuve à température cible »** : la température actuelle de la cuve
+est lue régulièrement (poller LG ThinQ + control_task 5 min) et stockée dans
+`water_heater_temp_c`. Le control_task date le premier instant où elle atteint
+`temp_max_c` (défaut **60 °C**) via `water_heater_temp_max_since`. Si elle reste
+≥ ce seuil pendant ≥ `temp_max_hold_secs` (défaut **600 s = 10 min**), le fait
+`temp_max_reached` passe à `true` → la PAC bascule en `VACATION` (inutile de
+continuer à chauffer). Le suivi est réarmé dès que la température redescend.
 
 **Flux de contrôle** (toutes les 5 min) :
 1. `lg.get_state()` → actual_mode, temp, target_temp
@@ -469,7 +479,7 @@ Sinon → VACATION
 - Métriques redb via metrics-store (toutes les 5 min)
 - WebSocket live `"water_heater_venus"`
 
-**Config** : `irradiance_min_wm2=300`, `mode_change_min_secs=900`, `heat_pump_target_c=60`, `vacation_target_c=45`, `temp_set_delay_secs=15`, `keepalive_secs=25`
+**Config** : `irradiance_min_wm2=300`, `mode_change_min_secs=900`, `heat_pump_target_c=60`, `vacation_target_c=45`, `temp_set_delay_secs=15`, `keepalive_secs=25`, `temp_max_c=60`, `temp_max_hold_secs=600`
 
 ---
 
@@ -1039,6 +1049,8 @@ heat_pump_target_c     = 60.0     # Température cible mode HEAT_PUMP
 vacation_target_c      = 45.0     # Température cible mode VACATION
 soc_min_pct            = 90.0     # SOC minimum pour activer HEAT_PUMP
 irradiance_min_wm2     = 300      # Irradiance minimale pour HEAT_PUMP
+temp_max_c             = 60.0     # Seuil « cuve à température cible »
+temp_max_hold_secs     = 600      # Maintien ≥ ce seuil → VACATION (10 min)
 temp_set_delay_secs    = 15       # Délai entre set_mode et set_target_temp
 keepalive_secs         = 25       # Fréquence keepalive MQTT PAC
 vm_url                 = "http://127.0.0.1:8080"  # URL daly-bms-server → metrics-store redb
@@ -1305,7 +1317,7 @@ Couverture des tests :
 | `irradiance` | 5 | valides/invalides, plage 0–2000 W/m² |
 | `smartshunt` | 6 | capture baseline chargée/déchargée |
 | `solar_power` | 4 | nouveau jour, baseline absente |
-| `water_heater` | 5 | grid connecté, SOC bas, irradiance faible |
+| `water_heater` | 6 | grid connecté, SOC bas, irradiance faible, cuve à température cible |
 
 **Ajouter un test** — dans le module `rules.rs` concerné, dans `#[cfg(test)] mod tests` :
 


### PR DESCRIPTION
… >10min

Ajoute une condition à la règle de gestion du chauffe-eau LG ThinQ : si la température actuelle de la cuve reste >= temp_max_c (défaut 60°C) pendant
>= temp_max_hold_secs (défaut 600s = 10 min), la PAC bascule en mode VACATION
(la cible est atteinte, inutile de continuer à chauffer).

- config: nouveaux champs temp_max_c / temp_max_hold_secs (WaterHeaterConfig)
- types: EnergyState.water_heater_temp_max_since (date de franchissement du seuil)
- rules.grl + rules.rs: nouveau fait WH.temp_max_reached + règle WH_Cond_TempMax
- water_heater/mod.rs: suivi de durée (température lue régulièrement via le control_task + poller LG) et passage du fait au moteur de règles
- live_ws/server.rs: expose temp_max_c/hold_secs/since/reached dans /api/rules-status
- monitor.html (Règles système): nouvelle ligne de condition + décision VACATION
- Config.toml + docs: documentation des nouveaux paramètres
- tests: nouveau cas temp_max_reached_forces_vacation


Claude-Session: https://claude.ai/code/session_01B7VPxRRuYwpjFekZyjbWzc