### PR TITLE
feat(daly-bms-server): télémétrie clim Toshiba → redb + dashboard Gra…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ Pi5 (192.168.1.141, pi5compute)
     └── publication MQTT → consommée par daly-bms-server (writes metrics-store)
   grafana-server (systemd, :3000)
     ├── Datasource : "Daly Metrics (redb)" → http://127.0.0.1:8080 (UID: daly-metrics)
-    ├── 21 dashboards provisionés dans /var/lib/grafana/dashboards/
+    ├── 22 dashboards provisionés dans /var/lib/grafana/dashboards/
     └── Données NVMe optionnel (/mnt/nvme/grafana)
 
 NanoPi (192.168.1.120, root)
@@ -188,10 +188,11 @@ contrib/energy-manager.service          ← unité systemd energy-manager
 contrib/journald/daly-bms.conf          ← drop-in journald (plafond journal : SystemMaxUse=200M)
                                           déployé par deploy-pi5.sh → /etc/systemd/journal.conf.d/
 contrib/grafana/                        ← provisioning Grafana complet
-  dashboards/01-bms.json … 21-memoire-daly-bms.json ← 21 dashboards JSON
+  dashboards/01-bms.json … 22-toshiba-clim.json ← 22 dashboards JSON
     (17→20 = dashboards évolués PromQL avancé : flotte/SLO, rendement PV,
      bilan énergie J/J-1, alertes multi-critères — cf. docs/metriques-promql-reference.md §9 ;
-     21 = mémoire process RSS/jemalloc — diagnostic fuite, cf. docs/diagnostic-depannage.md §17)
+     21 = mémoire process RSS/jemalloc — diagnostic fuite, cf. docs/diagnostic-depannage.md §17 ;
+     22 = climatiseurs Toshiba, séries toshiba_ac_* labellisées par zone — cf. docs/toshiba-suzumi-rs-plan.md §0.4)
   provisioning/datasources/daly-metrics.yaml        ← datasource PromQL → :8080
   provisioning/dashboards/daly-bms.yaml             ← provider → /var/lib/grafana/dashboards
 scripts/setup-grafana.sh                ← installation Grafana (première fois)
@@ -428,7 +429,7 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 | Déployer (Pi5 + NanoPi), procédures détaillées, restauration git | `docs/deploiement-exploitation.md` |
 | Architecture redb (schéma, tiering) + historique migration VM→redb | `docs/metriques-redb-architecture.md` |
 | Catalogue des métriques + requêtes & conformité PromQL | `docs/metriques-promql-reference.md` |
-| Grafana — 21 dashboards (liste, datasource, provisioning) | `docs/grafana-dashboards.md` |
+| Grafana — 22 dashboards (liste, datasource, provisioning) | `docs/grafana-dashboards.md` |
 | MQTT / Mosquitto (topics, bridge, anti-boucle, migration Docker→natif) | `docs/mqtt-mosquitto.md` |
 | Alertes (AlertEngine natif, règles, hysteresis, notifications) | `docs/alertes.md` |
 | Ajouter un appareil / BMS Daly, ATS CHINT, ET112, PRALRAN | `docs/integration-materiel.md` |

--- a/contrib/grafana/dashboards/22-toshiba-clim.json
+++ b/contrib/grafana/dashboards/22-toshiba-clim.json
@@ -1,0 +1,447 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Télémétrie des climatiseurs Toshiba (firmware ESP32 → santuario/toshiba/<zone>/state → séries redb toshiba_ac_*). Séries labellisées par zone (Shorai-3x).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Climatiseurs Toshiba",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "État (Marche / Arrêt)",
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "toshiba_ac_power",
+          "legendFormat": "{{zone}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "grey"
+              },
+              {
+                "value": 0.5,
+                "color": "green"
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Arrêt"
+                },
+                "1": {
+                  "text": "Marche"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Niveau de puissance",
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "toshiba_ac_pwr_level_pct",
+          "legendFormat": "{{zone}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 75,
+                "color": "orange"
+              },
+              {
+                "value": 100,
+                "color": "red"
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Auto-nettoyage",
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "toshiba_ac_self_clean",
+          "legendFormat": "{{zone}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "grey"
+              },
+              {
+                "value": 0.5,
+                "color": "blue"
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Non"
+                },
+                "1": {
+                  "text": "En cours"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Température : ambiante vs consigne (par pièce)",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "toshiba_ac_current_temp_c",
+          "legendFormat": "{{zone}} — ambiante",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "toshiba_ac_target_temp_c",
+          "legendFormat": "{{zone}} — consigne",
+          "refId": "B"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "drawStyle": "line",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*consigne.*"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    8,
+                    4
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Température extérieure (par unité)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "toshiba_ac_outdoor_temp_c",
+          "legendFormat": "{{zone}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "drawStyle": "line",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Niveau de puissance (par pièce)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "daly-metrics"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "daly-metrics"
+          },
+          "expr": "toshiba_ac_pwr_level_pct",
+          "legendFormat": "{{zone}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "drawStyle": "line",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "daly-bms",
+    "toshiba",
+    "climatisation",
+    "hvac"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Daly Metrics (redb)",
+          "value": "daly-metrics"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "label": "Datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Climatiseurs Toshiba",
+  "uid": "daly-toshiba-22",
+  "version": 1
+}

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -531,6 +531,8 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
         ("santuario/em/metrics", SUB_QOS),
         ("santuario/em/water_heater", SUB_QOS),
         ("santuario/em/solar", SUB_QOS),
+        // Télémétrie clim Toshiba (firmware ESP32) → séries redb toshiba_ac_*.
+        ("santuario/toshiba/+/state", SUB_QOS),
     ];
 
     for (topic, qos) in &topics {
@@ -596,6 +598,8 @@ pub async fn start_venus_mqtt_subscriber(state: AppState, cfg: MqttConfig) {
                         handle_wh_metrics_topic(&state, &json);
                     } else if topic == "santuario/em/solar" {
                         handle_em_solar_topic(&state, &json).await;
+                    } else if topic.starts_with("santuario/toshiba/") && topic.ends_with("/state") {
+                        handle_toshiba_state_topic(&state, topic, &json);
                     }
                 }
             }
@@ -960,6 +964,37 @@ fn handle_em_metrics_topic(state: &AppState, json: &Value) {
         net_tx_bps:     f("net_tx_bps"),
     };
     crate::redb_writes::write_em_metrics(&store.writer(), &state.redb_rl, &payload);
+}
+
+/// Traite `santuario/toshiba/<zone>/state` — télémétrie clim Toshiba publiée par
+/// le firmware ESP32 (cf. `docs/toshiba-suzumi-rs-plan.md`). Historise les champs
+/// numériques dans redb en séries `toshiba_ac_*` labellisées par `zone`.
+///
+/// Payload (tous champs optionnels) : `{ "power": true, "mode": "cool",
+/// "target_temp": 24, "current_temp": 21, "outdoor_temp": 8, "pwr_level": 100,
+/// "self_clean": false, ... }`.
+fn handle_toshiba_state_topic(state: &AppState, topic: &str, json: &Value) {
+    let Some(store) = &state.metrics_store else { return };
+    // santuario/toshiba/<zone>/state → <zone>
+    let Some(zone) = topic
+        .strip_prefix("santuario/toshiba/")
+        .and_then(|s| s.strip_suffix("/state"))
+        .filter(|z| !z.is_empty())
+    else {
+        return;
+    };
+
+    let b = |k: &str| json.get(k).and_then(|v| v.as_bool());
+    let f = |k: &str| json.get(k).and_then(|v| v.as_f64()).map(|v| v as f32);
+    let metrics = crate::redb_writes::ToshibaAcMetrics {
+        power:          b("power"),
+        target_temp_c:  f("target_temp"),
+        current_temp_c: f("current_temp"),
+        outdoor_temp_c: f("outdoor_temp"),
+        pwr_level_pct:  f("pwr_level"),
+        self_clean:     b("self_clean"),
+    };
+    crate::redb_writes::write_toshiba_ac(&store.writer(), &state.redb_rl, zone, &metrics);
 }
 
 /// Traite le topic `santuario/em/solar` — télémétrie solaire agrégée publiée

--- a/crates/daly-bms-server/src/redb_writes.rs
+++ b/crates/daly-bms-server/src/redb_writes.rs
@@ -389,6 +389,59 @@ pub fn write_et112(writer: &Writer, rl: &RateLimiter, snap: &Et112Snapshot) {
 }
 
 // =============================================================================
+// Toshiba climatiseurs (télémétrie publiée par le firmware ESP32 sur
+// santuario/toshiba/<zone>/state ; séries labellisées par `zone`)
+// =============================================================================
+
+/// Métriques numériques d'une clim Toshiba (tous champs optionnels — l'unité
+/// renseigne au fil de l'eau). Les champs chaîne (mode/fan/swing/preset) ne sont
+/// pas historisés ici (non numériques).
+#[derive(Default)]
+pub struct ToshibaAcMetrics {
+    pub power: Option<bool>,
+    pub target_temp_c: Option<f32>,
+    pub current_temp_c: Option<f32>,
+    pub outdoor_temp_c: Option<f32>,
+    pub pwr_level_pct: Option<f32>,
+    pub self_clean: Option<bool>,
+}
+
+pub fn write_toshiba_ac(writer: &Writer, rl: &RateLimiter, zone: &str, m: &ToshibaAcMetrics) {
+    let ts = now_ms();
+
+    if let Some(p) = m.power {
+        push(writer, rl, MIN_WRITE_INTERVAL, format_args!("toshiba_ac_power:{zone}"),
+             || Sample::new("toshiba_ac_power", ts, p as i32 as f64)
+                .with_label("zone", zone.to_string()));
+    }
+    if let Some(v) = m.target_temp_c {
+        push(writer, rl, TEMP_WRITE_INTERVAL, format_args!("toshiba_ac_target_temp_c:{zone}"),
+             || Sample::new("toshiba_ac_target_temp_c", ts, v as f64)
+                .with_label("zone", zone.to_string()));
+    }
+    if let Some(v) = m.current_temp_c {
+        push(writer, rl, TEMP_WRITE_INTERVAL, format_args!("toshiba_ac_current_temp_c:{zone}"),
+             || Sample::new("toshiba_ac_current_temp_c", ts, v as f64)
+                .with_label("zone", zone.to_string()));
+    }
+    if let Some(v) = m.outdoor_temp_c {
+        push(writer, rl, TEMP_WRITE_INTERVAL, format_args!("toshiba_ac_outdoor_temp_c:{zone}"),
+             || Sample::new("toshiba_ac_outdoor_temp_c", ts, v as f64)
+                .with_label("zone", zone.to_string()));
+    }
+    if let Some(v) = m.pwr_level_pct {
+        push(writer, rl, MIN_WRITE_INTERVAL, format_args!("toshiba_ac_pwr_level_pct:{zone}"),
+             || Sample::new("toshiba_ac_pwr_level_pct", ts, v as f64)
+                .with_label("zone", zone.to_string()));
+    }
+    if let Some(sc) = m.self_clean {
+        push(writer, rl, MIN_WRITE_INTERVAL, format_args!("toshiba_ac_self_clean:{zone}"),
+             || Sample::new("toshiba_ac_self_clean", ts, sc as i32 as f64)
+                .with_label("zone", zone.to_string()));
+    }
+}
+
+// =============================================================================
 // Irradiance
 // =============================================================================
 

--- a/docs/grafana-dashboards.md
+++ b/docs/grafana-dashboards.md
@@ -2,7 +2,7 @@
 
 > Guide complet de l'intégration Grafana sur le Raspberry Pi 5 : installation automatique
 > ou manuelle, configuration de la datasource PromQL vers `daly-bms-server` (redb,
-> UID `daly-metrics`), provisioning complet, catalogue des 21 dashboards, monitoring
+> UID `daly-metrics`), provisioning complet, catalogue des 22 dashboards, monitoring
 > PV solaire et dépannage.
 > Fait partie de l'[architecture documentaire](./ARCHITECTURE.md).
 > Dernière consolidation : 2026-06-07.
@@ -36,7 +36,7 @@
   - [6.2 Via fix-grafana.sh (import API — contourne bug Grafana 11+)](#62-via-fix-grafanash-import-api--contourne-bug-grafana-11)
   - [6.3 Copie manuelle](#63-copie-manuelle)
   - [6.4 Commandes Grafana de référence rapide](#64-commandes-grafana-de-reference-rapide)
-- [7. Catalogue des 21 dashboards](#7-catalogue-des-21-dashboards)
+- [7. Catalogue des 22 dashboards](#7-catalogue-des-22-dashboards)
   - [7.1 Dashboards 01 à 16 — Vue opérationnelle](#71-dashboards-01-a-16--vue-operationnelle)
   - [7.2 Dashboards 17 à 20 — PromQL avancé (Flotte, PV, Bilan, Alertes)](#72-dashboards-17-a-20--promql-avance-flotte-pv-bilan-alertes)
 - [8. Monitoring PV solaire — Dashboard comparaison 5 ans](#8-monitoring-pv-solaire--dashboard-comparaison-5-ans)
@@ -65,7 +65,7 @@ une datasource de type Prometheus (UID `daly-metrics`) pointant sur
 │   Grafana       │ ←────────────── │ daly-bms-server (redb :8080)         │
 │   (:3000)       │  /api/v1/query  │   (Stockage metrics-store — redb)    │
 │                 │  /query_range   │   Tiering raw 30 j / hourly 365 j /  │
-│   21 dashboards │  /labels        │   daily 5 ans                        │
+│   22 dashboards │  /labels        │   daily 5 ans                        │
 │   provisionnés  │                 │   Alimenté par :                     │
 └─────────────────┘                 │    - polling RS485 (BMS, ET112, ATS) │
                                     │    - MQTT (energy-manager, Victron)  │
@@ -76,7 +76,7 @@ une datasource de type Prometheus (UID `daly-metrics`) pointant sur
 les plugins sont stockés sur `/mnt/nvme/grafana` au lieu de la SD/eMMC — fortement
 recommandé en production.
 
-**21 dashboards provisionés** dans `/var/lib/grafana/dashboards/`, tous au format
+**22 dashboards provisionés** dans `/var/lib/grafana/dashboards/`, tous au format
 provisioning (pas export), tous utilisant l'UID datasource `daly-metrics`.
 
 > ⚠️ **Note architecture** : `daly-bms-server` embarque le metrics-store redb directement
@@ -150,7 +150,7 @@ Installation Grafana terminée
   URL          : http://192.168.1.141:3000
   Login        : admin / admin  (changer à la 1ʳᵉ connexion)
   Datasource   : Daly Metrics (redb) → http://127.0.0.1:8080  (provisionnée)
-  Dashboards   : 21 dashboards Grafana (dossier Daly-BMS)
+  Dashboards   : 22 dashboards Grafana (dossier Daly-BMS)
   Données NVMe : /mnt/nvme/grafana/
 
   Logs         : journalctl -u grafana-server -f
@@ -308,7 +308,7 @@ Paramètres clés :
 | `manageAlerts` | `false` | Ne pas déléguer les alertes à Grafana |
 
 > **IMPORTANT** : L'UID `daly-metrics` est la valeur de référence utilisée par les
-> 21 dashboards. Ne jamais utiliser `${datasource}` (format export) ni changer cet UID.
+> 22 dashboards. Ne jamais utiliser `${datasource}` (format export) ni changer cet UID.
 
 ### 4.2 Configuration manuelle via l'interface Grafana
 
@@ -387,7 +387,8 @@ contrib/grafana/
 │   ├── 18-rendement-pv.json
 │   ├── 19-bilan-energie.json
 │   ├── 20-alertes-avancees.json
-│   └── 21-memoire-daly-bms.json
+│   ├── 21-memoire-daly-bms.json
+│   └── 22-toshiba-clim.json
 └── provisioning/
     ├── datasources/
     │   └── daly-metrics.yaml        ← datasource PromQL → :8080
@@ -409,7 +410,8 @@ Déployé vers (sur le Pi5) :
 ├── 02-et112.json
 ... (20 fichiers)
 ├── 20-alertes-avancees.json
-└── 21-memoire-daly-bms.json
+├── 21-memoire-daly-bms.json
+└── 22-toshiba-clim.json
 ```
 
 ### 5.2 Provider dashboards (daly-bms.yaml)
@@ -485,7 +487,7 @@ print('OK — format provisioning correct')
 ### 6.1 Via deploy-pi5.sh (méthode standard)
 
 `scripts/deploy-pi5.sh` déploie l'ensemble (binaires + mosquitto.conf + Grafana) en une
-seule commande. Il inclut automatiquement le déploiement des 21 dashboards Grafana.
+seule commande. Il inclut automatiquement le déploiement des 22 dashboards Grafana.
 
 ```bash
 # Déploiement complet (binaires + dashboards)
@@ -576,7 +578,7 @@ sudo systemctl restart grafana-server
 
 ---
 
-## 7. Catalogue des 21 dashboards
+## 7. Catalogue des 22 dashboards
 
 Tous les dashboards sont dans le dossier Grafana **Daly-BMS**, provisionnés depuis
 `/var/lib/grafana/dashboards/`. Chaque JSON respecte les règles de format provisioning
@@ -923,6 +925,28 @@ process_jemalloc_allocated_bytes - (process_jemalloc_allocated_bytes offset 1h)
 process_rss_bytes - process_jemalloc_allocated_bytes
 ```
 
+### 7.3 Dashboard 22 — Climatiseurs Toshiba
+
+#### Dashboard 22 — Climatiseurs Toshiba
+**Fichier** : `22-toshiba-clim.json` | **UID** : `daly-toshiba-22` | **Tags** : `daly-bms`, `toshiba`, `climatisation`, `hvac`
+
+Télémétrie des 3 (→ 7 à terme) clim **Toshiba Shorai Edge**, publiée par le firmware
+ESP32 sur `santuario/toshiba/<zone>/state` → ingérée par `daly-bms-server`
+(`bridges/mqtt.rs::handle_toshiba_state_topic` → `redb_writes::write_toshiba_ac`) en
+séries **`toshiba_ac_*`** labellisées par **`zone`** (`Shorai-31/32/33`).
+
+Panels :
+- **État (Marche/Arrêt)** par pièce — `toshiba_ac_power` (0/1).
+- **Niveau de puissance** — `toshiba_ac_pwr_level_pct` (%).
+- **Auto-nettoyage** — `toshiba_ac_self_clean` (0/1).
+- **Température : ambiante vs consigne** par pièce — `toshiba_ac_current_temp_c` /
+  `toshiba_ac_target_temp_c` (consigne en pointillés).
+- **Température extérieure** — `toshiba_ac_outdoor_temp_c`.
+
+> Les champs chaîne (`mode`/`fan`/`swing`/`preset`) ne sont **pas** historisés (non
+> numériques). Tant qu'aucun firmware ne publie encore, le dashboard est **vide**
+> (attendu). Cf. `docs/toshiba-suzumi-rs-plan.md` §0.4 #5 + §18.
+
 ---
 
 ## 8. Monitoring PV solaire — Dashboard comparaison 5 ans
@@ -974,7 +998,7 @@ copier le fichier `metrics.redb` pour archivage externe.
 
 Le dashboard `pv-solar-5y` (titre : *PV Solaire - Monitoring & Comparaison 5 Ans*) est
 un dashboard autonome disponible dans `docs/Solar_PV.json` et `docs/grafana-pv_dashboard.json`.
-Il est distinct des 21 dashboards provisionnés (il est orienté import manuel ou intégration
+Il est distinct des 22 dashboards provisionnés (il est orienté import manuel ou intégration
 dans une présentation PV).
 
 **Structure en sections (rows)** :
@@ -1002,7 +1026,7 @@ dans une présentation PV).
 | Variable template | `$datasource` (type datasource Prometheus) |
 
 > ⚠️ Ce dashboard utilise `${datasource}` comme variable de template (format import),
-> contrairement aux 21 dashboards provisionnés qui utilisent directement l'UID
+> contrairement aux 22 dashboards provisionnés qui utilisent directement l'UID
 > `daly-metrics`. Lors d'un import manuel, sélectionner la datasource "Daly Metrics (redb)".
 
 ### 8.3 Requêtes PromQL pour le monitoring PV

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -137,10 +137,12 @@ donnée d'appairage :
    1 Hz + publication débouncée, testée) — §18.5. **Reste juste** : activer `control_enabled`
    dans Config.toml une fois les FP2 posés et la présence qui arrive sur le broker.
 
-**🟡 Faisable sans matériel, mais optionnel/prématuré** :
-5. **Télémétrie → Grafana** : faire ingérer `santuario/toshiba/+/state` par
-   `daly-bms-server` (→ séries redb `toshiba_ac_*`) + dashboard provisioning (règle #14).
-   Décision‑neutre, mais sans firmware qui publie encore, rien à afficher.
+**✅ Fait (sans matériel)** :
+5. **Télémétrie → Grafana** — ✅ **fait** : `daly-bms-server` ingère `santuario/toshiba/+/state`
+   (`bridges/mqtt.rs::handle_toshiba_state_topic` → `redb_writes::write_toshiba_ac`) en séries
+   redb **`toshiba_ac_*`** labellisées par `zone` + **dashboard 22** provisionné
+   (`contrib/grafana/dashboards/22-toshiba-clim.json`, format règle #14). **Vide tant qu'aucun
+   firmware ne publie** (attendu). Détail → `docs/grafana-dashboards.md` §7.3.
 
 > À la réception du matériel ESP32 : lire `firmware/toshiba-suzumi-rs/README.md` + ce §0,
 > puis ajouter la feature `esp32` et les 4 fichiers I/O (points 1‑2). Idem FP2 : lire
@@ -276,6 +278,16 @@ donnée d'appairage :
   `control_enabled=false`** (défaut Config.toml). `cargo test -p energy-manager toshiba` =
   **14 tests** verts, **clippy `-D warnings` propre**, `--check-config` OK. Reste : poser
   les FP2 + activer le flag. Composant B (§0.3) ✅. **Prochaine étape #1 terminée.**
+- **2026-07-07 (suite 18)** — **Télémétrie Toshiba → Grafana (#3, §0.4 #5)** — CODE.
+  `daly-bms-server` : souscription `santuario/toshiba/+/state` +
+  `handle_toshiba_state_topic` (`bridges/mqtt.rs`) → `redb_writes::write_toshiba_ac` (nouveau,
+  + struct `ToshibaAcMetrics`) qui historise `toshiba_ac_{power,target_temp_c,current_temp_c,
+  outdoor_temp_c,pwr_level_pct,self_clean}` labellisés par **`zone`** (rate-limité comme
+  les autres séries). **Dashboard 22** provisionné (`22-toshiba-clim.json`, uid
+  `daly-toshiba-22`, format règle #14 vérifié : pas de `__inputs`, datasource `daly-metrics`).
+  `clippy -D warnings` propre, `cargo test -p daly-bms-server` = 22 tests verts, 22 dashboards
+  JSON valides. Champs chaîne (mode/fan/swing/preset) non historisés. **Vide tant qu'aucun
+  firmware ne publie** (attendu). Doc : §0.4 #5, `grafana-dashboards.md` §7.3, CLAUDE.md (22).
 
 ---
 


### PR DESCRIPTION
…fana (#3)

Fait ingérer santuario/toshiba/<zone>/state par daly-bms-server et l'historise dans redb en séries toshiba_ac_* labellisées par zone, + un dashboard provisionné.

redb_writes.rs :
- struct ToshibaAcMetrics + write_toshiba_ac(writer, rl, zone, m) : séries toshiba_ac_{power,target_temp_c,current_temp_c,outdoor_temp_c,pwr_level_pct, self_clean} avec label zone, rate-limitées comme les autres écritures.

bridges/mqtt.rs :
- souscription santuario/toshiba/+/state + handle_toshiba_state_topic (extrait la zone du topic, parse le JSON d'état, écrit les métriques numériques).

contrib/grafana/dashboards/22-toshiba-clim.json :
- dashboard "Climatiseurs Toshiba" (uid daly-toshiba-22), format provisioning (datasource daly-metrics, pas de __inputs) : état marche/arrêt, niveau de puissance, auto-nettoyage, ambiante vs consigne, température extérieure.

Les champs chaîne (mode/fan/swing/preset) ne sont pas historisés (non numériques). Vide tant qu'aucun firmware ne publie (attendu).

clippy -D warnings propre ; cargo test -p daly-bms-server = 22 tests verts ; 22 dashboards JSON validés (uid unique, pas de __inputs/__requires).

Doc : plan §0.4 #5 + journal (suite 18), grafana-dashboards.md §7.3, CLAUDE.md (22).


Claude-Session: https://claude.ai/code/session_01HEDbizfgG3aycVMrhE62Gj