### PR TITLE
feat(topbar): déplacer les 4 nodes KPI dans le bandeau global

### DIFF
--- a/crates/daly-bms-server/templates/base.html
+++ b/crates/daly-bms-server/templates/base.html
@@ -350,12 +350,65 @@
       font-size: 0.95rem;
       font-weight: 700;
       color: var(--text);
-      flex: 1;
+      flex-shrink: 0;
     }
     .topbar-clock {
       font-family: 'JetBrains Mono', monospace;
       font-size: 0.75rem;
       color: var(--muted);
+      flex-shrink: 0;
+    }
+
+    /* ─── Topbar KPI nodes ───────────────────────────────────── */
+    .topbar-kpi {
+      display: flex;
+      align-items: center;
+      gap: 0;
+      flex: 1;
+      justify-content: center;
+      overflow: hidden;
+    }
+    .topbar-kpi-item {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0 0.85rem;
+      border-right: 1px solid var(--border);
+      white-space: nowrap;
+    }
+    .topbar-kpi-item:first-child { border-left: 1px solid var(--border); }
+    .topbar-kpi-icon { font-size: 0.9rem; flex-shrink: 0; }
+    .topbar-kpi-body { display: flex; flex-direction: column; gap: 0; }
+    .topbar-kpi-label {
+      font-size: 0.52rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--muted2);
+      line-height: 1;
+    }
+    .topbar-kpi-value {
+      font-size: 0.78rem;
+      font-weight: 700;
+      font-family: 'JetBrains Mono', monospace;
+      color: var(--text);
+      line-height: 1.3;
+    }
+    .topbar-kpi-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--muted2);
+      flex-shrink: 0;
+      transition: background 0.3s;
+    }
+    .topbar-kpi-dot.live  { background: var(--green);  box-shadow: 0 0 6px rgba(63,185,80,0.5); animation: pulse-dot 2s infinite; }
+    .topbar-kpi-dot.warn  { background: var(--yellow); box-shadow: 0 0 6px rgba(210,153,34,0.5); animation: pulse-dot 2s infinite; }
+    .topbar-kpi-dot.alarm { background: var(--red);    box-shadow: 0 0 6px rgba(248,81,73,0.5); animation: pulse-dot 2s infinite; }
+    @media (max-width: 920px) {
+      .topbar-kpi-item:nth-child(n+3) { display: none; }
+    }
+    @media (max-width: 600px) {
+      .topbar-kpi { display: none; }
     }
 
     /* ─── Main ───────────────────────────────────────────────── */
@@ -853,6 +906,40 @@
   <header class="topbar">
     <button class="topbar-burger" onclick="toggleSidebar()">☰</button>
     <div class="topbar-title">{% block page_title %}Monitoring{% endblock %}</div>
+    <div class="topbar-kpi" id="topbar-kpi">
+      <div class="topbar-kpi-item">
+        <span class="topbar-kpi-icon">☀️</span>
+        <div class="topbar-kpi-body">
+          <span class="topbar-kpi-label">Production</span>
+          <span class="topbar-kpi-value" id="hdr-prod">—</span>
+        </div>
+        <div class="topbar-kpi-dot" id="hdr-prod-dot"></div>
+      </div>
+      <div class="topbar-kpi-item">
+        <span class="topbar-kpi-icon">🔋</span>
+        <div class="topbar-kpi-body">
+          <span class="topbar-kpi-label">Batteries</span>
+          <span class="topbar-kpi-value" id="hdr-bat">—</span>
+        </div>
+        <div class="topbar-kpi-dot" id="hdr-bat-dot"></div>
+      </div>
+      <div class="topbar-kpi-item">
+        <span class="topbar-kpi-icon">🌤️</span>
+        <div class="topbar-kpi-body">
+          <span class="topbar-kpi-label">Météo</span>
+          <span class="topbar-kpi-value" id="hdr-meteo">—</span>
+        </div>
+        <div class="topbar-kpi-dot" id="hdr-meteo-dot"></div>
+      </div>
+      <div class="topbar-kpi-item">
+        <span class="topbar-kpi-icon">🌡️</span>
+        <div class="topbar-kpi-body">
+          <span class="topbar-kpi-label">Température</span>
+          <span class="topbar-kpi-value" id="hdr-temp">—</span>
+        </div>
+        <div class="topbar-kpi-dot" id="hdr-temp-dot"></div>
+      </div>
+    </div>
     <button class="tb-btn" id="fs-btn" onclick="toggleFullscreen()" title="Plein écran [F]">⛶</button>
     <button class="tb-btn" id="theme-btn" onclick="toggleTheme()" title="Thème sombre [D]">🌙</button>
     <div class="topbar-clock" id="tb-clock"></div>
@@ -992,6 +1079,83 @@ window.showToast = function(msg, type, duration) {
     setTimeout(function() { if (t.parentElement) t.remove(); }, 400);
   }, duration);
 };
+</script>
+
+<script>
+// ── Topbar KPI global fetch ────────────────────────────────────────────
+(function topbarKpi() {
+  const safe = p => p.catch(() => null);
+
+  function setText(id, val) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = val;
+  }
+  function setDot(id, cls) {
+    const el = document.getElementById(id);
+    if (el) el.className = 'topbar-kpi-dot' + (cls ? ' ' + cls : '');
+  }
+
+  async function fetchKpi() {
+    const [et7, irr, venusResp, shuntResp, bms1, bms2, bms3, tempResp] = await Promise.all([
+      safe(fetch('/api/v1/et112/7/status').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/irradiance/status').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/venus/mppt').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/venus/smartshunt').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/bms/1/status').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/bms/2/status').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/bms/3/status').then(r => r.ok ? r.json() : null)),
+      safe(fetch('/api/v1/venus/temperatures').then(r => r.ok ? r.json() : null)),
+    ]);
+
+    // Production
+    const mpptTotalW = venusResp?.total_power_w ?? 0;
+    const microW     = et7?.power_w ?? 0;
+    const totalProdW = microW + mpptTotalW;
+    const prodStr    = totalProdW > 0 || et7 || venusResp
+      ? ((totalProdW / 1000).toFixed(2) + ' kW')
+      : '—';
+    const prodDot    = (et7?.connected || (venusResp?.mppts?.length > 0))
+      ? (totalProdW > 50 ? 'live' : '') : '';
+    setText('hdr-prod', prodStr);
+    setDot('hdr-prod-dot', prodDot);
+
+    // Batteries
+    const shunt = shuntResp?.shunt ?? null;
+    const validBms = [bms1, bms2, bms3].filter(Boolean);
+    const avgSoc = validBms.length
+      ? (validBms.reduce((s, b) => s + (b.Soc ?? 0), 0) / validBms.length)
+      : null;
+    const totalPwr = validBms.reduce((s, b) => s + (b.Dc?.Power ?? 0), 0);
+    const displaySoc = shunt?.soc_percent != null ? shunt.soc_percent : avgSoc;
+    const batStr = displaySoc != null
+      ? ('SOC ' + displaySoc.toFixed(0) + '%' + (totalPwr ? (' ' + (totalPwr > 0 ? '+' : '') + (totalPwr / 1000).toFixed(1) + 'kW') : ''))
+      : '—';
+    const batDot = displaySoc == null ? '' : displaySoc > 50 ? 'live' : displaySoc > 20 ? 'warn' : 'alarm';
+    setText('hdr-bat', batStr);
+    setDot('hdr-bat-dot', batDot);
+
+    // Météo
+    const irrVal = irr?.irradiance_wm2 != null ? (irr.irradiance_wm2.toFixed(0) + ' W/m²') : '—';
+    setText('hdr-meteo', irrVal);
+    setDot('hdr-meteo-dot', irr ? 'live' : '');
+
+    // Température
+    const temps = tempResp?.temperatures ?? [];
+    const t0 = temps.length > 0 ? temps[0] : null;
+    const tempStr = t0?.temp_c != null
+      ? (t0.temp_c.toFixed(1) + '°C' + (t0.humidity_percent != null ? ' ' + t0.humidity_percent.toFixed(0) + '%HR' : ''))
+      : '—';
+    setText('hdr-temp', tempStr);
+    setDot('hdr-temp-dot', t0 ? 'live' : '');
+  }
+
+  fetchKpi();
+  setInterval(fetchKpi, 5000);
+
+  document.addEventListener('visibilitychange', function() {
+    if (!document.hidden) fetchKpi();
+  });
+})();
 </script>
 
 {% block scripts %}{% endblock %}

--- a/crates/daly-bms-server/templates/visualization.html
+++ b/crates/daly-bms-server/templates/visualization.html
@@ -52,10 +52,6 @@ const edgeTypes = { doubleLine: AnimatedFlowEdge, customBezier: CustomBezierEdge
 
 const NODES0 = [
   { id: 'spiral-race',   type: 'spiralRace',  position: { x: -350, y: -30  }, data: { prodKwh: 0, soc: 0, irrWm2: 0 } },
-  { id: 'production',  type: 'summary',     position: { x: -30,  y: -30  }, data: { label: 'Production',  icon: '☀️',  value: '—', sub: 'Micro-onduleurs',   dotClass: '' } },
-  { id: 'batteries',   type: 'summary',     position: { x: 170,  y: -30  }, data: { label: 'Batteries',   icon: '🔋', value: '—', sub: '360 Ah + 320 Ah + 620 Ah',  dotClass: '' } },
-  { id: 'meteo',       type: 'summary',     position: { x: 370,  y: -30  }, data: { label: 'Météo',       icon: '🌤️',  value: '—', sub: 'Irradiance solaire', dotClass: '' } },
-  { id: 'temp-ext',    type: 'temperature', position: { x: 570, y: -30 }, data: { label: 'Température', icon: '🌡️', live: null } },
   { id: 'chauffe-eau',   type: 'waterheater', position: { x: 780,  y: 550 }, data: { label: 'Chauffe-eau',   icon: '🚿', live: null, heatpump: null, isClimatisation: false } },
   { id: 'climatisation', type: 'waterheater', position: { x: 780,  y: 770 }, data: { label: 'Climatisation', icon: '❄️',  live: null, heatpump: null, isClimatisation: true  } },
   { id: 'micro-ond',   type: 'et112card',   position: { x: 400, y: 275 }, data: { label: 'Micro-onduleurs', address: 7, live: null } },
@@ -175,7 +171,6 @@ const atsExecRef = useRef(null);
     const mpptTotalDcA    = d.mpptTotalDcA     ?? 0;
     const shunt = d.shunt;
     const inverter = d.inverter;
-    const temp = d.temp;
     const ats = d.ats;
     const tasmotaDevices = d.tasmotaDevices || [];
     const heatpumps = d.heatpumps || [];
@@ -189,19 +184,6 @@ const atsExecRef = useRef(null);
     const totalPwr = validBms.reduce((s, b) => s + (b.Dc?.Power ?? 0), 0);
     // Use SmartShunt SOC (Victron) as primary — falls back to DALY average only if absent
     const displaySoc = shunt?.soc_percent != null ? shunt.soc_percent : (avgSoc != null ? parseFloat(avgSoc) : null);
-
-    const microPwr     = et7?.power_w ?? 0;
-    const totalProdPwr = microPwr + mpptTotalPowerW;
-    const prodVal      = fmtKw(totalProdPwr);
-    const mpptYieldSumG = mpptList.reduce((s, m) => s + (m.yield_today_kwh ?? 0), 0);
-    const prodSub      = et7 ? `${((et7.energy_export_wh ?? 0) / 1000).toFixed(1)} kWh ET112` : mpptList.length > 0 ? `${mpptYieldSumG.toFixed(2)} kWh MPPT` : 'Micro-onduleurs';
-    const prodDot      = (et7?.connected || mpptList.length > 0) ? (totalProdPwr > 50 ? 'live' : '') : '';
-    const batVal       = displaySoc != null ? `SOC ${displaySoc.toFixed(0)}%` : '—';
-    const batSub       = totalPwr ? `${totalPwr > 0 ? '+' : ''}${(totalPwr / 1000).toFixed(2)} kW` : '360 Ah + 320 Ah + 620 Ah';
-    const batDot       = displaySoc == null ? '' : displaySoc > 50 ? 'live' : displaySoc > 20 ? 'warn' : 'alarm';
-    const irrVal       = irr?.irradiance_wm2 != null ? `${irr.irradiance_wm2.toFixed(0)} W/m²` : '—';
-    const irrSub       = irr?.total_yield_kwh != null ? `☀ ${irr.total_yield_kwh.toFixed(1)} kWh` : 'Irradiance solaire';
-    const irrDot       = irr ? 'live' : '';
 
     setEdges(function (prev) {
       const withFlow = prev.map(function (e) {
@@ -303,12 +285,6 @@ const atsExecRef = useRef(null);
           const batDischargePwr = Math.max(0, -totalPwr);
           return { ...n, data: { ...n.data, microPwr: et7?.power_w ?? 0, mpptPwr: mpptTotalPowerW, batChargePwr, batDischargePwr, loadPwr } };
         }
-        case 'production':
-          return { ...n, data: { ...n.data, value: prodVal, sub: prodSub, dotClass: prodDot } };
-        case 'batteries':
-          return { ...n, data: { ...n.data, value: batVal, sub: batSub, dotClass: batDot } };
-        case 'meteo':
-          return { ...n, data: { ...n.data, value: irrVal, sub: irrSub, dotClass: irrDot } };
         case 'bms1': return { ...n, data: { ...n.data, live: bms1 ?? null } };
         case 'bms2': return { ...n, data: { ...n.data, live: bms2 ?? null } };
         case 'bms3': return { ...n, data: { ...n.data, live: bms3 ?? null } };
@@ -320,7 +296,6 @@ const atsExecRef = useRef(null);
         case 'climatisation': return { ...n, data: { ...n.data, live: et9 ?? null, heatpump: hp9 } };
         case 'mppt':        return { ...n, data: { ...n.data, mppts: mpptList, totalPowerW: mpptTotalPowerW, totalDcA: mpptTotalDcA } };
         case 'smartshunt':  return { ...n, data: { ...n.data, live: shunt ?? null } };
-        case 'temp-ext':    return { ...n, data: { ...n.data, live: temp ?? null } };
         case 'tongou-group': return { ...n, data: { ...n.data, switches: tasmotaDevices, disabled: atsProcessing, _rev: newRev } };
 
         case 'ats-reseau':


### PR DESCRIPTION
Les nodes production, batteries, météo et temp-ext sont retirés du canvas ReactFlow de la page /dashboard/visualization et intégrés dans la topbar (base.html) sous forme de widgets KPI compacts avec icône, valeur et dot de statut coloré.

Un fetch indépendant toutes les 5s interroge les mêmes endpoints REST que la page visualization, rendant ces KPI visibles sur toutes les pages. Les positions de tous les autres nodes de la page visualization sont inchangées.


Claude-Session: https://claude.ai/code/session_01DYbeMXjaWEifxfzfY55zVA