### PR TITLE
feat(toshiba): config de mise en service réseau (WiFi StarTh, DHCP/IP…

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -657,6 +657,8 @@ publish_interval_secs = 60
 # Voir docs/toshiba-suzumi-rs-plan.md. control_enabled réservé au futur pilotage.
 [energy_manager.toshiba_ac]
 enabled          = true
-zones            = ["salon", "chambre", "bureau"]
+# Nom de nœud = hostname ESP + segment de topic santuario/toshiba/<nom>.
+# 3 unités actuelles ; jusqu'à 7 Shorai-xx à terme (ajouter ici au fil des poses).
+zones            = ["Shorai-31", "Shorai-32", "Shorai-33"]
 stale_after_secs = 300
 control_enabled  = false

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -57,7 +57,7 @@ vide → zéro impact sur le build/CI daly-bms). Tester :
 | Accumulateur de trames RX incrémental (`validate_message_`) | `src/framing.rs` | ✅ **fait** (5 tests) |
 | Machine à états + file/pacing + watchdog + **simulateur d'unité** | `src/machine.rs` | ✅ **fait** (5 tests, dont handshake→online end-to-end) |
 | Codec MQTT applicatif (`ToshibaState`→JSON ; JSON→`Command`→`apply_command`) | `src/mqtt_payload.rs` | ✅ **fait** (8 tests, transport-agnostique) |
-| Config nœud + dérivation topics + validation | `src/config.rs` | ✅ **fait** (4 tests) |
+| Config nœud (identité `Shorai-3x`, WiFi StarTh, DHCP/IP statique, AP secours, broker, topics/hostname) + validation | `src/config.rs` | ✅ **fait** (5 tests) — §17 |
 | UART ESP-IDF (init 9600 8E1, lecture/écriture octets) | `src/uart.rs` | ⏳ **TODO (attend matériel)** |
 | WiFi + MQTT transport (`santuario/toshiba/<zone>`) | `src/{wifi,mqtt}.rs` | ⏳ TODO (matériel) |
 | `main.rs` + esp-idf-svc (feature `esp32`) | `src/main.rs` | ⏳ TODO (matériel) |
@@ -133,6 +133,13 @@ le matériel ESP32** :
   auto‑suffisante** : prérequis (Git/Python/pilote USB‑série), **clone du dépôt +
   `git checkout` de la branche + `cd firmware/toshiba-suzumi-rs`**, vérif host, install
   toolchain esp, puis flash (`cargo +esp run`) une fois la partie ESP32 ajoutée.
+- **2026-07-05 (suite 6)** — **Config réseau/identité de mise en service** (`config.rs`
+  réécrit + §17) : `NodeConfig::new("Shorai-31")` = 1 ligne/unité → WiFi **StarTh** (mot de
+  passe **injecté au flash/NVS, jamais commité** — règle #12), **DHCP** par défaut (ou
+  **IP statique** via `with_static_ip`), broker Pi5, `ap_fallback` (AP secours). Le
+  **`node_name` = hostname = segment de topic = SSID AP** (`Shorai-31/32/33`, → 7 à terme).
+  **Décision : station WiFi + AP de repli** (un AP principal isolerait du broker). Zones
+  `Config.toml` alignées sur `Shorai-3x`. 5 tests config, 39 tests firmware, clippy+fmt OK.
 
 ---
 
@@ -1197,6 +1204,86 @@ brownouts. (Cf. instabilités d'alim §3.3.)
 | Env | **sourcer `export-esp`** (LIBCLANG_PATH…) |
 | Flash | `cargo run --release` (runner espflash) ou `espflash flash --monitor` |
 | Antenne | **IPEX externe obligatoire** (variante `‑U`) |
+
+---
+
+## 17. Mise en service réseau (WiFi) & identité du nœud
+
+Couche **config déjà faite + testée** sur host (`src/config.rs`, `NodeConfig`) ; le
+code WiFi ESP‑IDF (`wifi.rs`) ne fera que la consommer (à réception matériel).
+
+### 17.1 Décision : **station WiFi** (pas d'AP principal) + **AP de secours**
+
+- Les ESP **doivent rejoindre `StarTh` en mode station** : c'est la seule façon
+  d'atteindre le **broker Mosquitto du Pi5** (`192.168.1.141`). Un **AP « réseau local »
+  comme réseau principal serait contre‑productif** — chaque ESP serait **isolé** sur son
+  propre réseau et **ne pourrait plus parler au broker** (tout le monde doit être sur le
+  **même LAN**).
+- L'AP n'a de sens qu'en **secours/provisioning** : si la connexion station échoue au boot,
+  l'ESP lève un AP `Shorai-31-setup` (portail captif) → on n'est **jamais bloqué**.
+  `ap_fallback = true` par défaut. **C'est le schéma retenu** (station + repli AP).
+
+### 17.2 Config minimale — **une ligne par unité**
+
+```rust
+// Suffit à mettre en service : StarTh, DHCP, broker Pi5, hostname/topics dérivés.
+let cfg = NodeConfig::new("Shorai-31")
+    .with_wifi_pass(option_env!("WIFI_PASS").unwrap_or_default()); // injecté au flash
+cfg.validate().expect("config invalide");
+// → hostname "Shorai-31", topics santuario/toshiba/Shorai-31/{state,command,availability}
+```
+
+Défauts appliqués par `new()` : `wifi_ssid="StarTh"`, `ip=Dhcp`, `mqtt=192.168.1.141:1883`,
+GPIO `33/32`, `ap_fallback=true`.
+
+### 17.3 Mot de passe WiFi — **jamais commité** (règle projet #12)
+
+Le SSID `StarTh` est en défaut (non secret), **mais pas le mot de passe**. Le fournir au
+**flash** via variable d'environnement, lue par `option_env!` :
+
+```bash
+# Windows PowerShell : $env:WIFI_PASS="Santuario1962"; cargo +esp run --release
+# Linux / macOS      : WIFI_PASS="Santuario1962" cargo +esp run --release
+```
+
+Alternatives : provisionner en **NVS** (persistant, modifiable sans reflash), ou un fichier
+**`.env` local non commité** (déjà couvert par `.gitignore`) sourcé avant le flash.
+**Ne jamais écrire le mot de passe dans un fichier commité.**
+
+### 17.4 Adresse IP — DHCP (défaut) ou statique
+
+- **DHCP par défaut** + **réservation par MAC** côté box Starlink (comme le Pi5,
+  CLAUDE.md §2) = le plus simple, IP stable, repérable par **hostname** `Shorai-3x`.
+- **IP statique** si pas de réservation possible :
+  ```rust
+  NodeConfig::new("Shorai-31").with_static_ip(
+      "192.168.1.131".parse().unwrap(), // ip
+      "192.168.1.1".parse().unwrap(),   // gateway
+      "255.255.255.0".parse().unwrap(), // netmask
+      "192.168.1.1".parse().unwrap());  // dns
+  ```
+
+### 17.5 Plan de nommage & d'adressage (jusqu'à 7 unités)
+
+`node_name` = **hostname** = **segment de topic** = base du **SSID AP secours**.
+
+| node_name | Topics | IP statique suggérée (si non‑DHCP) |
+|-----------|--------|:----------------------------------:|
+| `Shorai-31` | `santuario/toshiba/Shorai-31/…` | `192.168.1.131` |
+| `Shorai-32` | `santuario/toshiba/Shorai-32/…` | `192.168.1.132` |
+| `Shorai-33` | `santuario/toshiba/Shorai-33/…` | `192.168.1.133` |
+| `Shorai-34…37` | `…/Shorai-3x/…` | `192.168.1.134…137` |
+
+> IPs suggérées **hors** de la plage DHCP et des adresses prises (`141`=Pi5, `120`=NanoPi).
+> Côté Pi5, `[energy_manager.toshiba_ac].zones` liste ces noms (souscription réelle par
+> wildcard `santuario/toshiba/+/state`).
+
+### 17.6 Reste au firmware (à réception matériel)
+
+`wifi.rs` consommera `NodeConfig` : `EspWifi` **station**, `set_hostname(node_name)`,
+DHCP **ou** IP statique, **reconnexion à backoff**, et **bascule AP** (`ap_ssid()`) si la
+station échoue après N tentatives. La config (défauts, validation, dérivation) est **déjà
+faite et testée** — `wifi.rs` n'ajoute que l'I/O ESP‑IDF.
 
 ---
 

--- a/firmware/toshiba-suzumi-rs/src/config.rs
+++ b/firmware/toshiba-suzumi-rs/src/config.rs
@@ -1,52 +1,89 @@
-//! Configuration d'un **nœud** (un ESP32 = une unité intérieure = une « zone »)
-//! et dérivation des topics MQTT.
+//! Configuration d'un **nœud** (un ESP32 = une unité intérieure) : identité,
+//! WiFi, réseau (DHCP/IP statique), broker MQTT, brochage UART, et dérivation
+//! des topics MQTT.
 //!
-//! Logique **pure**, host-testable. Le chargement réel (NVS sur ESP32, ou fichier)
-//! sera un adaptateur mince ajouté avec la partie firmware ; ce module ne porte que
-//! la **structure**, la **validation** et la **dérivation des topics**.
+//! Logique **pure**, host-testable. Le chargement réel (NVS sur ESP32, variables
+//! d'environnement au flash) sera un adaptateur mince ajouté avec la partie
+//! firmware ; ce module ne porte que la **structure**, la **validation**, les
+//! **valeurs par défaut** et la **dérivation des topics/hostname**.
 //!
-//! **Schéma de topics retenu** (voie Rust — c'est le firmware qui les définit, donc
-//! plus besoin de « les observer au 1er boot » comme avec ESPHome) :
+//! **Identité du nœud** : `node_name` (ex. `"Shorai-31"`) sert de **3 choses à la
+//! fois** :
+//! 1. **hostname WiFi** (repérable / réservable par DHCP côté box),
+//! 2. **segment de topic MQTT** → `santuario/toshiba/Shorai-31/...`,
+//! 3. **SSID de l'AP de secours** → `Shorai-31-setup`.
 //!
+//! Un seul paramètre à changer par unité : `Shorai-31`, `-32`, `-33`, … jusqu'à `-37`.
+//!
+//! **Schéma de topics** (préfixe LOCAL, non relayé par le bridge NanoPi — règle #11) :
 //! ```text
-//! santuario/toshiba/<zone>/state         (publish, retained : télémétrie JSON)
-//! santuario/toshiba/<zone>/command       (subscribe : commande JSON)
-//! santuario/toshiba/<zone>/availability  (publish, LWT : "online"/"offline")
+//! santuario/toshiba/<node>/state         (publish, retained : télémétrie JSON)
+//! santuario/toshiba/<node>/command       (subscribe : commande JSON)
+//! santuario/toshiba/<node>/availability  (publish, LWT : "online"/"offline")
 //! ```
 //!
-//! ⚠️ Le préfixe `santuario/toshiba/...` est **local** (non relayé par le bridge
-//! NanoPi) → pas de risque de boucle (règle projet #11). Le module Pi5
-//! `energy-manager logic/toshiba_ac` consommera ce schéma.
+//! ⚠️ **Secret (règle projet #12)** : le **mot de passe WiFi n'est PAS** codé en dur
+//! ici. `new()` laisse `wifi_pass` **vide** ; la valeur réelle est injectée au
+//! **flash** (`option_env!("WIFI_PASS")`) ou provisionnée en **NVS** par le code
+//! firmware — jamais commitée.
+
+use std::net::Ipv4Addr;
 
 /// Racine de topics **locale** (non bridgée).
 pub const TOPIC_ROOT: &str = "santuario/toshiba";
 
+/// SSID WiFi par défaut (non secret).
+pub const DEFAULT_WIFI_SSID: &str = "StarTh";
+/// Broker MQTT par défaut (Mosquitto du Pi5).
+pub const DEFAULT_MQTT_HOST: &str = "192.168.1.141";
+/// Port MQTT par défaut.
+pub const DEFAULT_MQTT_PORT: u16 = 1883;
 /// GPIO par défaut (convention du composant ESPHome, cf. plan §3.2).
 pub const DEFAULT_TX_PIN: u8 = 33;
 pub const DEFAULT_RX_PIN: u8 = 32;
-/// Port MQTT par défaut (Mosquitto Pi5).
-pub const DEFAULT_MQTT_PORT: u16 = 1883;
+
+/// Mode d'adressage IP du nœud.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IpMode {
+    /// Adresse obtenue par DHCP (défaut). Réservation par MAC conseillée côté box.
+    #[default]
+    Dhcp,
+    /// IP fixe côté firmware (utile si pas de réservation DHCP possible).
+    Static {
+        ip: Ipv4Addr,
+        gateway: Ipv4Addr,
+        netmask: Ipv4Addr,
+        dns: Ipv4Addr,
+    },
+}
 
 /// Erreurs de validation de configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigError {
-    EmptyZone,
-    /// La zone contient un caractère interdit dans un segment de topic (`/`, `+`, `#`).
-    InvalidZone(char),
+    EmptyNodeName,
+    /// `node_name` contient un caractère interdit (topic/hostname) : `/ + # espace`.
+    InvalidNodeName(char),
     EmptyWifiSsid,
     EmptyMqttHost,
     ZeroMqttPort,
     /// TX et RX sur le même GPIO.
     DuplicatePins(u8),
+    /// IP statique invalide (adresse ou passerelle non spécifiée, masque nul).
+    InvalidStaticIp,
 }
 
-/// Configuration d'un nœud (une zone).
+/// Configuration d'un nœud. `NodeConfig::new("Shorai-31")` suffit pour une mise
+/// en service : WiFi `StarTh` en DHCP + broker Pi5, hostname/topics dérivés.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeConfig {
-    /// Segment de topic identifiant l'unité (ex. `"salon"`, `"chambre"`, `"bureau"`).
-    pub zone: String,
+    /// Identité (ex. `"Shorai-31"`) = hostname + segment de topic + SSID AP secours.
+    pub node_name: String,
     pub wifi_ssid: String,
+    /// Mot de passe WiFi — **injecté au flash/NVS**, jamais commité (vide par défaut).
     pub wifi_pass: String,
+    pub ip: IpMode,
+    /// AP de secours si la connexion station échoue (portail de config). Recommandé.
+    pub ap_fallback: bool,
     pub mqtt_host: String,
     pub mqtt_port: u16,
     pub mqtt_user: Option<String>,
@@ -56,19 +93,17 @@ pub struct NodeConfig {
 }
 
 impl NodeConfig {
-    /// Construit une config avec les valeurs par défaut (port 1883, GPIO 33/32,
-    /// broker anonyme). Les champs obligatoires sont demandés explicitement.
-    pub fn new(
-        zone: impl Into<String>,
-        wifi_ssid: impl Into<String>,
-        wifi_pass: impl Into<String>,
-        mqtt_host: impl Into<String>,
-    ) -> Self {
+    /// Config de mise en service avec **tous les défauts** : WiFi `StarTh` (mot de
+    /// passe à injecter), DHCP, broker Pi5 `192.168.1.141:1883`, GPIO 33/32, AP de
+    /// secours activé. Seul `node_name` change d'une unité à l'autre.
+    pub fn new(node_name: impl Into<String>) -> Self {
         Self {
-            zone: zone.into(),
-            wifi_ssid: wifi_ssid.into(),
-            wifi_pass: wifi_pass.into(),
-            mqtt_host: mqtt_host.into(),
+            node_name: node_name.into(),
+            wifi_ssid: DEFAULT_WIFI_SSID.to_string(),
+            wifi_pass: String::new(), // injecté au flash (WIFI_PASS) / NVS — règle #12
+            ip: IpMode::Dhcp,
+            ap_fallback: true,
+            mqtt_host: DEFAULT_MQTT_HOST.to_string(),
             mqtt_port: DEFAULT_MQTT_PORT,
             mqtt_user: None,
             mqtt_pass: None,
@@ -77,17 +112,40 @@ impl NodeConfig {
         }
     }
 
+    /// Fixe une IP statique (au lieu du DHCP par défaut).
+    pub fn with_static_ip(
+        mut self,
+        ip: Ipv4Addr,
+        gateway: Ipv4Addr,
+        netmask: Ipv4Addr,
+        dns: Ipv4Addr,
+    ) -> Self {
+        self.ip = IpMode::Static {
+            ip,
+            gateway,
+            netmask,
+            dns,
+        };
+        self
+    }
+
+    /// Renseigne le mot de passe WiFi (depuis env/NVS au bring-up).
+    pub fn with_wifi_pass(mut self, pass: impl Into<String>) -> Self {
+        self.wifi_pass = pass.into();
+        self
+    }
+
     /// Valide la configuration (à appeler au démarrage — échec = refus de boot).
     pub fn validate(&self) -> Result<(), ConfigError> {
-        if self.zone.is_empty() {
-            return Err(ConfigError::EmptyZone);
+        if self.node_name.is_empty() {
+            return Err(ConfigError::EmptyNodeName);
         }
         if let Some(c) = self
-            .zone
+            .node_name
             .chars()
-            .find(|&c| c == '/' || c == '+' || c == '#')
+            .find(|&c| c == '/' || c == '+' || c == '#' || c.is_whitespace())
         {
-            return Err(ConfigError::InvalidZone(c));
+            return Err(ConfigError::InvalidNodeName(c));
         }
         if self.wifi_ssid.is_empty() {
             return Err(ConfigError::EmptyWifiSsid);
@@ -101,29 +159,50 @@ impl NodeConfig {
         if self.uart_tx_pin == self.uart_rx_pin {
             return Err(ConfigError::DuplicatePins(self.uart_tx_pin));
         }
+        if let IpMode::Static {
+            ip,
+            gateway,
+            netmask,
+            ..
+        } = self.ip
+        {
+            if ip.is_unspecified() || gateway.is_unspecified() || netmask == Ipv4Addr::UNSPECIFIED {
+                return Err(ConfigError::InvalidStaticIp);
+            }
+        }
         Ok(())
     }
 
-    /// Topics MQTT dérivés de la zone.
+    /// Hostname WiFi = nom du nœud.
+    pub fn hostname(&self) -> &str {
+        &self.node_name
+    }
+
+    /// SSID de l'AP de secours (`<node_name>-setup`).
+    pub fn ap_ssid(&self) -> String {
+        format!("{}-setup", self.node_name)
+    }
+
+    /// Topics MQTT dérivés du nom du nœud.
     pub fn topics(&self) -> Topics {
-        Topics::for_zone(&self.zone)
+        Topics::for_node(&self.node_name)
     }
 }
 
-/// Topics MQTT d'une zone. Voir le schéma en tête de module.
+/// Topics MQTT d'un nœud. Voir le schéma en tête de module.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Topics {
     base: String,
 }
 
 impl Topics {
-    pub fn for_zone(zone: &str) -> Self {
+    pub fn for_node(node_name: &str) -> Self {
         Self {
-            base: format!("{TOPIC_ROOT}/{zone}"),
+            base: format!("{TOPIC_ROOT}/{node_name}"),
         }
     }
 
-    /// `santuario/toshiba/<zone>`
+    /// `santuario/toshiba/<node>`
     pub fn base(&self) -> &str {
         &self.base
     }
@@ -149,35 +228,70 @@ mod tests {
     use super::*;
 
     #[test]
-    fn defaults_are_applied() {
-        let c = NodeConfig::new("salon", "StarTh", "secret", "192.168.1.141");
-        assert_eq!(c.mqtt_port, DEFAULT_MQTT_PORT);
+    fn commissioning_defaults() {
+        // Une seule ligne suffit à mettre en service une unité.
+        let c = NodeConfig::new("Shorai-31");
+        assert_eq!(c.wifi_ssid, "StarTh");
+        assert_eq!(c.mqtt_host, "192.168.1.141");
+        assert_eq!(c.mqtt_port, 1883);
         assert_eq!(c.uart_tx_pin, 33);
         assert_eq!(c.uart_rx_pin, 32);
-        assert!(c.mqtt_user.is_none());
+        assert_eq!(c.ip, IpMode::Dhcp);
+        assert!(c.ap_fallback);
+        assert!(
+            c.wifi_pass.is_empty(),
+            "le mot de passe n'est PAS codé en dur (règle #12)"
+        );
         assert!(c.validate().is_ok());
     }
 
     #[test]
-    fn topics_are_derived_from_zone() {
-        let t = NodeConfig::new("chambre", "s", "p", "h").topics();
-        assert_eq!(t.base(), "santuario/toshiba/chambre");
-        assert_eq!(t.state(), "santuario/toshiba/chambre/state");
-        assert_eq!(t.command(), "santuario/toshiba/chambre/command");
-        assert_eq!(t.availability(), "santuario/toshiba/chambre/availability");
+    fn node_name_drives_hostname_topics_and_ap() {
+        let c = NodeConfig::new("Shorai-32");
+        assert_eq!(c.hostname(), "Shorai-32");
+        assert_eq!(c.ap_ssid(), "Shorai-32-setup");
+        let t = c.topics();
+        assert_eq!(t.base(), "santuario/toshiba/Shorai-32");
+        assert_eq!(t.state(), "santuario/toshiba/Shorai-32/state");
+        assert_eq!(t.command(), "santuario/toshiba/Shorai-32/command");
+        assert_eq!(t.availability(), "santuario/toshiba/Shorai-32/availability");
+    }
+
+    #[test]
+    fn static_ip_configurable_and_validated() {
+        let c = NodeConfig::new("Shorai-33").with_static_ip(
+            Ipv4Addr::new(192, 168, 1, 133),
+            Ipv4Addr::new(192, 168, 1, 1),
+            Ipv4Addr::new(255, 255, 255, 0),
+            Ipv4Addr::new(192, 168, 1, 1),
+        );
+        assert!(c.validate().is_ok());
+        assert!(matches!(c.ip, IpMode::Static { .. }));
+
+        // IP non spécifiée → rejetée.
+        let bad = NodeConfig::new("Shorai-33").with_static_ip(
+            Ipv4Addr::UNSPECIFIED,
+            Ipv4Addr::new(192, 168, 1, 1),
+            Ipv4Addr::new(255, 255, 255, 0),
+            Ipv4Addr::new(192, 168, 1, 1),
+        );
+        assert_eq!(bad.validate(), Err(ConfigError::InvalidStaticIp));
     }
 
     #[test]
     fn validation_rejects_bad_input() {
-        let mut c = NodeConfig::new("salon", "StarTh", "p", "h");
+        let mut c = NodeConfig::new("Shorai-31");
 
-        c.zone = String::new();
-        assert_eq!(c.validate(), Err(ConfigError::EmptyZone));
+        c.node_name = String::new();
+        assert_eq!(c.validate(), Err(ConfigError::EmptyNodeName));
 
-        c.zone = "sa/lon".to_string();
-        assert_eq!(c.validate(), Err(ConfigError::InvalidZone('/')));
+        c.node_name = "Shorai 31".to_string(); // espace interdit (hostname/topic)
+        assert_eq!(c.validate(), Err(ConfigError::InvalidNodeName(' ')));
 
-        c.zone = "salon".to_string();
+        c.node_name = "a/b".to_string();
+        assert_eq!(c.validate(), Err(ConfigError::InvalidNodeName('/')));
+
+        c.node_name = "Shorai-31".to_string();
         c.wifi_ssid = String::new();
         assert_eq!(c.validate(), Err(ConfigError::EmptyWifiSsid));
 
@@ -191,10 +305,10 @@ mod tests {
     }
 
     #[test]
-    fn wildcard_in_zone_is_rejected() {
-        let mut c = NodeConfig::new("a#b", "s", "p", "h");
-        assert_eq!(c.validate(), Err(ConfigError::InvalidZone('#')));
-        c.zone = "a+b".to_string();
-        assert_eq!(c.validate(), Err(ConfigError::InvalidZone('+')));
+    fn wildcard_in_node_name_is_rejected() {
+        let mut c = NodeConfig::new("a#b");
+        assert_eq!(c.validate(), Err(ConfigError::InvalidNodeName('#')));
+        c.node_name = "a+b".to_string();
+        assert_eq!(c.validate(), Err(ConfigError::InvalidNodeName('+')));
     }
 }


### PR DESCRIPTION
… statique, identité Shorai-3x)

Firmware config.rs enrichi (host-testable) pour la commission d'un ESP :
- NodeConfig::new("Shorai-31") = 1 ligne/unité → défauts : WiFi StarTh, DHCP, broker Pi5 192.168.1.141:1883, GPIO 33/32, AP de secours activé.
- node_name = hostname WiFi + segment de topic santuario/toshiba/<node> + base du SSID AP secours (<node>-setup). 3 usages, 1 seul paramètre par unité.
- IpMode Dhcp (défaut) | Static{ip,gateway,netmask,dns} via with_static_ip() ; validation IP statique. ap_fallback pour ne jamais rester bloqué.
- Mot de passe WiFi NON codé en dur (règle #12) : wifi_pass vide par défaut, injecté au flash (option_env!("WIFI_PASS")) ou NVS ; with_wifi_pass().
- Décision documentée (§17) : station WiFi obligatoire (rejoindre StarTh pour atteindre le broker) + AP seulement en secours ; un AP principal isolerait du broker. Plan de nommage/adressage Shorai-31..37 (IP .131..137).

Config.toml : zones toshiba_ac alignées sur Shorai-31/32/33 (7 à terme). 5 tests config, 39 tests firmware, clippy -D warnings + fmt propres, --check-config OK. Docs §17 + §0.3 + journal.


Claude-Session: https://claude.ai/code/session_01R5o2XuifGJPdXfiBxRtsm2