### PR TITLE
fix(fp2): appliquer la revue de code du pont + finaliser la doc de re…

### DIFF
--- a/bridge/aqara-fp2-mqtt/fp2_bridge/__main__.py
+++ b/bridge/aqara-fp2-mqtt/fp2_bridge/__main__.py
@@ -58,6 +58,10 @@ async def _cmd_dump(args) -> int:
     task = asyncio.create_task(hap.watch(unit, cfg.pairings_dir, show))
     await asyncio.sleep(3)
     task.cancel()
+    try:
+        await task  # laisse la tâche se terminer proprement (évite "Task was destroyed")
+    except asyncio.CancelledError:
+        pass
     return 0
 
 

--- a/bridge/aqara-fp2-mqtt/fp2_bridge/core.py
+++ b/bridge/aqara-fp2-mqtt/fp2_bridge/core.py
@@ -107,12 +107,18 @@ def parse_config(data: dict) -> BridgeConfig:
     if not units:
         raise ValueError("aucune unité configurée (section [[units]])")
 
+    # `heartbeat_secs <= 0` rendrait la condition `stale` toujours vraie dans
+    # PresenceTracker → publications MQTT en boucle continue (surcharge CPU).
+    heartbeat = int(data.get("heartbeat_secs", 60))
+    if heartbeat <= 0:
+        raise ValueError("heartbeat_secs doit être strictement supérieur à 0")
+
     return BridgeConfig(
         mqtt_host=str(mqtt.get("host", "127.0.0.1")),
         mqtt_port=int(mqtt.get("port", 1883)),
         mqtt_user=mqtt.get("user"),
         mqtt_pass=mqtt.get("password"),
         pairings_dir=str(data.get("pairings_dir", "pairings")),
-        heartbeat_secs=int(data.get("heartbeat_secs", 60)),
+        heartbeat_secs=heartbeat,
         units=tuple(units),
     )

--- a/bridge/aqara-fp2-mqtt/fp2_bridge/hap.py
+++ b/bridge/aqara-fp2-mqtt/fp2_bridge/hap.py
@@ -13,6 +13,7 @@ reste la référence pour le contrat MQTT.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from typing import Awaitable, Callable
@@ -55,6 +56,8 @@ async def pair(device_id: str, setup_code: str, zone: str, pairings_dir: str) ->
     os.makedirs(pairings_dir, exist_ok=True)
     async with Controller() as controller:
         disc = await controller.async_find(device_id)  # VERIFY
+        if disc is None:
+            raise RuntimeError(f"appareil HomeKit introuvable : {device_id} (essayer `discover`)")
         finish = await disc.async_start_pairing(zone)  # VERIFY
         pairing = await finish(setup_code)  # VERIFY
         data = pairing.pairing_data  # VERIFY: dict sérialisable
@@ -71,6 +74,11 @@ async def watch(
     appelle `on_room_presence(zone, present)` (présence pièce = OU des régions).
     """
     path = _pairing_path(pairings_dir, unit.zone)
+    if not os.path.exists(path):
+        raise RuntimeError(
+            f"aucun appairage pour la zone {unit.zone!r} ({path}) — "
+            f"appairer d'abord avec `pair --zone {unit.zone} --device-id … --code …`"
+        )
     with open(path, encoding="utf-8") as fh:
         pairing_data = json.load(fh)
 
@@ -101,18 +109,19 @@ async def watch(
             region_state[(aid, iid)] = bool(v.get("value"))
         await emit()
 
-        # Abonnement aux changements.
+        # Abonnement : ré-émettre **immédiatement** à chaque event (latence minimale),
+        # au lieu de sonder chaque seconde.
+        loop = asyncio.get_running_loop()
+
         def _on_event(data):  # VERIFY: forme de l'event
             for (aid, iid), v in data.items():
                 region_state[(aid, iid)] = bool(v.get("value"))
+            loop.create_task(emit())
 
         pairing.dispatcher_connect(_on_event)  # VERIFY
         await pairing.subscribe(occ)  # VERIFY
 
-        # La connexion est maintenue par le contexte ; les events déclenchent emit().
-        # (Boucle de maintien + ré-émission périodique gérées par l'appelant.)
-        import asyncio
-
+        # Boucle de maintien à basse fréquence = heartbeat (rafraîchit le retained).
         while True:
-            await asyncio.sleep(1)
+            await asyncio.sleep(30)
             await emit()

--- a/bridge/aqara-fp2-mqtt/fp2_bridge/mqtt_out.py
+++ b/bridge/aqara-fp2-mqtt/fp2_bridge/mqtt_out.py
@@ -45,7 +45,14 @@ class MqttPublisher:
 
     def close(self) -> None:
         try:
-            self._client.publish(AVAILABILITY_TOPIC, "offline", qos=1, retain=True)
+            # Attendre que le "offline" (retained) parte réellement : un disconnect()
+            # propre ne déclenche PAS le LWT côté broker, donc si ce message est perdu
+            # le broker garderait "online" indéfiniment.
+            info = self._client.publish(AVAILABILITY_TOPIC, "offline", qos=1, retain=True)
+            try:
+                info.wait_for_publish(timeout=2.0)
+            except Exception:  # noqa: BLE001 — publication best-effort
+                pass
             self._client.loop_stop()
             self._client.disconnect()
         except Exception:  # noqa: BLE001 — best-effort à l'arrêt

--- a/bridge/aqara-fp2-mqtt/tests/test_core.py
+++ b/bridge/aqara-fp2-mqtt/tests/test_core.py
@@ -91,6 +91,13 @@ class TestParseConfig(unittest.TestCase):
 
         self.assertRaises(ValueError, core.parse_config, {"units": []})  # aucune unité
 
+    def test_rejects_non_positive_heartbeat(self):
+        d = self._valid()
+        d["heartbeat_secs"] = 0
+        self.assertRaises(ValueError, core.parse_config, d)
+        d["heartbeat_secs"] = -5
+        self.assertRaises(ValueError, core.parse_config, d)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -40,6 +40,15 @@
 2. **Protocole SUZUMI vérifié** contre pedobry, **recoupé** avec o0Zz (§14) → fiable.
 3. **`issalig`/AB TCC-Link = protocole différent, non applicable** à nos Shorai Edge (§15).
 4. **Aucune spec officielle Toshiba** publique → §6 est la meilleure source (§15.1).
+5. **Réseau/identité** (§17) : ESP32 en **station WiFi `StarTh`** (DHCP par défaut, **IP
+   statique `.31–.37`** possible) + **AP de secours**. Identité **`Shorai-3x`** = hostname
+   + segment de topic + SSID AP. **Mot de passe WiFi injecté au flash/NVS, jamais commité**.
+6. **Topics figés** : `santuario/toshiba/<Shorai-3x>/{state,command,availability}` et
+   `santuario/toshiba/presence/<Shorai-3x>` (préfixe **local**, non bridgé).
+7. **Contrôle = présence** (Aqara FP2) : **ECO dès absence, OFF après 5 min** (§18). Pas de
+   pilotage sur la fréquence AC (une clim est une **charge**, pas une source PV).
+8. **FP2 = intégration LOCALE via HomeKit** (`aiohomekit → MQTT`, §18.4), pont Python
+   **sur le Pi5 (aucun matériel en plus)**, en parallèle du cloud Aqara.
 
 ### 0.3 État du code
 
@@ -47,7 +56,11 @@ Crate : **`firmware/toshiba-suzumi-rs/`** — **détaché** du workspace Pi5 (`[
 vide → zéro impact sur le build/CI daly-bms). Tester : 
 `cargo test --manifest-path firmware/toshiba-suzumi-rs/Cargo.toml`.
 
-**38 tests host verts** au total (clippy `-D warnings` + rustfmt propres).
+**3 composants** (tous verts). Résumé rapide :
+
+**A. Firmware ESP32** — `firmware/toshiba-suzumi-rs/` (crate **détaché**, zéro impact Pi5).
+Tester : `cargo test --manifest-path firmware/toshiba-suzumi-rs/Cargo.toml`. **39 tests
+host** (clippy `-D warnings` + rustfmt propres).
 
 | Composant | Fichier | État |
 |-----------|---------|------|
@@ -55,18 +68,25 @@ vide → zéro impact sur le build/CI daly-bms). Tester :
 | Handshake + timings + bornes température (constantes) | `src/protocol.rs` | ✅ fait |
 | Agrégat d'état (`ToshibaState`, applique les `Field`) | `src/state.rs` | ✅ **fait** (4 tests) |
 | Accumulateur de trames RX incrémental (`validate_message_`) | `src/framing.rs` | ✅ **fait** (5 tests) |
-| Machine à états + file/pacing + watchdog + **simulateur d'unité** | `src/machine.rs` | ✅ **fait** (5 tests, dont handshake→online end-to-end) |
+| Machine à états + file/pacing + watchdog + **simulateur d'unité** | `src/machine.rs` | ✅ **fait** (6 tests, dont handshake→online end-to-end) |
 | Codec MQTT applicatif (`ToshibaState`→JSON ; JSON→`Command`→`apply_command`) | `src/mqtt_payload.rs` | ✅ **fait** (8 tests, transport-agnostique) |
 | Config nœud (identité `Shorai-3x`, WiFi StarTh, DHCP/IP statique, AP secours, broker, topics/hostname) + validation | `src/config.rs` | ✅ **fait** (5 tests) — §17 |
 | UART ESP-IDF (init 9600 8E1, lecture/écriture octets) | `src/uart.rs` | ⏳ **TODO (attend matériel)** |
 | WiFi + MQTT transport (`santuario/toshiba/<zone>`) | `src/{wifi,mqtt}.rs` | ⏳ TODO (matériel) |
 | `main.rs` + esp-idf-svc (feature `esp32`) | `src/main.rs` | ⏳ TODO (matériel) |
 
-**Côté Pi5** (`crates/energy-manager`) : le module **`logic/toshiba_ac` (lecture seule)**
-est **fait** — souscrit `santuario/toshiba/<zone>/state`, remplit
-`EnergyState.toshiba_ac[zone]`, diffuse un event live. Config `[energy_manager.toshiba_ac]`
-(+ `--check-config`). 4 tests, clippy propre, build vert. La **phase contrôle**
-(`control_enabled`) reste à faire (dépend de la stratégie énergie, §10.4).
+**B. Module Pi5** — `crates/energy-manager/src/logic/toshiba_ac/`. Tester :
+`cargo test -p energy-manager toshiba` (**8 tests** : 4 parsing + 4 présence) ; clippy
+propre ; `ENERGY_CONFIG=Config.toml cargo run -p energy-manager -- --check-config` OK.
+- ✅ **Lecture seule** : souscrit `santuario/toshiba/<zone>/state` → `EnergyState.toshiba_ac[zone]` + event live.
+- ✅ **Règles de contrôle présence** pures (`rules.rs` : `decide_presence`, `presence_command_json`),
+  config `control_enabled`/`eco_after_secs`/`off_after_secs` (**OFF par défaut**).
+- ⏳ **Boucle de contrôle** (souscrire la présence + émettre les commandes) : à câbler quand les FP2 seront là (§18.5).
+
+**C. Pont présence FP2** — `bridge/aqara-fp2-mqtt/` (Python, sur le Pi5, HomeKit local →
+MQTT). Tester le cœur : `python3 tests/test_core.py` (**8 tests**).
+- ✅ **Cœur pur testé** (`fp2_bridge/core.py`) + CLI + MQTT + systemd + packaging.
+- ⏳ **`hap.py`** (`aiohomekit`) = scaffold à finaliser sur un **FP2 réel** (§18.6).
 
 > ✅ **Stratégie de contrôle TRANCHÉE = présence (capteurs Aqara FP2).** Politique :
 > **ECO dès absence, OFF après 5 min d'absence** (retour de présence → rallumage + preset
@@ -80,25 +100,33 @@ est **fait** — souscrit `santuario/toshiba/<zone>/state`, remplit
 > **source de présence** (topic MQTT des FP2 → zone) et la boucle d'émission débouncée.
 > Détail → §18.
 
-### 0.4 Prochaines étapes (ordre conseillé, sans matériel)
+### 0.4 Prochaines étapes — tout ce qui reste (par facteur bloquant)
 
-Faits (session 2026-07-05) : ✅ state machine (`machine.rs`), ✅ accumulateur RX
-(`framing.rs`), ✅ agrégat d'état (`state.rs`), ✅ simulateur d'unité (test end-to-end).
+**Toutes les couches purement logicielles sont faites et testées** (3 composants, §0.3).
+Le schéma de topics est **figé** (`santuario/toshiba/<zone>/{state,command,availability}`
++ `santuario/toshiba/presence/<zone>`). Ce qui reste est **bloqué** par le matériel ou une
+donnée d'appairage :
 
-Fait aussi (session 2026-07-05) : ✅ codec MQTT (`mqtt_payload.rs`) + `apply_command`,
-✅ config nœud + topics (`config.rs`). **Schéma de topics FIGÉ** :
-`santuario/toshiba/<zone>/{state,command,availability}` (la voie Rust définit ses
-propres topics → la contrainte ESPHome « observer au 1er boot » ne s'applique plus).
+**🔌 Bloqué par le matériel ESP32** (firmware, composant A) :
+1. `uart.rs` (ESP‑IDF 9600 8E1) → branche `Client::{on_rx_byte, poll_tx, on_tick}`.
+2. `wifi.rs` + `mqtt.rs` (transport esp‑idf‑svc, consomment `NodeConfig`) + `main.rs`
+   (feature `esp32`). Voir §16 (toolchain) + §17 (réseau). **Aucune logique protocolaire
+   nouvelle** — juste relayer vers `Client`.
 
-➡️ **Toutes les couches purement logicielles sont faites.** Ce qui reste **nécessite
-le matériel ESP32** :
-1. `uart.rs` (ESP-IDF, 9600 8E1, lecture/écriture octets) — branche `on_rx_byte`/`poll_tx`.
-2. `wifi.rs` + `mqtt.rs` (transport esp-idf-svc) + `main.rs` (feature `esp32`).
-3. Tests au banc : handshake réel, analyseur logique, commandes bout-en-bout.
+**🟢 Bloqué par les capteurs FP2** (présence, composants B+C) :
+3. Finaliser `bridge/aqara-fp2-mqtt/fp2_bridge/hap.py` sur un FP2 réel
+   (`discover`/`pair`/`dump`, marqueurs `# VERIFY`) — §18.6.
+4. Câbler la boucle de contrôle EM : souscrire `santuario/toshiba/presence/+`, appliquer
+   `decide_presence` (déjà testé) + débounce, activer `control_enabled` — §18.5.
 
-> À la réception du matériel : lire `README.md` du crate + ce §0, puis ajouter la
-> feature `esp32` (deps esp-idf-svc/hal/sys) et les 4 fichiers ci-dessus qui **ne font
-> que relayer** vers `Client`. Aucune logique protocolaire nouvelle à écrire.
+**🟡 Faisable sans matériel, mais optionnel/prématuré** :
+5. **Télémétrie → Grafana** : faire ingérer `santuario/toshiba/+/state` par
+   `daly-bms-server` (→ séries redb `toshiba_ac_*`) + dashboard provisioning (règle #14).
+   Décision‑neutre, mais sans firmware qui publie encore, rien à afficher.
+
+> À la réception du matériel ESP32 : lire `firmware/toshiba-suzumi-rs/README.md` + ce §0,
+> puis ajouter la feature `esp32` et les 4 fichiers I/O (points 1‑2). Idem FP2 : lire
+> `bridge/aqara-fp2-mqtt/README.md` + §18.
 
 ### 0.5 Journal des sessions
 
@@ -163,6 +191,12 @@ le matériel ESP32** :
   (discover/pair/dump/run), publisher MQTT (paho, LWT), unité systemd, `.gitignore`
   (clés d'appairage = secrets). `hap.py` (aiohomekit) = **scaffold à finaliser sur un FP2
   réel** (`# VERIFY`). Détail → §18.6.
+- **2026-07-06 (suite 10)** — **Revue de code du pont** (Gemini) : 6 remarques appliquées
+  — `close()` attend `wait_for_publish` (offline retained fiable), `heartbeat_secs>0`
+  validé (+ test → **8 tests cœur**), event HomeKit déclenche `emit()` **immédiatement**
+  (heartbeat 30 s), annulation propre dans `dump`, erreurs claires si appairage manquant /
+  appareil introuvable. **§0 finalisé pour reprise** : décisions §0.2 (8), état §0.3 (3
+  composants + compteurs), prochaines étapes §0.4 (par facteur bloquant).
 
 ---
 


### PR DESCRIPTION
…prise (§0)

Revue (6 remarques, toutes appliquées) :
- mqtt_out.close() : wait_for_publish(2s) pour que le "offline" retained parte vraiment (disconnect() ne déclenche pas le LWT → sinon "online" resterait collé).
- core.parse_config : valide heartbeat_secs > 0 (sinon boucle de publication CPU-intensive) + test dédié → 8 tests cœur verts.
- hap.watch : l'event HomeKit déclenche emit() IMMÉDIATEMENT (latence minimale) au lieu de sonder chaque seconde ; boucle de maintien = heartbeat 30 s.
- hap.pair : erreur claire si async_find renvoie None (appareil introuvable).
- hap.watch : erreur claire si le fichier d'appairage est absent (appairer d'abord).
- __main__._cmd_dump : await de la tâche annulée (évite "Task was destroyed").
- import asyncio remonté en tête de hap.py.

Doc (finalisation reprise de session) : §0.2 complété (8 décisions actées, dont réseau/identité, topics figés, contrôle présence, FP2 HomeKit local sur Pi5), §0.3 (3 composants A/B/C + compteurs de tests à jour), §0.4 (reste par facteur bloquant), journal §0.5 (suite 10).


Claude-Session: https://claude.ai/code/session_01R5o2XuifGJPdXfiBxRtsm2