### PR TITLE
docs(energy-manager): cohérence — commentaires struct DeyeCard + exem…

### DIFF
--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -154,9 +154,11 @@ struct DeyeCard {
     /// State-machine state: On / PendingCut / Lockout / Off / PendingRestore
     state:           Option<String>,
     last_change:     Option<DateTime<Utc>>,
-    /// Restore held off by the structural-excess guard (battery full + sun + not discharging)
+    /// Restore held off because the battery is full per the MPPT charge stage (4/5/6).
+    /// Sole restore gate now (no grid/SmartShunt input).
     restore_blocked: bool,
-    /// Combined islanding predicate (ac_ignore != 1 && ac_connected != 0)
+    /// Combined islanding predicate (ac_ignore != 1 && ac_connected != 0).
+    /// INFORMATIONAL ONLY — no longer part of the DEYE decision (Fréquence + MPPT).
     grid_connected:  bool,
     /// AC-out frequency driving the cut/restore thresholds (Hz)
     freq_hz:         Option<f64>,

--- a/docs/app-energy-manager.md
+++ b/docs/app-energy-manager.md
@@ -964,7 +964,10 @@ websocat ws://192.168.1.141:8081/live
     "restore_blocked": false,
     "grid_connected": true,
     "freq_hz": 50.01,
-    "ac_connected": 1
+    "ac_connected": 1,
+    "mppt_full": false,
+    "mppt_273_state": 3,
+    "mppt_289_state": 3
   },
   "soc_pct": null,
   "irradiance_wm2": null,
@@ -978,6 +981,8 @@ Champs `deye` :
 - `grid_connected` — prédicat d'îlotage combiné (`ac_ignore != 1` **et** `ac_connected != 0`). **Informatif uniquement** : n'intervient plus dans la décision DEYE.
 - `freq_hz` — fréquence AC-Out pilotant le seuil unique (≥51,0 coupe / <51,0 restaure).
 - `ac_connected` — connexion physique réseau (`1`=connecté, `0`=panne). **Informatif.**
+- `mppt_full` — au moins un MPPT signale « batterie pleine » (état dans `mppt_full_states`) → pilote la coupe anticipée et bloque la restauration.
+- `mppt_273_state` / `mppt_289_state` — codes State des MPPT (`3`=Bulk, `4`=Absorption, `5`=Float, `6`=Storage).
 
 Ces champs alimentent la carte **« Règles système → Gestion Relais DEYE »** de `/dashboard/monitor`.
 


### PR DESCRIPTION
…ple JSON live

Suite au passage Fréquence+MPPT : aligne les derniers artefacts qui décrivaient encore l'ancienne logique.

- live_ws/server.rs : commentaires DeyeCard.restore_blocked (= batterie pleine MPPT, plus de garde SmartShunt) et grid_connected (informatif, hors décision).
- app-energy-manager.md : exemple JSON live complété (mppt_full, mppt_273_state, mppt_289_state) + descriptions de ces champs.


Claude-Session: https://claude.ai/code/session_01Krwof8uqbU5anYC8ygX8Lq