### PR TITLE
fix(water_heater): ancrer le chrono temp_max dès la lecture du poller LG

### DIFF
--- a/crates/energy-manager/src/http_clients/lg_thinq.rs
+++ b/crates/energy-manager/src/http_clients/lg_thinq.rs
@@ -4,8 +4,11 @@ use serde_json::json;
 use tokio::time::{interval, Duration};
 use tracing::{debug, error, info, warn};
 
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
 use crate::bus::AppBus;
-use crate::config::LgThinqConfig;
+use crate::config::{LgThinqConfig, WaterHeaterConfig};
 use crate::types::{LiveEvent, WaterHeaterMode};
 
 // ---------------------------------------------------------------------------
@@ -216,7 +219,8 @@ impl LgThinqClient {
 pub async fn spawn_poller(
     cfg: LgThinqConfig,
     bus: AppBus,
-    state: std::sync::Arc<tokio::sync::RwLock<crate::types::EnergyState>>,
+    state: Arc<RwLock<crate::types::EnergyState>>,
+    wh_cfg: Arc<RwLock<WaterHeaterConfig>>,
 ) -> Option<LgThinqClient> {
     if !cfg.enabled {
         info!("LG ThinQ integration disabled");
@@ -242,10 +246,11 @@ pub async fn spawn_poller(
         }
     };
 
-    let poller = client.clone();
-    let cfg2   = cfg.clone();
-    let bus2   = bus.clone();
-    let state2 = state.clone();
+    let poller  = client.clone();
+    let cfg2    = cfg.clone();
+    let bus2    = bus.clone();
+    let state2  = state.clone();
+    let wh_cfg2 = wh_cfg.clone();
     crate::supervise::spawn_critical(async move {
         let vm_url = cfg2.vm_url.clone();
         let mut ticker = interval(Duration::from_secs(poller.cfg.poll_interval_secs));
@@ -254,12 +259,18 @@ pub async fn spawn_poller(
             let now = chrono::Utc::now();
             match poller.get_state().await {
                 Ok(snap) => {
+                    // Seuil « cuve à température cible » lu hors verrou `state`
+                    // (config rechargeable à chaud, partagée avec le control_task).
+                    let temp_max_c = wh_cfg2.read().await.temp_max_c;
                     {
                         let mut s = state2.write().await;
                         s.water_heater_mode      = snap.mode;
                         s.water_heater_temp_c    = snap.current_temp_c;
                         s.water_heater_target_c  = snap.target_temp_c;
                         s.water_heater_last_read = Some(now);
+                        // Ancre le chrono dès que le poller voit la cuve ≥ seuil,
+                        // sans attendre le tick de 5 min du control_task.
+                        crate::logic::water_heater::anchor_temp_max(&mut s, now, temp_max_c);
                     }
                     bus2.emit_live(LiveEvent::new("water_heater", &snap));
 

--- a/crates/energy-manager/src/logic/water_heater/mod.rs
+++ b/crates/energy-manager/src/logic/water_heater/mod.rs
@@ -53,34 +53,46 @@ async fn publish_to_venus(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
     bus.emit_live(LiveEvent::new("water_heater_venus", &payload));
 }
 
+/// Ancre (ou réarme) le chrono « cuve à température cible » en fonction de la
+/// dernière température lue, stockée au préalable dans `water_heater_temp_c`.
+///
+/// Appelée à **chaque** lecture de température — par le poller LG ThinQ ET par
+/// le `control_task` — afin que le chrono démarre dès l'instant où la cuve passe
+/// ≥ `temp_max_c`, sans attendre le prochain tick de 5 min du control_task.
+///
+/// - Temp ≥ seuil : on date le premier franchissement (`get_or_insert`).
+/// - Temp < seuil : la cible n'est plus tenue → on réarme.
+/// - Temp inconnue (erreur API/timeout transitoire) : on PRÉSERVE le chrono en
+///   cours pour ne pas perdre le temps accumulé.
+pub(crate) fn anchor_temp_max(s: &mut EnergyState, now: DateTime<Utc>, temp_max_c: f64) {
+    match s.water_heater_temp_c {
+        Some(t) if t >= temp_max_c => {
+            s.water_heater_temp_max_since.get_or_insert(now);
+        }
+        Some(_) => s.water_heater_temp_max_since = None,
+        None => {}
+    }
+}
+
 /// Met à jour le suivi « température cible atteinte » dans l'état partagé et
 /// renvoie `true` si la température de la cuve est restée ≥ `temp_max_c`
 /// pendant au moins `hold_secs`.
 ///
-/// La température est lue régulièrement (poller LG ThinQ + ce control_task) et
-/// stockée dans `water_heater_temp_c` ; on date le premier instant où le seuil
-/// est franchi (`water_heater_temp_max_since`) puis on mesure la durée écoulée.
-/// Dès qu'elle redescend, le suivi est réarmé.
+/// L'ancrage du chrono (`water_heater_temp_max_since`) est délégué à
+/// [`anchor_temp_max`] ; cette fonction ne fait que mesurer la durée écoulée
+/// depuis cet ancrage pour décider du passage en VACATION.
 fn update_temp_max_tracking(
     s: &mut EnergyState,
     now: DateTime<Utc>,
     temp_max_c: f64,
     hold_secs: u64,
 ) -> bool {
-    match s.water_heater_temp_c {
-        Some(t) if t >= temp_max_c => {
-            let since = *s.water_heater_temp_max_since.get_or_insert(now);
+    anchor_temp_max(s, now, temp_max_c);
+    match (s.water_heater_temp_c, s.water_heater_temp_max_since) {
+        (Some(t), Some(since)) if t >= temp_max_c => {
             (now - since).num_seconds().max(0) as u64 >= hold_secs
         }
-        // Lecture valide et SOUS le seuil → la cible n'est plus tenue, on réarme.
-        Some(_) => {
-            s.water_heater_temp_max_since = None;
-            false
-        }
-        // Température temporairement inconnue (erreur API/timeout transitoire) :
-        // on PRÉSERVE le suivi en cours pour ne pas perdre le temps accumulé,
-        // mais on ne force pas VACATION tant qu'on n'a pas reconfirmé le seuil.
-        None => false,
+        _ => false,
     }
 }
 

--- a/crates/energy-manager/src/main.rs
+++ b/crates/energy-manager/src/main.rs
@@ -71,11 +71,18 @@ async fn main() -> anyhow::Result<()> {
     // --- Spawn persist MQTT watcher (retained topics at startup) ---
     spawn_persist_watcher(bus.clone(), state.clone());
 
+    // Config chauffe-eau partagée (Arc<RwLock>) : rechargeable à chaud via
+    // POST /api/v1/em/rules/reload — le control_task la relit depuis le disque,
+    // le serveur HTTP lit la même source pour /api/rules-status, et le poller LG
+    // y lit `temp_max_c` pour ancrer le chrono « cuve à température cible ».
+    let wh_cfg = Arc::new(RwLock::new(cfg.water_heater.clone()));
+
     // --- LG ThinQ client ---
     let lg_client = http_clients::lg_thinq::spawn_poller(
         cfg.lg_thinq.clone(),
         bus.clone(),
         state.clone(),
+        wh_cfg.clone(),
     ).await;
     let lg_arc = lg_client.map(Arc::new);
 
@@ -98,10 +105,6 @@ async fn main() -> anyhow::Result<()> {
     logic::charge_current::spawn(vic.clone(), cfg.charge_current.clone(), bus.clone(), state.clone(), loader.clone()).await;
     logic::solar_power::spawn(vic.clone(), cfg.solar.clone(), bus.clone(), state.clone(), loader.clone()).await;
     logic::deye_command::spawn(vic.clone(), cfg.deye.clone(), bus.clone(), state.clone(), loader.clone()).await;
-    // Config chauffe-eau partagée (Arc<RwLock>) : rechargeable à chaud via
-    // POST /api/v1/em/rules/reload — le control_task la relit depuis le disque,
-    // le serveur HTTP lit la même source pour /api/rules-status.
-    let wh_cfg = Arc::new(RwLock::new(cfg.water_heater.clone()));
     logic::water_heater::spawn(wh_cfg.clone(), lg_arc.clone(), bus.clone(), state.clone(), loader.clone()).await;
     logic::meteo::spawn(cfg.solar.clone(), bus.clone(), state.clone()).await;
     logic::victron_keepalive::spawn(cfg.victron.portal_id.clone(), bus.clone()).await;


### PR DESCRIPTION
Le suivi « cuve à température cible » n'était mis à jour que dans le control_task (tick toutes les 5 min). L'horodatage de départ du chrono (water_heater_temp_max_since) était donc posé à un tick de control_task, pas au moment réel où la cuve franchissait temp_max_c — soit jusqu'à 5 min de retard avant que les 10 min de maintien ne commencent à courir.

Extraction de anchor_temp_max() (ancrage/réarmement), appelée à chaque lecture de température : le poller LG ThinQ l'invoque désormais juste après avoir écrit water_heater_temp_c, en plus du control_task. update_temp_max_tracking ne fait plus que mesurer la durée écoulée.

Le poller reçoit wh_cfg (Arc<RwLock<WaterHeaterConfig>>) pour lire temp_max_c (rechargeable à chaud). wh_cfg est créé en amont dans main.rs.


Claude-Session: https://claude.ai/code/session_01WKfLRP79r9dDxXyJksyfhX