### PR TITLE
feat(et112): afficher le node complet avec "---" quand aucune donnée

### DIFF
--- a/crates/daly-bms-server/templates/et112.html
+++ b/crates/daly-bms-server/templates/et112.html
@@ -9,8 +9,8 @@
 <div class="page-hdr">
   <a href="/dashboard/et112" class="btn btn-outline" style="font-size:0.75rem;padding:0.3rem 0.7rem;">← Retour</a>
   <h1>⚡ {{ name }}</h1>
-  <span class="badge {% if connected %}ok{% else %}muted{% endif %}">
-    {% if connected %}● Connecté{% else %}○ Hors ligne{% endif %}
+  <span class="badge {% if connected %}ok{% else %}muted{% endif %}" id="conn-badge">
+    {% if connected %}● Connecté{% else %}○ Données absentes{% endif %}
   </span>
   <div class="page-hdr-meta" style="margin-left:auto">
     <span>{{ addr_hex }}</span>
@@ -19,7 +19,19 @@
   </div>
 </div>
 
-{% if connected %}
+{# Le node reste complet même sans données : « --- » à la place des valeurs. #}
+
+{% if !connected %}
+<div class="card" style="margin-bottom:1.25rem;border-left:3px solid var(--muted2);">
+  <div style="display:flex;align-items:center;gap:0.6rem;padding:0.3rem 0.1rem;">
+    <span style="font-size:1.3rem">○</span>
+    <div>
+      <div style="font-weight:600;color:var(--text2)">Données absentes</div>
+      <div style="font-size:0.75rem;color:var(--muted)">Aucune donnée reçue pour <code>{{ addr_hex }}</code> (entrée non raccordée ou hors ligne).</div>
+    </div>
+  </div>
+</div>
+{% endif %}
 
 {# ─── Métriques instantanées ──────────────────────────────────────────── #}
 <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:0.85rem;margin-bottom:1.25rem;">
@@ -27,46 +39,46 @@
   <div class="card card-p" style="text-align:center;">
     <div class="card-title" style="margin-bottom:0.3rem">Puissance</div>
     <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;
-                color:{% if power_w >= 0.0 %}var(--green){% else %}var(--accent){% endif %}" id="val-power">
-      {{ power_w|f1 }} W
+                color:{% if !connected %}var(--muted){% else if power_w >= 0.0 %}var(--green){% else %}var(--accent){% endif %}" id="val-power">
+      {% if connected %}{{ power_w|f1 }} W{% else %}---{% endif %}
     </div>
     <div style="font-size:0.65rem;color:var(--muted);margin-top:0.2rem">
-      {% if power_w >= 0.0 %}Import{% else %}Export{% endif %}
+      {% if !connected %}—{% else if power_w >= 0.0 %}Import{% else %}Export{% endif %}
     </div>
   </div>
 
   <div class="card card-p" style="text-align:center;">
     <div class="card-title" style="margin-bottom:0.3rem">Tension</div>
-    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--accent)" id="val-voltage">
-      {{ voltage_v|f1 }} V
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:{% if connected %}var(--accent){% else %}var(--muted){% endif %}" id="val-voltage">
+      {% if connected %}{{ voltage_v|f1 }} V{% else %}---{% endif %}
     </div>
   </div>
 
   <div class="card card-p" style="text-align:center;">
     <div class="card-title" style="margin-bottom:0.3rem">Courant</div>
-    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--orange)" id="val-current">
-      {{ current_a|f2 }} A
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:{% if connected %}var(--orange){% else %}var(--muted){% endif %}" id="val-current">
+      {% if connected %}{{ current_a|f2 }} A{% else %}---{% endif %}
     </div>
   </div>
 
   <div class="card card-p" style="text-align:center;">
     <div class="card-title" style="margin-bottom:0.3rem">Facteur puissance</div>
-    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--text2)" id="val-pf">
-      {{ power_factor|f3 }}
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:{% if connected %}var(--text2){% else %}var(--muted){% endif %}" id="val-pf">
+      {% if connected %}{{ power_factor|f3 }}{% else %}---{% endif %}
     </div>
   </div>
 
   <div class="card card-p" style="text-align:center;">
     <div class="card-title" style="margin-bottom:0.3rem">Fréquence</div>
-    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--text)" id="val-freq">
-      {{ frequency_hz|f2 }} Hz
+    <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:{% if connected %}var(--text){% else %}var(--muted){% endif %}" id="val-freq">
+      {% if connected %}{{ frequency_hz|f2 }} Hz{% else %}---{% endif %}
     </div>
   </div>
 
   <div class="card card-p" style="text-align:center;">
     <div class="card-title" style="margin-bottom:0.3rem">Puiss. apparente</div>
     <div style="font-size:2.2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--muted)" id="val-apparent">
-      {{ apparent_power_va|f1 }} VA
+      {% if connected %}{{ apparent_power_va|f1 }} VA{% else %}---{% endif %}
     </div>
   </div>
 
@@ -76,17 +88,17 @@
 <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:1.25rem;">
   <div class="card card-p">
     <div class="card-title">⬇ Énergie importée</div>
-    <div style="font-size:2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--green)" id="val-import">
-      {{ energy_import_kwh|f3 }} kWh
+    <div style="font-size:2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:{% if connected %}var(--green){% else %}var(--muted){% endif %}" id="val-import">
+      {% if connected %}{{ energy_import_kwh|f3 }} kWh{% else %}---{% endif %}
     </div>
-    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.4rem">{{ energy_import_wh|f0 }} Wh brut cumulé</div>
+    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.4rem">{% if connected %}{{ energy_import_wh|f0 }} Wh brut cumulé{% else %}—{% endif %}</div>
   </div>
   <div class="card card-p">
     <div class="card-title">⬆ Énergie exportée</div>
-    <div style="font-size:2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:var(--accent)" id="val-export">
-      {{ energy_export_kwh|f3 }} kWh
+    <div style="font-size:2rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:{% if connected %}var(--accent){% else %}var(--muted){% endif %}" id="val-export">
+      {% if connected %}{{ energy_export_kwh|f3 }} kWh{% else %}---{% endif %}
     </div>
-    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.4rem">{{ energy_export_wh|f0 }} Wh brut cumulé</div>
+    <div style="font-size:0.65rem;color:var(--muted);margin-top:0.4rem">{% if connected %}{{ energy_export_wh|f0 }} Wh brut cumulé{% else %}—{% endif %}</div>
   </div>
 </div>
 
@@ -96,23 +108,16 @@
     <span class="chart-hdr-title">Historique puissance</span>
     <span class="chart-hdr-meta">Dernières mesures — rafraîchi toutes les 5s</span>
   </div>
+  {% if connected %}
   <div id="chart-power" style="height:260px;"></div>
-</div>
-
-{% else %}
-
-<div class="card">
-  <div class="empty-state">
-    <div class="empty-icon">⏳</div>
-    <div class="empty-title">En attente du premier snapshot ET112</div>
-    <div class="empty-sub">
-      Vérifiez que l'ET112 est alimenté sur <code>{{ addr_hex }}</code><br>
-      et que le bus RS485 est connecté sur <code>/dev/ttyUSB0</code>.
-    </div>
+  {% else %}
+  <div class="empty-state" style="height:260px;display:flex;flex-direction:column;justify-content:center;">
+    <div class="empty-icon">○</div>
+    <div class="empty-title">Données absentes</div>
+    <div class="empty-sub">Aucun historique tant qu'aucune donnée n'est reçue sur <code>{{ addr_hex }}</code>.</div>
   </div>
+  {% endif %}
 </div>
-
-{% endif %}
 
 {% endblock %}
 
@@ -159,12 +164,21 @@ if (chartDom) {
   window.addEventListener('resize', () => myChart && myChart.resize());
 }
 
+const set = (id, txt) => { const el = document.getElementById(id); if (el) el.textContent = txt; };
+
+// Affiche « --- » partout quand aucune donnée n'est reçue.
+function markMissing() {
+  ['val-power','val-voltage','val-current','val-pf','val-freq','val-apparent','val-import','val-export']
+    .forEach(id => { const el = document.getElementById(id); if (el) { el.textContent = '---'; el.style.color = 'var(--muted)'; } });
+  const badge = document.getElementById('conn-badge');
+  if (badge) { badge.textContent = '○ Données absentes'; badge.className = 'badge muted'; }
+}
+
 async function update() {
   try {
     const resp = await fetch(`/api/v1/et112/${ADDR}/status`);
-    if (!resp.ok) return;
+    if (!resp.ok) { markMissing(); return; }
     const d = await resp.json();
-    const set = (id, txt) => { const el = document.getElementById(id); if (el) el.textContent = txt; };
     set('val-power',    d.power_w.toFixed(1) + ' W');
     set('val-voltage',  d.voltage_v.toFixed(1) + ' V');
     set('val-current',  d.current_a.toFixed(2) + ' A');
@@ -176,7 +190,9 @@ async function update() {
     set('last-ts',      new Date().toLocaleTimeString('fr-FR'));
     const powEl = document.getElementById('val-power');
     if (powEl) powEl.style.color = d.power_w >= 0 ? 'var(--green)' : 'var(--accent)';
-  } catch(e) {}
+    const badge = document.getElementById('conn-badge');
+    if (badge) { badge.textContent = '● Connecté'; badge.className = 'badge ok'; }
+  } catch(e) { markMissing(); }
 }
 
 async function loadHistory() {

--- a/crates/daly-bms-server/templates/et112_all.html
+++ b/crates/daly-bms-server/templates/et112_all.html
@@ -18,16 +18,14 @@
 <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1.25rem;">
 
 {% for d in devices %}
-<div class="bms-card {% if !d.connected %}" style="opacity:0.7{% endif %}" id="et112-card-{{ d.address }}">
+<div class="bms-card {% if !d.connected %}" style="opacity:0.85{% endif %}" id="et112-card-{{ d.address }}">
 
   {# Header #}
   <div class="bms-hdr {% if !d.connected %}bms-hdr-offline{% else if d.service_type == "pvinverter" %}bms-hdr-pv{% else if d.service_type == "heatpump" %}bms-hdr-heat{% endif %}">
     <div class="bms-hdr-left">
-      {% if d.connected %}
-        <div class="bms-live"><div class="live-dot"></div>LIVE</div>
-      {% else %}
-        <span style="font-size:0.62rem;color:var(--muted2)">Hors ligne</span>
-      {% endif %}
+      <span id="state-{{ d.address }}">
+        {% if d.connected %}<span class="bms-live"><span class="live-dot"></span>LIVE</span>{% else %}<span style="font-size:0.62rem;color:var(--muted2)">○ Données absentes</span>{% endif %}
+      </span>
       <span class="bms-hdr-name">
         {% if d.service_type == "pvinverter" %}☀{% else if d.service_type == "heatpump" %}🌡{% else %}⚡{% endif %}
         {{ d.name }}
@@ -39,23 +37,21 @@
     </div>
   </div>
 
-  {% if d.connected %}
-
-  {# KPI 4 col #}
+  {# KPI 4 col — le node reste complet ; « --- » si aucune donnée reçue #}
   <div class="kpi4">
     <div class="kpi4-cell t-yellow">
       <div class="kpi4-lbl">Puissance</div>
-      <div class="kpi4-val {% if d.power_w >= 0.0 %}chg{% else %}dch{% endif %}" id="p-{{ d.address }}">
-        {{ d.power_w|f1 }} W
+      <div class="kpi4-val {% if !d.connected %}muted{% else if d.power_w >= 0.0 %}chg{% else %}dch{% endif %}" id="p-{{ d.address }}">
+        {% if d.connected %}{{ d.power_w|f1 }} W{% else %}---{% endif %}
       </div>
     </div>
     <div class="kpi4-cell t-blue">
       <div class="kpi4-lbl">Tension</div>
-      <div class="kpi4-val" id="v-{{ d.address }}">{{ d.voltage_v|f1 }} V</div>
+      <div class="kpi4-val {% if !d.connected %}muted{% endif %}" id="v-{{ d.address }}">{% if d.connected %}{{ d.voltage_v|f1 }} V{% else %}---{% endif %}</div>
     </div>
     <div class="kpi4-cell t-orange">
       <div class="kpi4-lbl">Courant</div>
-      <div class="kpi4-val" id="i-{{ d.address }}">{{ d.current_a|f2 }} A</div>
+      <div class="kpi4-val {% if !d.connected %}muted{% endif %}" id="i-{{ d.address }}">{% if d.connected %}{{ d.current_a|f2 }} A{% else %}---{% endif %}</div>
     </div>
     <div class="kpi4-cell">
       <div class="kpi4-lbl">Type</div>
@@ -63,27 +59,17 @@
     </div>
   </div>
 
-  {# Énergie #}
+  {# Énergie — toujours affichée (« --- » si aucune donnée) #}
   <div class="istrip c2">
     <div class="icell">
       <span class="i-lbl">⬇ Importée</span>
-      <span class="i-val ok" id="imp-{{ d.address }}">{{ d.energy_import_kwh|f2 }} kWh</span>
+      <span class="i-val {% if d.connected %}ok{% else %}muted{% endif %}" id="imp-{{ d.address }}">{% if d.connected %}{{ d.energy_import_kwh|f2 }} kWh{% else %}---{% endif %}</span>
     </div>
     <div class="icell">
       <span class="i-lbl">⬆ Exportée</span>
-      <span class="i-val blue" id="exp-{{ d.address }}">{{ d.energy_export_kwh|f2 }} kWh</span>
+      <span class="i-val {% if d.connected %}blue{% else %}muted{% endif %}" id="exp-{{ d.address }}">{% if d.connected %}{{ d.energy_export_kwh|f2 }} kWh{% else %}---{% endif %}</span>
     </div>
   </div>
-
-  {% else %}
-
-  <div class="empty-state" style="padding:2rem 1rem;">
-    <div class="empty-icon" style="font-size:1.5rem">⏳</div>
-    <div class="empty-title">En attente de données</div>
-    <div class="empty-sub">Adresse Modbus : <code>{{ d.addr_hex }}</code></div>
-  </div>
-
-  {% endif %}
 
   <div style="padding:0.5rem 0.75rem;display:flex;justify-content:flex-end;border-top:1px solid var(--border);">
     <a href="/dashboard/et112/{{ d.address }}" class="btn btn-outline" style="font-size:0.72rem;padding:0.3rem 0.7rem;">Détails →</a>
@@ -105,10 +91,28 @@ async function updateAll() {
   const tsEl = document.getElementById('et112-ts');
   if (tsEl) tsEl.textContent = ts;
 
+  const NA = '---';
+
+  // Bascule l'affichage d'une carte en « données absentes » (valeurs « --- »).
+  function markMissing(addr) {
+    const pw = document.getElementById(`p-${addr}`);
+    const vv = document.getElementById(`v-${addr}`);
+    const iv = document.getElementById(`i-${addr}`);
+    const im = document.getElementById(`imp-${addr}`);
+    const ex = document.getElementById(`exp-${addr}`);
+    const st = document.getElementById(`state-${addr}`);
+    if (pw) { pw.textContent = NA; pw.className = 'kpi4-val muted'; }
+    if (vv) { vv.textContent = NA; vv.className = 'kpi4-val muted'; }
+    if (iv) { iv.textContent = NA; iv.className = 'kpi4-val muted'; }
+    if (im) { im.textContent = NA; im.className = 'i-val muted'; }
+    if (ex) { ex.textContent = NA; ex.className = 'i-val muted'; }
+    if (st) st.innerHTML = '<span style="font-size:0.62rem;color:var(--muted2)">○ Données absentes</span>';
+  }
+
   for (const addr of ET112_ADDRS) {
     try {
       const resp = await fetch(`/api/v1/et112/${addr}/status`);
-      if (!resp.ok) continue;
+      if (!resp.ok) { markMissing(addr); continue; }
       const d = await resp.json();
 
       const pw = document.getElementById(`p-${addr}`);
@@ -117,14 +121,18 @@ async function updateAll() {
       const im = document.getElementById(`imp-${addr}`);
       const ex = document.getElementById(`exp-${addr}`);
       const tsEl2 = document.getElementById(`ts-${addr}`);
+      const st = document.getElementById(`state-${addr}`);
 
       if (pw) { pw.textContent = d.power_w.toFixed(1) + ' W'; pw.className = 'kpi4-val ' + (d.power_w >= 0 ? 'chg' : 'dch'); }
-      if (vv) vv.textContent = d.voltage_v.toFixed(1) + ' V';
-      if (iv) iv.textContent = d.current_a.toFixed(2) + ' A';
-      if (im) im.textContent = (d.energy_import_wh / 1000).toFixed(2) + ' kWh';
-      if (ex) ex.textContent = (d.energy_export_wh / 1000).toFixed(2) + ' kWh';
+      if (vv) { vv.textContent = d.voltage_v.toFixed(1) + ' V'; vv.className = 'kpi4-val'; }
+      if (iv) { iv.textContent = d.current_a.toFixed(2) + ' A'; iv.className = 'kpi4-val'; }
+      if (im) { im.textContent = (d.energy_import_wh / 1000).toFixed(2) + ' kWh'; im.className = 'i-val ok'; }
+      if (ex) { ex.textContent = (d.energy_export_wh / 1000).toFixed(2) + ' kWh'; ex.className = 'i-val blue'; }
       if (tsEl2) tsEl2.textContent = ts;
-    } catch(e) {}
+      if (st) st.innerHTML = '<span class="bms-live"><span class="live-dot"></span>LIVE</span>';
+    } catch(e) {
+      markMissing(addr);
+    }
   }
 }
 

--- a/crates/daly-bms-server/templates/viz_nodes_basic.js
+++ b/crates/daly-bms-server/templates/viz_nodes_basic.js
@@ -85,41 +85,39 @@ function Et112CardNode({ data }) {
     mkHandle('source', Position.Bottom, 'sb'),
     mkHandle('source', Position.Right,  'sr'),
     mkHandle('target', Position.Right,  'tr', { top: '50%' }),
-    h('div', { className: `bms-card-in-viz ${connected ? '' : 'offline-card'}`, style: { opacity: connected ? 1 : 0.7 } },
+    h('div', { className: `bms-card-in-viz ${connected ? '' : 'offline-card'}`, style: { opacity: connected ? 1 : 0.85 } },
       h('div', { className: `bms-hdr ${connected ? '' : 'offline'}` },
         h('div', { className: 'bms-hdr-left' },
-          connected ? h('div', { className: 'bms-live' }, h('div', { className: 'live-dot' }), 'LIVE') : h('span', { style: { fontSize: '0.62rem', color: 'var(--muted2)' } }, 'Hors ligne'),
+          connected ? h('div', { className: 'bms-live' }, h('div', { className: 'live-dot' }), 'LIVE') : h('span', { style: { fontSize: '0.62rem', color: 'var(--muted2)' } }, '○ Données absentes'),
           h('span', { className: 'bms-hdr-name' }, `${icon} `, data.label)
         ),
         h('div', { className: 'bms-hdr-right' }, h('span', { className: 'bms-badge' }, `0x0${addr.toString(16).toUpperCase()}`))
       ),
-      connected && live ? h('div', { className: 'kpi4' },
+      // Le node reste complet même sans données : « --- » à la place des valeurs.
+      h('div', { className: 'kpi4' },
         h('div', { className: 'kpi4-cell t-yellow' },
           h('div', { className: 'kpi4-lbl' }, 'Puissance'),
-          h('div', { className: `kpi4-val ${(pwr ?? 0) >= 0 ? 'chg' : 'dch'}` }, pwr != null ? `${pwr.toFixed(0)} W` : '—')
+          h('div', { className: `kpi4-val ${!connected ? 'muted' : ((pwr ?? 0) >= 0 ? 'chg' : 'dch')}` }, (connected && pwr != null) ? `${pwr.toFixed(0)} W` : '---')
         ),
         h('div', { className: 'kpi4-cell t-blue' },
           h('div', { className: 'kpi4-lbl' }, 'Tension'),
-          h('div', { className: 'kpi4-val' }, volt != null ? `${volt.toFixed(1)} V` : '—')
+          h('div', { className: `kpi4-val ${connected ? '' : 'muted'}` }, (connected && volt != null) ? `${volt.toFixed(1)} V` : '---')
         ),
         h('div', { className: 'kpi4-cell t-orange' },
           h('div', { className: 'kpi4-lbl' }, 'Courant'),
-          h('div', { className: 'kpi4-val' }, cur != null ? `${cur.toFixed(2)} A` : '—')
+          h('div', { className: `kpi4-val ${connected ? '' : 'muted'}` }, (connected && cur != null) ? `${cur.toFixed(2)} A` : '---')
         )
-      ) : h('div', { className: 'empty-state' },
-        h('div', { className: 'empty-icon' }, '⏳'),
-        h('div', { className: 'empty-title' }, 'En attente de données')
       ),
-      connected && live ? h('div', { className: 'istrip' },
+      h('div', { className: 'istrip' },
         h('div', { className: 'icell' },
           h('span', { className: 'i-lbl' }, '⬇ Importée'),
-          h('span', { className: 'i-val ok' }, imp != null ? `${imp.toFixed(2)} kWh` : '—')
+          h('span', { className: `i-val ${connected ? 'ok' : 'muted'}` }, (connected && imp != null) ? `${imp.toFixed(2)} kWh` : '---')
         ),
         h('div', { className: 'icell' },
           h('span', { className: 'i-lbl' }, '⬆ Exportée'),
-          h('span', { className: 'i-val blue' }, expW != null ? `${expW.toFixed(2)} kWh` : '—')
+          h('span', { className: `i-val ${connected ? 'blue' : 'muted'}` }, (connected && expW != null) ? `${expW.toFixed(2)} kWh` : '---')
         )
-      ) : null
+      )
     )
   );
 }


### PR DESCRIPTION
Les pages visualisation, « Compteurs ET112 » (liste) et le détail ET112 affichaient un état vide « En attente de données » lorsqu'un ET112 n'était pas connecté (cas du 0x09 « ET112 Réseau », 220V réseau volontairement déconnecté). Le node reste désormais entièrement représenté, avec « --- » à la place des valeurs et un marqueur « Données absentes ».

- et112_all.html : KPI (Puissance/Tension/Courant) + énergie toujours rendus ; « --- » en style muted si non connecté ; JS gère le 404 et les transitions en/hors ligne à chaud (markMissing / restauration LIVE).
- viz_nodes_basic.js (Et112CardNode) : layout KPI + énergie toujours affiché ; « --- » muted + en-tête « Données absentes ».
- et112.html (détail) : métriques instantanées + énergie toujours rendues avec « --- » ; bandeau « Données absentes » ; graphique remplacé par un placeholder ; badge de connexion synchronisé côté JS.


Claude-Session: https://claude.ai/code/session_016o8KjEUem51kFnbkCmvT9p