### PR TITLE
feat(matter): présence FP2 → Occupancy dans E + doc bridge/ (garder R…

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,32 @@
+# `bridge/` — ponts d'intégration (services Pi5 auxiliaires)
+
+Ce dossier regroupe les **ponts** : des services **auxiliaires** hébergés sur le Pi5 qui
+traduisent un protocole externe ↔ notre **dorsal MQTT** `santuario/…`. Chacun est une
+**unité de déploiement autonome** (son propre service systemd), **hors** du workspace Rust
+principal.
+
+> ℹ️ **Le regroupement se fait par *fonction* (pont d'intégration), PAS par langage.**
+> C'est pourquoi on trouve ici du **Rust et du Python** côte à côte — c'est voulu.
+
+## Pourquoi le Rust ici n'est **pas** dans `crates/`
+
+| Dossier | Signification | Build |
+|---------|---------------|-------|
+| `crates/` | **membres du workspace** (`members = [...]` racine) | compilés ensemble, **cross-buildés par la CI** (aarch64/armv7, toolchain 1.94.1), 1 seul `Cargo.lock` |
+| `bridge/`, `firmware/` | crates/services **détachés** (`[workspace]` vide) | isolés → **zéro impact** sur le build/CI de daly-bms |
+
+Un crate détaché (`matter-toshiba-rs`, comme `firmware/toshiba-suzumi-rs`) reste **dehors**
+pour garder ses **dépendances lourdes / expérimentales** (rs-matter : crypto, mDNS, pré-1.0)
+**hors** du workspace et de ses cross-builds. Le mettre dans `crates/` casserait cette
+isolation. → L'axe est **l'unité de déploiement**, pas le langage.
+
+## Les ponts
+
+| | Pont | Langage | Rôle | README |
+|---|------|---------|------|--------|
+| **C** | `aqara-fp2-mqtt/` | Python (aiohomekit) | lit la présence FP2 (HomeKit local) → publie `santuario/toshiba/presence/<zone>` | [→](./aqara-fp2-mqtt/README.md) |
+| **D** | `mqtt-homekit-occupancy/` | Python (HAP-python) | ré-expose la présence MQTT → capteurs d'occupation **Apple Home** | [→](./mqtt-homekit-occupancy/README.md) |
+| **E** | `matter-toshiba-rs/` | **Rust** (détaché) | expose les clim (Thermostat) + présence (Occupancy) en **Matter** multi-fabric | [→](./matter-toshiba-rs/README.md) |
+
+> Référence opérationnelle complète (contrat MQTT, carte des composants A–E, pipeline
+> présence, décision **E supersède D**) → [`docs/toshiba-bridges.md`](../docs/toshiba-bridges.md).

--- a/bridge/matter-toshiba-rs/README.md
+++ b/bridge/matter-toshiba-rs/README.md
@@ -18,12 +18,12 @@ n'est qu'un **traducteur au bord** (même patron que `bridge/mqtt-homekit-occupa
 
 ## État
 
-- ✅ **Cœur pur testé** (`cargo test`, **15 tests**, aucune dépendance réseau/crypto) :
+- ✅ **Cœur pur testé** (`cargo test`, **18 tests**, aucune dépendance réseau/crypto) :
   - `mapping.rs` — état Toshiba (JSON) ↔ attributs cluster **Thermostat** ; écriture
-    Matter → commande MQTT.
+    Matter → commande MQTT ; **présence FP2 → `Occupancy`** (cluster Occupancy Sensor).
   - `config.rs` — `NodeConfig` (zones, broker, **commissioning Matter**) + validation
-    (discriminateur 0..4095, passcode non-interdit par la spec) + dérivation des topics.
-  - `bridge.rs` — **orchestration** transport-agnostique (cache par zone).
+    (discriminateur 0..4095, passcode non-interdit par la spec) + topics (état **et** présence).
+  - `bridge.rs` — **orchestration** transport-agnostique (cache par zone : Thermostat + Occupancy).
 - ⏳ **Couche transport** (feature `matter`, **à câbler**) : `matter.rs` (rs-matter),
   `mqtt.rs` (rumqttc), `main.rs`. Ne fait que **relayer** vers `bridge::Bridge` — aucune
   logique nouvelle. Voir ci-dessous.
@@ -49,6 +49,13 @@ Tester le cœur : `cargo test --manifest-path bridge/matter-toshiba-rs/Cargo.tom
 (8°/Fireplace/ECO), `pwr_level`, `self_clean`, diagnostics ODU/IDU. La ventilation
 Toshiba se mappera sur un cluster **FanControl** séparé (évolution).
 
+### Présence FP2 → cluster **Occupancy Sensor**
+
+Le bridge expose **aussi** la présence (un endpoint Occupancy Sensor par pièce) : `Occupancy`
+(bitmap8, bit0) ← `santuario/toshiba/presence/<zone>` `{"present":bool}`. Comme Apple Home est
+un contrôleur Matter, ça **remplace** le pont HomeKit `mqtt-homekit-occupancy` (D) — cf.
+`docs/toshiba-bridges.md` §5 (« E supersède D »). Mapping pur = `mapping::occupancy_bitmap`.
+
 ## Couche transport à câbler (feature `matter`)
 
 Activer la feature et ajouter les dépendances (versions à figer au moment du câblage —
@@ -67,13 +74,14 @@ log       = { version = "0.4", optional = true }
 
 Puis 3 fichiers (relais pur vers `bridge::Bridge`) :
 
-1. **`mqtt.rs`** — client rumqttc : souscrit `santuario/toshiba/+/state`, extrait la zone
-   (`config::zone_from_state_topic`), appelle `Bridge::on_state_json` → transmet les
-   `ThermostatAttrs` au cluster ; publie `Bridge::on_matter_write(...)` sur
-   `config::command_topic(zone)` (QoS1, non-retained) sur écriture Matter.
+1. **`mqtt.rs`** — client rumqttc : souscrit `santuario/toshiba/+/state` **et**
+   `santuario/toshiba/presence/+` ; extrait la zone (`config::zone_from_state_topic` /
+   `zone_from_presence_topic`), appelle `Bridge::on_state_json` → `ThermostatAttrs` au cluster
+   Thermostat, et `Bridge::on_presence_json` → `Occupancy` au cluster Occupancy ; publie
+   `Bridge::on_matter_write(...)` sur `config::command_topic(zone)` (QoS1, non-retained).
 2. **`matter.rs`** — nœud rs-matter : un **Aggregator** (device-type Bridge) portant **un
-   endpoint Thermostat par zone** (+ Descriptor/Bridged Device Basic Information). Câbler
-   les *read/write callbacks* des attributs Thermostat (§« Mapping ») ↔ `Bridge`.
+   endpoint Thermostat + un endpoint Occupancy Sensor par zone** (+ Descriptor/Bridged Device
+   Basic Information). Câbler les *read/write callbacks* des attributs (§« Mapping ») ↔ `Bridge`.
    Commissioning depuis `NodeConfig` (discriminator/passcode/VID/PID). Le **multi-fabric**
    est natif (≥ 5 fabrics) → commissionner dans Homey **puis** partager à Apple/Google.
 3. **`main.rs`** — `#[tokio::main]` : charge la config, démarre MQTT + le nœud Matter,

--- a/bridge/matter-toshiba-rs/src/bridge.rs
+++ b/bridge/matter-toshiba-rs/src/bridge.rs
@@ -9,12 +9,18 @@
 
 use std::collections::HashMap;
 
-use crate::mapping::{attrs_from_state, command_json, MatterWrite, ThermostatAttrs, ToshibaStatePayload};
+use crate::mapping::{
+    attrs_from_state, command_json, occupancy_bitmap, MatterWrite, PresencePayload,
+    ThermostatAttrs, ToshibaStatePayload,
+};
 
-/// Cache par zone du dernier état projeté en attributs Matter.
+/// Cache par zone du dernier état projeté en attributs Matter :
+/// - `zones` : attributs du cluster **Thermostat** (télémétrie clim) ;
+/// - `occupancy` : attribut `Occupancy` du cluster **Occupancy Sensor** (présence FP2).
 #[derive(Default)]
 pub struct Bridge {
     zones: HashMap<String, ThermostatAttrs>,
+    occupancy: HashMap<String, u8>,
 }
 
 impl Bridge {
@@ -41,6 +47,21 @@ impl Bridge {
     /// complet est construit par le transport via `config::command_topic(zone)`.
     pub fn on_matter_write(&self, write: MatterWrite) -> Option<String> {
         command_json(write)
+    }
+
+    /// Traite un message de présence (`santuario/toshiba/presence/<zone>`). Renvoie la
+    /// valeur `Occupancy` (bitmap8) à pousser sur l'endpoint Occupancy Sensor de la zone,
+    /// ou `None` si le JSON est invalide.
+    pub fn on_presence_json(&mut self, zone: &str, json: &[u8]) -> Option<u8> {
+        let payload: PresencePayload = serde_json::from_slice(json).ok()?;
+        let occ = occupancy_bitmap(payload.present);
+        self.occupancy.insert(zone.to_string(), occ);
+        Some(occ)
+    }
+
+    /// Dernière valeur `Occupancy` connue d'une zone.
+    pub fn occupancy(&self, zone: &str) -> Option<u8> {
+        self.occupancy.get(zone).copied()
     }
 }
 
@@ -85,5 +106,18 @@ mod tests {
             b.on_matter_write(MatterWrite::Setpoint(2300)).unwrap(),
             r#"{"target_temp":23}"#
         );
+    }
+
+    #[test]
+    fn presence_message_updates_occupancy() {
+        let mut b = Bridge::new();
+        assert_eq!(b.on_presence_json("Shorai-31", br#"{"present":true}"#), Some(1));
+        assert_eq!(b.occupancy("Shorai-31"), Some(1));
+        assert_eq!(b.on_presence_json("Shorai-31", br#"{"present":false,"ts":9}"#), Some(0));
+        assert_eq!(b.occupancy("Shorai-31"), Some(0));
+        // JSON invalide → ignoré, cache inchangé.
+        assert!(b.on_presence_json("Shorai-31", b"nope").is_none());
+        assert_eq!(b.occupancy("Shorai-31"), Some(0));
+        assert!(b.occupancy("Shorai-99").is_none());
     }
 }

--- a/bridge/matter-toshiba-rs/src/config.rs
+++ b/bridge/matter-toshiba-rs/src/config.rs
@@ -84,6 +84,18 @@ pub fn zone_from_state_topic(topic: &str) -> Option<&str> {
         .filter(|z| !z.is_empty() && !z.contains('/'))
 }
 
+/// `santuario/toshiba/presence/<zone>` (souscrit — présence FP2 publiée par le pont C).
+pub fn presence_topic(zone: &str) -> String {
+    format!("{TOPIC_ROOT}/presence/{zone}")
+}
+
+/// Extrait `<zone>` d'un topic `santuario/toshiba/presence/<zone>`.
+pub fn zone_from_presence_topic(topic: &str) -> Option<&str> {
+    topic
+        .strip_prefix("santuario/toshiba/presence/")
+        .filter(|z| !z.is_empty() && !z.contains('/'))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,5 +141,16 @@ mod tests {
         );
         assert_eq!(zone_from_state_topic("santuario/toshiba/Shorai-31/command"), None);
         assert_eq!(zone_from_state_topic("santuario/toshiba/presence/Shorai-31"), None);
+    }
+
+    #[test]
+    fn presence_topic_helpers() {
+        assert_eq!(presence_topic("Shorai-31"), "santuario/toshiba/presence/Shorai-31");
+        assert_eq!(
+            zone_from_presence_topic("santuario/toshiba/presence/Shorai-31"),
+            Some("Shorai-31")
+        );
+        // Ne matche pas un topic d'état.
+        assert_eq!(zone_from_presence_topic("santuario/toshiba/Shorai-31/state"), None);
     }
 }

--- a/bridge/matter-toshiba-rs/src/mapping.rs
+++ b/bridge/matter-toshiba-rs/src/mapping.rs
@@ -150,6 +150,28 @@ pub fn command_json(w: MatterWrite) -> Option<String> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Présence FP2 → cluster Occupancy Sensor Matter
+// ---------------------------------------------------------------------------
+//
+// Permet au bridge d'exposer AUSSI la présence (un endpoint Occupancy Sensor par pièce),
+// ce qui rend le pont HomeKit `mqtt-homekit-occupancy` (D) redondant : Apple Home étant un
+// contrôleur Matter, l'Occupancy apparaît dans l'app Maison **et** dans Homey/Google.
+// Cf. `docs/toshiba-bridges.md` §5 (« E supersède D »).
+
+/// Payload de présence publié par le pont FP2 (`bridge/aqara-fp2-mqtt`) sur
+/// `santuario/toshiba/presence/<zone>` : `{"present": bool, "ts": epoch}` (`ts` ignoré).
+#[derive(Debug, Deserialize)]
+pub struct PresencePayload {
+    pub present: bool,
+}
+
+/// Présence → attribut `Occupancy` du cluster Occupancy Sensor Matter (**bitmap8**,
+/// bit0 = occupé) : `1` si présent, `0` sinon.
+pub fn occupancy_bitmap(present: bool) -> u8 {
+    u8::from(present)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,5 +261,15 @@ mod tests {
             let js = command_json(w).unwrap();
             let _: serde_json::Value = serde_json::from_str(&js).unwrap();
         }
+    }
+
+    #[test]
+    fn presence_maps_to_occupancy() {
+        assert_eq!(occupancy_bitmap(true), 1);
+        assert_eq!(occupancy_bitmap(false), 0);
+        let p: PresencePayload = serde_json::from_str(r#"{"present":true,"ts":1}"#).unwrap();
+        assert!(p.present);
+        let p: PresencePayload = serde_json::from_str(r#"{"present":false}"#).unwrap();
+        assert!(!p.present);
     }
 }

--- a/docs/toshiba-bridges.md
+++ b/docs/toshiba-bridges.md
@@ -88,7 +88,7 @@ complémentaires** : ce sont **deux barreaux de la même échelle**.
 |---|---|---|
 | Sortie | **HomeKit seul** (app Maison iPhone) | **Matter multi-fabric** : Apple **+** Homey **+** Google simultanés |
 | Couvre l'app Maison ? | ✅ | ✅ (Apple Home **est** un contrôleur Matter) |
-| Portée | présence (Occupancy) | clim (Thermostat) **+** présence (Occupancy, à ajouter) |
+| Portée | présence (Occupancy) | clim (Thermostat) **+** présence (Occupancy — mapping pur **fait**) |
 | Disponibilité | **maintenant**, sans passerelle | **futur** (transport rs-matter + passerelle) |
 | Techno | Python (HAP-python) | Rust (sans Node) |
 
@@ -98,9 +98,10 @@ et Google. Conséquences :
 
 - **D = stopgap** : à n'utiliser que pour obtenir les **tuiles présence dans Apple Home**
   **avant** d'avoir câblé le transport Matter (D est prêt et ne dépend d'aucune passerelle).
-- **E = cible** : quand le bridge Matter tourne, on lui ajoute un mapping **présence→Occupancy**
-  (trivial : `{"present":bool}` → `OccupancyDetected`) et **on retire D**. Un seul pont pour
-  **clim + présence**, multi-écosystème.
+- **E = cible** : le mapping **présence→Occupancy** est **déjà fait et testé** dans E
+  (`mapping::occupancy_bitmap` + `Bridge::on_presence_json`). Quand le transport rs-matter de E
+  sera câblé (endpoints Occupancy Sensor), **on retire D**. Un seul pont pour **clim + présence**,
+  multi-écosystème.
 
 Rationale complet → plan **§18.9** (scénario C) + **§18.12** (Matter).
 

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -107,8 +107,10 @@ Apple Home** (tuiles iPhone) — cf. §18.9. Tester le cœur : `python3 tests/te
 **E. Bridge Matter → passerelle (tout‑Rust, optionnel/futur)** — `bridge/matter-toshiba-rs/`
 (crate **détaché**, Rust pur, **sans Node.js**). Expose les clim en **endpoints Thermostat
 Matter** multi‑fabric depuis MQTT — cf. §18.12. Tester le cœur :
-`cargo test --manifest-path bridge/matter-toshiba-rs/Cargo.toml` (**15 tests**).
+`cargo test --manifest-path bridge/matter-toshiba-rs/Cargo.toml` (**18 tests**).
 - ✅ **Cœur pur testé** (`mapping.rs`/`config.rs`/`bridge.rs`, deps `serde` only) + README + systemd.
+  Couvre **Thermostat** (clim) **et** **Occupancy** (présence FP2 → `occupancy_bitmap`) → E
+  **supersède D** (§18.9 / `docs/toshiba-bridges.md` §5).
 - ⏳ **Couche transport** feature `matter` (`matter.rs` rs‑matter / `mqtt.rs` rumqttc / `main.rs`)
   = **pur relais** vers `bridge::Bridge`, à câbler quand une passerelle sera adoptée.
 
@@ -323,6 +325,14 @@ donnée d'appairage :
   (HomeKit re-expose)** — Apple Home consomme Matter → un endpoint Occupancy de E couvre les
   tuiles Maison **et** Homey/Google ; **D = stopgap**, **E = cible** (ajouter présence→Occupancy à
   E puis retirer D). Note ajoutée §18.9. **Doc seule.**
+- **2026-07-07 (suite 22)** — **`bridge/` clarifié + présence→Occupancy ajoutée à E**.
+  Question orga (Rust vs Python dans `bridge/`) : **ne pas migrer** vers `crates/` (= membres
+  workspace + CI cross‑build ; `matter-toshiba-rs` détaché comme `firmware/` pour tenir rs‑matter
+  hors CI). Axe = **unité de déploiement, pas langage**. Ajout `bridge/README.md` (convention).
+  **Code** : mapping pur **présence FP2 → cluster Occupancy** dans E (`mapping::occupancy_bitmap`,
+  `PresencePayload`, `config::presence_topic`/`zone_from_presence_topic`, `Bridge::on_presence_json`
+  + cache) → **matérialise « E supersède D »**. `cargo test` E = **18 tests** verts, clippy propre.
+  READMEs (crate E, `docs/toshiba-bridges.md` §5) mis à jour.
 
 ---
 


### PR DESCRIPTION
…ust dans bridge/)

Question orga tranchée : ne pas migrer matter-toshiba-rs vers crates/. L'axe du dépôt est l'unité de déploiement / le statut workspace, pas le langage :
- crates/ = membres du workspace (Cargo.lock partagé + CI cross-build aarch64/armv7)
- bridge/ + firmware/ = crates/services détachés (isolés de la CI) matter-toshiba-rs reste détaché (comme firmware/toshiba-suzumi-rs) pour tenir rs-matter hors du workspace. Ajout bridge/README.md documentant la convention.

Code (matérialise « E supersède D ») : mapping pur présence FP2 → cluster Occupancy Sensor dans le bridge Matter —
- mapping.rs : PresencePayload + occupancy_bitmap(present) -> u8 (bitmap8 bit0)
- config.rs : presence_topic / zone_from_presence_topic
- bridge.rs : on_presence_json + cache occupancy par zone E couvre désormais Thermostat (clim) ET Occupancy (présence) → un seul pont multi-fabric, rendant D (mqtt-homekit-occupancy) redondant à terme.

cargo test (E) = 18 tests verts ; clippy -D warnings propre. Doc : README crate E, docs/toshiba-bridges.md §5, plan §0.3 + journal (suite 22).


Claude-Session: https://claude.ai/code/session_01HEDbizfgG3aycVMrhE62Gj