### PR TITLE
docs(toshiba): acter la voie Rust (plus ESPHome) + validation croisée…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,6 +432,7 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 | MQTT / Mosquitto (topics, bridge, anti-boucle, migration Docker→natif) | `docs/mqtt-mosquitto.md` |
 | Alertes (AlertEngine natif, règles, hysteresis, notifications) | `docs/alertes.md` |
 | Ajouter un appareil / BMS Daly, ATS CHINT, ET112, PRALRAN | `docs/integration-materiel.md` |
-| **Intégrer les clim Toshiba SHORAI EDGE** (ESP32 + ESPHome sur CN22 → MQTT → module EM `logic/toshiba_ac`) | `docs/integration-toshiba-shorai-esphome.md` |
+| **Clim Toshiba SHORAI EDGE — VOIE RETENUE = firmware RUST natif ESP32** (protocole SUZUMI CN22 vérifié vs pedobry + o0Zz ; PAS ESPHome) | `docs/toshiba-suzumi-rs-plan.md` |
+| Clim Toshiba — **référence câblage/MQTT** (BOM, brochage CN22, topics `santuario/toshiba`, module EM `logic/toshiba_ac`, conso Tongou) — ⚠️ voie ESPHome **non retenue**, YAML §4 obsolète | `docs/integration-toshiba-shorai-esphome.md` |
 | Dépannage, netdiag réseau, debug onduleur/SmartShunt, memory-leak | `docs/diagnostic-depannage.md` |
 | **Audit robustesse 2026-06** — 18 axes (§3-§18 implémentés ; §1-§2 sécurité en attente d'action utilisateur) | `docs/audit-robustesse-2026-06.md` |

--- a/docs/integration-toshiba-shorai-esphome.md
+++ b/docs/integration-toshiba-shorai-esphome.md
@@ -1,12 +1,20 @@
 # Intégration Toshiba SHORAI EDGE R32 — ESP32 + ESPHome (CN22 → MQTT → Mosquitto Pi5)
 
+> **🚫 VOIE NON RETENUE (décision juillet 2026).** Le runtime ESP32 retenu est un
+> **firmware Rust natif**, PAS ESPHome → **voir `docs/toshiba-suzumi-rs-plan.md`**
+> (référence d'implémentation du projet). **Ce document reste utile en RÉFÉRENCE** pour
+> ses parties **indépendantes du runtime**, toujours valables et réutilisées par la voie
+> Rust : **§1 BOM, §2 brochage CN22, §3 câblage/sécurité, §5 schéma de topics MQTT
+> `santuario/toshiba/<zone>`, §6 module Pi5 `logic/toshiba_ac`, §7 mesure conso
+> Tongou/Tasmota**. **Ignorer §4 (YAML ESPHome)** — remplacé par le firmware Rust.
+>
 > **Statut** : plan de mise en œuvre (non déployé — système livré, pas encore installé).
 > **Topologie** : **multi‑split** = **1 unité extérieure** (compresseur) + **3 unités
 > intérieures**. Contrôle **local** (sans cloud Toshiba) via **un ESP32 par unité
 > intérieure** branché sur le connecteur **CN22**, publiant en **MQTT** vers le broker
 > Mosquitto du Pi5.
-> **Voie retenue** : composant ESPHome `pedobry/esphome_toshiba_suzumi` (couvre
-> explicitement le Shorai Edge). CN22 réputé facilement accessible sur ces unités.
+> **Protocole série** : identique quel que soit le runtime (ESPHome ou Rust) — spec
+> vérifiée dans `docs/toshiba-suzumi-rs-plan.md` §6. Le Shorai Edge est couvert.
 > **Mesure puissance/énergie** : **PAS de capteur sur les ESP32** (ni ACS712, ni PZEM,
 > ni pince). Sur un multi‑split la conso est quasi‑totale à l'unité extérieure → elle
 > est mesurée par le **switch Tongou (Tasmota) placé sur l'alim de l'unité extérieure**

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -3,21 +3,21 @@
 > **Référence** : [pedobry/esphome_toshiba_suzumi](https://github.com/pedobry/esphome_toshiba_suzumi)
 > **Objectif** : Remplacer le composant ESPHome (C++) par un firmware Rust autonome sur ESP32, sans dépendance à Home Assistant.
 >
-> **⚠️ Statut du document** : la spécification protocolaire ci‑dessous (§6, §8) a été
-> **vérifiée octet par octet contre le code source C++** (`toshiba_climate.cpp`,
-> `toshiba_climate.h`, `toshiba_climate_mode.cpp`/`.h`, `climate.py`) en juillet 2026.
-> Les valeurs marquées « ✅ source » sont **extraites du firmware d'origine**, plus des
-> suppositions. Voir le tableau de correspondance §6.5.
+> **✅ DÉCISION ACTÉE (juillet 2026) — la voie retenue est un firmware RUST natif, PAS ESPHome.**
+> Ce document est **la référence d'implémentation du projet** pour les 3 unités Toshiba
+> Shorai Edge. ESPHome n'est **plus** la solution retenue : le document
+> `docs/integration-toshiba-shorai-esphome.md` est **conservé uniquement en référence**
+> pour ses parties **toujours valables** (câblage CN22, brochage, schéma de topics MQTT
+> `santuario/toshiba/<zone>`, module Pi5 `energy-manager logic/toshiba_ac`, mesure conso
+> via Tongou/Tasmota) — mais **le runtime ESP32 sera le firmware Rust décrit ici**, pas
+> le composant ESPHome.
 >
-> **Relation avec les autres documents du projet** :
-> - **Voie retenue en production** = réutiliser le composant **ESPHome tel quel** →
->   `docs/integration-toshiba-shorai-esphome.md` (câblage CN22, YAML, MQTT, module
->   `energy-manager logic/toshiba_ac`, mesure conso via Tongou/Tasmota).
-> - **Ce document** = voie **alternative/avancée** : un firmware **Rust natif** qui
->   ré‑implémente le protocole (utile si on veut se passer d'ESPHome, réduire l'empreinte,
->   ou intégrer une logique embarquée). Le **protocole série est identique** dans les deux
->   cas ; seul l'hôte logiciel change. Le câblage, les topics MQTT et l'intégration Pi5
->   décrits dans l'autre document **restent valables**.
+> **⚠️ Statut de la spécification** : le protocole ci‑dessous (§6, §8) a été
+> **vérifié octet par octet contre le code source C++** de référence
+> (`toshiba_climate.cpp`, `.h`, `toshiba_climate_mode.cpp`/`.h`, `climate.py` — pedobry)
+> **et recoupé avec une seconde implémentation indépendante** (`o0Zz/climate-uart`,
+> `src/protocols/toshiba.cpp` — voir §14). Les deux aboutissent au **même protocole** →
+> confiance élevée. Les valeurs marquées « ✅ source » sont **extraites du firmware**.
 
 ---
 
@@ -278,6 +278,15 @@ HANDSHAKE[5] = {2, 0,   2,   0,   0, 0, 0, 254}
 AFTER_HANDSHAKE[0] = {2, 0, 2, 1, 0, 0, 2, 0, 0, 251}
 AFTER_HANDSHAKE[1] = {2, 0, 2, 2, 0, 0, 2, 0, 0, 250}
 ```
+
+> ⚠️ **Divergence `HANDSHAKE[4]` (dernier octet)** — repérée en recoupant avec
+> `o0Zz/climate-uart` (§14). pedobry termine cette trame par **`254` (0xFE)**, mais la
+> **règle de checksum donne `251` (0xFB)** (Σ index 1..8 = 5 → 256−5 = 251) — c'est la
+> valeur qu'utilise o0Zz (`kSyn5`). Les **7 autres trames sont checksum‑correctes** ; seule
+> celle‑ci ne l'est pas côté pedobry. Comme le firmware pedobry **fonctionne sur le terrain
+> avec 0xFE**, l'unité **ne valide probablement pas** le checksum des trames de handshake
+> (init figées). **Recommandation** : garder les octets pedobry tels quels pour la parité,
+> mais si le handshake échoue au banc, **tester `0xFB`**.
 
 **Déroulé exact** (`setup()` → `start_handshake()` puis `getInitData()`) :
 
@@ -727,7 +736,8 @@ cargo run --release
 | The Rust on ESP Book | https://docs.esp-rs.org/book/ |
 | esp-idf-hal documentation | https://docs.esp-rs.org/esp-idf-hal/ |
 | esp-idf-svc examples | https://github.com/esp-rs/esp-idf-svc/tree/master/examples |
-| Code source C++ original | https://github.com/pedobry/esphome_toshiba_suzumi |
+| Code source C++ référence (pedobry) | https://github.com/pedobry/esphome_toshiba_suzumi |
+| 2ᵉ implémentation (validation croisée, §14) | https://github.com/o0Zz/climate-uart — `src/protocols/toshiba.cpp` |
 | ESP-IDF UART API | https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/uart.html |
 | Projet connexe (Shorai) | https://github.com/toremick/shorai-esp32 |
 | Projet connexe (TConnect) | https://github.com/Vpowgh/TConnect |
@@ -784,6 +794,75 @@ ESP32 (WROOM‑32D) et ESP8266. → **compatible avec les 3 unités intérieures
 - [ ] Watchdog hardware alimenté (`CONFIG_ESP_TASK_WDT_EN=y`).
 - [ ] Mode AP de secours fonctionnel (si WiFi invalide).
 - [ ] Binaire signé pour OTA (si fonctionnalité activée).
+
+---
+
+## 14. Validation croisée avec `o0Zz/climate-uart`
+
+> Source : [`o0Zz/climate-uart`](https://github.com/o0Zz/climate-uart),
+> `src/protocols/toshiba.cpp` — une **2ᵉ implémentation C++ indépendante** du protocole
+> Toshiba UART, au sein d'une bibliothèque multi‑marques (Mitsubishi, **Toshiba**, Daikin
+> S21, Sharp, LG, Hitachi H‑Link, Fujitsu). Modèles Toshiba cités : **Seiya, Shorai, Yukai**.
+
+### 14.1 Verdict : **même protocole** (confirmation)
+
+Recoupement octet par octet : STX `0x02`, structure de trame (`[6]=dataSize+5`,
+`[11]=dataSize`, données = `{fonction, valeur}`), **checksum identique**
+(`−Σ octets[1..]`), et **valeurs identiques** pour les codes fonction et les mappings :
+
+| | pedobry (notre réf.) | o0Zz | |
+|---|---|---|---|
+| Power / Mode / Setpoint | `0x80 / 0xB0 / 0xB3` | `kFunctionPowerState/UnitMode/Setpoint` idem | ✅ |
+| Fan / Swing / RoomTemp | `0xA0 / 0xA3 / 0xBB` | idem | ✅ |
+| Power ON/OFF | `0x30 / 0x31` | `kPowerStateOn/Off` idem | ✅ |
+| Modes (Auto/Cool/Heat/Dry/Fan) | `0x41..0x45` | idem | ✅ |
+| Fan (Quiet…Auto) | `0x31..0x36, 0x41` | `kFanQuiet/Lvl1..5/Auto` idem | ✅ |
+| Swing (Fix/V/H/Both/Pos1‑5) | `0x31,0x41‑43,0x50‑54` | idem | ✅ |
+| Handshake | 8 trames | **7/8 identiques** | ⚠️ voir 14.2 |
+
+→ Deux reverse‑engineering indépendants convergent : **notre spécification §6 est fiable.**
+
+### 14.2 Un écart à connaître : `HANDSHAKE[4]` / `kSyn5`
+
+Détaillé en §6.4 : dernier octet **`0xFE` (pedobry) vs `0xFB` (o0Zz, checksum‑correct)**.
+L'unité ignore vraisemblablement le checksum des trames d'init → garder `0xFE`, tester
+`0xFB` seulement si le handshake échoue au banc.
+
+### 14.3 Apports utiles de o0Zz (à considérer)
+
+1. **Codes fonction supplémentaires nommés** par o0Zz, **absents** de pedobry — non
+   caractérisés, à sonder au `scan()` : `kFunctionStatus = 0x88`, `kFunctionGroup1 = 0xF8`.
+   (pedobry expose plutôt `SPECIAL_MODE = 0xF7`, absent de o0Zz.)
+2. **Indice de parsing des réponses** : o0Zz marque les réponses avec
+   `type = commande | masque_réponse = 0x10 | 0x80 = 0x90` (octet `[3]`). Utile pour
+   distinguer une **réponse** (`[3]=0x90`) d'un **ACK/commande** — complément à notre
+   dispatch par longueur (§6.9).
+3. **Timeout** : `kPacketReadTimeoutMs = 250 ms` (vs `RECEIVE_TIMEOUT = 200 ms` pedobry) —
+   même ordre de grandeur ; 200–250 ms est la bonne fenêtre.
+4. **Architecture logicielle** (inspiration directe pour notre `protocol.rs` / `uart.rs`) :
+   o0Zz sépare un **transport UART abstrait** (portable ESP32/Arduino) d'une **classe
+   protocole par marque** exposant une API unifiée (`query/sendCommand/setState/getState/
+   getRoomTemperature`). En Rust : un `trait UartTransport` + un `struct ToshibaProtocol`
+   pur (sans I/O) testable sur host → aligne bien avec les règles projet (#16 supervision,
+   décisions/parsing purs et testés).
+
+### 14.4 Ce que o0Zz **ne** couvre pas (→ on garde pedobry comme référence primaire)
+
+o0Zz/Toshiba est un **sous‑ensemble** « contrôle de base ». Il **n'implémente pas** ce que
+nous avons déjà documenté et qui a de la valeur pour le projet :
+
+- **Diagnostics ODU/IDU** (`0xE5`/`0xE4` : `cdu_*`, `fcu_*`, charge compresseur, RPM) — §6.10.
+- **Température extérieure** (`0xBE`) — §6.5.
+- **Auto‑nettoyage** (`0xCB`) et **LED WiFi** (`0xDE`/`0xDF`).
+- **Presets / modes spéciaux** (`0xF7` : 8°/garde hors‑gel, ECO, Hi‑Power, Sleep…) — §6.7/§6.11.
+
+### 14.5 Conclusion pour le projet
+
+**Aucun ajout protocolaire indispensable** : notre spec §6 est déjà un **sur‑ensemble** de
+o0Zz/Toshiba. Actions retenues : (a) **note `HANDSHAKE[4]`** intégrée (§6.4) ; (b) **sonder
+`0x88`/`0xF8`** lors du `scan()` de mise au point ; (c) **s'inspirer de l'architecture
+transport/protocole** de o0Zz pour le découpage Rust ; (d) fenêtre timeout **200–250 ms**.
+pedobry reste la **référence primaire** (couverture complète : diagnostics + presets).
 
 ---
 


### PR DESCRIPTION
… o0Zz/climate-uart

Décision projet actée : le runtime ESP32 retenu est un firmware Rust natif, pas ESPHome. Le doc integration-toshiba-shorai-esphome.md passe en référence câblage/MQTT uniquement (YAML §4 obsolète). Index CLAUDE.md mis à jour.

Validation croisée avec o0Zz/climate-uart (src/protocols/toshiba.cpp), 2e implémentation C++ indépendante :
- Même protocole confirmé (STX 0x02, structure de trame, checksum, codes fonction 0x80/0xB0/0xB3/0xA0/0xA3/0xBB, mappings mode/fan/swing identiques).
- Écart détecté : HANDSHAKE[4] pedobry finit par 0xFE alors que la règle de checksum (et o0Zz kSyn5) donne 0xFB → note ajoutée (§6.4), l'unité ignore probablement le checksum du handshake ; tester 0xFB si échec au banc.
- Apports notés (§14) : codes 0x88 (status) / 0xF8 (group) à sonder au scan ; masque réponse 0x90 = 0x10|0x80 (indice de parsing) ; timeout 250 ms ; architecture transport/protocole comme inspiration pour protocol.rs.
- o0Zz = sous-ensemble (pas de diagnostics ODU/IDU, temp ext., self-clean, LED WiFi, presets) → pedobry reste la référence primaire. Aucun ajout indispensable.


Claude-Session: https://claude.ai/code/session_01R5o2XuifGJPdXfiBxRtsm2