### PR TITLE
fix(et112): rendre les transitions en/hors ligne pleinement dynamique…

### DIFF
--- a/crates/daly-bms-server/templates/et112.html
+++ b/crates/daly-bms-server/templates/et112.html
@@ -21,8 +21,7 @@
 
 {# Le node reste complet même sans données : « --- » à la place des valeurs. #}
 
-{% if !connected %}
-<div class="card" style="margin-bottom:1.25rem;border-left:3px solid var(--muted2);">
+<div class="card" id="missing-data-banner" style="margin-bottom:1.25rem;border-left:3px solid var(--muted2);{% if connected %}display:none;{% endif %}">
   <div style="display:flex;align-items:center;gap:0.6rem;padding:0.3rem 0.1rem;">
     <span style="font-size:1.3rem">○</span>
     <div>
@@ -31,7 +30,6 @@
     </div>
   </div>
 </div>
-{% endif %}
 
 {# ─── Métriques instantanées ──────────────────────────────────────────── #}
 <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:0.85rem;margin-bottom:1.25rem;">
@@ -108,15 +106,12 @@
     <span class="chart-hdr-title">Historique puissance</span>
     <span class="chart-hdr-meta">Dernières mesures — rafraîchi toutes les 5s</span>
   </div>
-  {% if connected %}
-  <div id="chart-power" style="height:260px;"></div>
-  {% else %}
-  <div class="empty-state" style="height:260px;display:flex;flex-direction:column;justify-content:center;">
+  <div id="chart-power" style="height:260px;{% if !connected %}display:none;{% endif %}"></div>
+  <div id="chart-empty" class="empty-state" style="height:260px;flex-direction:column;justify-content:center;display:{% if connected %}none{% else %}flex{% endif %};">
     <div class="empty-icon">○</div>
     <div class="empty-title">Données absentes</div>
     <div class="empty-sub">Aucun historique tant qu'aucune donnée n'est reçue sur <code>{{ addr_hex }}</code>.</div>
   </div>
-  {% endif %}
 </div>
 
 {% endblock %}
@@ -165,6 +160,23 @@ if (chartDom) {
 }
 
 const set = (id, txt) => { const el = document.getElementById(id); if (el) el.textContent = txt; };
+const setVal = (id, txt, color) => { const el = document.getElementById(id); if (el) { el.textContent = txt; el.style.color = color; } };
+
+// Bascule l'affichage graphique ↔ placeholder « Données absentes ».
+function showChart(hasData) {
+  const banner  = document.getElementById('missing-data-banner');
+  const chartEl = document.getElementById('chart-power');
+  const emptyEl = document.getElementById('chart-empty');
+  if (banner)  banner.style.display  = hasData ? 'none' : 'block';
+  if (emptyEl) emptyEl.style.display = hasData ? 'none' : 'flex';
+  if (chartEl) {
+    const wasHidden = chartEl.style.display === 'none';
+    chartEl.style.display = hasData ? 'block' : 'none';
+    // ECharts initialisé sur un conteneur masqué (0×0) : recalculer les
+    // dimensions au moment où il redevient visible.
+    if (hasData && wasHidden && myChart) myChart.resize();
+  }
+}
 
 // Affiche « --- » partout quand aucune donnée n'est reçue.
 function markMissing() {
@@ -172,6 +184,7 @@ function markMissing() {
     .forEach(id => { const el = document.getElementById(id); if (el) { el.textContent = '---'; el.style.color = 'var(--muted)'; } });
   const badge = document.getElementById('conn-badge');
   if (badge) { badge.textContent = '○ Données absentes'; badge.className = 'badge muted'; }
+  showChart(false);
 }
 
 async function update() {
@@ -179,19 +192,18 @@ async function update() {
     const resp = await fetch(`/api/v1/et112/${ADDR}/status`);
     if (!resp.ok) { markMissing(); return; }
     const d = await resp.json();
-    set('val-power',    d.power_w.toFixed(1) + ' W');
-    set('val-voltage',  d.voltage_v.toFixed(1) + ' V');
-    set('val-current',  d.current_a.toFixed(2) + ' A');
-    set('val-pf',       d.power_factor.toFixed(3));
-    set('val-freq',     d.frequency_hz.toFixed(2) + ' Hz');
-    set('val-apparent', d.apparent_power_va.toFixed(1) + ' VA');
-    set('val-import',   (d.energy_import_wh / 1000).toFixed(3) + ' kWh');
-    set('val-export',   (d.energy_export_wh / 1000).toFixed(3) + ' kWh');
+    setVal('val-power',    d.power_w.toFixed(1) + ' W', d.power_w >= 0 ? 'var(--green)' : 'var(--accent)');
+    setVal('val-voltage',  d.voltage_v.toFixed(1) + ' V', 'var(--accent)');
+    setVal('val-current',  d.current_a.toFixed(2) + ' A', 'var(--orange)');
+    setVal('val-pf',       d.power_factor.toFixed(3), 'var(--text2)');
+    setVal('val-freq',     d.frequency_hz.toFixed(2) + ' Hz', 'var(--text)');
+    setVal('val-apparent', d.apparent_power_va.toFixed(1) + ' VA', 'var(--muted)');
+    setVal('val-import',   (d.energy_import_wh / 1000).toFixed(3) + ' kWh', 'var(--green)');
+    setVal('val-export',   (d.energy_export_wh / 1000).toFixed(3) + ' kWh', 'var(--accent)');
     set('last-ts',      new Date().toLocaleTimeString('fr-FR'));
-    const powEl = document.getElementById('val-power');
-    if (powEl) powEl.style.color = d.power_w >= 0 ? 'var(--green)' : 'var(--accent)';
     const badge = document.getElementById('conn-badge');
     if (badge) { badge.textContent = '● Connecté'; badge.className = 'badge ok'; }
+    showChart(true);
   } catch(e) { markMissing(); }
 }
 

--- a/crates/daly-bms-server/templates/et112_all.html
+++ b/crates/daly-bms-server/templates/et112_all.html
@@ -18,7 +18,7 @@
 <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1.25rem;">
 
 {% for d in devices %}
-<div class="bms-card {% if !d.connected %}" style="opacity:0.85{% endif %}" id="et112-card-{{ d.address }}">
+<div class="bms-card" style="{% if !d.connected %}opacity:0.85;{% endif %}" id="et112-card-{{ d.address }}">
 
   {# Header #}
   <div class="bms-hdr {% if !d.connected %}bms-hdr-offline{% else if d.service_type == "pvinverter" %}bms-hdr-pv{% else if d.service_type == "heatpump" %}bms-hdr-heat{% endif %}">
@@ -101,12 +101,14 @@ async function updateAll() {
     const im = document.getElementById(`imp-${addr}`);
     const ex = document.getElementById(`exp-${addr}`);
     const st = document.getElementById(`state-${addr}`);
+    const card = document.getElementById(`et112-card-${addr}`);
     if (pw) { pw.textContent = NA; pw.className = 'kpi4-val muted'; }
     if (vv) { vv.textContent = NA; vv.className = 'kpi4-val muted'; }
     if (iv) { iv.textContent = NA; iv.className = 'kpi4-val muted'; }
     if (im) { im.textContent = NA; im.className = 'i-val muted'; }
     if (ex) { ex.textContent = NA; ex.className = 'i-val muted'; }
     if (st) st.innerHTML = '<span style="font-size:0.62rem;color:var(--muted2)">○ Données absentes</span>';
+    if (card) card.style.opacity = '0.85';
   }
 
   for (const addr of ET112_ADDRS) {
@@ -122,6 +124,7 @@ async function updateAll() {
       const ex = document.getElementById(`exp-${addr}`);
       const tsEl2 = document.getElementById(`ts-${addr}`);
       const st = document.getElementById(`state-${addr}`);
+      const card = document.getElementById(`et112-card-${addr}`);
 
       if (pw) { pw.textContent = d.power_w.toFixed(1) + ' W'; pw.className = 'kpi4-val ' + (d.power_w >= 0 ? 'chg' : 'dch'); }
       if (vv) { vv.textContent = d.voltage_v.toFixed(1) + ' V'; vv.className = 'kpi4-val'; }
@@ -130,6 +133,7 @@ async function updateAll() {
       if (ex) { ex.textContent = (d.energy_export_wh / 1000).toFixed(2) + ' kWh'; ex.className = 'i-val blue'; }
       if (tsEl2) tsEl2.textContent = ts;
       if (st) st.innerHTML = '<span class="bms-live"><span class="live-dot"></span>LIVE</span>';
+      if (card) card.style.opacity = '1';
     } catch(e) {
       markMissing(addr);
     }


### PR DESCRIPTION
…s (revue)

Suite à la revue de code :

- et112_all.html : attribut `class` réécrit sous forme plus lisible (`class="bms-card" style="{% if %}...{% endif %}"`) ; l'opacité de la carte est désormais synchronisée en JS (0.85 hors ligne / 1 en ligne) dans markMissing() et au retour de données.
- et112.html : le bandeau « Données absentes » et le conteneur du graphique sont toujours présents dans le DOM, leur visibilité étant pilotée par CSS (display) via showChart(). Corrige un bug latent : chargé hors ligne, #chart-power n'existait pas → ECharts jamais initialisé → graphique absent même après retour en ligne. showChart() appelle myChart.resize() quand le conteneur redevient visible. Les couleurs des métriques sont restaurées via setVal() au retour en ligne (plus seulement la puissance).


Claude-Session: https://claude.ai/code/session_016o8KjEUem51kFnbkCmvT9p