### PR TITLE
fix(bridge): switch state via json_field (revue Gemini) + diagnostic …

### DIFF
--- a/bridge/mqtt-homekit-sensors/README.md
+++ b/bridge/mqtt-homekit-sensors/README.md
@@ -89,17 +89,27 @@ journalctl -u mqtt-homekit-sensors -f        # logs (dont "Enter this code..." a
 
 ## Diagnostic « accessoire sans réponse » (No Response)
 
-Un accessoire **capteur** reste « sans réponse » s'il ne reçoit **jamais** de valeur — c.-à-d.
-si le **champ n'existe pas** dans le payload publié. Exemple courant : `humidity` sur
-`santuario/heat/1/venus` alors que le capteur externe ne publie **que** la température.
+Deux causes possibles :
+
+**1. Réattribution d'AID après modification d'un bridge déjà appairé** *(cause la plus fréquente
+quand on ajoute des capteurs)*. HAP-python assigne les *Accessory ID* dans l'**ordre de la
+config** ; **insérer** un capteur au **milieu** décale les AID des suivants → l'iPad déjà appairé
+garde l'ancienne correspondance → l'accessoire décalé s'affiche « sans réponse ».
+
+- **Correctif** : dans l'app Maison, **supprimer le pont « Santuario Sensors » puis le ré-ajouter**
+  (ré‑appairage → l'iPad réapprend tous les AID). Alternative radicale : `rm -rf hap-state/` + relancer + ré‑appairer.
+- **Prévention** : **ajouter les nouveaux capteurs à la FIN** de `config.toml` (ne pas insérer au milieu).
+
+**2. Le capteur ne reçoit jamais de valeur** (champ réellement absent du payload) :
 
 ```bash
-mosquitto_sub -t 'santuario/heat/1/venus' -v      # le champ "Humidity" est-il présent ?
+mosquitto_sub -t 'santuario/heat/1/venus' -v      # le champ attendu est-il présent ?
 ```
 
-→ Si le champ est absent : **retirer ce capteur** de `config.toml` (ou le pointer sur une source
-qui publie réellement la valeur). Ce n'est **pas** un bug du pont : température (même topic) et
-switch fonctionnent car leurs valeurs, elles, arrivent.
+→ Si le champ est absent : retirer ce capteur, ou le pointer sur une source qui le publie.
+
+> Dans tous les cas ce **n'est pas un bug du pont** : les accessoires dont l'AID est stable **et**
+> qui reçoivent une valeur (température, switch…) fonctionnent.
 
 ## Sécurité (règle #12)
 

--- a/bridge/mqtt-homekit-sensors/config.example.toml
+++ b/bridge/mqtt-homekit-sensors/config.example.toml
@@ -24,10 +24,10 @@ type       = "temperature"
 topic      = "santuario/heat/1/venus"
 json_field = "Temperature"
 
-# Humidité (même payload que la température) → HumiditySensor (tuile Apple OK).
-# ⚠️ REQUIERT que le topic publie réellement le champ `Humidity`. Le capteur externe
-#    Venus (type 4) est souvent température SEULE → l'accessoire reste « sans réponse ».
-#    Vérifier : mosquitto_sub -t 'santuario/heat/1/venus' -v  (retirer ce bloc si pas de Humidity).
+# Humidité → HumiditySensor (tuile Apple OK). Le capteur ext. est un BME280 : le payload
+# porte bien Humidity + Pressure + Temperature (ex. {"Humidity":64.0,"Pressure":988.2,
+# "Temperature":29.3,"TemperatureType":4}). NB : la PRESSION n'a pas de type HomeKit standard
+# → non exposable en tuile (reste sur Grafana).
 [[sensors]]
 name       = "Humidité extérieure"
 type       = "humidity"

--- a/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/core.py
+++ b/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/core.py
@@ -88,9 +88,20 @@ def parse_value(spec: SensorSpec, raw) -> float | None:
     raw = raw.strip()
     if not raw:
         return None
-    # `switch` : l'état Tasmota est un texte "ON"/"OFF" (stat/<id>/POWER).
+    # `switch` : état soit texte brut "ON"/"OFF" (Tasmota `stat/<id>/POWER`), soit champ
+    # d'un JSON si `json_field` est défini (ex. `tele/<id>/STATE` `{"POWER":"ON"}`, ou
+    # Zigbee2MQTT `{"state":"ON"}`). Accepte ON/1/true et OFF/0/false.
     if spec.kind == "switch":
-        s = raw.upper()
+        extracted = raw
+        if spec.json_field is not None:
+            try:
+                obj = json.loads(raw)
+            except (ValueError, TypeError):
+                return None
+            if not isinstance(obj, dict) or spec.json_field not in obj:
+                return None
+            extracted = obj[spec.json_field]
+        s = str(extracted).strip().upper()
         if s in ("ON", "1", "TRUE"):
             return 1.0
         if s in ("OFF", "0", "FALSE"):

--- a/bridge/mqtt-homekit-sensors/tests/test_core.py
+++ b/bridge/mqtt-homekit-sensors/tests/test_core.py
@@ -52,6 +52,18 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(core.parse_value(s, "on"), 1.0)  # casse insensible
         self.assertIsNone(core.parse_value(s, b"blink"))
 
+    def test_state_json_parsing(self):
+        # État de switch niché dans un JSON (Tasmota tele/STATE, Zigbee2MQTT…).
+        s = core.SensorSpec(
+            "Sw", "switch", "tele/tongou_3ACC34/STATE",
+            json_field="POWER", command_topic="cmnd/tongou_3ACC34/POWER",
+        )
+        self.assertEqual(core.parse_value(s, b'{"POWER":"ON"}'), 1.0)
+        self.assertEqual(core.parse_value(s, b'{"POWER":false}'), 0.0)
+        self.assertIsNone(core.parse_value(s, b'{"POWER":"UNKNOWN"}'))
+        self.assertIsNone(core.parse_value(s, b'{"other":"ON"}'))  # champ absent
+        self.assertIsNone(core.parse_value(s, b"pas du json"))
+
     def test_to_char_bool_and_command(self):
         self.assertIs(core.to_char_value("switch", 1.0), True)
         self.assertIs(core.to_char_value("switch", 0.0), False)

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -363,13 +363,21 @@ donnée d'appairage :
   ✅ ; puissance/énergie/lux limités). Doc : README pont mis à jour. **Code + doc.**
 - **2026-07-07 (suite 26)** — **Validation terrain (2e passe) + service systemd**. Sur iPad :
   **switch Tongou apparu tout seul** (sans ré-appairage, contrôlable) ✅ ; **humidité = « sans
-  réponse »** → diagnostic : le capteur externe (`santuario/heat/1/venus`, Venus type 4) ne publie
-  probablement **que** la température, pas `Humidity` → l'accessoire ne reçoit jamais de valeur
-  (pas un bug ; vérifier `mosquitto_sub -t santuario/heat/1/venus -v`, retirer le bloc humidité si
-  absent). **Unité systemd finalisée** (`contrib/mqtt-homekit-sensors.service`, config **locale**
+  réponse »** (⚠️ diagnostic « champ Humidity absent » **infirmé en suite 27** — le champ est bien
+  présent). **Unité systemd finalisée** (`contrib/mqtt-homekit-sensors.service`, config **locale**
   `config.toml`, appairage persistant dans `hap-state/`) → pont **permanent** ; README complété
   (mise en service + diagnostic No Response). **Chaîne MQTT→HomeKit prouvée de bout en bout ;
   on revient à cette brique à l'arrivée des FP2.** Doc + unité.
+- **2026-07-07 (suite 27)** — **Diagnostic humidité corrigé + revue Gemini appliquée.**
+  `mosquitto_sub` : `heat/1/venus` **porte bien** `Humidity` (BME280 : Humidity+Pressure+Temperature)
+  → le diagnostic « champ absent » (suite 26) était **faux**. Vrai coupable du « sans réponse » =
+  **réattribution d'AID** : l'humidité insérée au *milieu* de la config a pris l'AID de l'ancien
+  capteur de lumière → l'iPad appairé est confus. **Correctif = supprimer + ré-ajouter le pont dans
+  Maison** (ou reset `hap-state/`) ; **prévention = ajouter les nouveaux capteurs en FIN de config**.
+  README réécrit (2 causes du No Response). **Revue Gemini (PR)** appliquée : `parse_value` d'un
+  `switch` respecte désormais `json_field` (état niché en JSON : `tele/<id>/STATE {"POWER":"ON"}`,
+  Zigbee2MQTT) + test dédié → **15 tests** verts. Pression BME280 = pas de type HomeKit → Grafana.
+  **Code + doc.**
 
 ---
 


### PR DESCRIPTION
…humidité corrigé

Revue Gemini (PR) appliquée : parse_value d'un switch ignorait json_field, rendant impossible de lire un état niché dans un JSON (Tasmota tele/<id>/STATE {"POWER": "ON"}, Zigbee2MQTT {"state":"ON"}). Désormais : si json_field est défini, on extrait le champ du JSON avant d'interpréter ON/1/true vs OFF/0/false. Test dédié (test_state_json_parsing) → 15 tests verts.

Diagnostic humidité « sans réponse » corrigé : mosquitto_sub montre que santuario/heat/1/venus porte bien Humidity (capteur BME280 : Humidity + Pressure
+ Temperature). Mon diagnostic précédent (champ absent) était FAUX. Vrai coupable = réattribution d'AID : insérer l'humidité au milieu de la config a décalé l'AID de l'ancien capteur de lumière → iPad appairé confus → "No Response". Correctif = supprimer + ré-ajouter le pont dans l'app Maison (ou reset hap-state/). Prévention = ajouter les nouveaux capteurs en FIN de config.

README réécrit (2 causes du No Response) ; config.example (BME280, pression sans type HomeKit) ; plan journal (suite 26 marquée corrigée, suite 27).


Claude-Session: https://claude.ai/code/session_01HEDbizfgG3aycVMrhE62Gj