### PR TITLE
docs(bridge): service systemd permanent + diagnostic "No Response" (h…

### DIFF
--- a/bridge/mqtt-homekit-sensors/README.md
+++ b/bridge/mqtt-homekit-sensors/README.md
@@ -70,10 +70,36 @@ python -m mqtt_hk_sensors run          --config config.toml
   remonte via `stat/<id>/POWER`. La **puissance W** mesurée par le Tongou ne s'affiche **pas**
   dans Apple Home (pas de type natif) → reste sur la page Tasmota / Grafana.
 
-## Déploiement systemd
+## Déploiement systemd (service permanent)
 
-Unité : `contrib/mqtt-homekit-sensors.service` (après `mosquitto-broker`). Config déployée en
-`/etc/daly-bms/mqtt-homekit-sensors.toml`.
+Pour que le pont tourne **en continu** (survit aux reboots) — unité fournie :
+`contrib/mqtt-homekit-sensors.service` (config **locale** `config.toml`, après `mosquitto-broker`).
+
+```bash
+# venv + deps + config déjà faits (cf. « Installation »). Puis :
+sudo cp contrib/mqtt-homekit-sensors.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now mqtt-homekit-sensors
+systemctl status mqtt-homekit-sensors        # doit être "active (running)"
+journalctl -u mqtt-homekit-sensors -f        # logs (dont "Enter this code..." au 1er appairage)
+```
+
+> L'appairage HomeKit **persiste** dans `hap-state/accessory.state` → après un redémarrage du
+> service ou du Pi5, les accessoires **restent appairés** (pas de ré-appairage).
+
+## Diagnostic « accessoire sans réponse » (No Response)
+
+Un accessoire **capteur** reste « sans réponse » s'il ne reçoit **jamais** de valeur — c.-à-d.
+si le **champ n'existe pas** dans le payload publié. Exemple courant : `humidity` sur
+`santuario/heat/1/venus` alors que le capteur externe ne publie **que** la température.
+
+```bash
+mosquitto_sub -t 'santuario/heat/1/venus' -v      # le champ "Humidity" est-il présent ?
+```
+
+→ Si le champ est absent : **retirer ce capteur** de `config.toml` (ou le pointer sur une source
+qui publie réellement la valeur). Ce n'est **pas** un bug du pont : température (même topic) et
+switch fonctionnent car leurs valeurs, elles, arrivent.
 
 ## Sécurité (règle #12)
 

--- a/bridge/mqtt-homekit-sensors/config.example.toml
+++ b/bridge/mqtt-homekit-sensors/config.example.toml
@@ -25,6 +25,9 @@ topic      = "santuario/heat/1/venus"
 json_field = "Temperature"
 
 # Humidité (même payload que la température) → HumiditySensor (tuile Apple OK).
+# ⚠️ REQUIERT que le topic publie réellement le champ `Humidity`. Le capteur externe
+#    Venus (type 4) est souvent température SEULE → l'accessoire reste « sans réponse ».
+#    Vérifier : mosquitto_sub -t 'santuario/heat/1/venus' -v  (retirer ce bloc si pas de Humidity).
 [[sensors]]
 name       = "Humidité extérieure"
 type       = "humidity"

--- a/bridge/mqtt-homekit-sensors/contrib/mqtt-homekit-sensors.service
+++ b/bridge/mqtt-homekit-sensors/contrib/mqtt-homekit-sensors.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=MQTT -> HomeKit sensors bridge (température / luminosité / occupation)
+Description=MQTT -> HomeKit sensors bridge (température / humidité / luminosité / switch)
 Documentation=file:///home/pi5compute/Daly-BMS-Rust/docs/toshiba-bridges.md
 After=network-online.target mosquitto-broker.service
 Wants=network-online.target
@@ -8,10 +8,11 @@ Wants=network-online.target
 Type=simple
 User=pi5compute
 WorkingDirectory=/home/pi5compute/Daly-BMS-Rust/bridge/mqtt-homekit-sensors
-ExecStart=/home/pi5compute/Daly-BMS-Rust/bridge/mqtt-homekit-sensors/.venv/bin/python -m mqtt_hk_sensors run --config /etc/daly-bms/mqtt-homekit-sensors.toml
+# Config LOCALE au dossier (config.toml, gitignoré — contient le PIN). CWD = WorkingDirectory.
+ExecStart=/home/pi5compute/Daly-BMS-Rust/bridge/mqtt-homekit-sensors/.venv/bin/python -m mqtt_hk_sensors run --config config.toml
 Restart=on-failure
 RestartSec=5
-# Durcissement léger
+# Durcissement léger. hap-state (clé d'appairage) = seul chemin inscriptible.
 NoNewPrivileges=true
 ProtectSystem=strict
 ReadWritePaths=/home/pi5compute/Daly-BMS-Rust/bridge/mqtt-homekit-sensors/hap-state

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -361,6 +361,15 @@ donnée d'appairage :
   `tongou_3ACC34` (⚠️ actionneur réel, **non** piloté par EM → pas de conflit ; `tongou_3BC764`
   chauffe-eau EM = à NE PAS exposer). Tri des types selon rendu Apple (switch/temp/humidité/occupation
   ✅ ; puissance/énergie/lux limités). Doc : README pont mis à jour. **Code + doc.**
+- **2026-07-07 (suite 26)** — **Validation terrain (2e passe) + service systemd**. Sur iPad :
+  **switch Tongou apparu tout seul** (sans ré-appairage, contrôlable) ✅ ; **humidité = « sans
+  réponse »** → diagnostic : le capteur externe (`santuario/heat/1/venus`, Venus type 4) ne publie
+  probablement **que** la température, pas `Humidity` → l'accessoire ne reçoit jamais de valeur
+  (pas un bug ; vérifier `mosquitto_sub -t santuario/heat/1/venus -v`, retirer le bloc humidité si
+  absent). **Unité systemd finalisée** (`contrib/mqtt-homekit-sensors.service`, config **locale**
+  `config.toml`, appairage persistant dans `hap-state/`) → pont **permanent** ; README complété
+  (mise en service + diagnostic No Response). **Chaîne MQTT→HomeKit prouvée de bout en bout ;
+  on revient à cette brique à l'arrivée des FP2.** Doc + unité.
 
 ---
 


### PR DESCRIPTION
…umidité)

Retour terrain (2e passe) : switch Tongou apparu tout seul et contrôlable ; humidité = "sans réponse".

- Diagnostic No Response : l'accessoire capteur reste "sans réponse" s'il ne reçoit jamais de valeur — champ absent du payload. Cas humidité : le capteur externe (santuario/heat/1/venus, Venus type 4) ne publie souvent que la température, pas Humidity. Pas un bug du pont. README + commentaire config ajoutent la vérif (mosquitto_sub) et l'action (retirer le bloc si absent).
- Service systemd finalisé : unité pointée sur la config LOCALE config.toml (alignée sur l'usage réel), appairage persistant dans hap-state/. README : section "Mise en service systemd" (enable --now, logs, persistance).

Chaîne MQTT→HomeKit prouvée de bout en bout ; on revient à cette brique à l'arrivée des FP2. Journal plan (suite 26). Doc + unité.


Claude-Session: https://claude.ai/code/session_01HEDbizfgG3aycVMrhE62Gj