### PR TITLE
fix(energy-manager): le Bulk MPPT autorise la restauration DEYE (prio…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -623,6 +623,7 @@ relay_resync_secs          = 60       # s — ré-affirmation périodique de l'�
 # seul MPPT, sans atteindre la fréquence haute. Bascule : mettre false pour fréquence seule.
 mppt_cut_enabled           = true     # active la coupure DEYE pilotée par l'état MPPT
 mppt_full_states           = [4, 5, 6] # codes State « batterie pleine » : 4=Absorption,5=Float,6=Storage
+mppt_charging_states       = [3]      # codes State « batterie en charge » : 3=Bulk → autorise la restauration (prioritaire sur le garde SmartShunt)
 mppt_cut_delay_secs        = 10       # s — débounce : MPPT « plein » maintenu avant coupure
 
 # --- Chauffe-eau LG ThinQ ---

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -323,6 +323,12 @@ pub struct DeyeConfig {
     /// Default [4,5,6] = Absorption, Float, Storage (3=Bulk means the battery still charges).
     #[serde(default = "default_mppt_full_states")]
     pub mppt_full_states: Vec<i64>,
+    /// MPPT solar-charger State codes meaning "battery actively accepting bulk charge" (NOT
+    /// full). While any charger reports one of these, the SmartShunt structural-excess guard
+    /// must not hold the DEYE off — the MPPT firmware stage is the authority (CLAUDE.md §13).
+    /// Default [3] = Bulk.
+    #[serde(default = "default_mppt_charging_states")]
+    pub mppt_charging_states: Vec<i64>,
     /// Debounce: the MPPT-full condition must hold this long before cutting (seconds).
     #[serde(default = "default_mppt_cut_delay_secs")]
     pub mppt_cut_delay_secs: u64,
@@ -339,6 +345,7 @@ fn default_restore_irradiance_wm2() -> f64 { 250.0 }
 fn default_corroboration_max_age_secs() -> u64 { 60 }
 fn default_relay_resync_secs() -> u64 { 60 }
 fn default_mppt_full_states() -> Vec<i64> { vec![4, 5, 6] }
+fn default_mppt_charging_states() -> Vec<i64> { vec![3] }
 fn default_mppt_cut_delay_secs() -> u64 { 10 }
 
 impl Default for DeyeConfig {
@@ -356,6 +363,7 @@ impl Default for DeyeConfig {
             relay_resync_secs: default_relay_resync_secs(),
             mppt_cut_enabled: false,
             mppt_full_states: default_mppt_full_states(),
+            mppt_charging_states: default_mppt_charging_states(),
             mppt_cut_delay_secs: default_mppt_cut_delay_secs(),
         }
     }

--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -407,10 +407,36 @@ async fn read_gates(state: &Arc<RwLock<EnergyState>>, cfg: &DeyeConfig, now: Dat
     let s = state.read().await;
     let grid_connected = is_grid_connected(s.ac_ignore, s.ac_connected);
     let mppt_full = mppt_battery_full(&s, cfg);
-    // Restore is held off while the battery is full per EITHER the MPPT charge stage or
-    // the SmartShunt-based structural-excess guard.
-    let restore_blocked = mppt_full || smartshunt_battery_full(&s, cfg, now);
+    let restore_blocked = restore_blocked(&s, cfg, now);
     (grid_connected, restore_blocked, mppt_full)
+}
+
+/// Whether DEYE restore must be held off (structural PV excess — restoring would just
+/// re-trigger a cut and thrash the relay).
+///
+/// Held off when the battery is full per the MPPT charge stage (Absorption/Float/Storage)
+/// OR per the SmartShunt structural-excess heuristic. **But** the MPPT firmware stage is the
+/// authority (CLAUDE.md §13): while any charger is still in Bulk the battery is actively
+/// accepting charge and is *not* full, so the SmartShunt heuristic is suppressed — restoring
+/// in Bulk cannot thrash the relay (the charge absorbs the power, frequency stays nominal).
+fn restore_blocked(s: &EnergyState, cfg: &DeyeConfig, now: DateTime<Utc>) -> bool {
+    if mppt_battery_full(s, cfg) {
+        return true;
+    }
+    smartshunt_battery_full(s, cfg, now) && !mppt_charging_bulk(s, cfg)
+}
+
+/// Battery actively accepting bulk charge per any MPPT solar-charger (Bulk stage). Pure
+/// firmware telemetry — a direct "the battery is NOT full" signal. Returns false when the
+/// MPPT-stage feature is disabled.
+fn mppt_charging_bulk(s: &EnergyState, cfg: &DeyeConfig) -> bool {
+    if !cfg.mppt_cut_enabled {
+        return false;
+    }
+    [s.mppt_273.state, s.mppt_289.state]
+        .into_iter()
+        .flatten()
+        .any(|st| cfg.mppt_charging_states.contains(&st))
 }
 
 /// Battery topping/full according to the MPPT charge stage (Absorption/Float/Storage on
@@ -465,7 +491,7 @@ fn smartshunt_battery_full(s: &EnergyState, cfg: &DeyeConfig, now: DateTime<Utc>
 
 #[cfg(test)]
 mod tests {
-    use super::is_grid_connected;
+    use super::*;
 
     #[test]
     fn grid_tied_when_connected_and_not_ignored() {
@@ -490,5 +516,72 @@ mod tests {
         assert!(is_grid_connected(None, None));
         assert!(is_grid_connected(Some(0), None));
         assert!(!is_grid_connected(Some(1), None));
+    }
+
+    // --- restore_blocked / MPPT-stage authority --------------------------------
+
+    fn cfg_mppt_on() -> DeyeConfig {
+        DeyeConfig { mppt_cut_enabled: true, ..Default::default() }
+    }
+
+    /// A state where the SmartShunt structural-excess heuristic alone returns true
+    /// (SOC ≥ 95 %, irradiance ≥ 250 W/m², not discharging, shunt fresh).
+    fn smartshunt_full_state(now: DateTime<Utc>) -> EnergyState {
+        EnergyState {
+            soc_pct: Some(96.0),
+            irradiance_wm2: Some(300.0),
+            battery_current_a: Some(0.0),
+            shunt_last_seen_ts: Some(now),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn smartshunt_alone_blocks_restore() {
+        let now = Utc::now();
+        let s = smartshunt_full_state(now);
+        // No MPPT stage data → only the SmartShunt heuristic governs → blocked.
+        assert!(restore_blocked(&s, &cfg_mppt_on(), now));
+    }
+
+    #[test]
+    fn mppt_bulk_overrides_smartshunt_guard() {
+        // ← le cas signalé : SmartShunt « plein » mais les MPPT en Bulk → la batterie
+        // accepte de la charge → la restauration NE doit PAS être bloquée.
+        let now = Utc::now();
+        let mut s = smartshunt_full_state(now);
+        s.mppt_273.state = Some(3); // Bulk
+        s.mppt_289.state = Some(3); // Bulk
+        assert!(!restore_blocked(&s, &cfg_mppt_on(), now));
+    }
+
+    #[test]
+    fn mppt_full_blocks_even_if_other_charger_bulk() {
+        // One charger in Absorption (full) → mppt_full wins, restore stays blocked,
+        // regardless of a Bulk reading on the other charger.
+        let now = Utc::now();
+        let mut s = smartshunt_full_state(now);
+        s.mppt_273.state = Some(4); // Absorption (full)
+        s.mppt_289.state = Some(3); // Bulk
+        assert!(restore_blocked(&s, &cfg_mppt_on(), now));
+    }
+
+    #[test]
+    fn mppt_bulk_override_respects_feature_toggle() {
+        // mppt_cut_enabled == false → MPPT stage ignored, SmartShunt guard governs alone.
+        let now = Utc::now();
+        let mut s = smartshunt_full_state(now);
+        s.mppt_273.state = Some(3); // Bulk
+        s.mppt_289.state = Some(3);
+        let cfg = DeyeConfig { mppt_cut_enabled: false, ..Default::default() };
+        assert!(restore_blocked(&s, &cfg, now));
+    }
+
+    #[test]
+    fn no_excess_does_not_block() {
+        // Neither MPPT-full nor SmartShunt-full → restore allowed.
+        let now = Utc::now();
+        let s = EnergyState::default(); // no soc/irradiance/shunt data
+        assert!(!restore_blocked(&s, &cfg_mppt_on(), now));
     }
 }


### PR DESCRIPTION
…ritaire sur le garde SmartShunt)

restore_blocked = mppt_full || smartshunt_battery_full : le garde SmartShunt (SOC≥95 % + irradiance≥250 + non-décharge) ignorait totalement l'étage de charge MPPT. Résultat observé : DEYE coupés alors que les deux MPPT sont en Bulk — c.-à-d. que la batterie tire activement du courant de charge (donc PAS pleine).

Le garde SmartShunt est une heuristique anti-thrash : ne pas restaurer si la batterie est structurellement pleine, sinon le DEYE repousse de la puissance, la fréquence monte et re-coupe. Mais en Bulk ce motif ne s'applique pas : la batterie absorbe la puissance, la fréquence reste nominale. L'étage MPPT est une mesure firmware, prioritaire sur tout dérivé (CLAUDE.md §13).

Correctif : tant qu'un MPPT est en Bulk (mppt_charging_states, défaut [3]), l'heuristique SmartShunt est neutralisée → la restauration est autorisée. mppt_full (Absorption/Float/Storage) continue de bloquer, y compris si l'autre chargeur est en Bulk. Gardé derrière mppt_cut_enabled (un seul interrupteur pour toute la logique pilotée par l'étage MPPT). Tests : 5 cas couvrant l'override, la priorité mppt_full, le respect du toggle, et l'absence d'excédent.


Claude-Session: https://claude.ai/code/session_01Krwof8uqbU5anYC8ygX8Lq