### PR TITLE
refactor(energy-manager): décision DEYE = Fréquence + MPPT uniquement…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -609,21 +609,18 @@ pv_excess_threshold_w = 50.0          # W minimum pour déclencher l'excédent
 
 # --- Commande relais DEYE (via Shelly) ---
 [energy_manager.deye]
-freq_high_hz               = 51.0     # Hz — coupure débouncée (sous l'auto-trip DEYE 51.5)
+# Décision DEYE : Fréquence AC + état des MPPT UNIQUEMENT (ni réseau, ni SmartShunt/SOC/irradiance).
+# Seuil de fréquence UNIQUE (pas de zone morte) : ≥ freq_high_hz → coupe ; < freq_high_hz → restaure.
+freq_high_hz               = 51.0     # Hz — seuil unique coupe/restaure (sous l'auto-trip DEYE 51.5)
 freq_hard_hz               = 51.3     # Hz — coupure immédiate (filet pré-trip)
-freq_low_hz                = 50.3     # Hz — seuil de réactivation
-cut_delay_secs             = 3        # s — débounce coupure (bat la rampe vers 51.5)
-reenable_delay_secs        = 45       # s — bas-soutenu avant réactivation
-lockout_secs               = 120      # s — anti-oscillation après coupure
-restore_soc_pct            = 95.0     # % — SOC ≥ → excédent structurel présumé → maintien coupé
-restore_irradiance_wm2     = 250.0    # W/m² — irradiance ≥ → soleil fort → maintien coupé
-corroboration_max_age_secs = 60       # s — fraîcheur SmartShunt (au-delà : fréquence seule, fail-open)
+cut_delay_secs             = 3        # s — débounce avant coupure douce (bat la rampe vers 51.5)
+reenable_delay_secs        = 45       # s — bas-soutenu sous le seuil avant restauration
+lockout_secs               = 120      # s — temps mort obligatoire après coupure (anti-rebattement principal)
 relay_resync_secs          = 60       # s — ré-affirmation périodique de l'état des 2 canaux
 # Coupure anticipée sur l'état de charge des MPPT (DC-couplé) — termine la charge sur le
 # seul MPPT, sans atteindre la fréquence haute. Bascule : mettre false pour fréquence seule.
 mppt_cut_enabled           = true     # active la coupure DEYE pilotée par l'état MPPT
-mppt_full_states           = [4, 5, 6] # codes State « batterie pleine » : 4=Absorption,5=Float,6=Storage
-mppt_charging_states       = [3]      # codes State « batterie en charge » : 3=Bulk → autorise la restauration (prioritaire sur le garde SmartShunt)
+mppt_full_states           = [4, 5, 6] # codes State « batterie pleine » : 4=Absorption,5=Float,6=Storage (3=Bulk → restaure)
 mppt_cut_delay_secs        = 10       # s — débounce : MPPT « plein » maintenu avant coupure
 
 # --- Chauffe-eau LG ThinQ ---

--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -184,7 +184,7 @@
             <div id="deye-change-ts" style="font-family:monospace;font-size:0.7rem;color:#64748b;">—</div>
           </div>
         </div>
-        <div style="font-family:monospace;font-size:0.6rem;color:#475569;margin-bottom:0.35rem;">Coupe ≥ 51,0 Hz (dur ≥ 51,3) · restaure ≤ 50,3 Hz · 2 DEYE</div>
+        <div style="font-family:monospace;font-size:0.6rem;color:#475569;margin-bottom:0.35rem;">Coupe ≥ 51,0 Hz (dur ≥ 51,3) · restaure &lt; 51,0 Hz · Fréq+MPPT · 2 DEYE</div>
         <div id="deye-rule-grid" style="display:flex;flex-direction:column;gap:0.35rem;"></div>
       </div>
 
@@ -631,7 +631,8 @@ async function fetchRulesStatus() {
       const mpptLabels = mpptStates.map(st => st == null ? '—' : (MPPT_STAGE[st] || st)).join(' / ');
 
       const rows = [
-        statusRow('Réseau', resVal, resColor, resDetail),
+        // Réseau : purement informatif — n'intervient plus dans la décision DEYE (Fréq + MPPT).
+        statusRow('Réseau (info)', resVal, resColor, resDetail),
         statusRow('Fréquence AC', deyeFreq != null ? deyeFreq.toFixed(2) + ' Hz' : '—', fColor, 'coupe ≥ 51,0 · dure ≥ 51,3'),
         statusRow('MPPT (charge)', mpptLabels,
                   deyeMpptFull ? AMBER : (mpptStates.some(st => st === 3) ? GREEN : GREY),
@@ -641,7 +642,7 @@ async function fetchRulesStatus() {
       if (relayOn === false) {
         rows.push(statusRow('Restauration', deyeBlock ? 'En attente' : 'Autorisée',
                   deyeBlock ? AMBER : GREEN,
-                  deyeBlock ? 'excédent : batterie pleine + soleil' : 'fréquence ≤ 50,3 Hz'));
+                  deyeBlock ? 'batterie pleine (MPPT) → maintien coupé' : 'fréquence < 51,0 Hz · MPPT pas plein'));
       }
       // Canaux Shelly — état réel de chaque relais (un canal par DEYE), sur la même ligne.
       const chTag = (lbl, out) => {

--- a/crates/energy-manager/rules/deye_command.grl
+++ b/crates/energy-manager/rules/deye_command.grl
@@ -1,38 +1,37 @@
 // DEYE relay state machine rules.
-// Manages the Shelly relay controlling the DEYE inverter based on AC frequency.
+// Manages the Shelly relay controlling the DEYE inverters based ONLY on:
+//   1. the AC-Out frequency, and
+//   2. the MPPT solar-charger charge stage.
+// No grid/SmartShunt/SOC/irradiance signal takes part in the decision.
+//
+// Single frequency boundary (no dead band): `freq_cut_hz` (default 51.0).
+//   freq ≥ freq_cut_hz  → cut side  (debounced, or immediate at freq_hard_hz)
+//   freq <  freq_cut_hz → restore side
+// Hysteresis against relay chattering is purely TEMPORAL: cut_delay (debounce
+// before a soft cut), lockout (mandatory off-time after a cut) and reenable_delay
+// (sustained low-frequency time before a restore).
 //
 // Input facts (injected from Rust before evaluate):
 //   DY.state                  (string: "On"|"PendingCut"|"Off"|"PendingRestore"|"Lockout")
-//   DY.freq_high_exceeded     (bool, pre-computed: freq_hz >= freq_high_hz)  — debounced cut
+//   DY.freq_cut_exceeded      (bool, pre-computed: freq_hz >= freq_cut_hz)   — cut side / restore gate
 //   DY.freq_hard_exceeded     (bool, pre-computed: freq_hz >= freq_hard_hz)  — immediate cut
-//   DY.freq_low_reached       (bool, pre-computed: freq_hz <= freq_low_hz)
 //   DY.cut_delay_elapsed      (bool, pre-computed: time_in_state_secs >= cut_delay_secs)
 //   DY.reenable_delay_elapsed (bool, pre-computed: time_in_state_secs >= reenable_delay_secs)
 //   DY.lockout_expired        (bool, pre-computed: now >= lockout_until)
-//   DY.grid_connected         (bool)
-//   DY.restore_blocked        (bool, pre-computed: structural PV excess — battery full
-//                              (MPPT stage and/or SmartShunt) → hold DEYE off)
-//   DY.mppt_cut               (bool, pre-computed: battery topping/full per the MPPT charge
-//                              stage, debounced → cut DEYE early, finish charge on MPPT alone)
+//   DY.restore_blocked        (bool, pre-computed: battery full per MPPT stage — Absorption/
+//                              Float/Storage → hold the DEYE off; Bulk/charging → allow restore)
+//   DY.mppt_cut               (bool, pre-computed: battery full per MPPT stage, debounced → cut
+//                              the DEYE early so the charge finishes on the DC-coupled MPPT alone)
 //
 // Output facts (read from Rust after execute):
 //   DY.next_state             (string, absent if no transition)
 //   DY.relay_on               (bool)
 //   DY.relay_off              (bool)
-//
-// IMPORTANT: normal rules (salience 100) include `DY.grid_connected == false`
-// to prevent them from overwriting grid-reconnect rules (salience 200).
-// The rule engine fires all matching rules; higher-salience fires first but
-// lower-salience can still overwrite the same fact without this guard.
 
 // ── Hard cut: immediate, pre-empts the DEYE 51.5 Hz self-trip (salience 150) ──
-// Fires above grid-reconnect priority guards (grid_connected==false) but below the
-// salience-200 reconnect rules, and is mutually exclusive with the debounced
-// DY_On_HighFreq path (which carries `freq_hard_exceeded == false`).
-
 rule "DY_On_HardFreq" salience 150 no-loop {
     when
-        DY.state == "On" && DY.freq_hard_exceeded == true && DY.grid_connected == false
+        DY.state == "On" && DY.freq_hard_exceeded == true
     then
         DY.next_state = "Lockout";
         DY.relay_off = true;
@@ -40,19 +39,18 @@ rule "DY_On_HardFreq" salience 150 no-loop {
 
 rule "DY_PendingCut_HardFreq" salience 150 no-loop {
     when
-        DY.state == "PendingCut" && DY.freq_hard_exceeded == true && DY.grid_connected == false
+        DY.state == "PendingCut" && DY.freq_hard_exceeded == true
     then
         DY.next_state = "Lockout";
         DY.relay_off = true;
 }
 
-// ── MPPT-based early cut (salience 130) ─────────────────────────────────────
-// Battery topping/full per the MPPT charge stage (Absorption/Float/Storage) → cut the
-// DEYE now, so the charge finishes on the DC-coupled MPPT alone, pre-empting the AC-out
-// frequency rise. Guarded against the grid-reconnect override (salience 200).
+// ── MPPT-based cut (salience 130) ───────────────────────────────────────────
+// Battery topping/full per the MPPT charge stage → cut the DEYE now, so the charge
+// finishes on the DC-coupled MPPT alone, pre-empting the AC-out frequency rise.
 rule "DY_On_MpptFull" salience 130 no-loop {
     when
-        DY.state == "On" && DY.mppt_cut == true && DY.grid_connected == false
+        DY.state == "On" && DY.mppt_cut == true
     then
         DY.next_state = "Lockout";
         DY.relay_off = true;
@@ -60,7 +58,7 @@ rule "DY_On_MpptFull" salience 130 no-loop {
 
 rule "DY_PendingCut_MpptFull" salience 130 no-loop {
     when
-        DY.state == "PendingCut" && DY.mppt_cut == true && DY.grid_connected == false
+        DY.state == "PendingCut" && DY.mppt_cut == true
     then
         DY.next_state = "Lockout";
         DY.relay_off = true;
@@ -68,100 +66,72 @@ rule "DY_PendingCut_MpptFull" salience 130 no-loop {
 
 // ── Normal state machine transitions (salience 100) ─────────────────────────
 
-// On → PendingCut when frequency exceeds the soft threshold (but not the hard one,
-// which is handled immediately above). Guarded against the grid-reconnect override and
-// the MPPT cut (so neither higher-salience Lockout is downgraded back to PendingCut).
+// On → PendingCut when frequency reaches the cut boundary (but not the hard one,
+// handled immediately above). Guarded against the MPPT cut so the higher-salience
+// Lockout is not downgraded back to PendingCut.
 rule "DY_On_HighFreq" salience 100 no-loop {
     when
-        DY.state == "On" && DY.freq_high_exceeded == true && DY.freq_hard_exceeded == false && DY.mppt_cut == false && DY.grid_connected == false
+        DY.state == "On" && DY.freq_cut_exceeded == true && DY.freq_hard_exceeded == false && DY.mppt_cut == false
     then
         DY.next_state = "PendingCut";
 }
 
-// PendingCut: cancel if frequency drops back (mutually exclusive with _Elapsed).
-// Guarded by mppt_cut==false so it doesn't cancel an MPPT-driven cut at low frequency.
+// PendingCut: cancel if frequency drops back below the boundary (mutually exclusive
+// with _Elapsed). Guarded by mppt_cut==false so it doesn't cancel an MPPT-driven cut.
 rule "DY_PendingCut_FreqDrop" salience 100 no-loop {
     when
-        DY.state == "PendingCut" && DY.freq_high_exceeded == false && DY.mppt_cut == false
+        DY.state == "PendingCut" && DY.freq_cut_exceeded == false && DY.mppt_cut == false
     then
         DY.next_state = "On";
 }
 
-// PendingCut → Lockout after delay (only if frequency is still high).
-// Grid guard prevents this from overwriting a salience-200 reconnect into Lockout.
+// PendingCut → Lockout after the debounce (only if frequency is still at/above boundary).
 rule "DY_PendingCut_Elapsed" salience 100 no-loop {
     when
-        DY.state == "PendingCut" && DY.cut_delay_elapsed == true && DY.freq_high_exceeded == true && DY.grid_connected == false
+        DY.state == "PendingCut" && DY.cut_delay_elapsed == true && DY.freq_cut_exceeded == true
     then
         DY.next_state = "Lockout";
         DY.relay_off = true;
 }
 
-// Lockout → Off once lockout expires (guard: grid not connected, else reconnect rule takes priority)
+// Lockout → Off once the mandatory off-time expires.
 rule "DY_Lockout_Expired" salience 100 no-loop {
     when
-        DY.state == "Lockout" && DY.lockout_expired == true && DY.grid_connected == false
+        DY.state == "Lockout" && DY.lockout_expired == true
     then
         DY.next_state = "Off";
 }
 
-// Off → PendingRestore when frequency drops to low threshold, UNLESS a fresh
-// structural PV excess is still present (restore_blocked) — that would just
-// re-trigger a cut, thrashing the relay. Guard: grid not connected.
-rule "DY_Off_LowFreq" salience 100 no-loop {
+// Off → PendingRestore when frequency is below the boundary AND the battery is not
+// full per the MPPT stage (restore_blocked). Single boundary → no dead band.
+rule "DY_Off_RestoreReady" salience 100 no-loop {
     when
-        DY.state == "Off" && DY.freq_low_reached == true && DY.grid_connected == false && DY.restore_blocked == false
+        DY.state == "Off" && DY.freq_cut_exceeded == false && DY.restore_blocked == false
     then
         DY.next_state = "PendingRestore";
 }
 
-// PendingRestore: cancel if frequency climbs back (guard: grid not connected)
+// PendingRestore: cancel if the frequency climbs back to the cut boundary.
 rule "DY_PendingRestore_FreqClimb" salience 100 no-loop {
     when
-        DY.state == "PendingRestore" && DY.freq_low_reached == false && DY.grid_connected == false
+        DY.state == "PendingRestore" && DY.freq_cut_exceeded == true
     then
         DY.next_state = "Off";
 }
 
-// PendingRestore → On after delay (only if frequency is still low)
+// PendingRestore: cancel if the battery fills up again (MPPT reaches a full stage)
+// during the restore wait.
+rule "DY_PendingRestore_Blocked" salience 100 no-loop {
+    when
+        DY.state == "PendingRestore" && DY.restore_blocked == true
+    then
+        DY.next_state = "Off";
+}
+
+// PendingRestore → On after the sustained low-frequency time, battery still not full.
 rule "DY_PendingRestore_Elapsed" salience 100 no-loop {
     when
-        DY.state == "PendingRestore" && DY.reenable_delay_elapsed == true && DY.freq_low_reached == true
-    then
-        DY.next_state = "On";
-        DY.relay_on = true;
-}
-
-// ── Grid reconnect override (salience 200) ───────────────────────────────────
-
-// Grid reconnected while DEYE was cut — restore relay immediately
-rule "DY_GridReconnect_From_Off" salience 200 no-loop {
-    when
-        DY.grid_connected == true && DY.state == "Off"
-    then
-        DY.next_state = "On";
-        DY.relay_on = true;
-}
-
-rule "DY_GridReconnect_From_PendingCut" salience 200 no-loop {
-    when
-        DY.grid_connected == true && DY.state == "PendingCut"
-    then
-        DY.next_state = "On";
-        DY.relay_on = true;
-}
-
-rule "DY_GridReconnect_From_PendingRestore" salience 200 no-loop {
-    when
-        DY.grid_connected == true && DY.state == "PendingRestore"
-    then
-        DY.next_state = "On";
-        DY.relay_on = true;
-}
-
-rule "DY_GridReconnect_From_Lockout" salience 200 no-loop {
-    when
-        DY.grid_connected == true && DY.state == "Lockout"
+        DY.state == "PendingRestore" && DY.reenable_delay_elapsed == true && DY.freq_cut_exceeded == false && DY.restore_blocked == false
     then
         DY.next_state = "On";
         DY.relay_on = true;

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -279,37 +279,25 @@ impl Default for ChargeCurrent {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct DeyeConfig {
-    /// Frequency threshold to cut DEYE after `cut_delay_secs` debounce (Hz).
-    /// Set below the DEYE's own 51.5 Hz self-trip so the Shelly relay pre-empts it.
+    /// Single frequency boundary (Hz): freq ≥ this → cut side (debounced by `cut_delay_secs`,
+    /// or immediate at `freq_hard_hz`); freq < this → restore side. No dead band. Set below
+    /// the DEYE's own 51.5 Hz self-trip so the Shelly relay pre-empts it.
     #[serde(default = "default_freq_high")]
     pub freq_high_hz: f64,
     /// Hard frequency threshold for an immediate cut, bypassing the debounce (Hz).
     /// Safety net if the frequency ramps quickly toward the 51.5 Hz self-trip.
     #[serde(default = "default_freq_hard")]
     pub freq_hard_hz: f64,
-    /// Frequency threshold to re-enable DEYE (Hz)
-    #[serde(default = "default_freq_low")]
-    pub freq_low_hz: f64,
-    /// Delay before cutting after threshold crossed (seconds)
+    /// Debounce before a soft cut: frequency must stay at/above the boundary this long (seconds).
     #[serde(default = "default_cut_delay_secs")]
     pub cut_delay_secs: u64,
-    /// Delay before re-enabling after low threshold (seconds)
+    /// Sustained below-boundary time required before restoring the DEYE (seconds).
     #[serde(default = "default_reenable_delay_secs")]
     pub reenable_delay_secs: u64,
-    /// Anti-oscillation lockout after cut (seconds)
+    /// Anti-oscillation lockout after a cut — mandatory off-time before the DEYE may restore
+    /// (seconds). Main anti-thrash mechanism now that the frequency hysteresis is purely temporal.
     #[serde(default = "default_lockout_secs")]
     pub lockout_secs: u64,
-    /// Battery SOC at/above which a structural PV excess is assumed, blocking
-    /// DEYE restore to avoid relay thrashing while the battery stays full (%).
-    #[serde(default = "default_restore_soc_pct")]
-    pub restore_soc_pct: f64,
-    /// Irradiance at/above which a structural PV excess is assumed (W/m²).
-    #[serde(default = "default_restore_irradiance_wm2")]
-    pub restore_irradiance_wm2: f64,
-    /// Max age of SmartShunt data for the restore-block guard to apply (seconds).
-    /// Beyond this the guard fails open → frequency-only hysteresis takes over.
-    #[serde(default = "default_corroboration_max_age_secs")]
-    pub corroboration_max_age_secs: u64,
     /// Period at which the desired relay state is re-asserted on every channel,
     /// so the physical relay reconverges after a missed command or Shelly reboot (seconds).
     #[serde(default = "default_relay_resync_secs")]
@@ -320,15 +308,10 @@ pub struct DeyeConfig {
     #[serde(default)]
     pub mppt_cut_enabled: bool,
     /// MPPT solar-charger State codes meaning "battery topping off / full" → cut & hold DEYE.
-    /// Default [4,5,6] = Absorption, Float, Storage (3=Bulk means the battery still charges).
+    /// Default [4,5,6] = Absorption, Float, Storage (3=Bulk means the battery still charges,
+    /// so a charger in Bulk allows restore).
     #[serde(default = "default_mppt_full_states")]
     pub mppt_full_states: Vec<i64>,
-    /// MPPT solar-charger State codes meaning "battery actively accepting bulk charge" (NOT
-    /// full). While any charger reports one of these, the SmartShunt structural-excess guard
-    /// must not hold the DEYE off — the MPPT firmware stage is the authority (CLAUDE.md §13).
-    /// Default [3] = Bulk.
-    #[serde(default = "default_mppt_charging_states")]
-    pub mppt_charging_states: Vec<i64>,
     /// Debounce: the MPPT-full condition must hold this long before cutting (seconds).
     #[serde(default = "default_mppt_cut_delay_secs")]
     pub mppt_cut_delay_secs: u64,
@@ -336,16 +319,11 @@ pub struct DeyeConfig {
 
 fn default_freq_high() -> f64 { 51.0 }
 fn default_freq_hard() -> f64 { 51.3 }
-fn default_freq_low() -> f64 { 50.3 }
 fn default_cut_delay_secs() -> u64 { 3 }
 fn default_reenable_delay_secs() -> u64 { 45 }
 fn default_lockout_secs() -> u64 { 120 }
-fn default_restore_soc_pct() -> f64 { 95.0 }
-fn default_restore_irradiance_wm2() -> f64 { 250.0 }
-fn default_corroboration_max_age_secs() -> u64 { 60 }
 fn default_relay_resync_secs() -> u64 { 60 }
 fn default_mppt_full_states() -> Vec<i64> { vec![4, 5, 6] }
-fn default_mppt_charging_states() -> Vec<i64> { vec![3] }
 fn default_mppt_cut_delay_secs() -> u64 { 10 }
 
 impl Default for DeyeConfig {
@@ -353,17 +331,12 @@ impl Default for DeyeConfig {
         Self {
             freq_high_hz: default_freq_high(),
             freq_hard_hz: default_freq_hard(),
-            freq_low_hz: default_freq_low(),
             cut_delay_secs: default_cut_delay_secs(),
             reenable_delay_secs: default_reenable_delay_secs(),
             lockout_secs: default_lockout_secs(),
-            restore_soc_pct: default_restore_soc_pct(),
-            restore_irradiance_wm2: default_restore_irradiance_wm2(),
-            corroboration_max_age_secs: default_corroboration_max_age_secs(),
             relay_resync_secs: default_relay_resync_secs(),
             mppt_cut_enabled: false,
             mppt_full_states: default_mppt_full_states(),
-            mppt_charging_states: default_mppt_charging_states(),
             mppt_cut_delay_secs: default_mppt_cut_delay_secs(),
         }
     }

--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -151,8 +151,7 @@ async fn run(
                         last_freq = freq;
 
                         let now = Utc::now();
-                        let (connected, restore_blocked, mppt_full) = read_gates(&state, &cfg, now).await;
-                        if connected { continue; }
+                        let mppt_full = read_mppt_full(&state, &cfg).await;
                         // Keep the MPPT-cut debounce in sync with the ticker so a nominal
                         // frequency update cannot cancel an active MPPT-driven cut.
                         mppt_full_since = if mppt_full { Some(mppt_full_since.unwrap_or(now)) } else { None };
@@ -165,14 +164,12 @@ async fn run(
                                 state_name(&deye_sm),
                                 last_freq,
                                 time_in_state_secs(&deye_sm, now),
-                                false,
                                 cfg.freq_high_hz,
                                 cfg.freq_hard_hz,
-                                cfg.freq_low_hz,
                                 cfg.cut_delay_secs,
                                 cfg.reenable_delay_secs,
                                 lockout_expired(&deye_sm, now),
-                                restore_blocked,
+                                mppt_full,
                                 mppt_cut,
                             ),
                             deye_sm,
@@ -190,55 +187,17 @@ async fn run(
                     }
 
                 } else if *t == t_connected {
+                    // Grid status no longer takes part in the DEYE decision (Fréquence + MPPT
+                    // only). Still tracked so the dashboard "Réseau" row stays meaningful.
                     if let Some(v) = msg.victron_value::<i64>() {
-                        // Track the physical grid connection (so read_gates can detect a real
-                        // outage) and only force an immediate reconnect when this makes us
-                        // *truly* grid-connected — not merely physically reconnected while the
-                        // ESS still deliberately ignores AC-in (ac_ignore==1) and keeps
-                        // frequency-shifting. Otherwise the ticker would re-cut 1 s later and
-                        // thrash the relay. Consistent with read_gates / is_grid_connected.
-                        let truly_connected = {
-                            let mut s = state.write().await;
-                            s.ac_connected = Some(v);
-                            is_grid_connected(s.ac_ignore, s.ac_connected)
-                        };
-                        if truly_connected {
-                            let now = Utc::now();
-                            let new_state = apply_decision(
-                                rule_engine.evaluate(
-                                    state_name(&deye_sm),
-                                    last_freq,
-                                    0,
-                                    true,
-                                    cfg.freq_high_hz,
-                                    cfg.freq_hard_hz,
-                                    cfg.freq_low_hz,
-                                    cfg.cut_delay_secs,
-                                    cfg.reenable_delay_secs,
-                                    false,
-                                    false,
-                                    false,
-                                ),
-                                deye_sm,
-                                now,
-                                &cfg,
-                                &bus,
-                                shelly_id,
-                                &channels,
-                            ).await;
-                            if new_state != deye_sm {
-                                deye_sm = new_state;
-                                persist_deye_state(&bus, &deye_sm).await;
-                                update_deye_state(&state, &deye_sm).await;
-                            }
-                        }
+                        state.write().await.ac_connected = Some(v);
                     }
                 }
             }
 
             _ = ticker.tick() => {
                 let now = Utc::now();
-                let (grid_connected, restore_blocked, mppt_full) = read_gates(&state, &cfg, now).await;
+                let mppt_full = read_mppt_full(&state, &cfg).await;
                 // Debounce the MPPT-full signal before it is allowed to cut the DEYE.
                 mppt_full_since = if mppt_full { Some(mppt_full_since.unwrap_or(now)) } else { None };
                 let mppt_cut = mppt_full_since
@@ -247,29 +206,26 @@ async fn run(
                 // Refresh observability fields (1 Hz) for /api/rules-status.
                 // deye_on is synced here too (not only on transition) so it can never
                 // diverge from the state machine — e.g. at startup before any transition.
+                // restore_blocked == mppt_full now (battery-full per the MPPT stage is the
+                // only restore gate; Bulk/charging unblocks it).
                 {
                     let mut s = state.write().await;
                     s.deye_on              = matches!(deye_sm, DeyeState::On | DeyeState::PendingCut(_));
                     s.deye_state           = Some(state_name(&deye_sm).to_string());
-                    s.deye_restore_blocked = restore_blocked;
+                    s.deye_restore_blocked = mppt_full;
                     s.deye_mppt_full       = mppt_full;
                 }
-                // Pass the real grid state: when grid-connected the GRL suppresses the
-                // cut rules (no spurious disconnect on a grid-frequency transient) and the
-                // salience-200 reconnect rules self-heal the relay back to On.
                 let new_state = apply_decision(
                     rule_engine.evaluate(
                         state_name(&deye_sm),
                         last_freq,
                         time_in_state_secs(&deye_sm, now),
-                        grid_connected,
                         cfg.freq_high_hz,
                         cfg.freq_hard_hz,
-                        cfg.freq_low_hz,
                         cfg.cut_delay_secs,
                         cfg.reenable_delay_secs,
                         lockout_expired(&deye_sm, now),
-                        restore_blocked,
+                        mppt_full,
                         mppt_cut,
                     ),
                     deye_sm,
@@ -401,46 +357,17 @@ async fn send_shelly(bus: &AppBus, shelly_id: &str, channels: &[u8], on: bool) {
     tracing::debug!("DEYE Shelly: channels {channels:?} = {}", if on { "ON" } else { "OFF" });
 }
 
-/// Reads the gating signals from shared state in a single lock acquisition.
-/// Returns `(grid_connected, restore_blocked, mppt_full)`.
-async fn read_gates(state: &Arc<RwLock<EnergyState>>, cfg: &DeyeConfig, now: DateTime<Utc>) -> (bool, bool, bool) {
+/// Reads the single MPPT-full gate from shared state. `mppt_full` (battery topping/full per
+/// the MPPT charge stage) drives BOTH the early cut (debounced → `mppt_cut`) and the restore
+/// gate (`restore_blocked`). It is the only non-frequency signal in the DEYE decision.
+async fn read_mppt_full(state: &Arc<RwLock<EnergyState>>, cfg: &DeyeConfig) -> bool {
     let s = state.read().await;
-    let grid_connected = is_grid_connected(s.ac_ignore, s.ac_connected);
-    let mppt_full = mppt_battery_full(&s, cfg);
-    let restore_blocked = restore_blocked(&s, cfg, now);
-    (grid_connected, restore_blocked, mppt_full)
-}
-
-/// Whether DEYE restore must be held off (structural PV excess — restoring would just
-/// re-trigger a cut and thrash the relay).
-///
-/// Held off when the battery is full per the MPPT charge stage (Absorption/Float/Storage)
-/// OR per the SmartShunt structural-excess heuristic. **But** the MPPT firmware stage is the
-/// authority (CLAUDE.md §13): while any charger is still in Bulk the battery is actively
-/// accepting charge and is *not* full, so the SmartShunt heuristic is suppressed — restoring
-/// in Bulk cannot thrash the relay (the charge absorbs the power, frequency stays nominal).
-fn restore_blocked(s: &EnergyState, cfg: &DeyeConfig, now: DateTime<Utc>) -> bool {
-    if mppt_battery_full(s, cfg) {
-        return true;
-    }
-    smartshunt_battery_full(s, cfg, now) && !mppt_charging_bulk(s, cfg)
-}
-
-/// Battery actively accepting bulk charge per any MPPT solar-charger (Bulk stage). Pure
-/// firmware telemetry — a direct "the battery is NOT full" signal. Returns false when the
-/// MPPT-stage feature is disabled.
-fn mppt_charging_bulk(s: &EnergyState, cfg: &DeyeConfig) -> bool {
-    if !cfg.mppt_cut_enabled {
-        return false;
-    }
-    [s.mppt_273.state, s.mppt_289.state]
-        .into_iter()
-        .flatten()
-        .any(|st| cfg.mppt_charging_states.contains(&st))
+    mppt_battery_full(&s, cfg)
 }
 
 /// Battery topping/full according to the MPPT charge stage (Absorption/Float/Storage on
-/// any solar charger). Pure solar-charger telemetry — works **without DVCC**. Returns
+/// any solar charger). Pure solar-charger telemetry — works **without DVCC**. Bulk (3) is
+/// NOT a full stage, so a charger in Bulk reports `false` → restore is allowed. Returns
 /// false when the feature is disabled.
 fn mppt_battery_full(s: &EnergyState, cfg: &DeyeConfig) -> bool {
     if !cfg.mppt_cut_enabled {
@@ -452,41 +379,10 @@ fn mppt_battery_full(s: &EnergyState, cfg: &DeyeConfig) -> bool {
         .any(|st| cfg.mppt_full_states.contains(&st))
 }
 
-/// Whether the Victron is grid-tied (NOT islanded). The DEYE cut logic must stay active
-/// whenever the Victron forms the AC-Out grid and can frequency-shift the DEYE — which
-/// happens both on a deliberate ignore (`IgnoreAcIn1 == 1`) AND on a real grid outage
-/// (`ActiveIn/Connected == 0`, where `IgnoreAcIn1` may remain 0).
-///
-/// The grid is considered connected only when *neither* signal indicates islanding.
-/// Unknown signals keep the conservative "assume connected" default — identical to the
-/// previous `ac_ignore`-only behaviour, so this degrades gracefully if `ac_connected`
-/// has not been observed yet.
+/// Whether the Victron is grid-tied (NOT islanded). **Informational only** — no longer part
+/// of the DEYE decision (Fréquence + MPPT only); kept for the dashboard "Réseau" row.
 pub(crate) fn is_grid_connected(ac_ignore: Option<i64>, ac_connected: Option<i64>) -> bool {
     ac_ignore != Some(1) && ac_connected != Some(0)
-}
-
-/// Structural PV-excess guard (SmartShunt). While the battery is full, irradiance is
-/// strong and the battery is not discharging, restoring the DEYE would immediately
-/// re-trigger a cut and thrash the relay — so hold them off.
-///
-/// Fails OPEN: if the SmartShunt data is stale or absent, returns `false` so the
-/// frequency hysteresis alone governs restore. The AC-out frequency (Victron) stays
-/// the authority for cutting; this only ever *delays a restore*.
-fn smartshunt_battery_full(s: &EnergyState, cfg: &DeyeConfig, now: DateTime<Utc>) -> bool {
-    let fresh = s
-        .shunt_last_seen_ts
-        .map(|ts| (now - ts).num_seconds() <= cfg.corroboration_max_age_secs as i64)
-        .unwrap_or(false);
-    if !fresh {
-        return false;
-    }
-    let Some(soc) = s.soc_pct else { return false };
-    let irradiance = s.irradiance_wm2.unwrap_or(0.0);
-    // Sign convention: + = charging, - = discharging. Allow 1 A of noise around zero.
-    let current = s.battery_current_a.unwrap_or(0.0);
-    soc >= cfg.restore_soc_pct
-        && irradiance >= cfg.restore_irradiance_wm2
-        && current >= -1.0
 }
 
 #[cfg(test)]
@@ -518,70 +414,43 @@ mod tests {
         assert!(!is_grid_connected(Some(1), None));
     }
 
-    // --- restore_blocked / MPPT-stage authority --------------------------------
+    // --- mppt_battery_full : seul signal non-fréquentiel de la décision DEYE ----
 
     fn cfg_mppt_on() -> DeyeConfig {
         DeyeConfig { mppt_cut_enabled: true, ..Default::default() }
     }
 
-    /// A state where the SmartShunt structural-excess heuristic alone returns true
-    /// (SOC ≥ 95 %, irradiance ≥ 250 W/m², not discharging, shunt fresh).
-    fn smartshunt_full_state(now: DateTime<Utc>) -> EnergyState {
-        EnergyState {
-            soc_pct: Some(96.0),
-            irradiance_wm2: Some(300.0),
-            battery_current_a: Some(0.0),
-            shunt_last_seen_ts: Some(now),
-            ..Default::default()
-        }
+    fn state_with_mppt(s273: Option<i64>, s289: Option<i64>) -> EnergyState {
+        let mut s = EnergyState::default();
+        s.mppt_273.state = s273;
+        s.mppt_289.state = s289;
+        s
     }
 
     #[test]
-    fn smartshunt_alone_blocks_restore() {
-        let now = Utc::now();
-        let s = smartshunt_full_state(now);
-        // No MPPT stage data → only the SmartShunt heuristic governs → blocked.
-        assert!(restore_blocked(&s, &cfg_mppt_on(), now));
+    fn both_mppt_bulk_not_full_restore_allowed() {
+        // ← le cas signalé : les deux MPPT en Bulk (3) → batterie PAS pleine → restore autorisé.
+        let s = state_with_mppt(Some(3), Some(3));
+        assert!(!mppt_battery_full(&s, &cfg_mppt_on()));
     }
 
     #[test]
-    fn mppt_bulk_overrides_smartshunt_guard() {
-        // ← le cas signalé : SmartShunt « plein » mais les MPPT en Bulk → la batterie
-        // accepte de la charge → la restauration NE doit PAS être bloquée.
-        let now = Utc::now();
-        let mut s = smartshunt_full_state(now);
-        s.mppt_273.state = Some(3); // Bulk
-        s.mppt_289.state = Some(3); // Bulk
-        assert!(!restore_blocked(&s, &cfg_mppt_on(), now));
+    fn any_mppt_full_blocks_restore() {
+        // Un seul chargeur en Absorption/Float/Storage suffit à considérer la batterie pleine.
+        assert!(mppt_battery_full(&state_with_mppt(Some(4), Some(3)), &cfg_mppt_on())); // Absorption
+        assert!(mppt_battery_full(&state_with_mppt(Some(3), Some(5)), &cfg_mppt_on())); // Float
+        assert!(mppt_battery_full(&state_with_mppt(Some(6), None),    &cfg_mppt_on())); // Storage
     }
 
     #[test]
-    fn mppt_full_blocks_even_if_other_charger_bulk() {
-        // One charger in Absorption (full) → mppt_full wins, restore stays blocked,
-        // regardless of a Bulk reading on the other charger.
-        let now = Utc::now();
-        let mut s = smartshunt_full_state(now);
-        s.mppt_273.state = Some(4); // Absorption (full)
-        s.mppt_289.state = Some(3); // Bulk
-        assert!(restore_blocked(&s, &cfg_mppt_on(), now));
+    fn no_mppt_data_not_full() {
+        assert!(!mppt_battery_full(&EnergyState::default(), &cfg_mppt_on()));
     }
 
     #[test]
-    fn mppt_bulk_override_respects_feature_toggle() {
-        // mppt_cut_enabled == false → MPPT stage ignored, SmartShunt guard governs alone.
-        let now = Utc::now();
-        let mut s = smartshunt_full_state(now);
-        s.mppt_273.state = Some(3); // Bulk
-        s.mppt_289.state = Some(3);
+    fn feature_disabled_never_full() {
+        // mppt_cut_enabled == false → étage MPPT ignoré (repli fréquence seule).
         let cfg = DeyeConfig { mppt_cut_enabled: false, ..Default::default() };
-        assert!(restore_blocked(&s, &cfg, now));
-    }
-
-    #[test]
-    fn no_excess_does_not_block() {
-        // Neither MPPT-full nor SmartShunt-full → restore allowed.
-        let now = Utc::now();
-        let s = EnergyState::default(); // no soc/irradiance/shunt data
-        assert!(!restore_blocked(&s, &cfg_mppt_on(), now));
+        assert!(!mppt_battery_full(&state_with_mppt(Some(4), Some(4)), &cfg));
     }
 }

--- a/crates/energy-manager/src/logic/deye_command/rules.rs
+++ b/crates/energy-manager/src/logic/deye_command/rules.rs
@@ -35,18 +35,19 @@ impl DeyeRuleEngine {
 
     /// Evaluates the state machine and returns the decision.
     ///
-    /// All threshold comparisons are pre-computed in Rust and passed as bool flags
-    /// to avoid fact-to-fact comparisons in GRL.
+    /// The decision depends ONLY on the AC-Out frequency and the MPPT charge stage.
+    /// A single frequency boundary (`cfg_freq_cut`) governs both cut and restore, so
+    /// there is no dead band; anti-chatter hysteresis is purely temporal (cut_delay,
+    /// lockout, reenable_delay). All threshold comparisons are pre-computed in Rust
+    /// and passed as bool flags to avoid fact-to-fact comparisons in GRL.
     #[allow(clippy::too_many_arguments)]
     pub fn evaluate(
         &mut self,
         state_str: &str,
         freq_hz: f64,
         time_in_state_secs: u64,
-        grid_connected: bool,
-        cfg_freq_high: f64,
+        cfg_freq_cut: f64,
         cfg_freq_hard: f64,
-        cfg_freq_low: f64,
         cfg_cut_delay: u64,
         cfg_reenable_delay: u64,
         lockout_expired: bool,
@@ -55,13 +56,11 @@ impl DeyeRuleEngine {
     ) -> anyhow::Result<DeyeDecision> {
         let facts = Facts::new();
         facts.set("DY.state",                  Value::String(state_str.to_string()));
-        facts.set("DY.freq_high_exceeded",     Value::Boolean(freq_hz >= cfg_freq_high));
+        facts.set("DY.freq_cut_exceeded",      Value::Boolean(freq_hz >= cfg_freq_cut));
         facts.set("DY.freq_hard_exceeded",     Value::Boolean(freq_hz >= cfg_freq_hard));
-        facts.set("DY.freq_low_reached",       Value::Boolean(freq_hz <= cfg_freq_low));
         facts.set("DY.cut_delay_elapsed",      Value::Boolean(time_in_state_secs >= cfg_cut_delay));
         facts.set("DY.reenable_delay_elapsed", Value::Boolean(time_in_state_secs >= cfg_reenable_delay));
         facts.set("DY.lockout_expired",        Value::Boolean(lockout_expired));
-        facts.set("DY.grid_connected",         Value::Boolean(grid_connected));
         facts.set("DY.restore_blocked",        Value::Boolean(restore_blocked));
         facts.set("DY.mppt_cut",               Value::Boolean(mppt_cut));
 
@@ -93,24 +92,24 @@ mod tests {
     fn e() -> DeyeRuleEngine { DeyeRuleEngine::new().unwrap() }
 
     // Shorthand: evaluate with default config thresholds
-    // (high 51.0 Hz / hard 51.3 Hz / low 50.3 Hz / cut 3s / reenable 45s, restore unblocked).
-    fn eval(engine: &mut DeyeRuleEngine, state: &str, freq: f64, time_s: u64, grid: bool, lockout_exp: bool) -> DeyeDecision {
-        engine.evaluate(state, freq, time_s, grid, 51.0, 51.3, 50.3, 3, 45, lockout_exp, false, false).unwrap()
+    // (cut 51.0 Hz / hard 51.3 Hz / cut_delay 3s / reenable 45s, battery not full).
+    fn eval(engine: &mut DeyeRuleEngine, state: &str, freq: f64, time_s: u64, lockout_exp: bool) -> DeyeDecision {
+        engine.evaluate(state, freq, time_s, 51.0, 51.3, 3, 45, lockout_exp, false, false).unwrap()
     }
 
-    // Variant exposing the restore-block guard.
-    fn eval_rb(engine: &mut DeyeRuleEngine, state: &str, freq: f64, time_s: u64, grid: bool, lockout_exp: bool, restore_blocked: bool) -> DeyeDecision {
-        engine.evaluate(state, freq, time_s, grid, 51.0, 51.3, 50.3, 3, 45, lockout_exp, restore_blocked, false).unwrap()
+    // Variant exposing the restore-block guard (battery full per MPPT stage).
+    fn eval_rb(engine: &mut DeyeRuleEngine, state: &str, freq: f64, time_s: u64, lockout_exp: bool, restore_blocked: bool) -> DeyeDecision {
+        engine.evaluate(state, freq, time_s, 51.0, 51.3, 3, 45, lockout_exp, restore_blocked, false).unwrap()
     }
 
-    // Variant exposing the MPPT-based cut signal (battery topping/full per the MPPT stage).
-    fn eval_mppt(engine: &mut DeyeRuleEngine, state: &str, freq: f64, grid: bool, mppt_cut: bool) -> DeyeDecision {
-        engine.evaluate(state, freq, 0, grid, 51.0, 51.3, 50.3, 3, 45, false, false, mppt_cut).unwrap()
+    // Variant exposing the MPPT-based cut signal (battery full per the MPPT stage, debounced).
+    fn eval_mppt(engine: &mut DeyeRuleEngine, state: &str, freq: f64, mppt_cut: bool) -> DeyeDecision {
+        engine.evaluate(state, freq, 0, 51.0, 51.3, 3, 45, false, false, mppt_cut).unwrap()
     }
 
     #[test]
     fn on_normal_freq_no_transition() {
-        let d = eval(&mut e(), "On", 50.0, 0, false, false);
+        let d = eval(&mut e(), "On", 50.0, 0, false);
         assert!(d.next_state.is_none());
         assert!(!d.relay_on);
         assert!(!d.relay_off);
@@ -118,8 +117,8 @@ mod tests {
 
     #[test]
     fn on_high_freq_transitions_pending_cut() {
-        // 51.1 Hz: above the soft cut (51.0) but below the hard cut (51.3) → debounced PendingCut.
-        let d = eval(&mut e(), "On", 51.1, 0, false, false);
+        // 51.1 Hz: at/above the cut boundary (51.0) but below the hard cut (51.3) → debounced PendingCut.
+        let d = eval(&mut e(), "On", 51.1, 0, false);
         assert_eq!(d.next_state.as_deref(), Some("PendingCut"));
         assert!(!d.relay_off);
     }
@@ -127,190 +126,174 @@ mod tests {
     #[test]
     fn on_hard_freq_cuts_immediately() {
         // 51.4 Hz ≥ hard threshold → straight to Lockout + relay_off, no debounce wait.
-        let d = eval(&mut e(), "On", 51.4, 0, false, false);
+        let d = eval(&mut e(), "On", 51.4, 0, false);
         assert_eq!(d.next_state.as_deref(), Some("Lockout"));
         assert!(d.relay_off);
     }
 
     #[test]
     fn pending_cut_hard_freq_cuts_immediately() {
-        // Hard threshold reached while waiting in PendingCut → cut now, even before cut_delay.
-        let d = eval(&mut e(), "PendingCut", 51.4, 1, false, false);
+        let d = eval(&mut e(), "PendingCut", 51.4, 1, false);
         assert_eq!(d.next_state.as_deref(), Some("Lockout"));
         assert!(d.relay_off);
     }
 
     #[test]
     fn mppt_full_cuts_even_at_low_freq() {
-        // Battery topping/full per MPPT → cut the DEYE even though AC frequency is nominal.
-        let d = eval_mppt(&mut e(), "On", 50.0, false, true);
+        // Battery full per MPPT → cut the DEYE even though AC frequency is nominal.
+        let d = eval_mppt(&mut e(), "On", 50.0, true);
         assert_eq!(d.next_state.as_deref(), Some("Lockout"));
         assert!(d.relay_off);
     }
 
     #[test]
     fn mppt_full_pending_cut_locks() {
-        let d = eval_mppt(&mut e(), "PendingCut", 50.0, false, true);
+        let d = eval_mppt(&mut e(), "PendingCut", 50.0, true);
         assert_eq!(d.next_state.as_deref(), Some("Lockout"));
         assert!(d.relay_off);
     }
 
     #[test]
-    fn mppt_full_grid_connected_no_cut() {
-        // Grid-tied: the MPPT-based cut is suppressed (frequency-shift only happens off-grid).
-        let d = eval_mppt(&mut e(), "On", 50.0, true, true);
-        assert!(d.next_state.is_none());
-        assert!(!d.relay_off);
-    }
-
-    #[test]
     fn mppt_not_full_low_freq_stays_on() {
-        let d = eval_mppt(&mut e(), "On", 50.0, false, false);
+        let d = eval_mppt(&mut e(), "On", 50.0, false);
         assert!(d.next_state.is_none());
         assert!(!d.relay_off);
     }
 
     #[test]
     fn pending_cut_freq_drops_cancels() {
-        let d = eval(&mut e(), "PendingCut", 50.0, 5, false, false);
+        let d = eval(&mut e(), "PendingCut", 50.0, 5, false);
         assert_eq!(d.next_state.as_deref(), Some("On"));
     }
 
     #[test]
     fn pending_cut_delay_elapsed_high_freq_locks() {
-        // 51.1 Hz (soft, not hard) held past cut_delay → Lockout via the debounce path.
-        let d = eval(&mut e(), "PendingCut", 51.1, 5, false, false);
+        // 51.1 Hz held past cut_delay → Lockout via the debounce path.
+        let d = eval(&mut e(), "PendingCut", 51.1, 5, false);
         assert_eq!(d.next_state.as_deref(), Some("Lockout"));
         assert!(d.relay_off);
     }
 
     #[test]
     fn lockout_expires_transitions_off() {
-        let d = eval(&mut e(), "Lockout", 50.0, 0, false, true);
+        let d = eval(&mut e(), "Lockout", 50.0, 0, true);
         assert_eq!(d.next_state.as_deref(), Some("Off"));
     }
 
     #[test]
-    fn off_low_freq_transitions_pending_restore() {
-        let d = eval(&mut e(), "Off", 50.1, 0, false, false);
+    fn off_below_boundary_transitions_pending_restore() {
+        // No dead band: anything below the cut boundary (51.0) is restore-eligible,
+        // including the old dead-band region (50.3–51.0).
+        let d = eval(&mut e(), "Off", 50.7, 0, false);
         assert_eq!(d.next_state.as_deref(), Some("PendingRestore"));
     }
 
     #[test]
-    fn off_low_freq_restore_blocked_stays_off() {
-        // Structural PV excess still present (battery full + sun) → hold DEYE off despite low freq.
-        let d = eval_rb(&mut e(), "Off", 50.1, 0, false, false, true);
+    fn off_below_boundary_restore_blocked_stays_off() {
+        // Battery full per MPPT → hold DEYE off despite a restorable frequency.
+        let d = eval_rb(&mut e(), "Off", 50.7, 0, false, true);
         assert!(d.next_state.is_none());
         assert!(!d.relay_on);
     }
 
     #[test]
-    fn pending_restore_elapsed_low_freq_restores() {
-        let d = eval(&mut e(), "PendingRestore", 50.0, 50, false, false);
+    fn pending_restore_elapsed_restores() {
+        let d = eval(&mut e(), "PendingRestore", 50.7, 50, false);
         assert_eq!(d.next_state.as_deref(), Some("On"));
         assert!(d.relay_on);
     }
 
     #[test]
-    fn on_hard_freq_grid_connected_no_cut() {
-        // Grid-connected: a high/hard frequency transient must NOT cut the DEYE
-        // (the ticker passes the real grid state, suppressing the cut rules).
-        let d = eval(&mut e(), "On", 51.4, 30, true, false);
-        assert!(d.next_state.is_none());
-        assert!(!d.relay_off);
+    fn pending_restore_freq_climbs_cancels() {
+        // Frequency climbs back to the cut boundary during the restore wait → back to Off.
+        let d = eval(&mut e(), "PendingRestore", 51.0, 50, false);
+        assert_eq!(d.next_state.as_deref(), Some("Off"));
         assert!(!d.relay_on);
     }
 
     #[test]
-    fn grid_reconnect_from_off_restores_immediately() {
-        let d = eval(&mut e(), "Off", 50.0, 0, true, false);
-        assert_eq!(d.next_state.as_deref(), Some("On"));
-        assert!(d.relay_on);
-    }
-
-    #[test]
-    fn grid_reconnect_overrides_restore_block() {
-        // Even with a structural excess flagged, grid reconnect restores immediately.
-        let d = eval_rb(&mut e(), "Off", 50.0, 0, true, false, true);
-        assert_eq!(d.next_state.as_deref(), Some("On"));
-        assert!(d.relay_on);
-    }
-
-    #[test]
-    fn grid_reconnect_from_lockout_restores_immediately() {
-        let d = eval(&mut e(), "Lockout", 50.0, 0, true, false);
-        assert_eq!(d.next_state.as_deref(), Some("On"));
-        assert!(d.relay_on);
-    }
-
-    #[test]
-    fn grid_reconnect_from_pending_cut_restores_immediately() {
-        // Hard freq + grid reconnect + cut_delay elapsed: grid override must win cleanly
-        // (no conflicting relay_off from the cut path).
-        let d = eval(&mut e(), "PendingCut", 51.4, 5, true, false);
-        assert_eq!(d.next_state.as_deref(), Some("On"));
-        assert!(d.relay_on);
-        assert!(!d.relay_off);
+    fn pending_restore_battery_fills_cancels() {
+        // Battery fills up (MPPT reaches a full stage) during the restore wait → back to Off.
+        let d = eval_rb(&mut e(), "PendingRestore", 50.0, 50, false, true);
+        assert_eq!(d.next_state.as_deref(), Some("Off"));
+        assert!(!d.relay_on);
     }
 
     // =========================================================================
-    // Rejeu de l'incident « micro-coupures 51,5 Hz » (audit 2026-06 §17).
-    // Cf. CLAUDE.md §8 : les DEYE s'auto-coupent à 51,5 Hz → le Shelly doit
-    // les couper AVANT (freq_hard = 51,3). Cette séquence déroule la machine
-    // d'états sur le scénario complet observé en prod : montée de fréquence,
-    // coupure, verrouillage anti-rebond, retour stable, restauration.
+    // No dead band: a DEYE cut at high frequency must restore as soon as the
+    // frequency falls back below the single boundary (51.0 Hz), even if it
+    // settles in the old 50.3–51.0 dead-band region.
+    // =========================================================================
+    #[test]
+    fn no_dead_band_restores_in_old_dead_zone() {
+        let mut engine = e();
+
+        // Cut at high frequency.
+        let d = eval(&mut engine, "On", 51.4, 0, false);
+        assert_eq!(d.next_state.as_deref(), Some("Lockout"));
+
+        // Lockout expires → Off.
+        let d = eval(&mut engine, "Lockout", 50.6, 0, true);
+        assert_eq!(d.next_state.as_deref(), Some("Off"));
+
+        // Frequency settles at 50.6 Hz (the OLD dead zone) → still restore-eligible now.
+        let d = eval(&mut engine, "Off", 50.6, 0, false);
+        assert_eq!(d.next_state.as_deref(), Some("PendingRestore"));
+
+        // Sustained below the boundary → restores.
+        let d = eval(&mut engine, "PendingRestore", 50.6, 50, false);
+        assert_eq!(d.next_state.as_deref(), Some("On"));
+        assert!(d.relay_on);
+    }
+
+    // =========================================================================
+    // Rejeu de l'incident « micro-coupures 51,5 Hz » (audit 2026-06 §17) :
+    // les DEYE s'auto-coupent à 51,5 Hz → le Shelly doit couper AVANT
+    // (freq_hard = 51,3). Déroule la machine sur le scénario complet.
     // =========================================================================
     #[test]
     fn scenario_montee_51_5_hz_coupe_avant_auto_trip_puis_restaure() {
         let mut engine = e();
 
-        // 1. Fréquence nominale : aucun mouvement.
-        let d = eval(&mut engine, "On", 50.0, 0, false, false);
+        let d = eval(&mut engine, "On", 50.0, 0, false);
         assert!(d.next_state.is_none() && !d.relay_off && !d.relay_on);
 
-        // 2. La fréquence monte (excédent PV off-grid) : 51,1 Hz → débounce.
-        let d = eval(&mut engine, "On", 51.1, 0, false, false);
+        // Montée à 51,1 Hz → débounce PendingCut.
+        let d = eval(&mut engine, "On", 51.1, 0, false);
         assert_eq!(d.next_state.as_deref(), Some("PendingCut"));
-        assert!(!d.relay_off, "coupure prématurée pendant le débounce");
+        assert!(!d.relay_off);
 
-        // 3. POINT CRITIQUE : 51,5 Hz atteint pendant le débounce (seuil
-        //    d'auto-trip DEYE). La coupure doit être IMMÉDIATE (51,5 ≥ hard
-        //    51,3), sans attendre cut_delay — sinon le DEYE s'auto-coupe et
-        //    provoque la micro-coupure AC Out.
-        let d = eval(&mut engine, "PendingCut", 51.5, 1, false, false);
+        // 51,5 Hz pendant le débounce → coupure IMMÉDIATE (≥ hard 51,3).
+        let d = eval(&mut engine, "PendingCut", 51.5, 1, false);
         assert_eq!(d.next_state.as_deref(), Some("Lockout"));
-        assert!(d.relay_off, "le relais doit couper avant l'auto-trip DEYE");
+        assert!(d.relay_off);
 
-        // 4. Anti-rebattement : fréquence retombée mais lockout non expiré →
-        //    on ne bouge pas (pas de cycle on/off rapide).
-        let d = eval(&mut engine, "Lockout", 50.6, 10, false, false);
+        // Lockout non expiré → on attend.
+        let d = eval(&mut engine, "Lockout", 50.6, 10, false);
         assert!(d.next_state.is_none() && !d.relay_on);
 
-        // 5. Lockout expiré → passage Off (toujours relais coupé).
-        let d = eval(&mut engine, "Lockout", 50.2, 0, false, true);
+        // Lockout expiré → Off.
+        let d = eval(&mut engine, "Lockout", 50.2, 0, true);
         assert_eq!(d.next_state.as_deref(), Some("Off"));
-        assert!(!d.relay_on);
 
-        // 6. Fréquence basse stable (≤ 50,3) → fenêtre de restauration.
-        let d = eval(&mut engine, "Off", 50.1, 0, false, false);
+        // Fréquence sous le seuil → fenêtre de restauration.
+        let d = eval(&mut engine, "Off", 50.1, 0, false);
         assert_eq!(d.next_state.as_deref(), Some("PendingRestore"));
 
-        // 7. Stabilité pas encore prouvée (10 s < reenable 45 s) → on attend.
-        let d = eval(&mut engine, "PendingRestore", 50.1, 10, false, false);
-        assert!(d.next_state.is_none() && !d.relay_on, "restauration trop précoce");
+        // Stabilité pas prouvée (10 s < 45 s) → on attend.
+        let d = eval(&mut engine, "PendingRestore", 50.1, 10, false);
+        assert!(d.next_state.is_none() && !d.relay_on);
 
-        // 8. 50 s stables → restauration effective.
-        let d = eval(&mut engine, "PendingRestore", 50.0, 50, false, false);
+        // 50 s stables → restauration.
+        let d = eval(&mut engine, "PendingRestore", 50.0, 50, false);
         assert_eq!(d.next_state.as_deref(), Some("On"));
         assert!(d.relay_on);
     }
 
     #[test]
     fn scenario_pic_brutal_51_5_hz_depuis_on() {
-        // Variante : montée si rapide que 51,5 Hz est vu directement depuis
-        // On (pas de passage PendingCut observable au tick précédent).
-        let d = eval(&mut e(), "On", 51.5, 0, false, false);
+        let d = eval(&mut e(), "On", 51.5, 0, false);
         assert_eq!(d.next_state.as_deref(), Some("Lockout"));
-        assert!(d.relay_off, "coupure immédiate requise à 51,5 Hz");
+        assert!(d.relay_off);
     }
 }


### PR DESCRIPTION
…, seuil unique (zéro zone morte)

Sur décision : la coupure/restauration des 2 canaux Shelly ne doit dépendre QUE de la fréquence AC et de l'étage des MPPT. Retrait des variables parasites et suppression de la zone morte.

Retiré de la décision :
- Réseau (grid_connected / ac_ignore / ac_connected) : plus aucune règle de suppression de coupure ni de reconnexion forcée. ac_connected reste suivi mais uniquement pour l'affichage (ligne « Réseau (info) » du widget).
- SmartShunt (SOC ≥95 %, irradiance ≥250, courant, fraîcheur) : garde structurel supprimé. C'est lui qui maintenait les DEYE coupés alors que les MPPT étaient en Bulk. La restauration ne dépend plus que de l'étage MPPT : Bulk (3) = pas plein → restaure ; Absorption/Float/Storage (4/5/6) → maintien coupé.

Zone morte supprimée — seuil de fréquence UNIQUE (freq_high_hz, 51,0) :
  freq ≥ 51,0 → côté coupe (débounce 3 s, ou immédiat à 51,3)
  freq < 51,0 → côté restauration
Plus d'écart 50,3↔51,0. L'anti-rebattement est purement temporel : cut_delay (3 s)
+ lockout (120 s, temps mort obligatoire après coupure) + reenable_delay (45 s). Cycle coupe→restauration minimal ≈ 165 s — mécanisme anti-déclenchements répétés du Shelly, réglable via lockout_secs.

Détails :
- GRL réécrit : suppression des règles grid (salience 200) et des gardes !grid ; freq_low_reached → freq_cut_exceeded==false ; ajout DY_PendingRestore_Blocked.
- evaluate() : params grid_connected et cfg_freq_low retirés.
- config : freq_low_hz, restore_soc_pct, restore_irradiance_wm2, corroboration_max_age_secs, mppt_charging_states retirés (parsing serde_ignored → configs déployées : simple warning, pas d'erreur). Config.toml nettoyé.
- monitor.html : textes mis à jour (« restaure < 51,0 Hz », Réseau informatif).
- Tests : 50 verts, dont no_dead_band_restores_in_old_dead_zone et both_mppt_bulk_not_full_restore_allowed.


Claude-Session: https://claude.ai/code/session_01Krwof8uqbU5anYC8ygX8Lq