### PR TITLE
fix(journald): borne le journal systemd + réduit le bruit de logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@
 | Profiler une fuite RSS (heap jemalloc, auto-restauré) | `sudo bash scripts/jemalloc-leak-profile.sh 2h` → rapport `/tmp/jeprof/leak-report-*.txt` (cf. docs/diagnostic-depannage.md §18) |
 | Diag pic réseau (veille auto-capture) | `sudo bash scripts/netdiag.sh --watch` → rapport `/tmp/netdiag-*.txt` |
 | Logs energy-manager | `journalctl -u energy-manager -f` |
+| Taille du journal systemd | `journalctl --disk-usage` |
+| Plafonner le journal (déjà fait par deploy-pi5.sh) | drop-in `contrib/journald/daly-bms.conf` → `/etc/systemd/journal.conf.d/` (SystemMaxUse=200M) ; purge immédiate : `sudo journalctl --vacuum-size=200M` |
 | Compiler energy-manager | `make build-energy-arm` |
 | Déployer energy-manager | `sudo systemctl stop energy-manager && sudo cp target/aarch64-unknown-linux-gnu/release/energy-manager /usr/local/bin/ && sudo systemctl start energy-manager` |
 | Appliquer Config energy-manager | `sudo cp Config.toml /etc/daly-bms/config.toml && sudo systemctl restart energy-manager` |
@@ -183,6 +185,8 @@ crates/energy-manager/src/              ← gestionnaire énergie (remplace Node
 crates/dbus-mqtt-venus/src/             ← bridge MQTT→D-Bus NanoPi
 contrib/daly-bms.service                ← unité systemd daly-bms-server
 contrib/energy-manager.service          ← unité systemd energy-manager
+contrib/journald/daly-bms.conf          ← drop-in journald (plafond journal : SystemMaxUse=200M)
+                                          déployé par deploy-pi5.sh → /etc/systemd/journal.conf.d/
 contrib/grafana/                        ← provisioning Grafana complet
   dashboards/01-bms.json … 21-memoire-daly-bms.json ← 21 dashboards JSON
     (17→20 = dashboards évolués PromQL avancé : flotte/SLO, rendement PV,
@@ -355,6 +359,7 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 | Config ignorée | Copier vers `/etc/daly-bms/config.toml` |
 | `scp: dest open Failure` | `ssh root@192.168.1.120 "svc -d /service/dbus-mqtt-venus"` puis redéployer |
 | Venus symlink disparu (màj firmware) | `ssh root@192.168.1.120 "ln -sf /data/etc/sv/dbus-mqtt-venus /service/dbus-mqtt-venus"` |
+| Journal systemd qui grossit (`journalctl --disk-usage`) | **Comportement normal** (journald grossit jusqu'au plafond puis rotationne). Plafond explicite borné à 200M via `contrib/journald/daly-bms.conf` (déployé par `deploy-pi5.sh`). Bruit réduit à la source : `info!→debug!` sur les boucles irradiance (30 s) et water_heater (5 min) — 2026-06. Détail → docs/diagnostic-depannage.md §11. Purge manuelle : `sudo journalctl --vacuum-size=200M`. |
 | Disque racine Pi5 se remplit (`df -h /` > 45 %) | Builds Rust cumulés dans `target/` (aarch64 + armv7 + natif debug/release). Les binaires prod sont dans `/usr/local/bin` → `target/` est jetable. Voir « Nettoyer disque (build) » §0. Ne **jamais** supprimer `~/.cargo/bin`, `/usr/local/bin/*`, ni `/mnt/nvme/.../metrics.redb`. |
 | `dbus-mqtt-venus` crash-loop sur NanoPi (`svstat` uptime=0, tous les services D-Bus absents) | Binaire armv7 mal compilé → **SIGILL** (exit 132). Cause : `target-cpu=native` dans le build armv7 (hôte aarch64 ≠ cible armv7). Corrigé dans le Makefile. Diag : lancer le binaire à la main sur le NanoPi. Indice au build : warnings `'+lse' is not a recognized feature`. |
 | `install-venus.sh: Permission denied` (`make install-venus-v7`) | Bit +x manquant → `chmod +x nanoPi/install-venus.sh` ou déployer via `ARCH=armv7 bash nanoPi/install-venus.sh 192.168.1.120`. |

--- a/contrib/journald/daly-bms.conf
+++ b/contrib/journald/daly-bms.conf
@@ -1,0 +1,31 @@
+# Drop-in journald pour le Pi5 Daly-BMS — borne la taille du journal systemd.
+#
+# Déployé vers /etc/systemd/journal.conf.d/daly-bms.conf par scripts/deploy-pi5.sh
+# (puis `systemctl restart systemd-journald`).
+#
+# Contexte (2026-06) : aucun plafond n'était configuré → journald s'appuyait sur
+# le défaut (min(4 Go, 10 % de la partition /var/log)). Le journal grossissait
+# donc sans borne explicite avant rotation. Ce drop-in fixe un plafond net,
+# SANS rien casser : journald ne fait que purger les plus VIEUX enregistrements
+# quand le plafond est atteint ; aucun service applicatif n'est impacté.
+#
+# Couplé à la réduction du bruit côté code (info!→debug! sur les boucles
+# irradiance/water_heater, 2026-06) : ces deux mesures se complètent.
+
+[Journal]
+# Plafond disque pour les journaux PERSISTANTS (/var/log/journal). 200 Mo
+# couvre largement plusieurs semaines au volume actuel (~1-2 Mo/jour après
+# réduction du bruit) tout en restant négligeable sur la rootfs du Pi5.
+SystemMaxUse=200M
+
+# Toujours laisser 500 Mo libres sur la partition, même si SystemMaxUse n'est
+# pas atteint (filet de sécurité si la rootfs se remplit pour une autre raison).
+SystemKeepFree=500M
+
+# Rétention temporelle : purge les entrées de plus d'un mois même si le plafond
+# de taille n'est pas atteint (garde un historique borné et prévisible).
+MaxRetentionSec=1month
+
+# Taille max d'un fichier journal individuel avant rotation (bornes le coût d'un
+# `journalctl --vacuum` et la granularité de purge).
+SystemMaxFileSize=50M

--- a/crates/energy-manager/src/logic/irradiance/mod.rs
+++ b/crates/energy-manager/src/logic/irradiance/mod.rs
@@ -39,7 +39,12 @@ async fn http_poll_task(bms_server_url: String, state: Arc<RwLock<EnergyState>>,
                                     "irradiance",
                                     serde_json::json!({ "irradiance_wm2": wm2 }),
                                 ));
-                                info!("Irradiance HTTP poll: {:.0} W/m²", wm2);
+                                // Démoté info!→debug! (2026-06) : ce poll tourne
+                                // toutes les 30 s (2880 lignes/jour, même la nuit à
+                                // 0 W/m²) → bruit dominant dans journald. La valeur
+                                // part déjà dans bus.emit_live + metrics-store : on
+                                // ne perd aucune donnée, seulement le doublon texte.
+                                debug!("Irradiance HTTP poll: {:.0} W/m²", wm2);
                             } else {
                                 warn!("Irradiance HTTP: out of range: {wm2} W/m² (state updated)");
                             }

--- a/crates/energy-manager/src/logic/water_heater/mod.rs
+++ b/crates/energy-manager/src/logic/water_heater/mod.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::{interval, sleep, Duration};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use crate::bus::AppBus;
 use crate::config::WaterHeaterConfig;
 use crate::http_clients::lg_thinq::LgThinqClient;
@@ -137,10 +137,10 @@ async fn control_task(
         let cfg = wh_cfg.read().await.clone();
 
         // Read actual state from LG ThinQ before deciding
-        info!("Water heater: calling lg.get_state()...");
+        debug!("Water heater: calling lg.get_state()...");
         let lg_snapshot = match lg.get_state().await {
             Ok(snap) => {
-                info!(
+                debug!(
                     "Water heater: LG get_state OK → mode={:?}, temp={:?}°C, target={:?}°C",
                     snap.mode, snap.current_temp_c, snap.target_temp_c
                 );
@@ -186,7 +186,7 @@ async fn control_task(
             (s.ac_ignore, s.soc_pct, s.irradiance_wm2)
         };
 
-        info!(
+        debug!(
             "Water heater tick — ac_ignore={:?}, soc={:?}, irradiance={:?} W/m² (min={})",
             ac_ignore_opt, soc_opt, irradiance, cfg.irradiance_min_wm2
         );
@@ -205,7 +205,7 @@ async fn control_task(
         let irradiance_low = match irradiance {
             Some(w) => {
                 let low = w < cfg.irradiance_min_wm2;
-                info!("Water heater: irradiance={:.1} W/m², min={}, irradiance_low={}", w, cfg.irradiance_min_wm2, low);
+                debug!("Water heater: irradiance={:.1} W/m², min={}, irradiance_low={}", w, cfg.irradiance_min_wm2, low);
                 low
             }
             None => {
@@ -218,13 +218,16 @@ async fn control_task(
         };
         let grid_connected = ac_ignore == 0;
         let soc_low = soc < cfg.soc_min_pct;
-        info!(
+        debug!(
             "Water heater: ac_ignore={}, grid_connected={}, soc={:.1}% (min={}%, soc_low={}), irradiance_low={}",
             ac_ignore, grid_connected, soc, cfg.soc_min_pct, soc_low, irradiance_low
         );
 
         let target_mode_str = rules::evaluate(grid_connected, soc_low, irradiance_low, temp_max_reached);
-        info!("Water heater: decision → target_mode={target_mode_str} (grid_connected={}, soc={:.1}%, irradiance_low={}, temp_max_reached={})",
+        // Démoté info!→debug! (2026-06) : la décision est ré-évaluée à chaque tick
+        // (toutes les 5 min) → 288 lignes/jour même sans changement. Le SEND réel
+        // (changement de mode effectif) reste en info! plus bas.
+        debug!("Water heater: decision → target_mode={target_mode_str} (grid_connected={}, soc={:.1}%, irradiance_low={}, temp_max_reached={})",
             grid_connected, soc, irradiance_low, temp_max_reached);
 
         let target_mode = match target_mode_str {
@@ -241,7 +244,7 @@ async fn control_task(
                 state.try_read().map(|s| s.water_heater_mode).unwrap_or(WaterHeaterMode::Vacation)
             });
 
-        info!(
+        debug!(
             "Water heater: target={:?}, actual (LG)={:?}, should_send={}",
             target_mode, actual_mode, actual_mode != target_mode
         );
@@ -249,7 +252,7 @@ async fn control_task(
         let should_send = actual_mode != target_mode;
 
         if !should_send {
-            info!(
+            debug!(
                 "Water heater: target={:?} matches actual={:?}, no command needed",
                 target_mode, actual_mode
             );
@@ -265,7 +268,7 @@ async fn control_task(
             let secs_left = cfg.mode_change_min_secs.saturating_sub(
                 last_change.map(|t| (now - t).num_seconds() as u64).unwrap_or(0)
             );
-            info!("Water heater: cooldown active, {}s remaining — target={:?}", secs_left, target_mode);
+            debug!("Water heater: cooldown active, {}s remaining — target={:?}", secs_left, target_mode);
             continue;
         }
 

--- a/docs/diagnostic-depannage.md
+++ b/docs/diagnostic-depannage.md
@@ -4,7 +4,8 @@
 > Couvre : table maîtresse des problèmes courants, diagnostic port série et permissions,
 > diagnostic services systemd, test API/WebSocket, diagnostic réseau (`netdiag`),
 > procédure d'investigation Onduleur & SmartShunt, investigation memory-leak (§1–§16),
-> nettoyage disque builds cumulés, et récupération Venus/NanoPi.
+> nettoyage disque builds cumulés, récupération Venus/NanoPi, et plafond du journal
+> systemd (§11).
 > Fait partie de l'[architecture documentaire](./ARCHITECTURE.md).
 > Dernière consolidation : 2026-06-07.
 
@@ -66,6 +67,11 @@
   - [10.5 Recréer le profil WiFi avec IP fixe](#105-recreer-le-profil-wifi-avec-ip-fixe-fiabilisation)
   - [10.6 Valider par un reboot + verrouiller côté Starlink](#106-valider-par-un-reboot--verrouiller-cote-starlink)
   - [10.7 Remettre en service après réparation](#107-remettre-en-service-apres-reparation)
+- [11. Journal systemd (journald) qui grossit — diagnostic et plafond](#11-journal-systemd-journald-qui-grossit--diagnostic-et-plafond)
+  - [11.1 Pourquoi le journal grossit](#111-pourquoi-le-journal-grossit)
+  - [11.2 Plafond explicite (drop-in journald)](#112-plafond-explicite-drop-in-journald)
+  - [11.3 Réduction du bruit à la source](#113-reduction-du-bruit-a-la-source)
+  - [11.4 Vérification et purge manuelle](#114-verification-et-purge-manuelle)
 - [Voir aussi](#voir-aussi)
 - [Sources consolidées](#sources-consolidees)
 
@@ -1913,6 +1919,96 @@ journalctl -u daly-bms -f                 # lecture BMS/ET112 OK ?
 # relancer le bridge MQTT → VRM se rafraîchit
 sudo systemctl restart mosquitto-broker
 journalctl -u mosquitto-broker -f | grep -i bridge   # attendu : "connected"
+```
+
+---
+
+## 11. Journal systemd (journald) qui grossit — diagnostic et plafond
+
+> Ajouté 2026-06 après constat « systemd-journal augmente avec le temps (~26 Mo) ».
+
+### 11.1 Pourquoi le journal grossit
+
+**Ce n'est pas une fuite — c'est le fonctionnement nominal de journald.** Le
+journal grossit jusqu'à un plafond, puis rotationne en purgeant ses plus vieux
+enregistrements. 26 Mo est minuscule : le défaut systemd (`min(4 Go, 10 % de la
+partition /var/log)`) laisserait le fichier monter beaucoup plus haut avant de
+rotationner. Le vrai problème historique : **ce plafond n'était nulle part
+configuré dans le repo** → on dépendait du défaut, sans borne explicite.
+
+Deux contributeurs de volume en régime permanent (avec `RUST_LOG=info`) :
+
+| Source | Fichier | Fréquence | Volume/jour |
+|--------|---------|-----------|-------------|
+| Sonde irradiance | `energy-manager/src/logic/irradiance/mod.rs` | **toutes les 30 s** | ~2 880 lignes |
+| Contrôle chauffe-eau (≈8 `info!`/cycle) | `energy-manager/src/logic/water_heater/mod.rs` | toutes les 5 min | ~2 300 lignes |
+
+Le cas irradiance était le pire : la ligne `Irradiance HTTP poll: N W/m²`
+loguait dès que la valeur était dans `0..=2000` — **même la nuit à 0 W/m²**,
+24h/24, valeur souvent inchangée. En face, les boucles vraiment chaudes étaient
+déjà propres : `charge_current` ne logue que sur changement, `solar_power` 1 Hz
+est en `debug!`, le polling BMS/ATS ne logue pas par cycle.
+
+Confirmer la répartition réelle sur le Pi5 :
+
+```bash
+journalctl --disk-usage                                          # taille + storage
+journalctl -u daly-bms -u energy-manager --since "1 day ago" | wc -l
+journalctl --since "1 day ago" -o cat | sort | uniq -c | sort -rn | head -20
+```
+
+### 11.2 Plafond explicite (drop-in journald)
+
+Borné par `contrib/journald/daly-bms.conf`, déployé automatiquement par
+`scripts/deploy-pi5.sh` (section 5.ter) vers
+`/etc/systemd/journal.conf.d/daly-bms.conf` :
+
+```ini
+[Journal]
+SystemMaxUse=200M          # plafond disque des journaux persistants
+SystemKeepFree=500M        # toujours laisser 500 Mo libres sur la partition
+MaxRetentionSec=1month     # purge les entrées de plus d'un mois
+SystemMaxFileSize=50M      # taille max d'un fichier avant rotation
+```
+
+C'est **purement défensif** : journald purge ses plus vieux enregistrements
+au-delà du plafond ; aucun service applicatif (daly-bms / energy-manager /
+mosquitto) n'est touché. `deploy-pi5.sh` copie le fichier, fait
+`systemctl restart systemd-journald`, puis `journalctl --vacuum-size=200M` pour
+appliquer la borne immédiatement (sinon elle n'agit qu'à la rotation suivante).
+
+Application manuelle (hors déploiement) :
+
+```bash
+sudo install -m 644 contrib/journald/daly-bms.conf /etc/systemd/journal.conf.d/daly-bms.conf
+sudo systemctl restart systemd-journald
+sudo journalctl --vacuum-size=200M
+```
+
+### 11.3 Réduction du bruit à la source
+
+En complément du plafond, les `info!` bavards par-tick ont été démotés en
+`debug!` (2026-06), **sans rien changer au comportement** : les valeurs partent
+déjà dans `bus.emit_live` + metrics-store (irradiance) et les transitions
+réelles restent en `info!` (water_heater : seul le `SEND` d'un changement de
+mode + le passage VACATION forcé loguent encore au niveau info).
+
+- `irradiance/mod.rs` : `Irradiance HTTP poll: N W/m²` → `debug!` (gain ~2 880 lignes/jour).
+- `water_heater/mod.rs` : dumps d'état par tick (get_state, irradiance, soc,
+  décision, cooldown, no-command-needed) → `debug!`.
+
+Pour réafficher ces lignes ponctuellement, monter le niveau de log sans
+recompiler — éditer l'unité energy-manager :
+`Environment=RUST_LOG=info,energy_manager::logic::water_heater=debug,energy_manager::logic::irradiance=debug`
+puis `sudo systemctl daemon-reload && sudo systemctl restart energy-manager`.
+
+### 11.4 Vérification et purge manuelle
+
+```bash
+journalctl --disk-usage                    # doit se stabiliser ≤ 200 Mo
+cat /etc/systemd/journal.conf.d/daly-bms.conf
+sudo journalctl --vacuum-size=200M         # purge immédiate à la borne
+sudo journalctl --vacuum-time=30d          # ou purge par âge
 ```
 
 ---

--- a/scripts/deploy-pi5.sh
+++ b/scripts/deploy-pi5.sh
@@ -271,6 +271,31 @@ else
     info "mosquitto.conf déjà à jour (ou absent du repo)"
 fi
 
+# ── 5.ter Journald : plafond de taille (si modifié) ───────────────────────────
+# Borne le journal systemd (cf. contrib/journald/daly-bms.conf). Purement
+# défensif : journald purge ses plus vieux enregistrements au-delà du plafond,
+# aucun service applicatif n'est touché → on peut redémarrer journald sans
+# risque pour daly-bms/energy-manager/mosquitto.
+JRNL_SRC=contrib/journald/daly-bms.conf
+JRNL_DST=/etc/systemd/journal.conf.d/daly-bms.conf
+if [[ -f "$JRNL_SRC" ]] && ! sudo diff -q "$JRNL_SRC" "$JRNL_DST" >/dev/null 2>&1; then
+    if $DRY_RUN; then
+        warn "[dry-run] $JRNL_DST absent/différent → serait déployé + restart systemd-journald"
+        sudo diff "$JRNL_DST" "$JRNL_SRC" 2>/dev/null | sed 's/^/    /' || true
+    else
+        step "Mise à jour du plafond journald ($JRNL_DST)…"
+        sudo mkdir -p /etc/systemd/journal.conf.d
+        sudo install -m 644 -o root -g root "$JRNL_SRC" "$JRNL_DST"
+        sudo systemctl restart systemd-journald
+        info "Plafond journald appliqué (SystemMaxUse=200M) + journald redémarré"
+        # Purge immédiate à la nouvelle borne (sinon le plafond n'est appliqué
+        # qu'à la prochaine rotation). Sans effet si déjà sous la borne.
+        sudo journalctl --vacuum-size=200M >/dev/null 2>&1 || true
+    fi
+else
+    info "Plafond journald déjà à jour (ou absent du repo)"
+fi
+
 # ── 6. Déploiement CIBLÉ des binaires ─────────────────────────────────────────
 # Redémarre un service ssi : binaire différent, OU unité changée (§5), OU config
 # changée (§3/§3.bis). Évite les interruptions de service inutiles.


### PR DESCRIPTION
Le journal systemd grossissait sans plafond explicite (on dépendait du défaut systemd min(4 Go, 10 % partition)). Deux causes de volume :
- sonde irradiance : info! toutes les 30 s (~2880 lignes/jour, même la nuit à 0 W/m²)
- contrôle chauffe-eau : ~8 info! par tick toutes les 5 min

Correctifs (sans rien casser) :
- A. Plafond explicite via drop-in contrib/journald/daly-bms.conf (SystemMaxUse=200M), déployé par deploy-pi5.sh (section 5.ter, idempotent + restart systemd-journald + vacuum immédiat). Purement défensif : aucun service applicatif impacté.
- B. Démotion info!->debug! des boucles bavardes (irradiance + dumps d'état water_heater). Comportement identique : valeurs déjà publiées via metrics-store/emit_live ; transitions réelles (SEND, VACATION forcé) restent en info!.

Doc : CLAUDE.md (§0/§4/§8) + docs/diagnostic-depannage.md §11.


Claude-Session: https://claude.ai/code/session_012mvEZadLKJBUMnPAw97iMx