### PR TITLE
docs(toshiba): doc opérationnelle dédiée des ponts/crates + décision …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,6 +434,7 @@ Dashboard SSR (Askama) : `/dashboard`, `/dashboard/bms/:id`,
 | Alertes (AlertEngine natif, règles, hysteresis, notifications) | `docs/alertes.md` |
 | Ajouter un appareil / BMS Daly, ATS CHINT, ET112, PRALRAN | `docs/integration-materiel.md` |
 | **Clim Toshiba SHORAI EDGE — VOIE RETENUE = firmware RUST natif ESP32** (protocole SUZUMI CN22 vérifié vs pedobry + o0Zz ; PAS ESPHome). **Reprise de session → §0 du doc.** Crate détaché `firmware/toshiba-suzumi-rs/` (couche protocole pure faite + testée host ; ESP32 en attente matériel). Test : `cargo test --manifest-path firmware/toshiba-suzumi-rs/Cargo.toml` | `docs/toshiba-suzumi-rs-plan.md` |
+| Clim Toshiba / FP2 — **référence opérationnelle des ponts & crates** (contrat MQTT, carte des composants A–E, pipeline présence, HomeKit **D** vs Matter **E**, commandes/tests). Allège le plan. | `docs/toshiba-bridges.md` |
 | Clim Toshiba — **référence câblage/MQTT** (BOM, brochage CN22, topics `santuario/toshiba`, module EM `logic/toshiba_ac`, conso Tongou) — ⚠️ voie ESPHome **non retenue**, YAML §4 obsolète | `docs/integration-toshiba-shorai-esphome.md` |
 | Dépannage, netdiag réseau, debug onduleur/SmartShunt, memory-leak | `docs/diagnostic-depannage.md` |
 | **Audit robustesse 2026-06** — 18 axes (§3-§18 implémentés ; §1-§2 sécurité en attente d'action utilisateur) | `docs/audit-robustesse-2026-06.md` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,17 +44,23 @@ transverse**. Tous les documents vivent dans `docs/`.
 | [deploiement-exploitation.md](./deploiement-exploitation.md) | Build (cibles Makefile), workflow de déploiement Pi5 + NanoPi, services systemd, logs/rétention, restauration git, conventions Git. |
 | [metriques-redb-architecture.md](./metriques-redb-architecture.md) | Moteur TSDB **redb** : schéma, encodage, write/read path, tiering & rétention. Annexe historique : migration VictoriaMetrics → redb. |
 | [metriques-promql-reference.md](./metriques-promql-reference.md) | **Catalogue des métriques** (labels hex), requêtes PromQL par appareil, roadmap d'implémentation, audit de conformité PromQL. |
-| [grafana-dashboards.md](./grafana-dashboards.md) | Grafana : installation, datasource (UID `daly-metrics`), provisioning, **21 dashboards**, monitoring PV. |
+| [grafana-dashboards.md](./grafana-dashboards.md) | Grafana : installation, datasource (UID `daly-metrics`), provisioning, **22 dashboards**, monitoring PV. |
 | [mqtt-mosquitto.md](./mqtt-mosquitto.md) | Architecture MQTT : Mosquitto natif systemd, topics `santuario/*`, bridge `pi5-nanopi`, anti-boucle, migration Docker → natif. |
 | [alertes.md](./alertes.md) | **AlertEngine** natif Rust : règles + hysteresis, persistance SQLite, notifications Telegram/SMTP, API alertes. |
 | [integration-materiel.md](./integration-materiel.md) | Inventaire RS485/D-Bus, **ajout d'un BMS Daly**, ATS CHINT, ET112, PRALRAN, Tasmota/Shelly. |
 | [integration-toshiba-shorai-esphome.md](./integration-toshiba-shorai-esphome.md) | **Plan d'intégration Toshiba SHORAI EDGE** (×3) : ESP32 + ESPHome `toshiba_suzumi` sur CN22 → MQTT Mosquitto → module EM `logic/toshiba_ac`. BOM, câblage, phases. |
+| [toshiba-suzumi-rs-plan.md](./toshiba-suzumi-rs-plan.md) | **Projet Toshiba — firmware Rust ESP32 + décisions d'intégration** (protocole SUZUMI vérifié, §18 décisions FP2/HomeKit/Homie/HomeSpan/Matter, reprise de session §0). Lourd → détail opérationnel déporté ci-dessous. |
+| [toshiba-bridges.md](./toshiba-bridges.md) | **Ponts & crates Toshiba/FP2 — référence opérationnelle** : contrat MQTT, carte des composants **A–E**, pipeline présence, HomeKit **D** vs Matter **E**, commandes/tests. |
 | [diagnostic-depannage.md](./diagnostic-depannage.md) | Dépannage transverse, `netdiag` réseau, debug onduleur/SmartShunt, investigation memory-leak (en cours). |
 
 ### Hors `docs/`
 
 - [`CLAUDE.md`](../CLAUDE.md) (racine) — mémoire projet : commandes rapides, inventaire RS485/D-Bus, règles de travail. Chargé à chaque session.
 - [`nanoPi/README.md`](../nanoPi/README.md) — README de composant pour la configuration Venus OS du NanoPi.
+- [`firmware/toshiba-suzumi-rs/README.md`](../firmware/toshiba-suzumi-rs/README.md) — crate détaché : firmware ESP32 (protocole SUZUMI). Composant **A**.
+- [`bridge/aqara-fp2-mqtt/README.md`](../bridge/aqara-fp2-mqtt/README.md) — pont FP2 → MQTT présence (aiohomekit). Composant **C**.
+- [`bridge/mqtt-homekit-occupancy/README.md`](../bridge/mqtt-homekit-occupancy/README.md) — pont MQTT → HomeKit (HAP-python). Composant **D**.
+- [`bridge/matter-toshiba-rs/README.md`](../bridge/matter-toshiba-rs/README.md) — crate détaché : bridge Matter (Rust, sans Node). Composant **E**.
 - [`README.md`](../README.md) (racine) — page d'accueil du dépôt.
 
 ---
@@ -118,7 +124,7 @@ Détails : [intégration matériel](./integration-materiel.md) · [MQTT](./mqtt-
 | **energy-manager** | Pi5 | 8081 | Automatisation énergie (solaire, DEYE, chauffe-eau, charge, météo) | [app-energy-manager.md](./app-energy-manager.md) |
 | **Mosquitto** | Pi5 | 1883 / 9001 | Broker MQTT natif systemd, bridge `pi5-nanopi` | [mqtt-mosquitto.md](./mqtt-mosquitto.md) |
 | **metrics-store (redb)** | Pi5 | (embarqué :8080) | TSDB pure-Rust, tiering raw 30 j / hourly 365 j / daily 5 ans | [metriques-redb-architecture.md](./metriques-redb-architecture.md) |
-| **grafana-server** | Pi5 | 3000 | Visualisation (datasource PromQL → :8080), 21 dashboards | [grafana-dashboards.md](./grafana-dashboards.md) |
+| **grafana-server** | Pi5 | 3000 | Visualisation (datasource PromQL → :8080), 22 dashboards | [grafana-dashboards.md](./grafana-dashboards.md) |
 | **dbus-mqtt-venus** | NanoPi | — | Bridge MQTT → D-Bus Venus OS (zbus) | [app-dbus-mqtt-venus.md](./app-dbus-mqtt-venus.md) |
 
 ---

--- a/docs/toshiba-bridges.md
+++ b/docs/toshiba-bridges.md
@@ -1,0 +1,134 @@
+# Ponts & crates d'intégration Toshiba / FP2 — **référence opérationnelle**
+
+> Cette doc porte le **quoi/comment** des composants (crates, ponts, contrat MQTT, tests).
+> Le **pourquoi** (décisions, comparatifs, sources) reste dans
+> [`toshiba-suzumi-rs-plan.md`](./toshiba-suzumi-rs-plan.md) **§18** (et la reprise de session
+> en **§0**). But : alléger le plan, devenu lourd, en sortant le détail opérationnel ici.
+
+---
+
+## 1. Vue d'ensemble
+
+```
+                         ┌──────────────── Pi5 (broker Mosquitto = dorsal) ─────────────────┐
+Clim Toshiba ×3→7        │                                                                  │
+  ↕ CN22 (UART SUZUMI)   │   santuario/toshiba/<zone>/state ─► energy-manager (B, lecture)  │
+[A] ESP32 (Rust+MQTT) ───┼──►                               ─► daly-bms-server (redb + Grafana 22)
+                         │                                  ─► [E] bridge Matter (Thermostat)│
+                         │   santuario/toshiba/<zone>/command ◄─ energy-manager (B, présence)│
+                         │                                    ◄─ [E] bridge Matter (écriture) │
+FP2 ×7 (WiFi/HomeKit) ───┼──[C] aiohomekit→MQTT─► presence/<zone> ─► energy-manager (B)      │
+                         │                                        ─► [D] MQTT→HomeKit (Apple)│
+                         │                                        ─► [E] Matter Occupancy (futur)
+Passerelle (Homey/Apple/Google) ◄──── Matter multi-fabric ──── [E] bridge Matter (Pi5)       │
+                         └──────────────────────────────────────────────────────────────────┘
+```
+
+**Principe directeur** (cf. plan §18.11/§18.12) : **un seul dorsal = MQTT**, source de vérité.
+Les protocoles smart-home (HomeKit, Matter) vivent **au bord**, sur le **Pi5** (traducteurs),
+jamais sur les ESP32 contraints. Le firmware ESP32 reste **Rust + MQTT**, léger.
+
+---
+
+## 2. Contrat MQTT (figé)
+
+Préfixe **local** `santuario/toshiba/…` — **non** relayé par le bridge NanoPi (règle #11).
+
+| Topic | Sens | Payload | Producteur → Consommateur(s) |
+|-------|------|---------|------------------------------|
+| `santuario/toshiba/<zone>/state` | télémétrie | `{power,mode,target_temp,current_temp,outdoor_temp,fan,swing,preset,pwr_level,self_clean}` | firmware **A** → EM **B** (lecture), daly-bms-server (redb `toshiba_ac_*`), bridge Matter **E** |
+| `santuario/toshiba/<zone>/command` | commande | `{power,mode,target_temp,preset,…}` (partiel) | EM **B** (présence) + bridge Matter **E** (écriture) → firmware **A** |
+| `santuario/toshiba/<zone>/availability` | dispo | `online`/`offline` (LWT) | firmware **A** |
+| `santuario/toshiba/presence/<zone>` | présence | `{"present":bool,"ts":epoch}` (retained) | pont FP2 **C** → EM **B** (contrôle), HomeKit **D**, Matter **E** (futur) |
+| `santuario/toshiba/presence/bridge/availability` | dispo | LWT du pont **C** | pont FP2 **C** |
+| `santuario/toshiba/presence/homekit-bridge/availability` | dispo | LWT du pont **D** | pont **D** |
+
+`<zone>` = nom du nœud Toshiba (`Shorai-31/32/33`, → 7). La présence est publiée **sous le
+même nom de zone** que la clim → **pas de table de mapping** côté EM/bridges.
+
+---
+
+## 3. Carte des composants
+
+| | Composant | Emplacement | Techno | Tests | README | Statut |
+|---|-----------|-------------|--------|-------|--------|--------|
+| **A** | Firmware ESP32 (protocole SUZUMI) | `firmware/toshiba-suzumi-rs/` | Rust (détaché) | `cargo test --manifest-path firmware/toshiba-suzumi-rs/Cargo.toml` (**39**) | [lien](../firmware/toshiba-suzumi-rs/README.md) | ✅ protocole pur ; ⏳ I/O ESP-IDF (matériel) |
+| **B** | Module EM `logic/toshiba_ac` | `crates/energy-manager/src/logic/toshiba_ac/` | Rust (workspace) | `cargo test -p energy-manager toshiba` (**14**) | plan §18.5 | ✅ lecture + **contrôle présence câblé** ; inerte tant que `control_enabled=false` |
+| **C** | Pont FP2 → MQTT présence | `bridge/aqara-fp2-mqtt/` | Python (aiohomekit) | `python3 bridge/aqara-fp2-mqtt/tests/test_core.py` (**8**) | [lien](../bridge/aqara-fp2-mqtt/README.md) | ✅ cœur pur ; ⏳ `hap.py` (FP2 réel) |
+| **D** | Pont MQTT → HomeKit (occupation) | `bridge/mqtt-homekit-occupancy/` | Python (HAP-python) | `python3 bridge/mqtt-homekit-occupancy/tests/test_core.py` (**10**) | [lien](../bridge/mqtt-homekit-occupancy/README.md) | ✅ cœur pur ; ⏳ `accessory.py`/`mqtt_in.py` (appairage) — **voir §5 : superseded par E** |
+| **E** | Bridge Matter (passerelle) | `bridge/matter-toshiba-rs/` | Rust (détaché, **sans Node**) | `cargo test --manifest-path bridge/matter-toshiba-rs/Cargo.toml` (**15**) | [lien](../bridge/matter-toshiba-rs/README.md) | ✅ cœur pur ; ⏳ transport rs-matter (passerelle) |
+
+> **Patron commun** à C/D/E (et A) : **cœur pur testé sur host** (logique/mapping, zéro I/O) +
+> **couche transport** à finaliser (marquée TODO/`# VERIFY`). Les décisions ayant conduit à
+> chaque brique sont dans le plan §18.
+
+---
+
+## 4. Pipeline présence FP2 → contrôle clim (C → B)
+
+1. **C** (`aiohomekit`, Pi5) s'appaire à chaque FP2 en **HomeKit local** (le FP2 est WiFi+HomeKit,
+   pas Zigbee), agrège ses zones (OU) et publie `presence/<zone>` *retained*.
+2. **B** (`logic/toshiba_ac`) souscrit `santuario/toshiba/presence/+`, alimente `PresenceControl`
+   (pur), et au tick 1 Hz applique `decide_presence` (**ECO dès absence, OFF après
+   `off_after_secs`**) → publie `presence_command_json` sur `.../<zone>/command` **sur changement**.
+3. **Inerte** tant que `[energy_manager.toshiba_ac].control_enabled=false`. À la pose des FP2 :
+   régler le **délai d'absence du FP2 court** (sinon ses 10 min masquent nos 5 min — plan §18.9),
+   puis `control_enabled=true`.
+
+Détail décision → plan §18 (§18.2/§18.3/§18.5).
+
+---
+
+## 5. Les deux bords smart-home — **D (HomeKit) vs E (Matter)** et la décision
+
+Les ponts **D** et **E** ré-exposent nos données vers un écosystème. Ils ne sont **pas
+complémentaires** : ce sont **deux barreaux de la même échelle**.
+
+| | **D. `mqtt-homekit-occupancy`** | **E. `matter-toshiba-rs`** |
+|---|---|---|
+| Sortie | **HomeKit seul** (app Maison iPhone) | **Matter multi-fabric** : Apple **+** Homey **+** Google simultanés |
+| Couvre l'app Maison ? | ✅ | ✅ (Apple Home **est** un contrôleur Matter) |
+| Portée | présence (Occupancy) | clim (Thermostat) **+** présence (Occupancy, à ajouter) |
+| Disponibilité | **maintenant**, sans passerelle | **futur** (transport rs-matter + passerelle) |
+| Techno | Python (HAP-python) | Rust (sans Node) |
+
+**Décision (2026-07-07) : E supersède D.** Puisque **Apple Home consomme Matter**, un endpoint
+**Occupancy** exposé par **E** apparaît dans l'app Maison **comme** le fait **D**, **plus** Homey
+et Google. Conséquences :
+
+- **D = stopgap** : à n'utiliser que pour obtenir les **tuiles présence dans Apple Home**
+  **avant** d'avoir câblé le transport Matter (D est prêt et ne dépend d'aucune passerelle).
+- **E = cible** : quand le bridge Matter tourne, on lui ajoute un mapping **présence→Occupancy**
+  (trivial : `{"present":bool}` → `OccupancyDetected`) et **on retire D**. Un seul pont pour
+  **clim + présence**, multi-écosystème.
+
+Rationale complet → plan **§18.9** (scénario C) + **§18.12** (Matter).
+
+---
+
+## 6. Commandes rapides
+
+```bash
+# Tests (cœurs purs — sans matériel)
+cargo test --manifest-path firmware/toshiba-suzumi-rs/Cargo.toml     # A (39)
+cargo test -p energy-manager toshiba                                 # B (14)
+python3 bridge/aqara-fp2-mqtt/tests/test_core.py                     # C (8)
+python3 bridge/mqtt-homekit-occupancy/tests/test_core.py            # D (10)
+cargo test --manifest-path bridge/matter-toshiba-rs/Cargo.toml       # E (15)
+
+# Valider un pont Python sans dépendance
+python3 -m mqtt_hk check-config --config config.example.toml         # D (dry-run)
+
+# Activer le contrôle présence (une fois les FP2 posés)
+#   [energy_manager.toshiba_ac] control_enabled = true   → Config.toml → redeploy
+```
+
+Déploiement systemd de chaque pont : voir le README du composant (unités dans `contrib/`).
+
+---
+
+## 7. Sécurité (règle #12)
+
+Aucun secret d'appairage commité : `bridge/*/pairings/`, `*.pairing.json` (C), `hap-state/`
++ PIN dans `config.toml` (D), passcode/discriminateur + fabric keys `matter-state/` (E). Seuls
+les `config.example.*` sont versionnés.

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -316,6 +316,13 @@ donnée d'appairage :
   propre**, deps `serde` uniquement. Couche transport (rs‑matter/rumqttc/main) derrière la
   feature `matter` = **pur relais**, à câbler à l'adoption d'une passerelle (README détaille deps
   + API rs‑matter + commissioning multi‑fabric). Composant **E** (§0.3). **Code (cœur) + doc.**
+- **2026-07-07 (suite 21)** — **Doc dédiée `docs/toshiba-bridges.md`** (référence opérationnelle
+  des composants A–E : contrat MQTT, carte, pipeline présence, commandes/tests) pour **alléger**
+  le plan (désormais focalisé firmware + décisions §18). Indexée dans CLAUDE.md §10 +
+  `ARCHITECTURE.md` (+ READMEs de crates listés). **Décision consignée : E (Matter) supersède D
+  (HomeKit re-expose)** — Apple Home consomme Matter → un endpoint Occupancy de E couvre les
+  tuiles Maison **et** Homey/Google ; **D = stopgap**, **E = cible** (ajouter présence→Occupancy à
+  E puis retirer D). Note ajoutée §18.9. **Doc seule.**
 
 ---
 
@@ -1709,6 +1716,12 @@ anti‑rebattement — **10 tests**, `python3 tests/test_core.py`) + **glu I/O `
 `hap-state/accessory.state` + `config.toml` (PIN) → jamais commités. Détail →
 `bridge/mqtt-homekit-occupancy/README.md`.
 
+> **⚠️ Ce pont (D) est *superseded* par le bridge Matter (E, §18.12).** Apple Home étant un
+> contrôleur **Matter**, un endpoint **Occupancy** exposé par E apparaît dans l'app Maison
+> **comme** D, **plus** Homey/Google (multi‑fabric). Donc **D = stopgap** (tuiles Apple Home
+> avant que le transport Matter soit câblé) ; **E = cible** (ajouter présence→Occupancy à E,
+> puis retirer D). Détail → `docs/toshiba-bridges.md` §5.
+
 ### 18.10 Interop **Homie / Homey** — adaptateur Pi5 **différé** (décision 2026‑07‑07)
 
 **Question étudiée** : adopter la convention MQTT **Homie** dès maintenant sur les 3 ESP32
@@ -1775,7 +1788,7 @@ bout en bout → on est libres du backbone). Or sur ce maillon libre, HomeKit **
    (§0.2 #1). Réécriture de l'éprouvé, pas simplification.
 2. **Aplatit la télémétrie** : diagnostics ODU/IDU (charge compresseur, courants, RPM, temp
    ext.), presets, self‑clean → un **HeaterCooler** HAP a un jeu de caractéristiques **fixe et
-   limité**. On perd la richesse (projet = **monitoring**, 21 dashboards). MQTT/JSON porte tout.
+   limité**. On perd la richesse (projet = **monitoring**, 22 dashboards). MQTT/JSON porte tout.
 3. **Déplace la commande, ne la simplifie pas** : la décision vit dans **energy‑manager (Rust,
    testé)**. « Sans MQTT », EM devrait commander **via aiohomekit (Python)** → IPC réintroduit
    (souvent MQTT) **+** saut HAP. « Sans MQTT » ne supprime pas MQTT, il le **relocalise**.


### PR DESCRIPTION
…E supersède D

Allège le plan toshiba-suzumi-rs-plan.md (devenu lourd) en sortant le détail opérationnel dans une doc dédiée.

- docs/toshiba-bridges.md (nouveau) : référence opérationnelle des composants A–E (contrat MQTT figé, carte des composants + emplacements/tests/README, pipeline présence FP2→contrôle, HomeKit D vs Matter E, commandes rapides, sécurité).
- Indexée : CLAUDE.md §10 + docs/ARCHITECTURE.md (§1 + READMEs de crates listés).
- Décision consignée : E (bridge Matter) supersède D (mqtt-homekit-occupancy). Apple Home consomme Matter → un endpoint Occupancy de E couvre les tuiles Maison ET Homey/Google. D = stopgap ; E = cible (ajouter présence→Occupancy à E puis retirer D). Note ajoutée plan §18.9 ; journal (suite 21).
- Corrige les derniers "21 dashboards" → 22 (ARCHITECTURE.md, plan §18.11).

Doc seule, aucun code touché.


Claude-Session: https://claude.ai/code/session_01HEDbizfgG3aycVMrhE62Gj