### PR TITLE
feat(bridge): pont MQTT→HomeKit multi-capteurs pour tester la chaîne …

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -25,7 +25,8 @@ isolation. → L'axe est **l'unité de déploiement**, pas le langage.
 | | Pont | Langage | Rôle | README |
 |---|------|---------|------|--------|
 | **C** | `aqara-fp2-mqtt/` | Python (aiohomekit) | lit la présence FP2 (HomeKit local) → publie `santuario/toshiba/presence/<zone>` | [→](./aqara-fp2-mqtt/README.md) |
-| **D** | `mqtt-homekit-occupancy/` | Python (HAP-python) | ré-expose la présence MQTT → capteurs d'occupation **Apple Home** | [→](./mqtt-homekit-occupancy/README.md) |
+| **D** | `mqtt-homekit-occupancy/` | Python (HAP-python) | ré-expose la présence MQTT → capteurs d'occupation **Apple Home** — *généralisé par `mqtt-homekit-sensors`* | [→](./mqtt-homekit-occupancy/README.md) |
+| **D′** | `mqtt-homekit-sensors/` | Python (HAP-python) | **généralise D** : MQTT → capteurs HomeKit **multi-types** (température, luminosité, occupation). Sert à **tester la chaîne** avec les capteurs déjà en place | [→](./mqtt-homekit-sensors/README.md) |
 | **E** | `matter-toshiba-rs/` | **Rust** (détaché) | expose les clim (Thermostat) + présence (Occupancy) en **Matter** multi-fabric | [→](./matter-toshiba-rs/README.md) |
 
 > Référence opérationnelle complète (contrat MQTT, carte des composants A–E, pipeline

--- a/bridge/mqtt-homekit-sensors/.gitignore
+++ b/bridge/mqtt-homekit-sensors/.gitignore
@@ -1,0 +1,10 @@
+# Secrets & état d'appairage HomeKit — NE JAMAIS committer (règle #12)
+hap-state/
+*.state
+config.toml
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+venv/

--- a/bridge/mqtt-homekit-sensors/README.md
+++ b/bridge/mqtt-homekit-sensors/README.md
@@ -1,0 +1,59 @@
+# mqtt-homekit-sensors — pont MQTT → HomeKit (capteurs multi-types)
+
+Service Python (sur le Pi5) qui expose des topics MQTT arbitraires comme **capteurs
+HomeKit** : **TemperatureSensor**, **LightSensor** (luminosité), **OccupancySensor**.
+
+Deux usages :
+1. **Tester la chaîne MQTT → HomeKit *maintenant*** avec les capteurs **déjà en place**
+   (température, irradiance) — **sans** matériel Toshiba/FP2. HAP-python est un accessoire
+   100 % logiciel : il suffit du Pi5 + un iPhone/iPad **sur le même WiFi** pour appairer.
+2. **Généralise / supersède `mqtt-homekit-occupancy`** : l'occupation n'est qu'un type
+   parmi d'autres. (Le pont Matter **E** supersède l'ensemble à terme — `docs/toshiba-bridges.md` §5.)
+
+## État
+
+- ✅ **Cœur pur testé** (`mqtt_hk_sensors/core.py`, **9 tests**, sans dépendance) :
+  extraction de valeur (champ JSON **ou** nombre brut), conversion → caractéristique HomeKit
+  (bornes respectées), config + validation.
+- ✅ **Couche HAP vérifiée** contre pyhap réel (services/caractéristiques sondés ;
+  **smoke-test** : build du Bridge + injection de valeurs simulées → les caractéristiques se
+  mettent à jour). Reste le seul geste matériel : **appairer l'iPad/iPhone**.
+
+Tester le cœur : `python3 bridge/mqtt-homekit-sensors/tests/test_core.py`
+
+## Types supportés
+
+| `type` | Service HomeKit | Caractéristique | Note |
+|--------|-----------------|-----------------|------|
+| `temperature` | TemperatureSensor | CurrentTemperature (°C) | `json_field` = ex. `"Temperature"` |
+| `light` | LightSensor | CurrentAmbientLightLevel (**lux**) | 0 → `0.0001` (min HomeKit) ; l'irradiance W/m² est portée telle quelle |
+| `occupancy` | OccupancySensor | OccupancyDetected (0/1) | `json_field="present"` (bool) accepté |
+
+`json_field` absent → le payload entier est parsé comme **nombre** (ex. `santuario/irradiance/raw` = `"750"`).
+
+## Installation & mise en service (Pi5)
+
+```bash
+cd bridge/mqtt-homekit-sensors
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+cp config.example.toml config.toml     # déjà pointé sur température + irradiance
+python -m mqtt_hk_sensors check-config --config config.toml   # dry-run (sans dépendance)
+python -m mqtt_hk_sensors run          --config config.toml
+# Puis app Maison (iPad/iPhone) : Ajouter un accessoire → « Plus d'options » →
+# choisir le Bridge (hap.bridge_name) → saisir le PIN (hap.pincode).
+```
+
+> **Réseau** : l'iPad et le Pi5 doivent être sur le **même sous-réseau L2** (StarTh) pour la
+> découverte mDNS/Bonjour `_hap._tcp`. Pas de hub requis pour l'**appairage local** (un
+> HomePod/Apple TV n'est nécessaire que pour l'accès distant / les automatisations).
+
+## Déploiement systemd
+
+Unité : `contrib/mqtt-homekit-sensors.service` (après `mosquitto-broker`). Config déployée en
+`/etc/daly-bms/mqtt-homekit-sensors.toml`.
+
+## Sécurité (règle #12)
+
+`hap-state/accessory.state` (clé d'appairage) + `config.toml` (PIN) → **jamais** commités.
+Changer le PIN par défaut avant la mise en service.

--- a/bridge/mqtt-homekit-sensors/config.example.toml
+++ b/bridge/mqtt-homekit-sensors/config.example.toml
@@ -1,0 +1,32 @@
+# Config du pont MQTT → HomeKit (capteurs). Copier en `config.toml` (non commité) et adapter.
+# Pointé sur les capteurs DÉJÀ EN PLACE → sert à tester la chaîne MQTT→HomeKit avant le FP2.
+
+[mqtt]
+host = "127.0.0.1"     # broker Mosquitto local du Pi5
+port = 1883
+# user     = "..."
+# password = "..."
+
+[hap]
+bridge_name = "Santuario Sensors"    # nom du Bridge à l'appairage dans l'app Maison
+port        = 51827
+pincode     = "031-45-155"           # à changer avant la mise en service
+state_dir   = "hap-state"
+
+# --- Capteurs réels déjà publiés sur le broker Pi5 ---
+
+# Température extérieure : payload JSON {"Temperature":15.3,"TemperatureType":4,"Humidity":65}
+[[sensors]]
+name       = "Température extérieure"
+type       = "temperature"
+topic      = "santuario/heat/1/venus"
+json_field = "Temperature"
+
+# Irradiance PRALRAN : payload = nombre brut (ex. "750") → exposé en LightSensor (lux).
+# NB : HomeKit n'a pas de type « irradiance » ; la valeur W/m² est portée telle quelle en lux
+# (approximation assumée — le but est de valider la découverte de l'accessoire).
+[[sensors]]
+name  = "Irradiance PRALRAN"
+type  = "light"
+topic = "santuario/irradiance/raw"
+# pas de json_field → payload numérique brut

--- a/bridge/mqtt-homekit-sensors/contrib/mqtt-homekit-sensors.service
+++ b/bridge/mqtt-homekit-sensors/contrib/mqtt-homekit-sensors.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=MQTT -> HomeKit sensors bridge (température / luminosité / occupation)
+Documentation=file:///home/pi5compute/Daly-BMS-Rust/docs/toshiba-bridges.md
+After=network-online.target mosquitto-broker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi5compute
+WorkingDirectory=/home/pi5compute/Daly-BMS-Rust/bridge/mqtt-homekit-sensors
+ExecStart=/home/pi5compute/Daly-BMS-Rust/bridge/mqtt-homekit-sensors/.venv/bin/python -m mqtt_hk_sensors run --config /etc/daly-bms/mqtt-homekit-sensors.toml
+Restart=on-failure
+RestartSec=5
+# Durcissement léger
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/home/pi5compute/Daly-BMS-Rust/bridge/mqtt-homekit-sensors/hap-state
+
+[Install]
+WantedBy=multi-user.target

--- a/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/__init__.py
+++ b/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/__init__.py
@@ -1,0 +1,6 @@
+"""Pont MQTT → HomeKit (capteurs multi-types : température, luminosité, occupation).
+
+`core` est **pur** (testable sans dépendance) ; `accessory`/`mqtt_in` sont la couche I/O
+(pyhap / paho). Sert de test de la chaîne MQTT→HomeKit et de successeur de
+`mqtt-homekit-occupancy`. Voir `docs/toshiba-bridges.md`.
+"""

--- a/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/__main__.py
+++ b/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/__main__.py
@@ -1,0 +1,89 @@
+"""CLI du pont MQTT → HomeKit (capteurs multi-types).
+
+    python -m mqtt_hk_sensors check-config --config config.toml   # valider (sans dépendance)
+    python -m mqtt_hk_sensors run          --config config.toml   # boucle principale (bloquant)
+
+`run` : démarre le serveur HomeKit (Bridge + 1 accessoire/capteur), souscrit au broker,
+pilote les caractéristiques depuis MQTT. Appairer ensuite le Bridge dans l'app **Maison**
+avec le **PIN** de la config (`hap.pincode`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import sys
+import tomllib
+
+from . import core
+
+
+def _load_config(path: str) -> core.BridgeConfig:
+    with open(path, "rb") as fh:
+        return core.parse_config(tomllib.load(fh))
+
+
+def _cmd_check_config(args) -> int:
+    cfg = _load_config(args.config)
+    print(f"OK — {len(cfg.sensors)} capteur(s), broker {cfg.mqtt_host}:{cfg.mqtt_port}")
+    print(f"HomeKit : bridge {cfg.hap_bridge_name!r}, port {cfg.hap_port}, PIN {cfg.hap_pincode}")
+    for s in cfg.sensors:
+        svc, char = core.service_and_char(s.kind)
+        src = f"{s.topic}" + (f" [{s.json_field}]" if s.json_field else " [nombre brut]")
+        print(f"  - {s.name!r}  ({svc}.{char})  ←  {src}")
+    return 0
+
+
+def _cmd_run(args) -> int:
+    from pyhap.accessory_driver import AccessoryDriver
+
+    from . import accessory, mqtt_in
+
+    cfg = _load_config(args.config)
+    os.makedirs(cfg.hap_state_dir, exist_ok=True)
+
+    driver = AccessoryDriver(
+        port=cfg.hap_port,
+        persist_file=os.path.join(cfg.hap_state_dir, "accessory.state"),
+        pincode=cfg.hap_pincode.encode(),
+    )
+    bridge, accessories = accessory.build_bridge(driver, cfg)
+    driver.add_accessory(bridge)
+
+    def on_value(name: str, value: float) -> None:
+        acc = accessories.get(name)
+        if acc is not None:
+            acc.set_from_value(value)
+
+    sub = mqtt_in.MqttSubscriber(cfg, on_value)
+    sub.connect()
+
+    signal.signal(signal.SIGTERM, lambda *_: driver.stop())
+    try:
+        driver.start()
+    finally:
+        sub.close()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="mqtt_hk_sensors", description="Pont MQTT → HomeKit (capteurs)")
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--config", default="config.toml", help="chemin du fichier de config")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("check-config", parents=[common], help="valider la config sans rien démarrer")
+    sub.add_parser("run", parents=[common], help="boucle principale (bloquant)")
+
+    args = p.parse_args(argv)
+    try:
+        if args.cmd == "check-config":
+            return _cmd_check_config(args)
+        return _cmd_run(args)
+    except (ValueError, OSError, tomllib.TOMLDecodeError) as e:
+        print(f"erreur de config ({args.config}) : {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/accessory.py
+++ b/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/accessory.py
@@ -1,0 +1,49 @@
+"""Serveur d'accessoires **HomeKit** (HAP-python / `pyhap`) — capteurs multi-types.
+
+Un accessoire par capteur configuré : *TemperatureSensor* / *LightSensor* /
+*OccupancySensor*. Les valeurs sont pilotées par les messages MQTT (`mqtt_in`).
+
+Le nœud s'appaire à l'app **Maison** de l'iPhone/iPad avec son **propre PIN** (accessoire
+100 % logiciel — aucun matériel requis hormis le Pi5 et l'appareil Apple sur le même LAN).
+Services/caractéristiques vérifiés contre pyhap (`Loader`) → API correcte.
+"""
+
+from __future__ import annotations
+
+from pyhap.accessory import Accessory, Bridge
+from pyhap.const import CATEGORY_SENSOR
+
+from . import core
+
+
+class SensorAccessory(Accessory):
+    """Un capteur HomeKit dont la caractéristique suit les messages MQTT."""
+
+    category = CATEGORY_SENSOR
+
+    def __init__(self, driver, spec: core.SensorSpec) -> None:
+        super().__init__(driver, spec.name)
+        service_name, char_name = core.service_and_char(spec.kind)
+        serv = self.add_preload_service(service_name)
+        # Valeur initiale neutre et valide (respecte les bornes HomeKit).
+        initial = core.to_char_value(spec.kind, 0.0)
+        self._char = serv.configure_char(char_name, value=initial)
+        self._kind = spec.kind
+
+    def set_from_value(self, value: float) -> None:
+        """Pousse une valeur numérique brute (convertie/bornée pour la caractéristique)."""
+        self._char.set_value(core.to_char_value(self._kind, value))
+
+
+def build_bridge(driver, cfg: core.BridgeConfig):
+    """Construit le Bridge HomeKit + un `SensorAccessory` par capteur configuré.
+
+    Retourne `(bridge, {nom: accessoire})` pour que la couche MQTT pousse les valeurs.
+    """
+    bridge = Bridge(driver, cfg.hap_bridge_name)
+    accessories: dict[str, SensorAccessory] = {}
+    for spec in cfg.sensors:
+        acc = SensorAccessory(driver, spec)
+        bridge.add_accessory(acc)
+        accessories[spec.name] = acc
+    return bridge, accessories

--- a/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/core.py
+++ b/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/core.py
@@ -1,0 +1,163 @@
+"""Cœur **PUR** du pont MQTT → HomeKit (capteurs multi-types) — aucune dépendance tierce.
+
+Généralise `mqtt-homekit-occupancy` (occupation seule) en un pont **multi-types** :
+expose des topics MQTT arbitraires comme capteurs HomeKit **TemperatureSensor**,
+**LightSensor** (luminosité) ou **OccupancySensor**. Sert à la fois de test de la chaîne
+MQTT→HomeKit (avec les capteurs déjà en place : température, irradiance) et, à terme, de
+successeur de `mqtt-homekit-occupancy` (l'occupation n'est qu'un type parmi d'autres).
+
+Ce module ne fait **ni HomeKit ni MQTT réseau** : uniquement config, extraction de valeur
+depuis le payload, et conversion → valeur de caractéristique HomeKit. Testable **sans**
+`pyhap`/`paho`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+#: Types de capteurs supportés → (service HAP, caractéristique HAP).
+SENSOR_KINDS: dict[str, tuple[str, str]] = {
+    "temperature": ("TemperatureSensor", "CurrentTemperature"),
+    "light": ("LightSensor", "CurrentAmbientLightLevel"),
+    "occupancy": ("OccupancySensor", "OccupancyDetected"),
+}
+
+#: Bornes HomeKit (extraites des définitions pyhap) à respecter côté valeurs.
+TEMP_MIN, TEMP_MAX = -273.1, 1000.0
+LUX_MIN = 0.0001  # CurrentAmbientLightLevel : minValue strictement > 0 → clamp du 0.
+
+#: Format du code d'appairage HomeKit : `XXX-XX-XXX`.
+_PINCODE_RE = re.compile(r"^\d{3}-\d{2}-\d{3}$")
+
+
+@dataclass(frozen=True)
+class SensorSpec:
+    """Un capteur exposé : un accessoire HomeKit alimenté par un topic MQTT."""
+
+    name: str  # nom affiché dans l'app Maison (unique)
+    kind: str  # clé de SENSOR_KINDS
+    topic: str  # topic MQTT souscrit
+    #: Champ JSON à extraire (ex. "Temperature"). `None` → payload = **nombre brut**
+    #: (ex. `santuario/irradiance/raw` = `"750"`).
+    json_field: str | None = None
+
+
+@dataclass(frozen=True)
+class BridgeConfig:
+    mqtt_host: str = "127.0.0.1"
+    mqtt_port: int = 1883
+    mqtt_user: str | None = None
+    mqtt_pass: str | None = None
+    hap_bridge_name: str = "Santuario Sensors"
+    hap_port: int = 51827
+    hap_pincode: str = "031-45-155"
+    hap_state_dir: str = "hap-state"
+    sensors: tuple[SensorSpec, ...] = ()
+
+
+def service_and_char(kind: str) -> tuple[str, str]:
+    """(service HAP, caractéristique HAP) pour un type de capteur."""
+    return SENSOR_KINDS[kind]
+
+
+def parse_value(spec: SensorSpec, raw) -> float | None:
+    """Extrait la valeur numérique du payload selon `spec.json_field`.
+
+    - `json_field` défini → `json.loads(payload)[json_field]` (nombre **ou** booléen).
+    - sinon → le payload entier est parsé comme un **nombre** (ex. `"750"`).
+    Retourne `None` si illisible (message ignoré, dernière valeur conservée).
+    """
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            raw = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    if not isinstance(raw, str):
+        return None
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        if spec.json_field is not None:
+            obj = json.loads(raw)
+            if not isinstance(obj, dict) or spec.json_field not in obj:
+                return None
+            return float(obj[spec.json_field])  # bool True/False → 1.0/0.0
+        return float(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def to_char_value(kind: str, value: float) -> float | int:
+    """Valeur numérique → valeur de caractéristique HomeKit (bornée/typée)."""
+    if kind == "temperature":
+        return float(min(max(value, TEMP_MIN), TEMP_MAX))
+    if kind == "light":
+        # HomeKit lux : minValue = 0.0001 → 0 W/m² (nuit) devient 0.0001 pour rester valide.
+        return float(max(value, LUX_MIN))
+    if kind == "occupancy":
+        return 1 if value >= 0.5 else 0
+    raise ValueError(f"type de capteur inconnu : {kind!r}")
+
+
+def _valid_topic(topic: str) -> bool:
+    return bool(topic) and not any(c in topic for c in "+# ")
+
+
+def parse_config(data: dict) -> BridgeConfig:
+    """Construit et **valide** une `BridgeConfig` depuis un dict (issu de `tomllib`)."""
+    mqtt = data.get("mqtt", {}) or {}
+    hap = data.get("hap", {}) or {}
+    sensors_raw = data.get("sensors", []) or []
+
+    sensors: list[SensorSpec] = []
+    seen_names: set[str] = set()
+    seen_topics: set[str] = set()
+    for s in sensors_raw:
+        name = str(s.get("name", "")).strip()
+        kind = str(s.get("kind", s.get("type", ""))).strip()
+        topic = str(s.get("topic", "")).strip()
+        field = s.get("json_field")
+        field = str(field).strip() if field is not None else None
+        if not name:
+            raise ValueError("capteur sans `name`")
+        if kind not in SENSOR_KINDS:
+            raise ValueError(f"capteur {name!r} : type inconnu {kind!r} (attendu {sorted(SENSOR_KINDS)})")
+        if not _valid_topic(topic):
+            raise ValueError(f"capteur {name!r} : topic invalide {topic!r}")
+        if name in seen_names:
+            raise ValueError(f"nom d'accessoire dupliqué : {name!r}")
+        if topic in seen_topics:
+            raise ValueError(f"topic dupliqué : {topic!r}")
+        seen_names.add(name)
+        seen_topics.add(topic)
+        sensors.append(SensorSpec(name=name, kind=kind, topic=topic, json_field=field or None))
+
+    if not sensors:
+        raise ValueError("aucun capteur configuré (section [[sensors]])")
+
+    pincode = str(hap.get("pincode", "031-45-155"))
+    if not _PINCODE_RE.match(pincode):
+        raise ValueError(f"hap.pincode doit être au format XXX-XX-XXX : {pincode!r}")
+    port = int(hap.get("port", 51827))
+    if not 1024 <= port <= 65535:
+        raise ValueError(f"hap.port hors plage 1024–65535 : {port}")
+
+    return BridgeConfig(
+        mqtt_host=str(mqtt.get("host", "127.0.0.1")),
+        mqtt_port=int(mqtt.get("port", 1883)),
+        mqtt_user=mqtt.get("user"),
+        mqtt_pass=mqtt.get("password"),
+        hap_bridge_name=str(hap.get("bridge_name", "Santuario Sensors")),
+        hap_port=port,
+        hap_pincode=pincode,
+        hap_state_dir=str(hap.get("state_dir", "hap-state")),
+        sensors=tuple(sensors),
+    )
+
+
+def build_route(cfg: BridgeConfig) -> dict[str, SensorSpec]:
+    """Table `topic MQTT → SensorSpec` (dispatch des messages reçus)."""
+    return {s.topic: s for s in cfg.sensors}

--- a/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/mqtt_in.py
+++ b/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/mqtt_in.py
@@ -1,0 +1,70 @@
+"""Souscription MQTT (paho-mqtt) — mince couche I/O au-dessus de `core`.
+
+Souscrit les topics des capteurs configurés et met à jour la caractéristique HomeKit
+correspondante. Compatible paho-mqtt 1.x **et** 2.x.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import paho.mqtt.client as mqtt
+
+from . import core
+
+AVAILABILITY_TOPIC = "santuario/homekit-sensors/availability"
+
+
+def _make_client(client_id: str) -> mqtt.Client:
+    try:  # paho-mqtt >= 2.0
+        return mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=client_id)
+    except (AttributeError, TypeError):  # paho-mqtt < 2.0
+        return mqtt.Client(client_id=client_id)
+
+
+class MqttSubscriber:
+    def __init__(
+        self,
+        cfg: core.BridgeConfig,
+        on_value: Callable[[str, float], None],
+        client_id: str = "mqtt-homekit-sensors",
+    ) -> None:
+        self._cfg = cfg
+        self._on_value = on_value
+        self._route = core.build_route(cfg)
+        self._client = _make_client(client_id)
+        if cfg.mqtt_user:
+            self._client.username_pw_set(cfg.mqtt_user, cfg.mqtt_pass or "")
+        self._client.will_set(AVAILABILITY_TOPIC, "offline", qos=1, retain=True)
+        self._client.on_connect = self._on_connect
+        self._client.on_message = self._on_message
+
+    def _on_connect(self, client, userdata, flags, reason_code, properties=None) -> None:
+        for topic in self._route:
+            client.subscribe(topic, qos=0)
+        client.publish(AVAILABILITY_TOPIC, "online", qos=1, retain=True)
+
+    def _on_message(self, client, userdata, msg) -> None:
+        spec = self._route.get(msg.topic)
+        if spec is None:
+            return
+        value = core.parse_value(spec, msg.payload)
+        if value is None:
+            return
+        self._on_value(spec.name, value)
+
+    def connect(self) -> None:
+        self._client.connect(self._cfg.mqtt_host, self._cfg.mqtt_port, keepalive=30)
+        self._client.loop_start()
+
+    def close(self) -> None:
+        try:
+            info = self._client.publish(AVAILABILITY_TOPIC, "offline", qos=1, retain=True)
+            try:
+                info.wait_for_publish(timeout=2.0)
+            except Exception:  # noqa: BLE001
+                pass
+            self._client.loop_stop()
+            self._client.disconnect()
+        except Exception:  # noqa: BLE001
+            pass

--- a/bridge/mqtt-homekit-sensors/requirements.txt
+++ b/bridge/mqtt-homekit-sensors/requirements.txt
@@ -1,0 +1,3 @@
+# Pont MQTT → HomeKit (capteurs). Python 3.11+ (tomllib en stdlib).
+HAP-python>=4.9
+paho-mqtt>=1.6

--- a/bridge/mqtt-homekit-sensors/tests/test_core.py
+++ b/bridge/mqtt-homekit-sensors/tests/test_core.py
@@ -1,0 +1,93 @@
+"""Tests du cœur pur (aucune dépendance tierce). Lancer :
+
+    python3 bridge/mqtt-homekit-sensors/tests/test_core.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from mqtt_hk_sensors import core  # noqa: E402
+
+
+class TestParseValue(unittest.TestCase):
+    def temp(self):
+        return core.SensorSpec("T", "temperature", "santuario/heat/1/venus", "Temperature")
+
+    def light(self):
+        return core.SensorSpec("L", "light", "santuario/irradiance/raw", None)
+
+    def occ(self):
+        return core.SensorSpec("O", "occupancy", "p/x", "present")
+
+    def test_json_field(self):
+        v = core.parse_value(self.temp(), b'{"Temperature":15.3,"Humidity":65}')
+        self.assertAlmostEqual(v, 15.3)
+
+    def test_raw_number(self):
+        self.assertEqual(core.parse_value(self.light(), b"750"), 750.0)
+        self.assertEqual(core.parse_value(self.light(), "0"), 0.0)
+
+    def test_bool_field_for_occupancy(self):
+        self.assertEqual(core.parse_value(self.occ(), b'{"present":true}'), 1.0)
+        self.assertEqual(core.parse_value(self.occ(), b'{"present":false}'), 0.0)
+
+    def test_ignored(self):
+        for raw in (b"", "  ", b"\xff", "pas nombre", b'{"Humidity":65}', None):
+            self.assertIsNone(core.parse_value(self.temp(), raw), repr(raw))
+
+
+class TestToCharValue(unittest.TestCase):
+    def test_temperature_clamped(self):
+        self.assertEqual(core.to_char_value("temperature", 15.3), 15.3)
+        self.assertEqual(core.to_char_value("temperature", -999), core.TEMP_MIN)
+
+    def test_light_zero_becomes_min_lux(self):
+        # 0 W/m² (nuit) → lux minimal valide (HomeKit refuse 0).
+        self.assertEqual(core.to_char_value("light", 0.0), core.LUX_MIN)
+        self.assertEqual(core.to_char_value("light", 750.0), 750.0)
+
+    def test_occupancy_is_binary(self):
+        self.assertEqual(core.to_char_value("occupancy", 1.0), 1)
+        self.assertEqual(core.to_char_value("occupancy", 0.0), 0)
+
+
+class TestConfig(unittest.TestCase):
+    def _valid(self):
+        return {
+            "mqtt": {"host": "127.0.0.1"},
+            "hap": {"pincode": "031-45-155"},
+            "sensors": [
+                {"name": "Temp ext", "type": "temperature", "topic": "santuario/heat/1/venus", "json_field": "Temperature"},
+                {"name": "Irradiance", "type": "light", "topic": "santuario/irradiance/raw"},
+            ],
+        }
+
+    def test_valid(self):
+        cfg = core.parse_config(self._valid())
+        self.assertEqual(len(cfg.sensors), 2)
+        self.assertEqual(cfg.sensors[0].json_field, "Temperature")
+        self.assertIsNone(cfg.sensors[1].json_field)
+        route = core.build_route(cfg)
+        self.assertEqual(route["santuario/irradiance/raw"].kind, "light")
+
+    def test_rejects_bad(self):
+        d = self._valid()
+        d["sensors"][0]["type"] = "pressure"  # type inconnu
+        self.assertRaises(ValueError, core.parse_config, d)
+
+        d = self._valid()
+        d["sensors"][1]["name"] = "Temp ext"  # nom dupliqué
+        self.assertRaises(ValueError, core.parse_config, d)
+
+        d = self._valid()
+        d["hap"]["pincode"] = "12345678"  # mauvais format
+        self.assertRaises(ValueError, core.parse_config, d)
+
+        self.assertRaises(ValueError, core.parse_config, {"sensors": []})  # aucun capteur
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/toshiba-bridges.md
+++ b/docs/toshiba-bridges.md
@@ -98,6 +98,12 @@ et Google. Conséquences :
 
 - **D = stopgap** : à n'utiliser que pour obtenir les **tuiles présence dans Apple Home**
   **avant** d'avoir câblé le transport Matter (D est prêt et ne dépend d'aucune passerelle).
+  D est **généralisé** par `bridge/mqtt-homekit-sensors/` (**D′**) : MQTT → capteurs HomeKit
+  **multi-types** (température / luminosité / occupation). D′ permet de **tester la chaîne
+  MQTT→HomeKit dès maintenant** avec les capteurs déjà en place (température `santuario/heat/1/venus`,
+  irradiance `santuario/irradiance/raw`) — **sans** matériel Toshiba/FP2 : HAP-python est un
+  accessoire logiciel, il suffit du Pi5 + un iPad/iPhone sur le même WiFi pour appairer. Couche
+  HAP **vérifiée par smoke-test** (build + injection de valeurs). Cf. `bridge/mqtt-homekit-sensors/README.md`.
 - **E = cible** : le mapping **présence→Occupancy** est **déjà fait et testé** dans E
   (`mapping::occupancy_bitmap` + `Bridge::on_presence_json`). Quand le transport rs-matter de E
   sera câblé (endpoints Occupancy Sensor), **on retire D**. Un seul pont pour **clim + présence**,

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -333,6 +333,17 @@ donnée d'appairage :
   `PresencePayload`, `config::presence_topic`/`zone_from_presence_topic`, `Bridge::on_presence_json`
   + cache) → **matérialise « E supersède D »**. `cargo test` E = **18 tests** verts, clippy propre.
   READMEs (crate E, `docs/toshiba-bridges.md` §5) mis à jour.
+- **2026-07-07 (suite 23)** — **Pont test chaîne MQTT→HomeKit livré** : `bridge/mqtt-homekit-sensors/`
+  (Python HAP-python) — généralise D en capteurs **multi-types** (TemperatureSensor / LightSensor /
+  OccupancySensor) pour **valider la chaîne dès maintenant** avec les capteurs déjà en place
+  (température `santuario/heat/1/venus`, irradiance `santuario/irradiance/raw`), **sans** Toshiba/FP2.
+  **Cœur pur** `core.py` (extraction champ JSON **ou** nombre brut, conversion→caractéristique
+  bornée, config+validation) — **9 tests** verts. **Couche HAP vérifiée par smoke-test réel**
+  (pyhap en venv : build du Bridge + injection simulée → 15,3 °C / 750 lux / 0→0,0001 lux clampé).
+  **Distinction Matter/hub clarifiée** : rs-matter sait faire contrôleur, mais notre bridge E est
+  le **côté device** ; le besoin de hub vient de l'**écosystème** (Homey Pro = hub intégré → **pas**
+  de hub en plus ; Apple Home = **exige** HomePod/Apple TV pour commissionner du Matter). Reste sur
+  D′ : appairer l'iPad (seul geste matériel). Doc : README pont, `toshiba-bridges.md` §5, bridge/README.
 
 ---
 


### PR DESCRIPTION
…(temp + irradiance)

Généralise mqtt-homekit-occupancy (D) en un pont de capteurs HomeKit multi-types (TemperatureSensor / LightSensor / OccupancySensor), pour valider la chaîne MQTT→HomeKit DÈS MAINTENANT avec les capteurs déjà en place — sans matériel Toshiba/FP2. HAP-python est un accessoire logiciel : Pi5 + iPad sur le même WiFi.

bridge/mqtt-homekit-sensors/ :
- core.py (pur, 9 tests) : extraction de valeur (champ JSON OU nombre brut), conversion → caractéristique HomeKit bornée (temp clampée ; lux min 0.0001 → 0 W/m² valide ; occupancy 0/1), config + validation (types, PIN, unicité).
- accessory.py / mqtt_in.py / __main__.py : couche HAP+MQTT. API pyhap vérifiée contre le Loader réel ; SMOKE-TEST (venv) : build du Bridge + injection de valeurs simulées → caractéristiques mises à jour (15,3 °C / 750 lux / 0→0,0001).
- config.example.toml pointé sur santuario/heat/1/venus (température, champ JSON) et santuario/irradiance/raw (nombre brut) ; README + systemd + .gitignore.

Seul geste matériel restant : appairer l'iPad/iPhone (même WiFi, mDNS _hap._tcp ; pas de hub requis pour l'appairage local).

Clarification consignée : rs-matter sait faire contrôleur, mais E est le côté device ; le besoin de hub vient de l'écosystème (Homey = hub intégré → pas de hub en plus ; Apple Home = exige HomePod/Apple TV pour du Matter).

Doc : README pont, docs/toshiba-bridges.md §5, bridge/README.md, plan journal (suite 23).


Claude-Session: https://claude.ai/code/session_01HEDbizfgG3aycVMrhE62Gj