### PR TITLE
fix(bridge): AID HomeKit stables par nom → fin des "No Response" aprè…

### DIFF
--- a/bridge/mqtt-homekit-sensors/README.md
+++ b/bridge/mqtt-homekit-sensors/README.md
@@ -91,14 +91,19 @@ journalctl -u mqtt-homekit-sensors -f        # logs (dont "Enter this code..." a
 
 Deux causes possibles :
 
-**1. Réattribution d'AID après modification d'un bridge déjà appairé** *(cause la plus fréquente
-quand on ajoute des capteurs)*. HAP-python assigne les *Accessory ID* dans l'**ordre de la
-config** ; **insérer** un capteur au **milieu** décale les AID des suivants → l'iPad déjà appairé
-garde l'ancienne correspondance → l'accessoire décalé s'affiche « sans réponse ».
+**1. Réattribution d'AID après modification d'un bridge déjà appairé.** Historiquement,
+HAP-python assignait les *Accessory ID* dans l'**ordre de la config** ; insérer un capteur au
+milieu décalait les AID des suivants → l'iPad déjà appairé gardait l'ancienne correspondance →
+« sans réponse ». **Corrigé** : ce pont **épingle un AID stable dérivé du nom**
+(`core.stable_aid`) → réordonner / insérer / retirer d'autres capteurs **ne décale plus rien**.
+**Transition unique** : le passage aux AID épinglés change les AID actuels → il faut
+**supprimer le pont dans l'app Maison puis le ré-ajouter UNE fois** ; ensuite les éditions de
+config ne cassent plus l'appairage.
 
 - **Correctif** : dans l'app Maison, **supprimer le pont « Santuario Sensors » puis le ré-ajouter**
   (ré‑appairage → l'iPad réapprend tous les AID). Alternative radicale : `rm -rf hap-state/` + relancer + ré‑appairer.
-- **Prévention** : **ajouter les nouveaux capteurs à la FIN** de `config.toml` (ne pas insérer au milieu).
+- **Bon réflexe** : garder les `name` **stables** dans `config.toml` (renommer dans l'app Maison,
+  pas dans la config — changer un `name` change l'aid de CE capteur → à re-découvrir).
 
 **2. Le capteur ne reçoit jamais de valeur** (champ réellement absent du payload) :
 

--- a/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/accessory.py
+++ b/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/accessory.py
@@ -26,8 +26,8 @@ class SensorAccessory(Accessory):
 
     category = CATEGORY_SENSOR
 
-    def __init__(self, driver, spec: core.SensorSpec) -> None:
-        super().__init__(driver, spec.name)
+    def __init__(self, driver, spec: core.SensorSpec, aid: int) -> None:
+        super().__init__(driver, spec.name, aid=aid)  # AID épinglé (stable) → cf. core.stable_aid
         service_name, char_name = core.service_and_char(spec.kind)
         serv = self.add_preload_service(service_name)
         initial = core.to_char_value(spec.kind, 0.0)
@@ -43,8 +43,8 @@ class SwitchAccessory(Accessory):
 
     category = CATEGORY_SWITCH
 
-    def __init__(self, driver, spec: core.SensorSpec, publish: PublishCommand) -> None:
-        super().__init__(driver, spec.name)
+    def __init__(self, driver, spec: core.SensorSpec, publish: PublishCommand, aid: int) -> None:
+        super().__init__(driver, spec.name, aid=aid)  # AID épinglé (stable)
         serv = self.add_preload_service("Switch")
         # `setter_callback` = appelé UNIQUEMENT sur écriture HomeKit (pas par set_value)
         # → pas de boucle quand on reflète l'état physique via `set_from_value`.
@@ -68,11 +68,17 @@ def build_bridge(driver, cfg: core.BridgeConfig, publish: PublishCommand):
     """
     bridge = Bridge(driver, cfg.hap_bridge_name)
     accessories: dict[str, Accessory] = {}
+    used_aids: set[int] = {1}  # 1 = Bridge lui-même
     for spec in cfg.sensors:
+        # AID stable par nom (+ anti-collision : bump en cas de rare collision de hash).
+        aid = core.stable_aid(spec.name)
+        while aid in used_aids:
+            aid = aid + 1 if aid < 2**31 - 1 else 2
+        used_aids.add(aid)
         if spec.kind in core.CONTROLLABLE_KINDS:
-            acc: Accessory = SwitchAccessory(driver, spec, publish)
+            acc: Accessory = SwitchAccessory(driver, spec, publish, aid)
         else:
-            acc = SensorAccessory(driver, spec)
+            acc = SensorAccessory(driver, spec, aid)
         bridge.add_accessory(acc)
         accessories[spec.name] = acc
     return bridge, accessories

--- a/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/core.py
+++ b/bridge/mqtt-homekit-sensors/mqtt_hk_sensors/core.py
@@ -13,6 +13,7 @@ depuis le payload, et conversion → valeur de caractéristique HomeKit. Testabl
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from dataclasses import dataclass
@@ -198,6 +199,17 @@ def parse_config(data: dict) -> BridgeConfig:
         hap_state_dir=str(hap.get("state_dir", "hap-state")),
         sensors=tuple(sensors),
     )
+
+
+def stable_aid(name: str) -> int:
+    """AID HomeKit **stable** dérivé du nom (indépendant de l'ordre de la config).
+
+    Avec des AID épinglés par nom, ajouter/retirer/**réordonner** d'autres accessoires ne
+    décale plus les AID existants → plus de « sans réponse » après édition d'un bridge déjà
+    appairé (seul renommer un accessoire change SON aid). `1` est réservé au Bridge lui-même.
+    """
+    digest = hashlib.sha256(name.encode("utf-8")).digest()
+    return 2 + (int.from_bytes(digest[:6], "big") % (2**31 - 3))
 
 
 def build_route(cfg: BridgeConfig) -> dict[str, list[SensorSpec]]:

--- a/bridge/mqtt-homekit-sensors/tests/test_core.py
+++ b/bridge/mqtt-homekit-sensors/tests/test_core.py
@@ -90,6 +90,23 @@ class TestToCharValue(unittest.TestCase):
         self.assertEqual(core.to_char_value("occupancy", 0.0), 0)
 
 
+class TestStableAid(unittest.TestCase):
+    def test_deterministic_and_valid(self):
+        a = core.stable_aid("Température extérieure")
+        self.assertEqual(a, core.stable_aid("Température extérieure"))  # déterministe
+        self.assertGreaterEqual(a, 2)  # jamais 1 (réservé au Bridge)
+        self.assertLess(a, 2**31)
+
+    def test_independent_of_order(self):
+        # Le point clé : l'aid ne dépend QUE du nom, pas de la position dans la config.
+        names = ["Température extérieure", "Humidité extérieure", "Irradiance PRALRAN", "Prise séjour (Tongou)"]
+        aids = {n: core.stable_aid(n) for n in names}
+        self.assertEqual(len(set(aids.values())), len(names))  # tous distincts
+        # Réordonner les noms ne change aucun aid.
+        for n in reversed(names):
+            self.assertEqual(core.stable_aid(n), aids[n])
+
+
 class TestConfig(unittest.TestCase):
     def _valid(self):
         return {

--- a/docs/toshiba-suzumi-rs-plan.md
+++ b/docs/toshiba-suzumi-rs-plan.md
@@ -378,6 +378,15 @@ donnée d'appairage :
   `switch` respecte désormais `json_field` (état niché en JSON : `tele/<id>/STATE {"POWER":"ON"}`,
   Zigbee2MQTT) + test dédié → **15 tests** verts. Pression BME280 = pas de type HomeKit → Grafana.
   **Code + doc.**
+- **2026-07-07 (suite 28)** — **Cause « sans réponse » PROUVÉE + corrigée définitivement.**
+  Simulation du chemin réseau réel (`_on_message`→accessoires) avec le payload exact : humidité
+  reçoit bien **64** côté service (aucun bug serveur) ; les **AID** confirment le conflit
+  (Temp=2, **Humidité=3**, Irradiance=4, Switch=5 → l'humidité a hérité de l'aid 3 = ancien capteur
+  de lumière de l'iPad appairé). **Correctif permanent** : **AID épinglés stables par nom**
+  (`core.stable_aid`, sha256 → aid déterministe ≥2, anti-collision dans `build_bridge`) →
+  réordonner/insérer/retirer un capteur **ne décale plus** les autres (vérifié : AID identiques
+  quel que soit l'ordre). Nécessite **un** ré-appairage (transition). `cargo`… non — **17 tests
+  Python** verts, smoke-test AID stables OK. README diagnostic réécrit. **Code + doc.**
 
 ---
 


### PR DESCRIPTION
…s édition de config

Cause du "sans réponse" de l'humidité PROUVÉE (pas devinée) : simulation du chemin réseau réel montre que le service met bien humidité=64 (aucun bug serveur) ; les AID assignés (Temp=2, Humidité=3, Irradiance=4, Switch=5) confirment le conflit — l'humidité, insérée au milieu de la config, a hérité de l'aid 3 que l'iPad appairé associait à l'ancien capteur de lumière → "No Response".

Correctif permanent : AID épinglés, dérivés du NOM (core.stable_aid, sha256 → entier déterministe >=2, jamais 1 ; anti-collision dans build_bridge). Résultat vérifié : les AID sont identiques quel que soit l'ordre de la config → ajouter / retirer / réordonner un capteur ne décale plus les autres. Seul renommer un capteur (champ name) change SON aid.

Transition : le passage aux AID épinglés change les AID actuels → un ré-appairage unique est nécessaire (à faire de toute façon pour l'humidité) ; ensuite les éditions de config ne cassent plus l'appairage.

17 tests verts ; smoke-test (venv pyhap) : AID stables sur réordonnancement. README diagnostic réécrit ; plan journal (suite 28).


Claude-Session: https://claude.ai/code/session_01HEDbizfgG3aycVMrhE62Gj