### PR TITLE
feat(toshiba): module Pi5 energy-manager logic/toshiba_ac (lecture se…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -651,3 +651,12 @@ host_tag             = "pi5"
 # --- Statut plateforme ---
 [energy_manager.platform]
 publish_interval_secs = 60
+
+# --- Climatiseurs Toshiba (télémétrie lecture seule via ESP32 Rust / CN22) ---
+# Souscrit santuario/toshiba/<zone>/state (préfixe LOCAL, non bridgé — règle #11).
+# Voir docs/toshiba-suzumi-rs-plan.md. control_enabled réservé au futur pilotage.
+[energy_manager.toshiba_ac]
+enabled          = true
+zones            = ["salon", "chambre", "bureau"]
+stale_after_secs = 300
+control_enabled  = false

--- a/crates/energy-manager/src/config.rs
+++ b/crates/energy-manager/src/config.rs
@@ -33,6 +33,8 @@ pub struct EnergyManagerConfig {
     pub solar: SolarConfig,
     #[serde(default)]
     pub platform: PlatformConfig,
+    #[serde(default)]
+    pub toshiba_ac: ToshibaAcConfig,
 }
 
 // ---------------------------------------------------------------------------
@@ -452,6 +454,40 @@ impl Default for PlatformConfig {
 fn default_true() -> bool { true }
 
 // ---------------------------------------------------------------------------
+// Toshiba climatiseurs (télémétrie lecture seule ; contrôle opt-in futur)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ToshibaAcConfig {
+    /// Active le module (souscription `santuario/toshiba/+/state`).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Zones attendues (informatif — la souscription utilise un wildcard).
+    #[serde(default)]
+    pub zones: Vec<String>,
+    /// Âge (s) au-delà duquel une unité est considérée muette (liveness).
+    #[serde(default = "default_toshiba_stale_secs")]
+    pub stale_after_secs: u64,
+    /// Pilotage des clim par l'EM (phase contrôle) — OFF par défaut : la stratégie
+    /// énergie (effacement/solaire) n'est pas encore arrêtée. Réservé au futur.
+    #[serde(default)]
+    pub control_enabled: bool,
+}
+
+fn default_toshiba_stale_secs() -> u64 { 300 }
+
+impl Default for ToshibaAcConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            zones: Vec::new(),
+            stale_after_secs: default_toshiba_stale_secs(),
+            control_enabled: false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Loader
 // ---------------------------------------------------------------------------
 
@@ -519,6 +555,12 @@ impl EnergyManagerConfig {
             anyhow::ensure!(
                 self.lg_thinq.poll_interval_secs > 0,
                 "config invalide : `energy_manager.lg_thinq.poll_interval_secs` doit être > 0"
+            );
+        }
+        if self.toshiba_ac.enabled {
+            anyhow::ensure!(
+                self.toshiba_ac.stale_after_secs > 0,
+                "config invalide : `energy_manager.toshiba_ac.stale_after_secs` doit être > 0"
             );
         }
         Ok(())

--- a/crates/energy-manager/src/logic/mod.rs
+++ b/crates/energy-manager/src/logic/mod.rs
@@ -8,5 +8,6 @@ pub mod smartshunt;
 pub mod solar_power;
 pub mod switch_ats;
 pub mod tasmota;
+pub mod toshiba_ac;
 pub mod victron_keepalive;
 pub mod water_heater;

--- a/crates/energy-manager/src/logic/toshiba_ac/mod.rs
+++ b/crates/energy-manager/src/logic/toshiba_ac/mod.rs
@@ -1,0 +1,66 @@
+//! Module climatiseurs Toshiba — **phase lecture seule**.
+//!
+//! Souscrit `santuario/toshiba/<zone>/state` (publié par le firmware ESP32 Rust,
+//! cf. `docs/toshiba-suzumi-rs-plan.md`), remplit `EnergyState.toshiba_ac[zone]`
+//! et diffuse un événement live. **Aucune commande émise** à ce stade.
+//!
+//! Pattern calqué sur `logic/tasmota` (consommateur MQTT lecture seule). La logique
+//! de parsing pure est isolée dans [`rules`] (testée sur host). Le futur pilotage
+//! (opt-in `control_enabled`) s'ajoutera ici sur le modèle de `logic/deye_command`.
+
+pub mod rules;
+
+use std::sync::Arc;
+use tokio::sync::{broadcast, RwLock};
+use tracing::{debug, info, warn};
+
+use crate::bus::AppBus;
+use crate::config::ToshibaAcConfig;
+use crate::types::{EnergyState, LiveEvent};
+
+use rules::{parse_zone, snapshot_from_payload, ToshibaStatePayload};
+
+pub async fn spawn(cfg: ToshibaAcConfig, bus: AppBus, state: Arc<RwLock<EnergyState>>) {
+    if !cfg.enabled {
+        debug!("toshiba_ac désactivé (energy_manager.toshiba_ac.enabled=false)");
+        return;
+    }
+    info!(
+        zones = ?cfg.zones,
+        control_enabled = cfg.control_enabled,
+        stale_after_secs = cfg.stale_after_secs,
+        "toshiba_ac activé (télémétrie lecture seule)"
+    );
+    crate::supervise::spawn_critical(run(bus, state));
+}
+
+async fn run(bus: AppBus, state: Arc<RwLock<EnergyState>>) {
+    let mut rx = bus.subscribe_mqtt();
+    loop {
+        let msg = match rx.recv().await {
+            Ok(m) => m,
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                warn!("toshiba_ac MQTT subscriber lagged, dropped {n} message(s)");
+                continue;
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
+        };
+
+        let Some(zone) = parse_zone(&msg.topic) else {
+            continue;
+        };
+        let Some(payload) = msg.json::<ToshibaStatePayload>() else {
+            debug!("toshiba_ac: JSON d'état invalide sur {}", msg.topic);
+            continue;
+        };
+
+        let snap = snapshot_from_payload(payload, chrono::Utc::now());
+        state
+            .write()
+            .await
+            .toshiba_ac
+            .insert(zone.to_string(), snap.clone());
+        bus.emit_live(LiveEvent::new(format!("toshiba_{zone}"), &snap));
+        debug!("toshiba_ac[{zone}] mis à jour (mode={:?})", snap.mode);
+    }
+}

--- a/crates/energy-manager/src/logic/toshiba_ac/rules.rs
+++ b/crates/energy-manager/src/logic/toshiba_ac/rules.rs
@@ -1,0 +1,106 @@
+//! Logique **pure** du module toshiba_ac (parsing) — testable sans runtime.
+//!
+//! Phase actuelle = **lecture seule** : pas de décision de contrôle. Le futur
+//! pilotage (effacement/solaire, opt-in `control_enabled`) viendra ici sous forme
+//! de fonctions pures + tests, sur le modèle de `logic/deye_command/rules.rs`.
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::types::ToshibaAcSnapshot;
+
+/// Extrait la `zone` d'un topic `santuario/toshiba/<zone>/state`.
+/// Renvoie `None` pour tout autre topic (le module ne traite que celui-ci).
+pub fn parse_zone(topic: &str) -> Option<&str> {
+    let mut it = topic.split('/');
+    match (it.next(), it.next(), it.next(), it.next(), it.next()) {
+        (Some("santuario"), Some("toshiba"), Some(zone), Some("state"), None)
+            if !zone.is_empty() =>
+        {
+            Some(zone)
+        }
+        _ => None,
+    }
+}
+
+/// Payload JSON d'état publié par le firmware ESP32 (`mqtt_payload::state_to_json`).
+/// Tous les champs sont optionnels (l'unité les renseigne au fil de l'eau).
+#[derive(Debug, Deserialize)]
+pub struct ToshibaStatePayload {
+    pub power: Option<bool>,
+    pub mode: Option<String>,
+    pub target_temp: Option<u8>,
+    pub current_temp: Option<i8>,
+    pub outdoor_temp: Option<i8>,
+    pub fan: Option<String>,
+    pub swing: Option<String>,
+    pub preset: Option<String>,
+    pub pwr_level: Option<u8>,
+    #[serde(default)]
+    pub self_clean: bool,
+}
+
+/// Convertit un payload reçu en instantané stocké dans `EnergyState`.
+pub fn snapshot_from_payload(p: ToshibaStatePayload, now: DateTime<Utc>) -> ToshibaAcSnapshot {
+    ToshibaAcSnapshot {
+        power: p.power,
+        mode: p.mode,
+        target_temp_c: p.target_temp,
+        current_temp_c: p.current_temp,
+        outdoor_temp_c: p.outdoor_temp,
+        fan: p.fan,
+        swing: p.swing,
+        preset: p.preset,
+        pwr_level_pct: p.pwr_level,
+        self_clean: p.self_clean,
+        last_update: Some(now),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_zone_accepts_state_topic() {
+        assert_eq!(parse_zone("santuario/toshiba/salon/state"), Some("salon"));
+        assert_eq!(parse_zone("santuario/toshiba/chambre/state"), Some("chambre"));
+    }
+
+    #[test]
+    fn parse_zone_rejects_other_topics() {
+        assert_eq!(parse_zone("santuario/toshiba/salon/command"), None);
+        assert_eq!(parse_zone("santuario/toshiba/salon/state/extra"), None);
+        assert_eq!(parse_zone("santuario/toshiba//state"), None); // zone vide
+        assert_eq!(parse_zone("stat/tongou/POWER"), None);
+        assert_eq!(parse_zone("santuario/toshiba/salon"), None);
+    }
+
+    #[test]
+    fn payload_maps_to_snapshot() {
+        let json = r#"{"power":true,"mode":"cool","target_temp":24,"current_temp":21,
+            "outdoor_temp":8,"fan":"auto","swing":"vertical","preset":"standard",
+            "pwr_level":100,"self_clean":false}"#;
+        let p: ToshibaStatePayload = serde_json::from_str(json).unwrap();
+        let now = Utc::now();
+        let s = snapshot_from_payload(p, now);
+        assert_eq!(s.power, Some(true));
+        assert_eq!(s.mode.as_deref(), Some("cool"));
+        assert_eq!(s.target_temp_c, Some(24));
+        assert_eq!(s.current_temp_c, Some(21));
+        assert_eq!(s.outdoor_temp_c, Some(8));
+        assert_eq!(s.pwr_level_pct, Some(100));
+        assert!(!s.self_clean);
+        assert_eq!(s.last_update, Some(now));
+    }
+
+    #[test]
+    fn partial_payload_is_accepted() {
+        // L'unité peut n'avoir renseigné que quelques champs.
+        let p: ToshibaStatePayload = serde_json::from_str(r#"{"mode":"off"}"#).unwrap();
+        let s = snapshot_from_payload(p, Utc::now());
+        assert_eq!(s.mode.as_deref(), Some("off"));
+        assert_eq!(s.target_temp_c, None);
+        assert!(!s.self_clean);
+    }
+}

--- a/crates/energy-manager/src/main.rs
+++ b/crates/energy-manager/src/main.rs
@@ -89,6 +89,7 @@ async fn main() -> anyhow::Result<()> {
     logic::smartshunt::spawn(vic.clone(), bus.clone(), state.clone()).await;
     logic::irradiance::spawn(bus.clone(), state.clone(), cfg.solar.bms_server_url.clone()).await;
     logic::tasmota::spawn(vic.clone(), bus.clone(), state.clone()).await;
+    logic::toshiba_ac::spawn(cfg.toshiba_ac.clone(), bus.clone(), state.clone()).await;
     logic::switch_ats::spawn(bus.clone(), state.clone()).await;
     logic::platform::spawn(cfg.platform.clone(), bus.clone()).await;
     logic::charge_current::spawn(vic.clone(), cfg.charge_current.clone(), bus.clone(), state.clone()).await;

--- a/crates/energy-manager/src/mqtt/topics.rs
+++ b/crates/energy-manager/src/mqtt/topics.rs
@@ -82,6 +82,10 @@ pub fn all_subscriptions(portal_id: &str, vebus: u32, mppt1: u32, mppt2: u32, pv
         "stat/tongou_3BC764/POWER".to_string(),
         "tele/tongou_3BC764/SENSOR".to_string(),
 
+        // --- Toshiba climatiseurs (télémétrie lecture seule, wildcard par zone).
+        //     Préfixe LOCAL, non relayé par le bridge NanoPi (règle #11). ---
+        "santuario/toshiba/+/state".to_string(),
+
         // --- Persist (retained baselines + DEYE state) ---
         "santuario/persist/pvinv_baseline".to_string(),
         "santuario/persist/yield_yesterday".to_string(),

--- a/crates/energy-manager/src/types.rs
+++ b/crates/energy-manager/src/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // Incoming MQTT message dispatched to all logic tasks
@@ -234,6 +235,11 @@ pub struct EnergyState {
     pub shunt_discharged_baseline_kwh:   Option<f64>,
     pub shunt_charged_day:               i32,
     pub shunt_discharged_day:            i32,
+
+    // --- Climatiseurs Toshiba (télémétrie lecture seule) ---
+    // Alimenté par logic/toshiba_ac depuis `santuario/toshiba/<zone>/state`
+    // (publié par le firmware ESP32 Rust). Clé = zone (salon/chambre/bureau).
+    pub toshiba_ac: HashMap<String, ToshibaAcSnapshot>,
 }
 
 #[derive(Debug, Default, Clone, Serialize)]
@@ -248,6 +254,26 @@ pub struct MpptState {
     /// Timestamp of the last `/State` update — freshness guard for the DEYE decision
     /// (a frozen State must not strand the relay; see deye_command).
     pub state_last_ts: Option<DateTime<Utc>>,
+}
+
+/// Instantané télémétrie d'un climatiseur Toshiba (une zone), reçu en JSON sur
+/// `santuario/toshiba/<zone>/state`. Champs `Option` tant qu'ils n'ont pas été
+/// reçus. Voir `docs/toshiba-suzumi-rs-plan.md` (firmware `mqtt_payload`).
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct ToshibaAcSnapshot {
+    pub power: Option<bool>,
+    /// Mode « effectif » : `"off"` si éteint, sinon `heat/cool/dry/fan_only/heat_cool`.
+    pub mode: Option<String>,
+    pub target_temp_c: Option<u8>,
+    pub current_temp_c: Option<i8>,
+    pub outdoor_temp_c: Option<i8>,
+    pub fan: Option<String>,
+    pub swing: Option<String>,
+    pub preset: Option<String>,
+    pub pwr_level_pct: Option<u8>,
+    pub self_clean: bool,
+    /// Horodatage de la dernière trame reçue (liveness — audit 2026-06 §18).
+    pub last_update: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/docs/integration-toshiba-shorai-esphome.md
+++ b/docs/integration-toshiba-shorai-esphome.md
@@ -293,8 +293,15 @@ Après toute modif de topics/bridge : `sudo /usr/local/bin/verify-no-loop.sh` (r
 
 ## 6. Logiciel Pi5 — module `energy-manager` `logic/toshiba_ac`
 
-Nouveau module calqué sur `logic/water_heater` (contrôle + télémétrie) et
-`logic/deye_command` (règles **Rust pures, stateless** ré‑évaluées chaque seconde).
+> ✅ **Phase lecture seule IMPLÉMENTÉE** (2026-07) : `crates/energy-manager/src/logic/
+> toshiba_ac/` (`mod.rs` + `rules.rs`), config `[energy_manager.toshiba_ac]`, souscription
+> `santuario/toshiba/+/state`, remplissage `EnergyState.toshiba_ac[zone]` + event live.
+> Tests verts, clippy propre, `--check-config` OK. **Phase contrôle** (`control_enabled`)
+> = à faire (dépend de la stratégie énergie, §10). Détail/journal :
+> `docs/toshiba-suzumi-rs-plan.md` §0.
+
+Module calqué sur `logic/tasmota` (consommateur MQTT lecture seule) ; le futur contrôle
+suivra `logic/deye_command` (règles **Rust pures, stateless**).
 
 ### 6.1 Arborescence
 

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -62,6 +62,12 @@ vide → zéro impact sur le build/CI daly-bms). Tester :
 | WiFi + MQTT transport (`santuario/toshiba/<zone>`) | `src/{wifi,mqtt}.rs` | ⏳ TODO (matériel) |
 | `main.rs` + esp-idf-svc (feature `esp32`) | `src/main.rs` | ⏳ TODO (matériel) |
 
+**Côté Pi5** (`crates/energy-manager`) : le module **`logic/toshiba_ac` (lecture seule)**
+est **fait** — souscrit `santuario/toshiba/<zone>/state`, remplit
+`EnergyState.toshiba_ac[zone]`, diffuse un event live. Config `[energy_manager.toshiba_ac]`
+(+ `--check-config`). 4 tests, clippy propre, build vert. La **phase contrôle**
+(`control_enabled`) reste à faire (dépend de la stratégie énergie, §10.4).
+
 ### 0.4 Prochaines étapes (ordre conseillé, sans matériel)
 
 Faits (session 2026-07-05) : ✅ state machine (`machine.rs`), ✅ accumulateur RX
@@ -104,6 +110,12 @@ le matériel ESP32** :
   `santuario/toshiba/<zone>/{state,command,availability}`. Ajout `README.md` du crate.
   **38 tests verts**. Toutes les couches logicielles pures sont terminées ; le reste
   (uart/wifi/mqtt/main) attend le matériel.
+- **2026-07-05 (suite 4)** — **Côté Pi5** : module `energy-manager logic/toshiba_ac`
+  **lecture seule** (souscription `santuario/toshiba/<zone>/state` → `EnergyState` +
+  event live), config `[energy_manager.toshiba_ac]` + validation, souscription broker
+  wildcard, `rules.rs` pur (parse_zone/payload) testé. Section ajoutée à `Config.toml`.
+  Build energy-manager vert, clippy `-D warnings` propre, 4 tests + suite complète (34)
+  OK, `--check-config` OK. Phase **contrôle** encore à faire (stratégie énergie §10.4).
 
 ---
 


### PR DESCRIPTION
…ule)

Côté serveur Pi5 : consommation de la télémétrie des 3 clim Toshiba publiée par le futur firmware ESP32 sur santuario/toshiba/<zone>/state.

- logic/toshiba_ac/rules.rs : logique PURE testée (parse_zone du topic + ToshibaStatePayload → ToshibaAcSnapshot). 4 tests.
- logic/toshiba_ac/mod.rs : tâche spawn_critical (pattern logic/tasmota) — souscrit le bus MQTT, filtre santuario/toshiba/<zone>/state, remplit EnergyState.toshiba_ac[zone], diffuse un LiveEvent. Aucune commande émise.
- types.rs : ToshibaAcSnapshot + champ EnergyState.toshiba_ac (HashMap par zone).
- config.rs : [energy_manager.toshiba_ac] (enabled/zones/stale_after_secs/ control_enabled) + validation ; câblage main.rs ; souscription broker wildcard santuario/toshiba/+/state (topics.rs).
- Config.toml : section [energy_manager.toshiba_ac] (enabled, 3 zones).

Build energy-manager vert, clippy -D warnings propre, suite complète 34 tests OK (4 nouveaux), --check-config OK. Phase contrôle (control_enabled) réservée au futur (stratégie énergie à trancher). Docs plan §0 + doc intégration §6 à jour.


Claude-Session: https://claude.ai/code/session_01R5o2XuifGJPdXfiBxRtsm2