### PR TITLE
feat(fp2): scaffold pont Aqara FP2 -> MQTT (HomeKit local, hébergé Pi5)

### DIFF
--- a/bridge/aqara-fp2-mqtt/.gitignore
+++ b/bridge/aqara-fp2-mqtt/.gitignore
@@ -1,0 +1,10 @@
+# Secrets & artefacts — NE JAMAIS committer (règle projet #12)
+pairings/
+*.pairing.json
+config.toml
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+venv/

--- a/bridge/aqara-fp2-mqtt/README.md
+++ b/bridge/aqara-fp2-mqtt/README.md
@@ -1,0 +1,59 @@
+# aqara-fp2-mqtt — pont présence FP2 → MQTT (HomeKit **local**, sans cloud)
+
+Petit service Python (à héberger **sur le Pi5 existant**, aucun matériel supplémentaire)
+qui lit la **présence** des capteurs **Aqara FP2** via **HomeKit en local** (`aiohomekit`,
+sans Home Assistant ni cloud Aqara) et la publie en **MQTT** pour l'`energy-manager`.
+
+> Contexte & décisions : `docs/toshiba-suzumi-rs-plan.md` **§18**.
+> Le FP2 est en **WiFi + HomeKit** (pas Zigbee). HomeKit est un protocole **local/offline**.
+> La liaison **cloud Aqara reste possible en parallèle** (l'appairage HomeKit est exclusif
+> à un seul contrôleur : ce pont **ou** Apple Home — pas les deux).
+
+## Contrat MQTT (retained)
+
+```
+santuario/toshiba/presence/<zone>              {"present": true|false, "ts": <epoch>}
+santuario/toshiba/presence/bridge/availability online | offline   (LWT)
+```
+`<zone>` = nom du nœud Toshiba correspondant (`Shorai-31`, `Shorai-32`, …). Présence
+« pièce » = **OU** des zones/régions détectées par le FP2.
+
+## État
+
+- ✅ **Cœur pur testé** (`fp2_bridge/core.py`) : config, topics/payloads, agrégation,
+  anti‑rebattement. Tests : `python3 tests/test_core.py -v` (aucune dépendance).
+- ⏳ **Couche HomeKit** (`fp2_bridge/hap.py`) : **scaffold à finaliser sur un FP2 réel**
+  (les appels `aiohomekit` marqués `# VERIFY` dépendent de la version + de l'appareil).
+
+## Installation (sur le Pi5)
+
+```bash
+cd bridge/aqara-fp2-mqtt
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+cp config.example.toml config.toml   # puis éditer (device_id via `discover`)
+```
+
+## Mise en service (une fois un FP2 dispo)
+
+```bash
+# 1) Découvrir les accessoires HomeKit sur le LAN
+python -m fp2_bridge --config config.toml discover
+# 2) Appairer chaque FP2 (code d'appairage 8 chiffres au dos / dans l'app Aqara)
+python -m fp2_bridge --config config.toml pair --device-id AA:BB:.. --code 12345678 --zone Shorai-31
+# 3) Vérifier l'occupation (repérer les zones du FP2)
+python -m fp2_bridge --config config.toml dump --zone Shorai-31
+# 4) Lancer la boucle (présence → MQTT)
+python -m fp2_bridge --config config.toml run
+```
+
+## Déploiement systemd
+
+Unité fournie : `contrib/aqara-fp2-mqtt.service` (démarre après `mosquitto-broker`).
+Config déployée en `/etc/daly-bms/fp2-bridge.toml`. Les **données d'appairage**
+(`pairings/`) sont des **secrets** → jamais commitées (`.gitignore`).
+
+## Sécurité (règle projet #12)
+
+- `pairings/*.pairing.json` = clés HomeKit → **jamais** commitées.
+- `config.toml` (éventuel mot de passe MQTT) → **jamais** commité (seul `config.example.toml` l'est).

--- a/bridge/aqara-fp2-mqtt/config.example.toml
+++ b/bridge/aqara-fp2-mqtt/config.example.toml
@@ -1,0 +1,25 @@
+# Config du pont Aqara FP2 → MQTT. Copier en `config.toml` (non commité) et adapter.
+
+[mqtt]
+host = "127.0.0.1"     # broker Mosquitto local du Pi5
+port = 1883
+# user     = "..."     # seulement si une ACL Mosquitto est activée
+# password = "..."
+
+# Dossier des clés d'appairage HomeKit — SECRET, jamais commité (voir .gitignore).
+pairings_dir   = "pairings"
+# Republication périodique de la présence (rafraîchit le message retained).
+heartbeat_secs = 60
+
+# Un FP2 par pièce = une zone Shorai. Le `device_id` s'obtient via `discover`.
+[[units]]
+zone      = "Shorai-31"
+device_id = "AA:BB:CC:DD:EE:01"
+
+[[units]]
+zone      = "Shorai-32"
+device_id = "AA:BB:CC:DD:EE:02"
+
+[[units]]
+zone      = "Shorai-33"
+device_id = "AA:BB:CC:DD:EE:03"

--- a/bridge/aqara-fp2-mqtt/contrib/aqara-fp2-mqtt.service
+++ b/bridge/aqara-fp2-mqtt/contrib/aqara-fp2-mqtt.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Aqara FP2 -> MQTT presence bridge (HomeKit local, sans cloud)
+Documentation=file:///home/pi5compute/Daly-BMS-Rust/docs/toshiba-suzumi-rs-plan.md
+After=network-online.target mosquitto-broker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi5compute
+WorkingDirectory=/home/pi5compute/Daly-BMS-Rust/bridge/aqara-fp2-mqtt
+ExecStart=/home/pi5compute/Daly-BMS-Rust/bridge/aqara-fp2-mqtt/.venv/bin/python -m fp2_bridge run --config /etc/daly-bms/fp2-bridge.toml
+Restart=on-failure
+RestartSec=5
+# Durcissement léger
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/home/pi5compute/Daly-BMS-Rust/bridge/aqara-fp2-mqtt/pairings
+
+[Install]
+WantedBy=multi-user.target

--- a/bridge/aqara-fp2-mqtt/fp2_bridge/__init__.py
+++ b/bridge/aqara-fp2-mqtt/fp2_bridge/__init__.py
@@ -1,0 +1,7 @@
+"""Pont Aqara FP2 (HomeKit local) → MQTT.
+
+Voir `README.md` et `docs/toshiba-suzumi-rs-plan.md` §18.
+Le cœur pur (config, agrégation, payloads) est dans `core.py` — testable sans matériel.
+"""
+
+__all__ = ["core"]

--- a/bridge/aqara-fp2-mqtt/fp2_bridge/__main__.py
+++ b/bridge/aqara-fp2-mqtt/fp2_bridge/__main__.py
@@ -1,0 +1,115 @@
+"""CLI du pont Aqara FP2 → MQTT.
+
+    python -m fp2_bridge discover                       # lister les accessoires HomeKit
+    python -m fp2_bridge pair --device-id ID --code 12345678 --zone Shorai-31
+    python -m fp2_bridge dump  --zone Shorai-31         # lister les caractéristiques
+    python -m fp2_bridge run   --config config.toml     # boucle principale
+
+Le sous-commande `run` : charge la config, se connecte au broker, et pour chaque FP2
+suit l'occupation → publie la présence *retained* sur `santuario/toshiba/presence/<zone>`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import tomllib
+
+from . import core
+
+
+def _load_config(path: str) -> core.BridgeConfig:
+    with open(path, "rb") as fh:
+        return core.parse_config(tomllib.load(fh))
+
+
+async def _cmd_discover(_args) -> int:
+    from . import hap
+
+    for d in await hap.discover():
+        flag = "appairé" if d.get("paired") else "libre"
+        print(f"{d['device_id']}  {d.get('name', '')}  [{flag}]")
+    return 0
+
+
+async def _cmd_pair(args) -> int:
+    from . import hap
+
+    cfg = _load_config(args.config)
+    await hap.pair(args.device_id, args.code, args.zone, cfg.pairings_dir)
+    print(f"Appairé : {args.zone} → {cfg.pairings_dir}/{args.zone}.pairing.json")
+    return 0
+
+
+async def _cmd_dump(args) -> int:
+    from . import hap
+
+    cfg = _load_config(args.config)
+    unit = next((u for u in cfg.units if u.zone == args.zone), None)
+    if unit is None:
+        print(f"zone inconnue : {args.zone}", file=sys.stderr)
+        return 2
+
+    async def show(zone: str, present: bool) -> None:
+        print(f"{zone}: présence = {present}")
+
+    # `watch` imprime l'état initial via le callback, puis boucle : on coupe vite.
+    task = asyncio.create_task(hap.watch(unit, cfg.pairings_dir, show))
+    await asyncio.sleep(3)
+    task.cancel()
+    return 0
+
+
+async def _cmd_run(args) -> int:
+    from . import hap, mqtt_out
+
+    cfg = _load_config(args.config)
+    pub = mqtt_out.MqttPublisher(cfg)
+    pub.connect()
+    tracker = core.PresenceTracker(heartbeat_secs=cfg.heartbeat_secs)
+    loop = asyncio.get_running_loop()
+
+    async def on_presence(zone: str, present: bool) -> None:
+        decision = tracker.update(zone, present, loop.time())
+        if decision is not None:
+            pub.publish_presence(zone, decision)
+
+    try:
+        await asyncio.gather(
+            *(hap.watch(u, cfg.pairings_dir, on_presence) for u in cfg.units)
+        )
+    finally:
+        pub.close()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="fp2_bridge", description="Pont Aqara FP2 → MQTT")
+    p.add_argument("--config", default="config.toml", help="chemin du fichier de config")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("discover", help="lister les accessoires HomeKit du LAN")
+
+    sp = sub.add_parser("pair", help="appairer un FP2")
+    sp.add_argument("--device-id", required=True)
+    sp.add_argument("--code", required=True, help="code d'appairage 8 chiffres")
+    sp.add_argument("--zone", required=True, help="ex. Shorai-31")
+
+    sd = sub.add_parser("dump", help="lister l'occupation d'un FP2 appairé")
+    sd.add_argument("--zone", required=True)
+
+    sub.add_parser("run", help="boucle principale (présence → MQTT)")
+
+    args = p.parse_args(argv)
+    handler = {
+        "discover": _cmd_discover,
+        "pair": _cmd_pair,
+        "dump": _cmd_dump,
+        "run": _cmd_run,
+    }[args.cmd]
+    return asyncio.run(handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bridge/aqara-fp2-mqtt/fp2_bridge/core.py
+++ b/bridge/aqara-fp2-mqtt/fp2_bridge/core.py
@@ -1,0 +1,118 @@
+"""Cœur **PUR** du pont Aqara FP2 → MQTT — aucune dépendance tierce, testable.
+
+Contrat MQTT (cf. `docs/toshiba-suzumi-rs-plan.md` §18) — messages *retained* :
+
+    santuario/toshiba/presence/<zone>   →   {"present": true|false, "ts": <epoch>}
+
+Ce module ne fait **ni HomeKit ni MQTT réseau** : uniquement config, agrégation de
+présence (zones du FP2 → présence « pièce »), construction des payloads et
+anti‑rebattement. Il est importable et testable **sans** `aiohomekit`/`paho`.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+
+#: Racine des topics de présence (locale, non bridgée — règle projet #11).
+TOPIC_ROOT = "santuario/toshiba/presence"
+
+
+@dataclass(frozen=True)
+class UnitConfig:
+    """Un FP2 = une pièce = une zone Shorai."""
+
+    zone: str  # ex. "Shorai-31" (= segment de topic + nom du nœud Toshiba)
+    device_id: str  # identifiant HomeKit de l'accessoire (ex. "AA:BB:CC:DD:EE:FF")
+
+
+@dataclass(frozen=True)
+class BridgeConfig:
+    mqtt_host: str = "127.0.0.1"
+    mqtt_port: int = 1883
+    mqtt_user: str | None = None
+    mqtt_pass: str | None = None
+    #: Dossier des données d'appairage HomeKit (SECRET — jamais commité).
+    pairings_dir: str = "pairings"
+    #: Republication périodique même sans changement (rafraîchit le retained).
+    heartbeat_secs: int = 60
+    units: tuple[UnitConfig, ...] = ()
+
+
+def presence_topic(zone: str) -> str:
+    """`santuario/toshiba/presence/<zone>`."""
+    return f"{TOPIC_ROOT}/{zone}"
+
+
+def presence_payload(present: bool, now: float | None = None) -> str:
+    """JSON compact `{"present": bool, "ts": epoch}`."""
+    ts = int(now if now is not None else time.time())
+    return json.dumps({"present": bool(present), "ts": ts}, separators=(",", ":"))
+
+
+def aggregate_presence(region_states) -> bool:
+    """Présence « pièce » = **OU** logique sur les régions occupées du FP2.
+
+    Le FP2 expose plusieurs capteurs d'occupation (une par zone/région) ; la pièce
+    est considérée occupée dès qu'**au moins une** région l'est.
+    """
+    return any(bool(x) for x in region_states)
+
+
+class PresenceTracker:
+    """Anti‑rebattement : ne publie que sur **changement**, plus un **heartbeat**.
+
+    `update(zone, present, now)` renvoie la valeur à publier (bool) si l'état a
+    changé **ou** si le heartbeat est écoulé, sinon `None`.
+    """
+
+    def __init__(self, heartbeat_secs: int = 60) -> None:
+        self.heartbeat_secs = heartbeat_secs
+        self._last: dict[str, tuple[bool, float]] = {}
+
+    def update(self, zone: str, present: bool, now: float) -> bool | None:
+        prev = self._last.get(zone)
+        changed = prev is None or prev[0] != present
+        stale = prev is not None and (now - prev[1]) >= self.heartbeat_secs
+        if changed or stale:
+            self._last[zone] = (present, now)
+            return present
+        return None
+
+
+def _valid_zone(zone: str) -> bool:
+    return bool(zone) and not any(c in zone for c in "/+# ")
+
+
+def parse_config(data: dict) -> BridgeConfig:
+    """Construit et **valide** une `BridgeConfig` depuis un dict (issu de `tomllib`)."""
+    mqtt = data.get("mqtt", {}) or {}
+    units_raw = data.get("units", []) or []
+
+    units: list[UnitConfig] = []
+    seen: set[str] = set()
+    for u in units_raw:
+        zone = str(u.get("zone", "")).strip()
+        dev = str(u.get("device_id", "")).strip()
+        if not _valid_zone(zone):
+            raise ValueError(f"zone invalide ou vide (segment de topic) : {zone!r}")
+        if not dev:
+            raise ValueError(f"unité {zone!r} sans `device_id` HomeKit")
+        if zone in seen:
+            raise ValueError(f"zone dupliquée : {zone!r}")
+        seen.add(zone)
+        units.append(UnitConfig(zone=zone, device_id=dev))
+
+    if not units:
+        raise ValueError("aucune unité configurée (section [[units]])")
+
+    return BridgeConfig(
+        mqtt_host=str(mqtt.get("host", "127.0.0.1")),
+        mqtt_port=int(mqtt.get("port", 1883)),
+        mqtt_user=mqtt.get("user"),
+        mqtt_pass=mqtt.get("password"),
+        pairings_dir=str(data.get("pairings_dir", "pairings")),
+        heartbeat_secs=int(data.get("heartbeat_secs", 60)),
+        units=tuple(units),
+    )

--- a/bridge/aqara-fp2-mqtt/fp2_bridge/hap.py
+++ b/bridge/aqara-fp2-mqtt/fp2_bridge/hap.py
@@ -1,0 +1,118 @@
+"""Contrôleur **HomeKit local** (`aiohomekit`) pour les FP2 — couche I/O.
+
+⚠️ **Scaffold à finaliser sur un FP2 réel.** La logique de flux (découverte →
+appairage → abonnement occupation → agrégation → callback) est en place, mais les
+**appels exacts d'`aiohomekit` varient selon la version** installée. Les points à
+confirmer sur l'appareil sont marqués `# VERIFY`. Utiliser `python -m fp2_bridge
+discover` puis `... pair` pour caler les identifiants, et `... dump` pour lister les
+caractéristiques d'occupation (une par zone du FP2).
+
+Aucune de ces fonctions n'est testée hors matériel ; le cœur pur (`core.py`, testé)
+reste la référence pour le contrat MQTT.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Awaitable, Callable
+
+from aiohomekit import Controller  # type: ignore
+from aiohomekit.model.characteristics import CharacteristicsTypes  # type: ignore
+
+from . import core
+
+#: Caractéristique HAP standard d'un capteur d'occupation (0 = libre, 1 = présence).
+OCCUPANCY = CharacteristicsTypes.OCCUPANCY_DETECTED
+
+
+def _pairing_path(pairings_dir: str, zone: str) -> str:
+    return os.path.join(pairings_dir, f"{zone}.pairing.json")
+
+
+async def discover(timeout: int = 10) -> list[dict]:
+    """Liste les accessoires HomeKit visibles sur le LAN (mDNS)."""
+    found: list[dict] = []
+    async with Controller() as controller:
+        async for disc in controller.async_discover(timeout):  # VERIFY: signature
+            info = disc.description
+            found.append(
+                {
+                    "device_id": info.id,  # VERIFY: champ id (device_id HAP)
+                    "name": getattr(info, "name", ""),
+                    "paired": not getattr(info, "status_flags", 1) & 0x01,
+                }
+            )
+    return found
+
+
+async def pair(device_id: str, setup_code: str, zone: str, pairings_dir: str) -> None:
+    """Appaire un FP2 (code d'appairage 8 chiffres) et **persiste** la clé.
+
+    ⚠️ La donnée d'appairage contient des **secrets** → dossier `pairings/` **jamais
+    commité** (cf. `.gitignore`).
+    """
+    os.makedirs(pairings_dir, exist_ok=True)
+    async with Controller() as controller:
+        disc = await controller.async_find(device_id)  # VERIFY
+        finish = await disc.async_start_pairing(zone)  # VERIFY
+        pairing = await finish(setup_code)  # VERIFY
+        data = pairing.pairing_data  # VERIFY: dict sérialisable
+    with open(_pairing_path(pairings_dir, zone), "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+
+async def watch(
+    unit: core.UnitConfig,
+    pairings_dir: str,
+    on_room_presence: Callable[[str, bool], Awaitable[None]],
+) -> None:
+    """Se connecte au FP2 de `unit`, suit l'occupation de toutes ses zones et
+    appelle `on_room_presence(zone, present)` (présence pièce = OU des régions).
+    """
+    path = _pairing_path(pairings_dir, unit.zone)
+    with open(path, encoding="utf-8") as fh:
+        pairing_data = json.load(fh)
+
+    async with Controller() as controller:
+        controller.load_pairing(unit.zone, pairing_data)  # VERIFY
+        pairing = controller.pairings[unit.zone]
+
+        accessories = await pairing.list_accessories_and_characteristics()  # VERIFY
+        # Repérer toutes les caractéristiques d'occupation (une par zone du FP2).
+        occ: list[tuple[int, int]] = []  # (aid, iid)
+        for acc in accessories:
+            aid = acc["aid"]
+            for svc in acc.get("services", []):
+                for ch in svc.get("characteristics", []):
+                    if ch.get("type") == OCCUPANCY:
+                        occ.append((aid, ch["iid"]))
+        if not occ:
+            raise RuntimeError(f"{unit.zone}: aucune caractéristique d'occupation trouvée")
+
+        region_state: dict[tuple[int, int], bool] = {c: False for c in occ}
+
+        async def emit() -> None:
+            await on_room_presence(unit.zone, core.aggregate_presence(region_state.values()))
+
+        # État initial.
+        current = await pairing.get_characteristics(occ)  # VERIFY
+        for (aid, iid), v in current.items():
+            region_state[(aid, iid)] = bool(v.get("value"))
+        await emit()
+
+        # Abonnement aux changements.
+        def _on_event(data):  # VERIFY: forme de l'event
+            for (aid, iid), v in data.items():
+                region_state[(aid, iid)] = bool(v.get("value"))
+
+        pairing.dispatcher_connect(_on_event)  # VERIFY
+        await pairing.subscribe(occ)  # VERIFY
+
+        # La connexion est maintenue par le contexte ; les events déclenchent emit().
+        # (Boucle de maintien + ré-émission périodique gérées par l'appelant.)
+        import asyncio
+
+        while True:
+            await asyncio.sleep(1)
+            await emit()

--- a/bridge/aqara-fp2-mqtt/fp2_bridge/mqtt_out.py
+++ b/bridge/aqara-fp2-mqtt/fp2_bridge/mqtt_out.py
@@ -1,0 +1,52 @@
+"""Publication MQTT (paho-mqtt) — mince couche I/O au-dessus de `core`.
+
+Publie la présence *retained* sur `santuario/toshiba/presence/<zone>` et une
+disponibilité LWT `santuario/toshiba/presence/bridge/availability`.
+"""
+
+from __future__ import annotations
+
+import paho.mqtt.client as mqtt
+
+from . import core
+
+AVAILABILITY_TOPIC = f"{core.TOPIC_ROOT}/bridge/availability"
+
+
+def _make_client(client_id: str) -> mqtt.Client:
+    """Compatible paho-mqtt 1.x **et** 2.x."""
+    try:  # paho-mqtt >= 2.0
+        return mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=client_id)
+    except (AttributeError, TypeError):  # paho-mqtt < 2.0
+        return mqtt.Client(client_id=client_id)
+
+
+class MqttPublisher:
+    def __init__(self, cfg: core.BridgeConfig, client_id: str = "aqara-fp2-bridge") -> None:
+        self._cfg = cfg
+        self._client = _make_client(client_id)
+        if cfg.mqtt_user:
+            self._client.username_pw_set(cfg.mqtt_user, cfg.mqtt_pass or "")
+        # LWT : signale l'arrêt du pont si la connexion tombe.
+        self._client.will_set(AVAILABILITY_TOPIC, "offline", qos=1, retain=True)
+
+    def connect(self) -> None:
+        self._client.connect(self._cfg.mqtt_host, self._cfg.mqtt_port, keepalive=30)
+        self._client.loop_start()
+        self._client.publish(AVAILABILITY_TOPIC, "online", qos=1, retain=True)
+
+    def publish_presence(self, zone: str, present: bool, now: float | None = None) -> None:
+        self._client.publish(
+            core.presence_topic(zone),
+            core.presence_payload(present, now),
+            qos=1,
+            retain=True,
+        )
+
+    def close(self) -> None:
+        try:
+            self._client.publish(AVAILABILITY_TOPIC, "offline", qos=1, retain=True)
+            self._client.loop_stop()
+            self._client.disconnect()
+        except Exception:  # noqa: BLE001 — best-effort à l'arrêt
+            pass

--- a/bridge/aqara-fp2-mqtt/requirements.txt
+++ b/bridge/aqara-fp2-mqtt/requirements.txt
@@ -1,0 +1,3 @@
+# Pont Aqara FP2 (HomeKit local) → MQTT. Python 3.11+ (tomllib en stdlib).
+aiohomekit
+paho-mqtt>=1.6

--- a/bridge/aqara-fp2-mqtt/tests/test_core.py
+++ b/bridge/aqara-fp2-mqtt/tests/test_core.py
@@ -1,0 +1,96 @@
+"""Tests du cœur pur (aucune dépendance tierce). Lancer :
+
+    python3 -m unittest discover -s bridge/aqara-fp2-mqtt -p 'test_*.py'
+"""
+
+import json
+import os
+import sys
+import unittest
+
+# Rendre le paquet importable quel que soit le CWD.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fp2_bridge import core  # noqa: E402
+
+
+class TestTopicsPayloads(unittest.TestCase):
+    def test_topic(self):
+        self.assertEqual(
+            core.presence_topic("Shorai-31"),
+            "santuario/toshiba/presence/Shorai-31",
+        )
+
+    def test_payload(self):
+        js = core.presence_payload(True, now=1720000000)
+        self.assertEqual(json.loads(js), {"present": True, "ts": 1720000000})
+        # ts entier même si now est un float.
+        self.assertEqual(json.loads(core.presence_payload(False, now=1.9))["ts"], 1)
+        self.assertIs(json.loads(core.presence_payload(False, now=0))["present"], False)
+
+
+class TestAggregate(unittest.TestCase):
+    def test_or_logic(self):
+        self.assertFalse(core.aggregate_presence([]))
+        self.assertFalse(core.aggregate_presence([False, False]))
+        self.assertTrue(core.aggregate_presence([False, True, False]))
+        self.assertTrue(core.aggregate_presence([1]))  # truthy
+
+
+class TestTracker(unittest.TestCase):
+    def test_change_and_heartbeat(self):
+        t = core.PresenceTracker(heartbeat_secs=60)
+        # 1er échantillon → publie.
+        self.assertEqual(t.update("z", False, now=0.0), False)
+        # Même valeur avant heartbeat → rien.
+        self.assertIsNone(t.update("z", False, now=10.0))
+        # Changement → publie.
+        self.assertEqual(t.update("z", True, now=11.0), True)
+        # Même valeur, mais heartbeat écoulé → republie.
+        self.assertEqual(t.update("z", True, now=11.0 + 60), True)
+
+    def test_zones_are_independent(self):
+        t = core.PresenceTracker(heartbeat_secs=60)
+        self.assertEqual(t.update("a", True, 0.0), True)
+        self.assertEqual(t.update("b", False, 0.0), False)
+        self.assertIsNone(t.update("a", True, 1.0))
+
+
+class TestParseConfig(unittest.TestCase):
+    def _valid(self):
+        return {
+            "mqtt": {"host": "192.168.1.141", "port": 1883},
+            "units": [
+                {"zone": "Shorai-31", "device_id": "AA:BB:CC:DD:EE:01"},
+                {"zone": "Shorai-32", "device_id": "AA:BB:CC:DD:EE:02"},
+            ],
+        }
+
+    def test_valid(self):
+        cfg = core.parse_config(self._valid())
+        self.assertEqual(cfg.mqtt_host, "192.168.1.141")
+        self.assertEqual(len(cfg.units), 2)
+        self.assertEqual(cfg.units[0].zone, "Shorai-31")
+
+    def test_rejects_bad(self):
+        d = self._valid()
+        d["units"][0]["zone"] = ""  # vide
+        self.assertRaises(ValueError, core.parse_config, d)
+
+        d = self._valid()
+        d["units"][0]["zone"] = "a/b"  # caractère de topic interdit
+        self.assertRaises(ValueError, core.parse_config, d)
+
+        d = self._valid()
+        d["units"][1]["zone"] = "Shorai-31"  # doublon
+        self.assertRaises(ValueError, core.parse_config, d)
+
+        d = self._valid()
+        d["units"][0].pop("device_id")  # device_id manquant
+        self.assertRaises(ValueError, core.parse_config, d)
+
+        self.assertRaises(ValueError, core.parse_config, {"units": []})  # aucune unité
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -156,6 +156,13 @@ le matériel ESP32** :
   Pi5 (contrôleur HomeKit IP autonome, sans HA ni cloud) ; alternative = HA
   `homekit_controller`. Contrat MQTT `santuario/toshiba/presence/<Shorai-3x>` défini.
   Sources : aqara.com, home‑assistant.io (homekit_controller), github Jc2k/aiohomekit.
+- **2026-07-06 (suite 9)** — **Scaffold du pont FP2→MQTT** : `bridge/aqara-fp2-mqtt/`
+  (Python, hébergé sur le Pi5, **aucun matériel en plus**). Cœur **pur testé**
+  (`fp2_bridge/core.py` : config, contrat MQTT `presence/<zone>`, agrégation OU des zones,
+  anti‑rebattement) — **7 tests unittest verts** sans dépendance ni matériel. CLI
+  (discover/pair/dump/run), publisher MQTT (paho, LWT), unité systemd, `.gitignore`
+  (clés d'appairage = secrets). `hap.py` (aiohomekit) = **scaffold à finaliser sur un FP2
+  réel** (`# VERIFY`). Détail → §18.6.
 
 ---
 
@@ -1391,13 +1398,24 @@ agrège en une présence « pièce » ou publie par zone selon le découpage).
    tick 1 s → `decide_presence(present, now−last_ts, eco, off)` → si l'action change,
    publier `presence_command_json` sur `.../command` (débounce).
 
-### 18.6 À finaliser / décider
+### 18.6 Le pont (Option A) — **scaffold en place**
 
-- **Option A (pont `aiohomekit` local — recommandé) vs B (Home Assistant).**
-- **Construire le pont** (petit service Python `aiohomekit → MQTT` sur le Pi5) — livrable
-  séparé, à faire quand un FP2 réel est disponible pour l'appairage.
-- **Vérifier l'appairage** FP2 ↔ contrôleur local (contrainte mono‑contrôleur ci‑dessus).
-- **Mapping** FP2 → pièce → `Shorai-3x` (+ découpage en zones du FP2).
+Livré : **`bridge/aqara-fp2-mqtt/`** (service Python, à héberger sur le Pi5) :
+- ✅ **Cœur pur testé** (`fp2_bridge/core.py`) : config, topics/payloads du contrat MQTT,
+  agrégation présence (OU des zones FP2), anti‑rebattement + heartbeat. **7 tests**
+  (`python3 tests/test_core.py`) — aucune dépendance, tournent sans matériel.
+- ✅ CLI (`discover` / `pair` / `dump` / `run`), publisher MQTT (`paho`, LWT), unité
+  **systemd**, `config.example.toml`, `.gitignore` (les clés d'appairage = secrets).
+- ⏳ **Couche HomeKit** (`fp2_bridge/hap.py`) : **scaffold à finaliser sur un FP2 réel**
+  (appels `aiohomekit` marqués `# VERIFY`, dépendants de la version + de l'appareil).
+
+### 18.7 À finaliser / décider (à réception des FP2)
+
+- **Finaliser `hap.py`** sur un FP2 réel (appairage `pair`, repérage des zones via `dump`).
+- **Vérifier l'appairage** mono‑contrôleur (ce pont **ou** Apple Home ; cloud Aqara en //).
+- **Mapping** FP2 → pièce → `Shorai-3x` (renseigner `device_id` via `discover`).
+- **Câbler l'EM** : souscrire `santuario/toshiba/presence/+`, appliquer `decide_presence`
+  (§18.5), activer `control_enabled`.
 - Confirmer **ECO immédiat / OFF 5 min** ou ajuster `eco_after_secs`/`off_after_secs`.
 
 > **Sources** : Aqara FP2 (WiFi, HomeKit, multi‑zones) — aqara.com ; HomeKit = protocole


### PR DESCRIPTION
bridge/aqara-fp2-mqtt/ : service Python qui lit la présence des FP2 via HomeKit LOCAL (aiohomekit, sans HA ni cloud) et publie en MQTT pour l'energy-manager. Aucun matériel supplémentaire (FP2 = WiFi/HomeKit-over-IP, tourne sur le Pi5).

- fp2_bridge/core.py : cœur PUR (aucune dépendance) — config + validation, contrat MQTT santuario/toshiba/presence/<zone> {"present":bool,"ts"}, agrégation présence (OU des zones FP2), anti-rebattement + heartbeat. 7 tests unittest verts, testés sans matériel (python3 tests/test_core.py).
- fp2_bridge/mqtt_out.py : publisher paho (retained + LWT availability), compat paho 1.x/2.x.
- fp2_bridge/hap.py : contrôleur aiohomekit — SCAFFOLD à finaliser sur un FP2 réel (appels marqués # VERIFY selon version/appareil). Imports paresseux (le cœur et la CLI --help marchent sans aiohomekit/paho installés).
- fp2_bridge/__main__.py : CLI discover / pair / dump / run.
- Packaging : requirements.txt, config.example.toml, README, unité systemd, .gitignore (clés d'appairage HomeKit + config.toml = secrets, jamais commités — règle #12).

Docs : plan §18.6/§18.7 (scaffold en place, reste à finaliser hap.py + câbler l'EM) + journal §0.5.


Claude-Session: https://claude.ai/code/session_01R5o2XuifGJPdXfiBxRtsm2