### PR TITLE
docs(energy-manager): précisions review Gemini (restore gate non-fréq…

### DIFF
--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -167,7 +167,8 @@ struct DeyeCard {
     state:           Option<String>,
     last_change:     Option<DateTime<Utc>>,
     /// Restore held off because the battery is full per the MPPT charge stage (4/5/6).
-    /// Sole restore gate now (no grid/SmartShunt input).
+    /// Sole non-frequency restore gate now (no grid/SmartShunt input); AC frequency
+    /// remains the primary restore condition.
     restore_blocked: bool,
     /// Combined islanding predicate (ac_ignore != 1 && ac_connected != 0).
     /// INFORMATIONAL ONLY — no longer part of the DEYE decision (Fréquence + MPPT).

--- a/docs/app-energy-manager.md
+++ b/docs/app-energy-manager.md
@@ -997,7 +997,7 @@ Champs `deye` :
 - `freq_hz` — fréquence AC-Out pilotant le seuil unique (≥51,0 coupe / <51,0 restaure).
 - `ac_connected` — connexion physique réseau (`1`=connecté, `0`=panne). **Informatif.**
 - `mppt_full` — au moins un MPPT signale « batterie pleine » (état dans `mppt_full_states`) → pilote la coupe anticipée et bloque la restauration.
-- `mppt_273_state` / `mppt_289_state` — codes State des MPPT (`3`=Bulk, `4`=Absorption, `5`=Float, `6`=Storage).
+- `mppt_273_state` / `mppt_289_state` — codes State des MPPT (`3`=Bulk, `4`=Absorption, `5`=Float, `6`=Storage, etc. — liste non exhaustive ; aussi `0`=Off, `2`=Fault, `7`=Equalize…).
 
 Ces champs alimentent la carte **« Règles système → Gestion Relais DEYE »** de `/dashboard/monitor`.
 


### PR DESCRIPTION
…uentiel + codes MPPT non exhaustifs)

- server.rs : restore_blocked décrit comme la seule barrière NON-fréquentielle (la fréquence AC reste la condition principale de restauration).
- app-energy-manager.md : codes State MPPT marqués non exhaustifs (0=Off, 2=Fault, 7=Equalize… en plus de 3/4/5/6).


Claude-Session: https://claude.ai/code/session_01Krwof8uqbU5anYC8ygX8Lq