### PR TITLE
feat(energy-manager): seuils chauffe-eau rechargeables à chaud + corr…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -637,6 +637,8 @@ keepalive_secs        = 25            # s — keepalive Venus OS watchdog
 irradiance_min_wm2    = 300         # W/m² — irradiance min pour activer HEAT_PUMP
 temp_max_c            = 60.0          # °C — seuil « cuve à température cible » : si la temp. actuelle reste ≥…
 temp_max_hold_secs    = 600           # s — …pendant ≥ 10 min → on force VACATION (inutile de chauffer plus)
+# ⮑ Ces seuils sont rechargeables À CHAUD : éditer puis POST /api/v1/em/rules/reload {"name":"water_heater"}
+#    (aucun recompile, aucun redémarrage). Détail : docs/app-energy-manager.md §13.2
 vm_url                = "http://127.0.0.1:8080"  # daly-bms-server → metrics-store redb (POST /api/v1/import/prometheus)
 
 # --- Production solaire ---

--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -520,7 +520,10 @@ async function fetchRulesStatus() {
     let tempVal = '—', tempDetail = null;
     if (wh?.current_temp_c != null) {
       tempVal = wh.current_temp_c.toFixed(1) + ' °C';
-      if (tMaxSince) {
+      // N'afficher le compteur que si la température est TOUJOURS ≥ seuil :
+      // évite un message « ≥ 60°C depuis 12min » alors que la valeur affichée
+      // est déjà redescendue (poller plus rapide que le tick qui efface tMaxSince).
+      if (tMaxSince && wh.current_temp_c >= tMaxC) {
         const heldS = Math.max(0, Math.floor((Date.now() - new Date(tMaxSince)) / 1000));
         const heldStr = heldS < 60 ? `${heldS}s` : `${Math.floor(heldS/60)}min`;
         tempDetail = tMaxReached ? `≥ ${tMaxC}°C depuis ${heldStr} → cible atteinte`

--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -38,7 +38,7 @@ struct ServerState {
     lg:          Option<Arc<LgThinqClient>>,
     loader:      Arc<RulesLoader>,
     rule_reload: broadcast::Sender<String>,
-    wh_cfg:      WaterHeaterConfig,
+    wh_cfg:      Arc<RwLock<WaterHeaterConfig>>,
 }
 
 pub async fn serve(
@@ -48,7 +48,7 @@ pub async fn serve(
     lg: Option<Arc<LgThinqClient>>,
     loader: Arc<RulesLoader>,
     rule_reload: broadcast::Sender<String>,
-    wh_cfg: WaterHeaterConfig,
+    wh_cfg: Arc<RwLock<WaterHeaterConfig>>,
 ) {
     let srv = ServerState { tx: live_tx, state, lg, loader, rule_reload, wh_cfg };
 
@@ -195,13 +195,17 @@ struct RulesStatus {
 }
 
 async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
+    let wh_cfg = srv.wh_cfg.read().await.clone();
     let s = srv.state.read().await;
     // « Température cible atteinte » : la cuve tient temp_max_c depuis ≥ hold_secs.
-    // Recalculé ici à partir de l'horodatage tenu par le control_task, pour que
-    // la carte monitoring reste cohérente avec la décision du moteur de règles.
+    // Recalculé ici à partir de l'horodatage tenu par le control_task. On exige
+    // aussi que la température actuelle soit TOUJOURS ≥ temp_max_c : si elle est
+    // déjà redescendue (poller plus rapide que le tick control_task qui efface
+    // l'horodatage), la carte ne doit pas afficher « cible atteinte » à tort.
     let temp_max_reached = s.water_heater_temp_max_since
         .map(|since| {
-            (Utc::now() - since).num_seconds().max(0) as u64 >= srv.wh_cfg.temp_max_hold_secs
+            s.water_heater_temp_c.map(|t| t >= wh_cfg.temp_max_c).unwrap_or(false)
+                && (Utc::now() - since).num_seconds().max(0) as u64 >= wh_cfg.temp_max_hold_secs
         })
         .unwrap_or(false);
     let status = RulesStatus {
@@ -213,8 +217,8 @@ async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
             last_change_ts: s.water_heater_last_change,
             send_count:     s.water_heater_send_count,
             lg_enabled:     srv.lg.is_some(),
-            temp_max_c:     srv.wh_cfg.temp_max_c,
-            temp_max_hold_secs: srv.wh_cfg.temp_max_hold_secs,
+            temp_max_c:     wh_cfg.temp_max_c,
+            temp_max_hold_secs: wh_cfg.temp_max_hold_secs,
             temp_max_since: s.water_heater_temp_max_since,
             temp_max_reached,
         },

--- a/crates/energy-manager/src/logic/water_heater/mod.rs
+++ b/crates/energy-manager/src/logic/water_heater/mod.rs
@@ -15,15 +15,18 @@ use crate::rules_loader::RulesLoader;
 use crate::types::{EnergyState, LiveEvent, MqttOutgoing, WaterHeaterMode};
 
 pub async fn spawn(
-    cfg: WaterHeaterConfig,
+    wh_cfg: Arc<RwLock<WaterHeaterConfig>>,
     lg: Option<Arc<LgThinqClient>>,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
     loader: Arc<RulesLoader>,
 ) {
-    crate::supervise::spawn_critical(keepalive_task(cfg.keepalive_secs, bus.clone(), state.clone()));
+    // keepalive_secs est lu une seule fois (l'intervalle du ticker est fixé au
+    // démarrage ; seuls les seuils métier sont rechargeables à chaud).
+    let keepalive_secs = wh_cfg.read().await.keepalive_secs;
+    crate::supervise::spawn_critical(keepalive_task(keepalive_secs, bus.clone(), state.clone()));
     if let Some(lg_client) = lg {
-        crate::supervise::spawn_critical(control_task(cfg, lg_client, bus, state, loader));
+        crate::supervise::spawn_critical(control_task(wh_cfg, lg_client, bus, state, loader));
     } else {
         info!("Water heater auto-control disabled (no LG ThinQ client)");
     }
@@ -69,10 +72,15 @@ fn update_temp_max_tracking(
             let since = *s.water_heater_temp_max_since.get_or_insert(now);
             (now - since).num_seconds().max(0) as u64 >= hold_secs
         }
-        _ => {
+        // Lecture valide et SOUS le seuil → la cible n'est plus tenue, on réarme.
+        Some(_) => {
             s.water_heater_temp_max_since = None;
             false
         }
+        // Température temporairement inconnue (erreur API/timeout transitoire) :
+        // on PRÉSERVE le suivi en cours pour ne pas perdre le temps accumulé,
+        // mais on ne force pas VACATION tant qu'on n'a pas reconfirmé le seuil.
+        None => false,
     }
 }
 
@@ -99,7 +107,7 @@ async fn write_wh_metrics(vm_url: &str, mode: WaterHeaterMode, temp: Option<f64>
 }
 
 async fn control_task(
-    cfg: WaterHeaterConfig,
+    wh_cfg: Arc<RwLock<WaterHeaterConfig>>,
     lg: Arc<LgThinqClient>,
     bus: AppBus,
     state: Arc<RwLock<EnergyState>>,
@@ -124,6 +132,11 @@ async fn control_task(
         tokio::select! {
         _ = ticker.tick() => {
         let now = Utc::now();
+
+        // Snapshot des seuils courants (rechargeable à chaud via reload_rx) :
+        // un clone par tick (toutes les 5 min) → coût négligeable, et tous les
+        // paramètres chauffe-eau deviennent modifiables sans redémarrage.
+        let cfg = wh_cfg.read().await.clone();
 
         // Read actual state from LG ThinQ before deciding
         info!("Water heater: calling lg.get_state()...");
@@ -323,6 +336,23 @@ async fn control_task(
                 match rules::WaterHeaterRuleEngine::with_source(&src) {
                     Ok(e) => { rule_engine = e; info!("water_heater rule engine reloaded"); }
                     Err(e) => tracing::warn!("water_heater reload failed (keeping old engine): {e}"),
+                }
+                // Recharge les seuils depuis Config.toml (temp_max_c, hold, etc.)
+                // → modifiables à chaud, sans recompiler ni redémarrer le service.
+                // Le serveur HTTP partage le même Arc<RwLock> → /api/rules-status
+                // reflète immédiatement les nouvelles valeurs.
+                match crate::config::load() {
+                    Ok(c) => {
+                        let new = c.water_heater;
+                        info!(
+                            "water_heater config reloaded (temp_max_c={}, temp_max_hold_secs={}, \
+                             irradiance_min_wm2={}, soc_min_pct={})",
+                            new.temp_max_c, new.temp_max_hold_secs,
+                            new.irradiance_min_wm2, new.soc_min_pct,
+                        );
+                        *wh_cfg.write().await = new;
+                    }
+                    Err(e) => tracing::warn!("water_heater config reload failed (keeping old): {e}"),
                 }
             }
         }

--- a/crates/energy-manager/src/main.rs
+++ b/crates/energy-manager/src/main.rs
@@ -98,7 +98,11 @@ async fn main() -> anyhow::Result<()> {
     logic::charge_current::spawn(vic.clone(), cfg.charge_current.clone(), bus.clone(), state.clone(), loader.clone()).await;
     logic::solar_power::spawn(vic.clone(), cfg.solar.clone(), bus.clone(), state.clone(), loader.clone()).await;
     logic::deye_command::spawn(vic.clone(), cfg.deye.clone(), bus.clone(), state.clone(), loader.clone()).await;
-    logic::water_heater::spawn(cfg.water_heater.clone(), lg_arc.clone(), bus.clone(), state.clone(), loader.clone()).await;
+    // Config chauffe-eau partagée (Arc<RwLock>) : rechargeable à chaud via
+    // POST /api/v1/em/rules/reload — le control_task la relit depuis le disque,
+    // le serveur HTTP lit la même source pour /api/rules-status.
+    let wh_cfg = Arc::new(RwLock::new(cfg.water_heater.clone()));
+    logic::water_heater::spawn(wh_cfg.clone(), lg_arc.clone(), bus.clone(), state.clone(), loader.clone()).await;
     logic::meteo::spawn(cfg.solar.clone(), bus.clone(), state.clone()).await;
     logic::victron_keepalive::spawn(cfg.victron.portal_id.clone(), bus.clone()).await;
 
@@ -109,7 +113,7 @@ async fn main() -> anyhow::Result<()> {
     let srv_lg       = lg_arc.clone();
     let srv_loader   = loader.clone();
     let srv_reload   = bus.rule_reload.clone();
-    let srv_wh_cfg   = cfg.water_heater.clone();
+    let srv_wh_cfg   = wh_cfg.clone();
     supervise::spawn_critical(async move {
         live_ws::server::serve(&bind, live_tx, srv_state, srv_lg, srv_loader, srv_reload, srv_wh_cfg).await;
     });

--- a/docs/app-energy-manager.md
+++ b/docs/app-energy-manager.md
@@ -1145,12 +1145,36 @@ curl -s http://192.168.1.141:8081/api/v1/em/rules | python3 -m json.tool
 
 Si `rules.dir` n'est pas configuré ou si le fichier n'existe pas sur disque, le système utilise automatiquement la règle **embarquée dans le binaire**.
 
+> **Seuils chauffe-eau rechargeables à chaud** — l'appel `reload` ci-dessus
+> (`{"name":"water_heater"}` ou `{"name":"*"}`) recharge **aussi** les seuils de
+> la section `[energy_manager.water_heater]` depuis `Config.toml`, en plus du
+> fichier `.grl`. Les paramètres `temp_max_c` (60 °C par défaut),
+> `temp_max_hold_secs`, `irradiance_min_wm2`, `soc_min_pct`,
+> `mode_change_min_secs`, `heat_pump_target_c`, `vacation_target_c` et
+> `temp_set_delay_secs` prennent effet **sans recompiler ni redémarrer** le
+> service. Le control_task et l'endpoint `/api/rules-status` partagent la même
+> config (`Arc<RwLock<WaterHeaterConfig>>`) → la page « Règles système » reflète
+> immédiatement la nouvelle valeur. Procédure :
+>
+> ```bash
+> # 1. Éditer le seuil dans la config active du service
+> sudo nano /etc/daly-bms/config.toml      # [energy_manager.water_heater] temp_max_c = 58.0
+> # 2. Recharger à chaud (aucun restart)
+> curl -s -X POST http://192.168.1.141:8081/api/v1/em/rules/reload \
+>      -H "Content-Type: application/json" -d '{"name":"water_heater"}'
+> # 3. Vérifier la valeur prise en compte
+> curl -s http://192.168.1.141:8081/api/rules-status | python3 -m json.tool | grep temp_max
+> ```
+>
+> Seul `keepalive_secs` (intervalle du ticker keepalive Venus) reste fixé au
+> démarrage et nécessite un `systemctl restart energy-manager`.
+
 ### 13.3 Changer la logique métier (recompilation requise)
 
 | Besoin | Fichier | Ce qu'il faut changer |
 |--------|---------|----------------------|
 | Seuil DEYE fréquence | `config.rs` (DeyeConfig) + `Config.toml` | Paramètre `freq_high_hz` |
-| Délai debounce chauffe-eau | `config.rs` (WaterHeaterConfig) + `Config.toml` | `debounce_secs` |
+| Seuils chauffe-eau (temp_max_c, soc_min_pct, irradiance_min_wm2…) | `Config.toml` `[energy_manager.water_heater]` | **Aucune recompilation** — éditer + `POST /api/v1/em/rules/reload` (hot-reload, cf. §13.2) |
 | Ajouter un MPPT | `config.rs` (VictronConfig), `mqtt/topics.rs`, `solar_power.rs`, `types.rs` | Nouvelle instance + topic |
 | Nouveau topic Victron à surveiller | `mqtt/topics.rs` (`all_subscriptions`) + module concerné | Abonnement + handler |
 | Changer fréquence d'écriture DB | `logic/solar_power.rs` ligne `interval(Duration::from_secs(1))` | Valeur en secondes |


### PR DESCRIPTION
…ectifs review

Rend les seuils du chauffe-eau (temp_max_c 60°C, temp_max_hold_secs, etc.) modifiables sans recompiler NI redémarrer le service : POST /api/v1/em/rules/reload {"name":"water_heater"} relit Config.toml et met à jour la config partagée (Arc<RwLock<WaterHeaterConfig>>), lue à la fois par le control_task et par l'endpoint /api/rules-status (page « Règles système »).

Correctifs suite à la revue automatique :
- update_temp_max_tracking: une lecture None (erreur API/timeout transitoire) ne réarme plus le timer — le temps accumulé est préservé (seul un Some(<seuil>) réarme).
- /api/rules-status: temp_max_reached exige aussi temp_actuelle >= temp_max_c, pour ne pas afficher « cible atteinte » si la temp est déjà redescendue avant que le tick control_task n'efface l'horodatage.
- monitor.html: le compteur de durée ne s'affiche que si la temp actuelle est toujours >= seuil (cohérence d'affichage).

Doc: docs/app-energy-manager.md §13.2 (procédure hot-reload) + Config.toml.


Claude-Session: https://claude.ai/code/session_01B7VPxRRuYwpjFekZyjbWzc