### PR TITLE
feat(mqtt): topics scalaires pour dashboards externes (Dashboard Studio)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,27 @@ Topics internes `santuario/em/*` (energy-manager → daly-bms-server, pas de D-B
 solaire 1 Hz — remplace l'ancien POST HTTP `/api/v1/solar/mppt-yield`, conservé
 en fallback ; cf. docs/diagnostic-depannage.md §17).
 
+### Topics SCALAIRES (nombre nu, retain=true) — dashboards externes
+
+Pour les tableaux de bord type **Dashboard Studio** qui lient « 1 topic = 1 valeur
+numérique » **sans extraction JSON** (le champ VALUE est une formule numérique, pas
+un JSON path). Publiés **en plus** des payloads `.../venus` (JSON), qui restent
+inchangés. Restent **locaux** au broker Pi5 (pas dans le bridge NanoPi).
+
+| Source | Topic scalaire | Code |
+|--------|----------------|------|
+| BMS `{n}` | `bms/{n}/soc` `voltage` `current` `power` `temperature` | `bridges/mqtt.rs::publish_snapshot` |
+| ET112 `{addr}` (7/8/9) | `et112/{addr}/power` `voltage` `current` `apparent_power` `frequency` `energy_import` `energy_export` | `bridges/mqtt.rs::publish_et112_scalars` |
+| Tongou `{tasmota_id}` | `tasmota/{id}/power` `state`(0/1) `voltage` `current` `energy_today` | `bridges/mqtt.rs::publish_tasmota_scalars` |
+| ATS CHINT | `ats/source`(0/1/2) `ats/mode`(auto=1) | `bridges/mqtt.rs::publish_ats_scalars` |
+| Irradiance | `irradiance/raw` (déjà scalaire) | `bridges/mqtt.rs::publish_irradiance` |
+| Chauffe-eau | `em/water_heater/temp` `target` `mode`(0/1/2) | `energy-manager water_heater/mod.rs::publish_to_venus` |
+| Solaire (agrégats EM) | `em/solar/total_w` `pv_w` `pvinv_w` `yield_kwh` `house_w` | `energy-manager solar_power/mod.rs::writer_task` |
+
+> Victron (`N/{portal}/…`) n'est **pas** sous `santuario/` → hors abonnement
+> `santuario/#` d'un dashboard. Le SOC/tension/… batterie sont dispo via les
+> topics `bms/{n}/…` ci-dessus ; le reste Victron via l'app Victron officielle.
+
 ---
 
 ## 7. API ENDPOINTS (extraits — voir `crates/daly-bms-server/src/api/mod.rs`)

--- a/crates/daly-bms-server/src/bridges/mqtt.rs
+++ b/crates/daly-bms-server/src/bridges/mqtt.rs
@@ -149,6 +149,8 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
             if let Err(e) = publish_et112_snapshot(&client, &cfg, snap, idx, position, service_type).await {
                 error!("MQTT publish ET112 erreur : {:?}", e);
             }
+            // Topics scalaires dédiés (dashboards externes type Dashboard Studio).
+            publish_et112_scalars(&client, &cfg, snap).await;
         }
 
         // ── Irradiance PRALRAN → santuario/irradiance/raw ────────────────────
@@ -166,6 +168,7 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
                     if let Err(e) = publish_ats_snapshot(&client, &cfg, &ats_snap, ats_cfg.mqtt_index).await {
                         error!("MQTT publish ATS erreur : {:?}", e);
                     }
+                    publish_ats_scalars(&client, &cfg, &ats_snap).await;
                 }
             }
         }
@@ -173,6 +176,8 @@ pub async fn run_mqtt_bridge(state: AppState, cfg: MqttConfig, addr_map: HashMap
         // ── Tasmota → forward Venus OS switch/acload si mqtt_index défini ──
         let tasmota_snaps = state.tasmota_latest_all().await;
         for snap in &tasmota_snaps {
+            // Topics scalaires dédiés (puissance/état par prise Tongou).
+            publish_tasmota_scalars(&client, &cfg, snap).await;
             let dev_cfg = state.config.tasmota.devices
                 .iter()
                 .find(|d| d.id == snap.id);
@@ -206,6 +211,59 @@ async fn publish_irradiance(
         .publish(&topic, PUB_QOS, true, payload)
         .await?;
     Ok(())
+}
+
+// =============================================================================
+// Topics scalaires (une valeur numérique par topic, retain=true)
+// -----------------------------------------------------------------------------
+// Destinés aux tableaux de bord externes (Dashboard Studio, etc.) qui lient un
+// topic = un nombre, SANS extraction de champ JSON. Complètent les payloads
+// `.../venus` (JSON) sans les modifier.
+// =============================================================================
+
+/// Racine des topics (préfixe sans le dernier segment, ex: "santuario").
+fn scalar_base(cfg: &MqttConfig) -> &str {
+    cfg.topic_prefix.rsplit_once('/').map(|(p, _)| p).unwrap_or("santuario")
+}
+
+/// Publie une valeur scalaire (nombre nu) en retain.
+async fn pub_scalar(client: &AsyncClient, topic: String, value: String) {
+    if let Err(e) = client.publish(topic, PUB_QOS, true, value).await {
+        warn!("MQTT publish scalaire échoué : {e}");
+    }
+}
+
+/// ET112 → `{base}/et112/{addr}/{champ}` (inclut fréquence + puissance apparente,
+/// absentes du payload Venus).
+async fn publish_et112_scalars(client: &AsyncClient, cfg: &MqttConfig, snap: &Et112Snapshot) {
+    let base = scalar_base(cfg);
+    let a = snap.address;
+    pub_scalar(client, format!("{base}/et112/{a}/power"),          format!("{:.1}", snap.power_w)).await;
+    pub_scalar(client, format!("{base}/et112/{a}/voltage"),        format!("{:.1}", snap.voltage_v)).await;
+    pub_scalar(client, format!("{base}/et112/{a}/current"),        format!("{:.2}", snap.current_a)).await;
+    pub_scalar(client, format!("{base}/et112/{a}/apparent_power"), format!("{:.1}", snap.apparent_power_va)).await;
+    pub_scalar(client, format!("{base}/et112/{a}/frequency"),      format!("{:.2}", snap.frequency_hz)).await;
+    pub_scalar(client, format!("{base}/et112/{a}/energy_import"),  format!("{:.3}", snap.energy_import_kwh())).await;
+    pub_scalar(client, format!("{base}/et112/{a}/energy_export"),  format!("{:.3}", snap.energy_export_kwh())).await;
+}
+
+/// Tasmota/Tongou → `{base}/tasmota/{tasmota_id}/{champ}` (état relais en 0/1).
+async fn publish_tasmota_scalars(client: &AsyncClient, cfg: &MqttConfig, snap: &TasmotaSnapshot) {
+    let base = scalar_base(cfg);
+    let id = &snap.tasmota_id;
+    pub_scalar(client, format!("{base}/tasmota/{id}/power"),        format!("{:.1}", snap.power_w)).await;
+    pub_scalar(client, format!("{base}/tasmota/{id}/state"),        (if snap.power_on { 1 } else { 0 }).to_string()).await;
+    pub_scalar(client, format!("{base}/tasmota/{id}/voltage"),      format!("{:.1}", snap.voltage_v)).await;
+    pub_scalar(client, format!("{base}/tasmota/{id}/current"),      format!("{:.2}", snap.current_a)).await;
+    pub_scalar(client, format!("{base}/tasmota/{id}/energy_today"), format!("{:.3}", snap.energy_today_kwh)).await;
+}
+
+/// ATS CHINT → `{base}/ats/{source|mode}` (source active 0/1/2, mode auto=1/manuel=0).
+async fn publish_ats_scalars(client: &AsyncClient, cfg: &MqttConfig, snap: &AtsSnapshot) {
+    let base = scalar_base(cfg);
+    let source = if snap.sw2_closed { 2 } else if snap.sw1_closed { 1 } else { 0 };
+    pub_scalar(client, format!("{base}/ats/source"), source.to_string()).await;
+    pub_scalar(client, format!("{base}/ats/mode"),   (if snap.sw_mode { 1 } else { 0 }).to_string()).await;
 }
 
 /// Publie un snapshot ET112 sur le topic `santuario/{service_type}/{idx}/venus`.
@@ -382,6 +440,7 @@ async fn publish_snapshot(
     publish_str(client, &format!("{}/voltage", prefix), &format!("{:.2}", snap.dc.voltage)).await;
     publish_str(client, &format!("{}/current", prefix), &format!("{:.1}", snap.dc.current)).await;
     publish_str(client, &format!("{}/power",   prefix), &format!("{:.1}", snap.dc.power)).await;
+    publish_str(client, &format!("{}/temperature", prefix), &format!("{:.1}", snap.dc.temperature)).await;
 
     // JSON status complet
     let status_json = serde_json::to_string(snap)?;

--- a/crates/energy-manager/src/logic/solar_power/mod.rs
+++ b/crates/energy-manager/src/logic/solar_power/mod.rs
@@ -197,6 +197,13 @@ async fn writer_task(
         // (conservé en fallback).
         bus.publish(MqttOutgoing::transient(publish::EM_SOLAR, &body)).await;
 
+        // Topics scalaires (dashboards externes) — agrégats solaires en nombre nu.
+        bus.publish(MqttOutgoing::raw("santuario/em/solar/total_w",   format!("{solar_total:.0}"), true)).await;
+        bus.publish(MqttOutgoing::raw("santuario/em/solar/pv_w",      format!("{dc_pv_w:.0}"),     true)).await;
+        bus.publish(MqttOutgoing::raw("santuario/em/solar/pvinv_w",   format!("{pvinv_w:.0}"),     true)).await;
+        bus.publish(MqttOutgoing::raw("santuario/em/solar/yield_kwh", format!("{total_yield:.2}"), true)).await;
+        bus.publish(MqttOutgoing::raw("santuario/em/solar/house_w",   format!("{house_power:.0}"), true)).await;
+
         bus.emit_live(LiveEvent::new("solar", json!({
             "solar_total_w": solar_total,
             "dc_pv_power_w": dc_pv_w,

--- a/crates/energy-manager/src/logic/water_heater/mod.rs
+++ b/crates/energy-manager/src/logic/water_heater/mod.rs
@@ -39,14 +39,25 @@ async fn keepalive_task(interval_secs: u64, bus: AppBus, state: Arc<RwLock<Energ
 
 async fn publish_to_venus(bus: &AppBus, state: &Arc<RwLock<EnergyState>>) {
     let s = state.read().await;
+    let mode   = s.water_heater_mode.to_venus_state();
+    let temp   = s.water_heater_temp_c;
+    let target = s.water_heater_target_c;
     let payload = json!({
-        "State": s.water_heater_mode.to_venus_state(),
-        "Temperature": s.water_heater_temp_c,
-        "TargetTemperature": s.water_heater_target_c,
+        "State": mode,
+        "Temperature": temp,
+        "TargetTemperature": target,
         "Position": 0,
     });
     drop(s);
     bus.publish(MqttOutgoing::retained(publish::HEATPUMP_VENUS, &payload)).await;
+    // Topics scalaires (dashboards externes type Dashboard Studio) : °C et mode 0/1/2.
+    if let Some(t) = temp {
+        bus.publish(MqttOutgoing::raw("santuario/em/water_heater/temp", format!("{t:.1}"), true)).await;
+    }
+    if let Some(t) = target {
+        bus.publish(MqttOutgoing::raw("santuario/em/water_heater/target", format!("{t:.1}"), true)).await;
+    }
+    bus.publish(MqttOutgoing::raw("santuario/em/water_heater/mode", mode.to_string(), true)).await;
     bus.emit_live(LiveEvent::new("water_heater_venus", &payload));
 }
 


### PR DESCRIPTION
Publie des topics MQTT "1 topic = 1 valeur numérique" (retain=true) pour les tableaux de bord qui ne savent pas extraire de champ JSON (le champ VALUE est une formule numérique). Publiés EN PLUS des payloads .../venus (JSON inchangés), locaux au broker Pi5 (hors bridge NanoPi).

daly-bms-server (bridges/mqtt.rs) :
- ET112 {7,8,9} : power, voltage, current, apparent_power, frequency, energy_import, energy_export (dont fréquence + VA absentes du Venus)
- BMS {n} : ajout de temperature
- Tongou/Tasmota {id} : power, state(0/1), voltage, current, energy_today
- ATS : source(0/1/2), mode(auto=1)

energy-manager :
- Chauffe-eau : em/water_heater/{temp,target,mode}
- Solaire : em/solar/{total_w,pv_w,pvinv_w,yield_kwh,house_w}

CLAUDE.md §6 : table des topics scalaires documentée.


Claude-Session: https://claude.ai/code/session_019nQMEznziNKhsHi66FgNmL