### PR TITLE
feat(deye): gardes de fraîcheur sur freq + état MPPT (anti-blocage re…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -622,6 +622,10 @@ relay_resync_secs          = 60       # s — ré-affirmation périodique de l'�
 mppt_cut_enabled           = true     # active la coupure DEYE pilotée par l'état MPPT
 mppt_full_states           = [4, 5, 6] # codes State « batterie pleine » : 4=Absorption,5=Float,6=Storage (3=Bulk → restaure)
 mppt_cut_delay_secs        = 10       # s — débounce : MPPT « plein » maintenu avant coupure
+# Garde de fraîcheur des entrées (fréquence + état MPPT). Au-delà : télémétrie « périmée »
+# (topic muet) → fréquence traitée nominale (restaure permise, filet = auto-trip DEYE 51.5),
+# état MPPT figé ne bloque plus la restauration. Doit rester > keepalive Venus (30 s).
+input_max_age_secs         = 90       # s — anti-blocage relais sur télémétrie figée (3× keepalive)
 
 # --- Chauffe-eau LG ThinQ ---
 [energy_manager.water_heater]

--- a/crates/daly-bms-server/templates/monitor.html
+++ b/crates/daly-bms-server/templates/monitor.html
@@ -595,6 +595,8 @@ async function fetchRulesStatus() {
     const deyeBlock = deye?.restore_blocked ?? false;
     const deyeAcCon = deye?.ac_connected ?? null;     // 1=connecté, 0=panne réseau
     const deyeMpptFull = deye?.mppt_full ?? false;    // l'état MPPT signale batterie pleine
+    const deyeFreqStale = deye?.freq_stale ?? false;  // topic fréquence muet → traité nominal
+    const deyeMpptStale = deye?.mppt_stale ?? false;  // topic état MPPT muet → traité pas-plein
     const mpptStates = [deye?.mppt_273_state, deye?.mppt_289_state];
     // Real per-channel relay state from the Shelly Pro 2PM (daly-bms-server). output=true ⇒
     // relay closed ⇒ DEYE powered. One Shelly device → take the first.
@@ -658,10 +660,13 @@ async function fetchRulesStatus() {
       const rows = [
         // Réseau : purement informatif — n'intervient plus dans la décision DEYE (Fréq + MPPT).
         statusRow('Réseau (info)', resVal, resColor, resDetail),
-        statusRow('Fréquence AC', deyeFreq != null ? deyeFreq.toFixed(2) + ' Hz' : '—', fColor, 'coupe ≥ 51,0 · dure ≥ 51,3'),
+        statusRow('Fréquence AC', deyeFreq != null ? deyeFreq.toFixed(2) + ' Hz' : '—',
+                  deyeFreqStale ? RED : fColor,
+                  deyeFreqStale ? '⚠ télémétrie périmée → traitée nominale (restaure)' : 'coupe ≥ 51,0 · dure ≥ 51,3'),
         statusRow('MPPT (charge)', mpptLabels,
-                  deyeMpptFull ? AMBER : (mpptStates.some(st => st === 3) ? GREEN : GREY),
-                  deyeMpptFull ? 'batterie pleine → coupe DEYE' : null),
+                  deyeMpptStale ? RED : (deyeMpptFull ? AMBER : (mpptStates.some(st => st === 3) ? GREEN : GREY)),
+                  deyeMpptStale ? '⚠ télémétrie périmée → ignorée (ne bloque pas la restauration)'
+                                : (deyeMpptFull ? 'batterie pleine → coupe DEYE' : null)),
       ];
       // Restauration : pertinente seulement quand le relais est ouvert (DEYE coupés)
       if (relayOn === false) {

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -315,6 +315,13 @@ pub struct DeyeConfig {
     /// Debounce: the MPPT-full condition must hold this long before cutting (seconds).
     #[serde(default = "default_mppt_cut_delay_secs")]
     pub mppt_cut_delay_secs: u64,
+    /// Freshness window for the DEYE decision inputs (frequency + MPPT State), in seconds.
+    /// Beyond this a telemetry value is considered stale (topic silent): a stale MPPT State
+    /// no longer blocks restore, and a stale frequency is treated as nominal (restore allowed,
+    /// the DEYE 51.5 Hz auto-trip being the hardware net). Must stay well above the Venus
+    /// keepalive period (30 s) to avoid false positives. Default 90 s (3× keepalive).
+    #[serde(default = "default_input_max_age_secs")]
+    pub input_max_age_secs: u64,
 }
 
 fn default_freq_high() -> f64 { 51.0 }
@@ -325,6 +332,7 @@ fn default_lockout_secs() -> u64 { 120 }
 fn default_relay_resync_secs() -> u64 { 60 }
 fn default_mppt_full_states() -> Vec<i64> { vec![4, 5, 6] }
 fn default_mppt_cut_delay_secs() -> u64 { 10 }
+fn default_input_max_age_secs() -> u64 { 90 }
 
 impl Default for DeyeConfig {
     fn default() -> Self {
@@ -338,6 +346,7 @@ impl Default for DeyeConfig {
             mppt_cut_enabled: false,
             mppt_full_states: default_mppt_full_states(),
             mppt_cut_delay_secs: default_mppt_cut_delay_secs(),
+            input_max_age_secs: default_input_max_age_secs(),
         }
     }
 }

--- a/crates/energy-manager/src/live_ws/server.rs
+++ b/crates/energy-manager/src/live_ws/server.rs
@@ -182,6 +182,12 @@ struct DeyeCard {
     /// MPPT solar-charger State codes (3=Bulk, 4=Absorption, 5=Float, 6=Storage…)
     mppt_273_state:  Option<i64>,
     mppt_289_state:  Option<i64>,
+    /// AC-frequency telemetry is stale (topic silent) → decision treats it as nominal
+    /// (restore allowed; DEYE 51.5 Hz auto-trip is the net). Observability/alerting.
+    freq_stale:      bool,
+    /// MPPT State telemetry is stale (topic silent) → decision treats battery as NOT full
+    /// (does not strand the relay off). Observability/alerting.
+    mppt_stale:      bool,
 }
 
 #[derive(Serialize)]
@@ -241,6 +247,8 @@ async fn rules_status_handler(State(srv): State<ServerState>) -> Response {
             mppt_full:       s.deye_mppt_full,
             mppt_273_state:  s.mppt_273.state,
             mppt_289_state:  s.mppt_289.state,
+            freq_stale:      s.deye_freq_stale,
+            mppt_stale:      s.deye_mppt_stale,
         },
         soc_pct:        s.soc_pct,
         irradiance_wm2: s.irradiance_wm2,

--- a/crates/energy-manager/src/logic/deye_command/mod.rs
+++ b/crates/energy-manager/src/logic/deye_command/mod.rs
@@ -152,8 +152,11 @@ async fn run(
 
                         let now = Utc::now();
                         // Réaction immédiate : `freq` du message est la valeur la plus fraîche
-                        // pour ce chemin (le ticker, lui, recale sur `ac_frequency_hz`).
-                        let (_, mppt_full) = read_freq_and_mppt(&state, &cfg).await;
+                        // pour ce chemin (le ticker, lui, recale sur `ac_frequency_hz`) → pas de
+                        // garde de staleness fréquence ici. La garde MPPT s'applique néanmoins :
+                        // un état MPPT figé « plein » ne doit pas bloquer la restauration.
+                        let inp = read_deye_inputs(&state, &cfg, now).await;
+                        let mppt_full = effective_mppt_full(inp.mppt_full, inp.mppt_stale);
                         // Keep the MPPT-cut debounce in sync with the ticker so a nominal
                         // frequency update cannot cancel an active MPPT-driven cut.
                         mppt_full_since = if mppt_full { Some(mppt_full_since.unwrap_or(now)) } else { None };
@@ -199,14 +202,15 @@ async fn run(
 
             _ = ticker.tick() => {
                 let now = Utc::now();
-                // Source de vérité UNIQUE pour la fréquence : préférer la valeur partagée
-                // `ac_frequency_hz` (maintenue par le module inverter, identique au widget et
-                // toujours fraîche) à la `last_freq` locale. Cette dernière peut rester figée
-                // sur une dernière valeur HAUTE si l'abonnement fréquence propre à la boucle
-                // deye se tarit (mismatch de topic, flux interrompu) → le relais resterait
-                // ouvert indéfiniment alors que la fréquence est redescendue (bug terrain).
-                let (shared_freq, mppt_full) = read_freq_and_mppt(&state, &cfg).await;
-                last_freq = decision_freq(shared_freq, last_freq);
+                // Source de vérité UNIQUE + GARDES DE FRAÎCHEUR (anti-blocage relais).
+                // - fréquence : préférer la valeur partagée `ac_frequency_hz` (= widget) à la
+                //   `last_freq` locale (qui peut rester figée haut si l'abonnement deye se tarit) ;
+                //   si la télémétrie est périmée, on la traite comme nominale (restauration permise).
+                // - MPPT : un état figé « plein » (topic muet) ne doit plus bloquer la restauration.
+                let inp = read_deye_inputs(&state, &cfg, now).await;
+                last_freq = decision_freq(inp.shared_freq, last_freq);
+                let eff_freq = effective_freq(last_freq, inp.freq_stale);
+                let mppt_full = effective_mppt_full(inp.mppt_full, inp.mppt_stale);
                 // Debounce the MPPT-full signal before it is allowed to cut the DEYE.
                 mppt_full_since = if mppt_full { Some(mppt_full_since.unwrap_or(now)) } else { None };
                 let mppt_cut = mppt_full_since
@@ -215,19 +219,21 @@ async fn run(
                 // Refresh observability fields (1 Hz) for /api/rules-status.
                 // deye_on is synced here too (not only on transition) so it can never
                 // diverge from the state machine — e.g. at startup before any transition.
-                // restore_blocked == mppt_full now (battery-full per the MPPT stage is the
-                // only restore gate; Bulk/charging unblocks it).
+                // restore_blocked == effective mppt_full (battery-full per the MPPT stage, only
+                // when fresh, is the only restore gate; Bulk/charging/stale unblocks it).
                 {
                     let mut s = state.write().await;
                     s.deye_on              = matches!(deye_sm, DeyeState::On | DeyeState::PendingCut(_));
                     s.deye_state           = Some(state_name(&deye_sm).to_string());
                     s.deye_restore_blocked = mppt_full;
                     s.deye_mppt_full       = mppt_full;
+                    s.deye_freq_stale      = inp.freq_stale;
+                    s.deye_mppt_stale      = inp.mppt_stale;
                 }
                 let new_state = apply_decision(
                     rule_engine.evaluate(
                         state_name(&deye_sm),
-                        last_freq,
+                        eff_freq,
                         time_in_state_secs(&deye_sm, now),
                         cfg.freq_high_hz,
                         cfg.freq_hard_hz,
@@ -366,15 +372,44 @@ async fn send_shelly(bus: &AppBus, shelly_id: &str, channels: &[u8], on: bool) {
     tracing::debug!("DEYE Shelly: channels {channels:?} = {}", if on { "ON" } else { "OFF" });
 }
 
-/// Reads the DEYE decision inputs from shared state in a single lock:
-/// - the freshest AC-Out frequency (`ac_frequency_hz`, the SAME source the widget shows,
-///   maintained by the inverter module) — used to recalibrate the decision frequency so it
-///   can never diverge from the display nor stick on a stale deye-local reading;
-/// - the MPPT-full gate (battery topping/full per the MPPT charge stage), which drives both
-///   the early cut (debounced → `mppt_cut`) and the restore gate (`restore_blocked`).
-async fn read_freq_and_mppt(state: &Arc<RwLock<EnergyState>>, cfg: &DeyeConfig) -> (Option<f64>, bool) {
+/// DEYE decision inputs read from shared state, with freshness flags.
+struct DeyeInputs {
+    /// Shared AC-Out frequency (`ac_frequency_hz`, same source as the widget).
+    shared_freq: Option<f64>,
+    /// AC-Out frequency telemetry is stale (topic silent > `input_max_age_secs`).
+    freq_stale: bool,
+    /// Battery topping/full per the MPPT charge stage (raw, before freshness guard).
+    mppt_full: bool,
+    /// MPPT State telemetry is stale (both chargers silent > `input_max_age_secs`).
+    mppt_stale: bool,
+}
+
+/// Reads the DEYE decision inputs from shared state in a single lock, including the
+/// freshness of each input (frequency + MPPT State). A frozen telemetry value (topic gone
+/// silent while the loop stays alive) must never strand the relay — `apply_freshness`
+/// turns these flags into a safe effective decision.
+async fn read_deye_inputs(state: &Arc<RwLock<EnergyState>>, cfg: &DeyeConfig, now: DateTime<Utc>) -> DeyeInputs {
     let s = state.read().await;
-    (s.ac_frequency_hz, mppt_battery_full(&s, cfg))
+    let max = cfg.input_max_age_secs as i64;
+    // MPPT is fresh if at least one charger reported its State recently.
+    let mppt_stale = [s.mppt_273.state_last_ts, s.mppt_289.state_last_ts]
+        .into_iter()
+        .flatten()
+        .map(|t| (now - t).num_seconds())
+        .min()
+        .map(|age| age > max)
+        .unwrap_or(true);
+    DeyeInputs {
+        shared_freq: s.ac_frequency_hz,
+        freq_stale: !is_fresh(s.ac_frequency_last_ts, now, max),
+        mppt_full: mppt_battery_full(&s, cfg),
+        mppt_stale,
+    }
+}
+
+/// Whether a timestamp is within `max_age` seconds of `now` (absent → not fresh).
+fn is_fresh(ts: Option<DateTime<Utc>>, now: DateTime<Utc>, max_age: i64) -> bool {
+    ts.map(|t| (now - t).num_seconds() <= max_age).unwrap_or(false)
 }
 
 /// Frequency the DEYE decision must use: prefer the shared, inverter-maintained
@@ -383,6 +418,23 @@ async fn read_freq_and_mppt(state: &Arc<RwLock<EnergyState>>, cfg: &DeyeConfig) 
 /// high reading. Falls back to the local value when the shared one is not yet available.
 fn decision_freq(shared: Option<f64>, local: f64) -> f64 {
     shared.unwrap_or(local)
+}
+
+/// Nominal AC frequency used when the real one is stale (well below any cut threshold).
+const NOMINAL_FREQ_HZ: f64 = 50.0;
+
+/// Effective frequency for the decision: when the telemetry is stale, treat it as nominal
+/// (50 Hz) so the relay is NOT latched off on a frozen high reading — restore is allowed and
+/// no frequency-based cut fires. Per ops policy, the DEYE 51.5 Hz hardware auto-trip is the
+/// safety net while AC-frequency telemetry is unavailable.
+fn effective_freq(freq_hz: f64, freq_stale: bool) -> f64 {
+    if freq_stale { NOMINAL_FREQ_HZ } else { freq_hz }
+}
+
+/// Effective MPPT-full for the decision: a stale MPPT State is treated as NOT full, so a
+/// frozen "battery full" reading can never strand the relay off (the bug class this guards).
+fn effective_mppt_full(mppt_full: bool, mppt_stale: bool) -> bool {
+    mppt_full && !mppt_stale
 }
 
 /// Battery topping/full according to the MPPT charge stage (Absorption/Float/Storage on
@@ -481,6 +533,36 @@ mod tests {
     fn decision_freq_falls_back_to_local_when_shared_absent() {
         // Pas encore de valeur partagée (démarrage) → repli sur la locale.
         assert_eq!(decision_freq(None, 50.0), 50.0);
+    }
+
+    // --- gardes de fraîcheur (anti-blocage relais sur télémétrie figée) ----------
+
+    #[test]
+    fn is_fresh_within_and_beyond_window() {
+        let now = Utc::now();
+        assert!(is_fresh(Some(now - chrono::Duration::seconds(30)), now, 90));   // récent
+        assert!(!is_fresh(Some(now - chrono::Duration::seconds(120)), now, 90)); // périmé
+        assert!(!is_fresh(None, now, 90));                                        // jamais vu
+    }
+
+    #[test]
+    fn stale_freq_treated_as_nominal_allows_restore() {
+        // Fréquence figée HAUT mais périmée → traitée comme nominale (50 Hz) → côté restauration,
+        // aucune coupure fréquence. Le filet = auto-trip DEYE 51,5 Hz (politique ops).
+        assert_eq!(effective_freq(51.4, true), NOMINAL_FREQ_HZ);
+        // Fraîche → valeur réelle conservée.
+        assert_eq!(effective_freq(51.4, false), 51.4);
+    }
+
+    #[test]
+    fn stale_mppt_full_does_not_block_restore() {
+        // État MPPT figé « plein » mais périmé → traité comme NON plein → ne bloque pas la
+        // restauration (c'est exactement la classe de bug que la garde protège).
+        assert!(!effective_mppt_full(true, true));
+        // Frais + plein → bloque bien.
+        assert!(effective_mppt_full(true, false));
+        // Frais + pas plein → ne bloque pas.
+        assert!(!effective_mppt_full(false, false));
     }
 
     #[test]

--- a/crates/energy-manager/src/logic/inverter/mod.rs
+++ b/crates/energy-manager/src/logic/inverter/mod.rs
@@ -81,7 +81,10 @@ async fn handle(
         }
     } else if t.contains("/vebus/") && t.ends_with("/Ac/Out/L1/F") {
         if let Some(v) = msg.victron_value::<f64>() {
-            state.write().await.ac_frequency_hz = Some(v);
+            let mut s = state.write().await;
+            s.ac_frequency_hz = Some(v);
+            // Freshness stamp for the DEYE decision (a frozen freq must not strand the relay).
+            s.ac_frequency_last_ts = Some(chrono::Utc::now());
             return true;
         }
     } else if t.contains("/vebus/") && t.ends_with("/Ac/Out/L1/P") {

--- a/crates/energy-manager/src/logic/solar_power/mod.rs
+++ b/crates/energy-manager/src/logic/solar_power/mod.rs
@@ -132,8 +132,10 @@ async fn mqtt_task(
                 s.mppt_289.max_power_today_w = msg.victron_value::<f64>();
             } else if *t == t_m1_state {
                 s.mppt_273.state = msg.victron_value::<i64>();
+                s.mppt_273.state_last_ts = Some(chrono::Utc::now());
             } else if *t == t_m2_state {
                 s.mppt_289.state = msg.victron_value::<i64>();
+                s.mppt_289.state_last_ts = Some(chrono::Utc::now());
             } else if *t == t_m1_pv_v {
                 s.mppt_273.pv_voltage_v = msg.victron_value::<f64>();
             } else if *t == t_m2_pv_v {

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -140,6 +140,8 @@ pub struct EnergyState {
     pub ac_ignore: Option<i64>,         // IgnoreAcIn1: 0=grid, 1=off-grid
     pub ac_connected: Option<i64>,      // ActiveIn/Connected
     pub ac_frequency_hz: Option<f64>,
+    /// Timestamp of the last AC-Out frequency update — freshness guard for the DEYE decision.
+    pub ac_frequency_last_ts: Option<DateTime<Utc>>,
 
     // --- VEBus (inverter) ---
     pub dc_voltage_v: Option<f64>,
@@ -174,6 +176,12 @@ pub struct EnergyState {
     pub deye_restore_blocked: bool,
     /// Whether the MPPT charge stage signals a full battery (the MPPT-based cut driver) — observability.
     pub deye_mppt_full: bool,
+    /// AC-Out frequency telemetry is stale (topic silent > input_max_age_secs) — observability.
+    /// On stale freq the decision treats it as nominal (restore allowed; DEYE 51.5 Hz auto-trip is the net).
+    pub deye_freq_stale: bool,
+    /// MPPT State telemetry is stale (topic silent > input_max_age_secs) — observability.
+    /// On stale MPPT the decision treats the battery as NOT full (does not strand the relay off).
+    pub deye_mppt_stale: bool,
 
     // --- Irradiance ---
     pub irradiance_wm2: Option<f64>,
@@ -237,6 +245,9 @@ pub struct MpptState {
     pub yield_today_kwh: Option<f64>,
     pub max_power_today_w: Option<f64>,
     pub state: Option<i64>,
+    /// Timestamp of the last `/State` update — freshness guard for the DEYE decision
+    /// (a frozen State must not strand the relay; see deye_command).
+    pub state_last_ts: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/docs/app-energy-manager.md
+++ b/docs/app-energy-manager.md
@@ -372,6 +372,19 @@ puisque la frontière de fréquence est unique. `cut_delay_secs` (3 s, débounce
 restauration pendant ce délai) + `reenable_delay_secs` (45 s sous le seuil avant restauration). Cycle
 coupe→restauration minimal ≈ **165 s** → fréquence de bascule du relais bornée. Réglable via `lockout_secs`.
 
+**Gardes de fraîcheur (anti-blocage relais sur télémétrie figée)** : la décision n'utilise jamais une
+entrée périmée. Chaque écriture horodate sa source (`ac_frequency_last_ts` par le module `inverter`,
+`mppt_*.state_last_ts` par `solar_power`). Au-delà de `input_max_age_secs` (90 s, soit 3× le keepalive
+Venus 30 s), l'entrée est « périmée » (topic muet alors que la boucle reste vivante) et :
+- **état MPPT périmé** → traité comme **NON plein** (`effective_mppt_full`) : un état figé « batterie pleine »
+  ne peut plus verrouiller le relais ouvert (c'est exactement la classe de bug évitée) ;
+- **fréquence périmée** → traitée comme **nominale (50 Hz)** (`effective_freq`) : restauration permise,
+  aucune coupure fréquence — le filet est l'**auto-trip matériel DEYE à 51,5 Hz** (politique ops).
+
+Côté fréquence, la décision recale aussi `last_freq` sur la valeur partagée `ac_frequency_hz` (= widget,
+via `decision_freq`) pour ne jamais diverger de l'affichage. Les drapeaux `freq_stale`/`mppt_stale` sont
+exposés (`/api/rules-status`) et signalés en rouge dans le widget « Gestion Relais DEYE ».
+
 **Règles GRL** (`deye_command.grl`) :
 
 | État courant | Condition | → Nouvel état | Relay | Salience |
@@ -435,7 +448,7 @@ Payload (pour chaque canal de shelly_deye_channels) :
 - `"On"` — DEYE actif (états `On` ou `PendingCut`)
 - `"Off"` — DEYE coupé (états `Off`, `Lockout`, `PendingRestore`)
 
-**Config** (`[energy_manager.deye]`) : `freq_high_hz=51.0` (seuil unique coupe/restaure), `freq_hard_hz=51.3` (coupe immédiate), `cut_delay_secs=3`, `reenable_delay_secs=45`, `lockout_secs=120`, `relay_resync_secs=60`, `mppt_cut_enabled=true`, `mppt_full_states=[4,5,6]`, `mppt_cut_delay_secs=10`. *(Retirés : `freq_low_hz`, `restore_soc_pct`, `restore_irradiance_wm2`, `corroboration_max_age_secs`, `mppt_charging_states` — plus de zone morte ni de garde SmartShunt.)*
+**Config** (`[energy_manager.deye]`) : `freq_high_hz=51.0` (seuil unique coupe/restaure), `freq_hard_hz=51.3` (coupe immédiate), `cut_delay_secs=3`, `reenable_delay_secs=45`, `lockout_secs=120`, `relay_resync_secs=60`, `mppt_cut_enabled=true`, `mppt_full_states=[4,5,6]`, `mppt_cut_delay_secs=10`, `input_max_age_secs=90` (garde de fraîcheur freq + MPPT). *(Retirés : `freq_low_hz`, `restore_soc_pct`, `restore_irradiance_wm2`, `corroboration_max_age_secs`, `mppt_charging_states` — plus de zone morte ni de garde SmartShunt.)*
 Canaux : `[energy_manager.victron] shelly_deye_channels = [0, 1]` (un canal par DEYE ; fallback mono-canal `shelly_deye_channel` si la liste est vide).
 
 ---
@@ -982,7 +995,9 @@ websocat ws://192.168.1.141:8081/live
     "ac_connected": 1,
     "mppt_full": false,
     "mppt_273_state": 3,
-    "mppt_289_state": 3
+    "mppt_289_state": 3,
+    "freq_stale": false,
+    "mppt_stale": false
   },
   "soc_pct": null,
   "irradiance_wm2": null,
@@ -998,6 +1013,8 @@ Champs `deye` :
 - `ac_connected` — connexion physique réseau (`1`=connecté, `0`=panne). **Informatif.**
 - `mppt_full` — au moins un MPPT signale « batterie pleine » (état dans `mppt_full_states`) → pilote la coupe anticipée et bloque la restauration.
 - `mppt_273_state` / `mppt_289_state` — codes State des MPPT (`3`=Bulk, `4`=Absorption, `5`=Float, `6`=Storage, etc. — liste non exhaustive ; aussi `0`=Off, `2`=Fault, `7`=Equalize…).
+- `freq_stale` — la télémétrie fréquence est périmée (topic muet > `input_max_age_secs`) → la décision la traite comme nominale (restauration permise ; filet = auto-trip DEYE 51,5 Hz).
+- `mppt_stale` — la télémétrie d'état MPPT est périmée → traitée comme « pas plein » (ne bloque pas la restauration → anti-blocage relais).
 
 Ces champs alimentent la carte **« Règles système → Gestion Relais DEYE »** de `/dashboard/monitor`.
 


### PR DESCRIPTION
…lais généralisé)

Suite à l'audit de la classe « entrée figée verrouille la machine d'états » : la fréquence n'était pas le seul risque. L'état MPPT (mppt_273/289.state, qui pilote restore_blocked/mppt_cut) n'avait AUCUN horodatage de fraîcheur → s'il se fige à « plein » (4/5/6) topic muet, les DEYE restent bloqués Off — même symptôme.

Gardes de fraîcheur (input_max_age_secs=90s, 3× keepalive Venus 30s) :
- horodatage des sources : ac_frequency_last_ts (inverter), mppt_*.state_last_ts (solar_power) ;
- état MPPT périmé → traité NON plein (effective_mppt_full) → ne bloque plus la restauration ;
- fréquence périmée → traitée nominale 50 Hz (effective_freq) → restauration permise, pas de coupure freq ; filet = auto-trip matériel DEYE 51,5 Hz (politique ops choisie).

Observabilité : freq_stale/mppt_stale exposés dans /api/rules-status (DeyeCard) et signalés en rouge dans le widget « Gestion Relais DEYE ».

Helpers purs testés : is_fresh, effective_freq, effective_mppt_full (+3 tests) → 56 verts. Config.toml + doc §4.3 mis à jour.

Note : charge_current et water_heater (entrées soc/irradiance/ac_ignore) restent en défaut fail-safe (VACATION / latch événementiel) — aucune ne peut bloquer un relais.


Claude-Session: https://claude.ai/code/session_01Krwof8uqbU5anYC8ygX8Lq